### PR TITLE
fix(chat): bump client timeout 90s -> 180s

### DIFF
--- a/public/js/components/health-chat.js
+++ b/public/js/components/health-chat.js
@@ -564,7 +564,7 @@ class HealthChat extends LitElement {
 
   // ---------- Chat pipeline ----------
 
-  async _fetchChat(messages, voiceMode, timeoutMs = 90000) {
+  async _fetchChat(messages, voiceMode, timeoutMs = 180000) {
     if (this._abortController) this._abortController.abort();
     this._abortController = new AbortController();
     const timeoutId = setTimeout(() => this._abortController?.abort(), timeoutMs);


### PR DESCRIPTION
Chat widget's \`_fetchChat\` was aborting after 90s; Sonnet-4-6 can generate 90-120s on complex prompts ("add peptides card + build a protocol"-shaped asks). Bumped client timeout to 180s to match the server-side proxy timeout. No other changes.

## Verified
- 271/271 tests pass.
- Reproduced the timeout on klebb-test; re-run after this fix will land shortly.

Fixes #21