### PR TITLE
chore: gitignore private hand-off briefs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,9 @@ System Volume Information
 # Scratch
 /tmp/
 /scratch/
+
+# Private hand-off briefs — never ship in the public repo
+BRIEF-*.md
+
+# Private hand-off briefs — never ship in the public repo
+BRIEF-*.md


### PR DESCRIPTION
One-line .gitignore addition so internal hand-off documents (BRIEF-*.md) can live in the working copy without any risk of being committed.