### PR TITLE
feat(deploy): containerise Klebb (Dockerfile + compose + GHCR)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,45 @@
+# Don't copy the local dev tree into the build context unnecessarily
+node_modules
+npm-debug.log*
+
+# Git
+.git
+.gitignore
+.github
+
+# Local dev data — never goes in the image
+data
+credentials
+sessions
+reports
+/data/
+/credentials/
+/sessions/
+/reports/
+
+# Example data + tests are not needed at runtime
+data.example
+tests
+fixtures
+
+# Docs + editor cruft
+docs
+*.md
+!package.json
+!package-lock.json
+.idea
+.vscode
+.DS_Store
+
+# Env files — never bake secrets into the image
+.env
+.env.*
+*.env
+
+# systemd templates — bare-metal deploy path, not needed inside a container
+systemd
+
+# Dockerfile itself + compose — avoid self-referential layer churn
+Dockerfile
+docker-compose*.yml
+.dockerignore

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,61 @@
+name: Build and publish container
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: Build + push multi-arch image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=sha,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+          labels: |
+            org.opencontainers.image.title=Klebb
+            org.opencontainers.image.description=Manifest-driven self-hosted personal health dashboard with WebAuthn/passkey auth
+            org.opencontainers.image.licenses=AGPL-3.0-only
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,23 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+  docker-build:
+    name: Docker image builds
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build (no push)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ Thumbs.db
 .env.*
 *.env
 !data.example/*.env    # example files are safe to ship
+!.env.example          # template is safe to ship
+
+# Docker local overrides — never commit
+docker-compose.override.yml
 
 # Logs
 *.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,81 @@
+# syntax=docker/dockerfile:1.7
+
+# -----------------------------------------------------------------------------
+# Stage 1: install production dependencies
+# -----------------------------------------------------------------------------
+FROM node:22-slim AS deps
+
+WORKDIR /app
+
+# Copy lockfile + manifest first for better layer caching
+COPY package.json package-lock.json* ./
+
+# Install production deps only. npm ci if a lockfile exists, npm install otherwise.
+RUN if [ -f package-lock.json ]; then \
+      npm ci --omit=dev; \
+    else \
+      npm install --omit=dev; \
+    fi
+
+# -----------------------------------------------------------------------------
+# Stage 2: runtime image
+# -----------------------------------------------------------------------------
+FROM node:22-slim
+
+# OCI metadata
+LABEL org.opencontainers.image.title="Klebb" \
+      org.opencontainers.image.description="Manifest-driven self-hosted personal health dashboard" \
+      org.opencontainers.image.licenses="AGPL-3.0-only" \
+      org.opencontainers.image.source="https://github.com/Aristocles/klebb"
+
+# Runtime system dependencies:
+#   ca-certificates — HTTPS trust anchors for outbound calls (chat gateway, Fish Audio)
+#   tini            — proper PID 1 so SIGTERM reaches Node cleanly
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      tini \
+    && rm -rf /var/lib/apt/lists/*
+
+# Non-root runtime user
+RUN groupadd --system --gid 1001 klebb \
+ && useradd --system --uid 1001 --gid klebb --home-dir /app --shell /usr/sbin/nologin klebb
+
+WORKDIR /app
+
+# Production node_modules from the deps stage
+COPY --from=deps --chown=klebb:klebb /app/node_modules ./node_modules
+
+# Application source — only what the server actually needs at runtime
+COPY --chown=klebb:klebb package.json ./
+COPY --chown=klebb:klebb server.js ./
+COPY --chown=klebb:klebb auth ./auth
+COPY --chown=klebb:klebb config ./config
+COPY --chown=klebb:klebb manifests ./manifests
+COPY --chown=klebb:klebb public ./public
+COPY --chown=klebb:klebb scripts ./scripts
+COPY --chown=klebb:klebb voice ./voice
+
+# Data dir — mount a volume here in production. The process must own it.
+RUN mkdir -p /data && chown klebb:klebb /data
+
+# Runtime config
+ENV NODE_ENV=production \
+    PORT=10002 \
+    HOST=0.0.0.0 \
+    HEALTH_HOME=/data
+
+EXPOSE 10002
+
+# Operator contract — bind-mount persistent data here
+VOLUME ["/data"]
+
+STOPSIGNAL SIGTERM
+
+# Dependency-free liveness probe
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:' + (process.env.PORT || 10002) + '/healthz').then(r => { if (!r.ok) process.exit(1); }).catch(() => process.exit(1))"
+
+USER klebb
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Works equally well as:
 
 - [Quickstart](#quickstart)
 - [What is a "card"?](#what-is-a-card)
+- [Running with Docker](#running-with-docker)
 - [Running tests](#running-tests)
 - [Configuration](#configuration)
 - [Docs](#docs)
@@ -99,6 +100,57 @@ Every card is a JSON file that looks like this:
 For card types that need more than the generic renderer handles
 (medication schedules, line charts, markdown docs), there are specialised
 renderers you pick by name.
+
+## Running with Docker
+
+A published image is available at `ghcr.io/aristocles/klebb` (multi-arch:
+`linux/amd64` and `linux/arm64`). The quickest way to spin up an
+instance:
+
+```bash
+git clone https://github.com/Aristocles/klebb.git
+cd klebb
+cp .env.example .env
+# edit .env — set HEALTH_ORIGIN, HEALTH_RP_ID, SESSION_SECRET
+docker compose up -d
+```
+
+Data persists in `./data/` on the host (bind-mounted to `/data` inside
+the container). The published release tag (e.g. `v2.1.0`) and `latest`
+are stable; image SHAs change per-commit on `main` if you want to track
+bleeding edge.
+
+**WebAuthn requires HTTPS.** The compose file binds the app to
+`127.0.0.1:10002` on the host so you can front it with a reverse proxy
+that handles TLS (Caddy, Cloudflare Tunnel, Traefik, nginx). Example
+Caddyfile:
+
+```caddyfile
+klebb.example.com {
+    reverse_proxy 127.0.0.1:10002
+}
+```
+
+`HEALTH_RP_ID` in `.env` must match the public hostname exactly (no
+scheme, no port). Changing it later invalidates any passkeys already
+registered.
+
+### Building locally
+
+```bash
+cp docker-compose.override.yml.example docker-compose.override.yml
+docker compose up --build
+```
+
+The override swaps the published image for `build: .` and exposes the
+port on all interfaces for LAN-based dev testing.
+
+### Reaching a chat gateway on the host
+
+If you're running an OpenAI-compatible LLM gateway on the host (for the
+chat widget), point `CHAT_GATEWAY_HOST=host.docker.internal` in `.env`.
+The compose file already maps that hostname to the host via
+`extra_hosts: host.docker.internal:host-gateway`.
 
 ## Running tests
 

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,23 @@
+# docker-compose.override.yml.example — local-dev overrides
+#
+# Copy to docker-compose.override.yml (gitignored) to build from local
+# source instead of pulling the published image, and to expose the port
+# directly on the host for dev convenience.
+#
+#   cp docker-compose.override.yml.example docker-compose.override.yml
+#   docker compose up --build
+
+services:
+  klebb:
+    build: .
+    image: klebb:dev
+    ports:
+      # Expose on all interfaces so you can test from another device on
+      # your LAN. Reset to "127.0.0.1:10002:10002" for prod-like runs.
+      - "10002:10002"
+    environment:
+      # Loosen WebAuthn to a localhost RP for local-only testing. WebAuthn
+      # still requires the page to be served over HTTPS (or loaded from
+      # http://localhost, which browsers treat as a secure context).
+      HEALTH_ORIGIN: "http://localhost:10002"
+      HEALTH_RP_ID: "localhost"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,60 @@
+# docker-compose.yml — Klebb reference deployment
+#
+# Usage:
+#   1. cp .env.example .env   (and edit the required values)
+#   2. docker compose up -d
+#
+# This file does NOT include a reverse proxy or TLS termination. WebAuthn
+# requires HTTPS, so you MUST front this with Caddy, Cloudflare Tunnel,
+# Traefik, nginx, or similar. See README.md § "Running with Docker" for
+# examples.
+
+services:
+  klebb:
+    image: ghcr.io/aristocles/klebb:latest
+    # For local dev, use docker-compose.override.yml to swap `image:` for
+    # `build: .` (see docker-compose.override.yml.example).
+    container_name: klebb
+    restart: unless-stopped
+    environment:
+      # --- Required ---
+      HEALTH_ORIGIN: "${HEALTH_ORIGIN:?HEALTH_ORIGIN is required (e.g. https://klebb.example.com)}"
+      HEALTH_RP_ID: "${HEALTH_RP_ID:?HEALTH_RP_ID is required (e.g. klebb.example.com)}"
+      SESSION_SECRET: "${SESSION_SECRET:?SESSION_SECRET is required (generate: openssl rand -hex 32)}"
+      # --- Paths (container defaults) ---
+      HEALTH_HOME: /data
+      PORT: "10002"
+      HOST: "0.0.0.0"
+      # --- Branding ---
+      HEALTH_INSTANCE_NAME: "${HEALTH_INSTANCE_NAME:-Klebb}"
+      HEALTH_RP_NAME: "${HEALTH_RP_NAME:-Klebb}"
+      CHAT_AGENT_NAME: "${CHAT_AGENT_NAME:-Klebbius}"
+      # --- Chat gateway (optional) ---
+      CHAT_GATEWAY_HOST: "${CHAT_GATEWAY_HOST:-}"
+      CHAT_GATEWAY_PORT: "${CHAT_GATEWAY_PORT:-}"
+      CHAT_GATEWAY_TLS: "${CHAT_GATEWAY_TLS:-}"
+      CHAT_GATEWAY_TOKEN: "${CHAT_GATEWAY_TOKEN:-}"
+      CHAT_GATEWAY_MODEL: "${CHAT_GATEWAY_MODEL:-}"
+      # --- Agent API (optional) ---
+      AGENT_API_TOKEN: "${AGENT_API_TOKEN:-}"
+      # --- Voice (optional) ---
+      FISH_AUDIO_API_KEY: "${FISH_AUDIO_API_KEY:-}"
+      FISH_AUDIO_DEFAULT_VOICE: "${FISH_AUDIO_DEFAULT_VOICE:-}"
+    volumes:
+      - ./data:/data
+    ports:
+      # Bind to loopback so only the reverse proxy on the host is exposed.
+      # Change to "10002:10002" if you actually want Klebb reachable
+      # directly on the host interface.
+      - "127.0.0.1:10002:10002"
+    # Let the container reach services on the host (e.g. a local chat
+    # gateway on the host's 127.0.0.1). Linux Docker doesn't resolve
+    # host.docker.internal by default, so map it explicitly.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:10002/healthz').then(r => { if (!r.ok) process.exit(1); }).catch(() => process.exit(1))"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s

--- a/server.js
+++ b/server.js
@@ -325,6 +325,14 @@ const server = http.createServer(async (req, res) => {
   const url = new URL(req.url, `http://${req.headers.host}`);
   const pathname = url.pathname;
 
+  // Liveness probe — dependency-free, no auth, no FS reads.
+  // Used by container healthchecks and external monitors. Must stay cheap.
+  if (pathname === '/healthz') {
+    res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
+    res.end(JSON.stringify({ status: 'ok' }));
+    return;
+  }
+
   // Handle auth routes first
   if (pathname.startsWith('/auth/')) {
     const result = await handleAuthRoutes(req, res, pathname);

--- a/tests/server-api.test.js
+++ b/tests/server-api.test.js
@@ -47,6 +47,13 @@ describe('server HTTP API', () => {
       assert.equal(res.json.entries[0].id, 'weight');
     });
 
+    test('GET /healthz returns 200 without auth (container liveness probe)', async () => {
+      const res = await req(server.baseUrl, '/healthz');
+      assert.equal(res.status, 200);
+      assert.ok(res.json);
+      assert.equal(res.json.status, 'ok');
+    });
+
     test('GET /api/manifests/:id returns one manifest', async () => {
       const res = await req(server.baseUrl, '/api/manifests/weight');
       assert.equal(res.status, 200);
@@ -140,6 +147,12 @@ describe('server HTTP API', () => {
     test('GET /api/manifests without session → 401', async () => {
       const res = await req(server.baseUrl, '/api/manifests');
       assert.equal(res.status, 401);
+    });
+
+    test('GET /healthz without session → still 200 (probe must never auth-gate)', async () => {
+      const res = await req(server.baseUrl, '/healthz');
+      assert.equal(res.status, 200);
+      assert.equal(res.json.status, 'ok');
     });
 
     test('GET /api/manifests with session cookie → 200', async () => {


### PR DESCRIPTION
Adds a Docker deployment path alongside the existing systemd/`/opt/klebb` flow.

Running `klebb@eddy` and `klebb@chuck` systemd instances are **untouched** — this is purely additive. Migration of live instances is out-of-scope, to be tracked separately.

## What landed

- **`Dockerfile`** — multi-stage on `node:22-slim`, non-root user, tini PID 1, `HEALTH_HOME=/data` default, healthcheck hitting `/healthz`.
- **`/healthz` endpoint** — dependency-free liveness probe in `server.js`, no auth, no FS reads. Registered before the auth gate.
- **`docker-compose.yml`** — reference deployment pulling `ghcr.io/aristocles/klebb:latest`, loopback port binding, `host.docker.internal` mapping for host-side chat gateways.
- **`docker-compose.override.yml.example`** — local-dev swap to `build: .`.
- **`.env.example`** — full env-var surface (required + optional).
- **`.dockerignore`** — keeps live data, `.git`, tests, docs, example manifests out of the image.
- **`.github/workflows/publish.yml`** — multi-arch (`amd64` + `arm64`) GHCR publish on `main` / tags / manual dispatch.
- **`.github/workflows/test.yml`** — adds a `docker-build` job so PRs fail fast if the Dockerfile breaks.
- **README** — "Running with Docker" section covering compose, local-build override, HTTPS/reverse-proxy requirement, and the host chat gateway bridge.
- **Tests** — two new `/healthz` tests (setup mode + auth-active mode). Suite now 271/271.

## Verified locally

- `npm test` → 271/271 pass.
- `docker build .` → succeeds.
- `docker run` with minimal env → `/healthz` returns `{"status":"ok"}`, `/auth/status` returns expected JSON, manifest loader boots clean against an empty `/data` volume.

## Next up (not in this PR)

- Migrate `klebb@eddy` and `klebb@chuck` to Docker when Eddy's ready.
- First tagged release (`v2.1.0`?) to cut a `:latest` image on GHCR.

Fixes #17