### PR TITLE
fix(docker): chown /data volume on entrypoint so fresh bind-mounts work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,11 @@ LABEL org.opencontainers.image.title="Klebb" \
 # Runtime system dependencies:
 #   ca-certificates — HTTPS trust anchors for outbound calls (chat gateway, Fish Audio)
 #   tini            — proper PID 1 so SIGTERM reaches Node cleanly
+#   gosu            — privilege drop from root -> klebb in the entrypoint
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates \
       tini \
+      gosu \
     && rm -rf /var/lib/apt/lists/*
 
 # Non-root runtime user
@@ -55,8 +57,14 @@ COPY --chown=klebb:klebb public ./public
 COPY --chown=klebb:klebb scripts ./scripts
 COPY --chown=klebb:klebb voice ./voice
 
-# Data dir — mount a volume here in production. The process must own it.
+# Data dir — mount a volume here in production. The entrypoint chowns
+# this to the runtime user at container start so bind-mounts owned by
+# the host user Just Work on first boot.
 RUN mkdir -p /data && chown klebb:klebb /data
+
+# Entrypoint script — runs as root, fixes /data ownership, drops to klebb.
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod 0755 /usr/local/bin/docker-entrypoint.sh
 
 # Runtime config
 ENV NODE_ENV=production \
@@ -75,7 +83,8 @@ STOPSIGNAL SIGTERM
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD node -e "fetch('http://127.0.0.1:' + (process.env.PORT || 10002) + '/healthz').then(r => { if (!r.ok) process.exit(1); }).catch(() => process.exit(1))"
 
-USER klebb
+# NOTE: no `USER klebb` directive here — the entrypoint runs as root so
+# it can chown /data, then drops to klebb via gosu before exec'ing node.
 
-ENTRYPOINT ["/usr/bin/tini", "--"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/docker-entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# docker-entrypoint.sh — runs as root on container start, fixes up volume
+# ownership, then drops to the `klebb` user and execs the CMD.
+#
+# Why: the /data volume is commonly a bind-mount owned by the host user
+# (typically UID 1000). The container's runtime user is klebb (UID 1001),
+# so without this entrypoint it can't create credentials/, sessions/, etc.,
+# and WebAuthn registration fails on first use.
+#
+# Idempotent: re-runs chown on every start; cheap, and means an operator
+# can drop new files onto the host volume without worrying about ownership.
+
+set -eu
+
+DATA_DIR="${HEALTH_HOME:-/data}"
+RUN_UID="${PUID:-1001}"
+RUN_GID="${PGID:-1001}"
+RUN_USER="klebb"
+
+# If we're not root, we can't chown — just exec straight through. This
+# branch covers users who override --user on the `docker run` invocation.
+if [ "$(id -u)" != "0" ]; then
+    exec "$@"
+fi
+
+# Make sure the volume root + standard subdirs exist. The app's
+# ensureWritableDirs() also does this, but doing it here means the chown
+# below covers everything in one pass.
+mkdir -p \
+    "$DATA_DIR" \
+    "$DATA_DIR/data" \
+    "$DATA_DIR/credentials" \
+    "$DATA_DIR/sessions" \
+    "$DATA_DIR/reports"
+
+# Fail loudly if the volume isn't writable by root (e.g. read-only mount).
+if ! touch "$DATA_DIR/.klebb-entrypoint-probe" 2>/dev/null; then
+    echo "[entrypoint] FATAL: $DATA_DIR is not writable by root." >&2
+    echo "[entrypoint] Check the volume mount — is it read-only?" >&2
+    exit 1
+fi
+rm -f "$DATA_DIR/.klebb-entrypoint-probe"
+
+# chown the volume tree to the runtime user. Quiet on stdout, errors to stderr.
+chown -R "$RUN_UID:$RUN_GID" "$DATA_DIR"
+
+# Drop privileges to the runtime user and exec the real command. Using
+# `exec` keeps tini as PID 1 and ensures signals propagate cleanly to Node.
+exec gosu "$RUN_USER" "$@"


### PR DESCRIPTION
Follow-up to #17. Fresh `docker compose up -d` against a host-owned empty `./data/` was failing passkey registration with `ENOENT: /data/credentials/webauthn.json` because the bind-mount was UID 1000 and the container's runtime user is `klebb` (UID 1001).

Hit in the wild on the klebb-test deployment.

## Fix

Standard Docker volume-ownership pattern: entrypoint runs as root, chowns the volume, then drops to the runtime user via `gosu` before exec'ing node. Keeps tini as PID 1 so signals propagate cleanly.

- `docker-entrypoint.sh` (new) — chown + gosu drop, idempotent, fails loud on read-only volumes, exec's straight through if already non-root.
- `Dockerfile` — adds `gosu`, removes `USER klebb` (entrypoint handles the drop), wires the script in under tini.

## Verified

- `npm test` → 271/271.
- Fresh empty UID-1000-owned `./data/` on `docker run`:
  - `credentials/`, `sessions/`, `reports/`, `data/` all created and chowned to UID 1001 on start.
  - `/healthz` returns `{"status":"ok"}`.
  - `touch /data/credentials/...` from inside the container → works.
  - `docker stop` completes in **0.2s** (signal propagation intact through tini → entrypoint → gosu → node).

Fixes #19