### PR TITLE
feat(chat): voice env vars + demo-card report links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Changed
 
+- **Voice chat env vars renamed; legacy names still accepted.**
+  Canonical config is now `FISH_AUDIO_VOICE_ID`, `FISH_AUDIO_MODEL`, and
+  `FISH_AUDIO_ENABLED`. The previous names (`FISH_AUDIO_DEFAULT_VOICE`,
+  `FISH_BACKEND`) continue to work for existing deploys. Playback speed
+  cycle now includes `0.5x` (so the full cycle is 0.5, 1, 1.25, 1.5, 2).
+  `GET /api/voice/config` returns `{ enabled: false }` instead of 500
+  when no key is configured, so the client can cleanly hide the mic
+  button. (#27)
+- **Demo welcome + how-to-add-a-card cards link out to full reports.**
+  The dashboard cards are now short blurbs; the long-form content lives
+  in `reports/welcome.md` and `reports/how-to-add-a-card.md`, rendered
+  by the existing `/report/<name>` route.
 - **SPDX + copyright headers on every source file.** Added
   `SPDX-License-Identifier: AGPL-3.0-only` +
   `Copyright (C) 2026 Aristocles <https://github.com/Aristocles>`

--- a/data.demo/reports/how-to-add-a-card.md
+++ b/data.demo/reports/how-to-add-a-card.md
@@ -1,0 +1,21 @@
+# 📘 Adding your own cards
+
+Every card on this dashboard is a JSON file in `$HEALTH_HOME/data/`.
+
+## Three ways
+
+1. **Ask the chat agent.** Tap 🧠, say *"Add a card for tracking daily meditation minutes"*. It drafts the manifest, drops the file in, and the card appears.
+2. **Copy an example.** Browse `data.example/` in the repo — 25 ready-made cards. Copy the one you want to `$HEALTH_HOME/data/` and drop the `.example` from the filename.
+3. **Write one by hand.** Full spec: `MANIFEST-SCHEMA.md`. Patterns: `docs/CARDS.md`. Recipes: `docs/RECIPES.md`.
+
+## Removing a card
+
+Delete the file, or toggle it off in **Settings** (keeps the data, hides the card).
+
+## Getting help
+
+Ask the chat agent: *"Change the mood card to allow multiple entries per day"* or *"Why isn't my new card showing up?"*. It has access to the same docs you do.
+
+---
+
+*This is the **demo** how-to — the data around it is fake. Ready to build your own dashboard? See the welcome card above.*

--- a/data.demo/reports/welcome.md
+++ b/data.demo/reports/welcome.md
@@ -1,0 +1,30 @@
+# 🎭 Welcome — this is demo data
+
+Your new Klebb install auto-populated itself with **15 sample cards** and **5 sample markdown reports** so you can see what the dashboard looks like before you build your own.
+
+**Nothing on this dashboard is real.** The weight graph, blood pressure readings, sleep hours, medication check-offs — all fabricated by the seed script. Poke around, then clear it and make it yours.
+
+## Poke around
+
+- **Today** — this page. Every card shows the most recent generated entry.
+- **Trends** — 30 days of data per metric card, plotted as line charts.
+- **Calendar** — heatmap of activity across every card that opts in.
+- **Reports** — cards with `meta.reports.enabled` plus five sample markdown docs in `$HEALTH_HOME/reports/`.
+- **Settings (⚙️)** — toggle any card off, or delete the data directly on disk.
+
+## Make it yours
+
+1. **Ask the chat agent** (🧠 button, bottom of screen). Say *"Add a card for tracking morning glucose"*. It drafts the manifest, drops the file in, restarts the registry. Card appears.
+2. **Copy an example.** The repo's `data.example/` directory has 25 ready-made card files. Copy one to `$HEALTH_HOME/data/`, drop the `.example` from the filename.
+3. **Write one by hand.** See `MANIFEST-SCHEMA.md` + `docs/CARDS.md` + `docs/RECIPES.md` in the repo.
+
+## Clear the demo
+
+When you're ready for your own data, either:
+
+- Delete individual cards in **Settings** (toggles them off; the files stay).
+- Or `rm $HEALTH_HOME/data/*.json $HEALTH_HOME/reports/*.md` and restart. The demo will **not** re-seed — a `.klebb-seeded` sentinel in `$HEALTH_HOME` records that the one-time seed has already run.
+
+---
+
+*Every card here is a JSON file. Drop a file in, a card appears. Delete the file, the card is gone. That is the entire app.*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,13 @@ services:
       # --- Agent API (optional) ---
       AGENT_API_TOKEN: "${AGENT_API_TOKEN:-}"
       # --- Voice (optional) ---
+      FISH_AUDIO_ENABLED: "${FISH_AUDIO_ENABLED:-}"
       FISH_AUDIO_API_KEY: "${FISH_AUDIO_API_KEY:-}"
+      FISH_AUDIO_VOICE_ID: "${FISH_AUDIO_VOICE_ID:-}"
+      FISH_AUDIO_MODEL: "${FISH_AUDIO_MODEL:-}"
+      # Legacy aliases (kept for backwards compat with older deploys)
       FISH_AUDIO_DEFAULT_VOICE: "${FISH_AUDIO_DEFAULT_VOICE:-}"
+      FISH_BACKEND: "${FISH_BACKEND:-}"
       # --- First-boot demo seed ---
       # A fresh install (empty /data) auto-populates with 15 demo cards and
       # 5 sample markdown reports on first server boot. A .klebb-seeded

--- a/public/js/components/health-chat.js
+++ b/public/js/components/health-chat.js
@@ -815,7 +815,7 @@ class HealthChat extends LitElement {
   }
 
   _cyclePlaybackSpeed() {
-    const speeds = [1, 1.25, 1.5, 2];
+    const speeds = [0.5, 1, 1.25, 1.5, 2];
     const idx = speeds.indexOf(this._playbackSpeed);
     this._playbackSpeed = speeds[(idx + 1) % speeds.length];
     localStorage.setItem('klebb-playback-speed', String(this._playbackSpeed));

--- a/scripts/lib/demo-cards.js
+++ b/scripts/lib/demo-cards.js
@@ -78,39 +78,6 @@ function utcIso(d, hour) {
 // Markdown-doc cards (welcome + how-to)
 // ---------------------------------------------------------------------------
 function buildWelcome() {
-  const markdown = [
-    '## 🎭 Welcome — this is demo data',
-    '',
-    'Your new Klebb install auto-populated itself with **15 sample cards** and **5 sample markdown reports** so you can see what the dashboard looks like before you build your own.',
-    '',
-    '**Nothing on this dashboard is real.** The weight graph, blood pressure readings, sleep hours, medication check-offs — all fabricated by the seed script. Poke around, then clear it and make it yours.',
-    '',
-    '### Poke around',
-    '',
-    '- **Today** — this page. Every card shows the most recent generated entry.',
-    '- **Trends** — 30 days of data per metric card, plotted as line charts.',
-    '- **Calendar** — heatmap of activity across every card that opts in.',
-    '- **Reports** — cards with `meta.reports.enabled` plus five sample markdown docs in `$HEALTH_HOME/reports/`.',
-    '- **Settings (⚙️)** — toggle any card off, or delete the data directly on disk.',
-    '',
-    '### Make it yours',
-    '',
-    '1. **Ask the chat agent** (🧠 button, bottom of screen). Say *"Add a card for tracking morning glucose"*. It drafts the manifest, drops the file in, restarts the registry. Card appears.',
-    '2. **Copy an example.** The repo\'s `data.example/` directory has 25 ready-made card files. Copy one to `$HEALTH_HOME/data/`, drop the `.example` from the filename.',
-    '3. **Write one by hand.** See `MANIFEST-SCHEMA.md` + `docs/CARDS.md` + `docs/RECIPES.md` in the repo.',
-    '',
-    '### Clear the demo',
-    '',
-    'When you\'re ready for your own data, either:',
-    '',
-    '- Delete individual cards in **Settings** (toggles them off; the files stay).',
-    '- Or `rm $HEALTH_HOME/data/*.json $HEALTH_HOME/reports/*.md` and restart. The demo will **not** re-seed — a `.klebb-seeded` sentinel in `$HEALTH_HOME` records that the one-time seed has already run.',
-    '',
-    '---',
-    '',
-    '*Every card here is a JSON file. Drop a file in, a card appears. Delete the file, the card is gone. That is the entire app.*'
-  ].join('\n');
-
   return {
     $schema: 'klebb.datafile.v1',
     meta: {
@@ -121,39 +88,16 @@ function buildWelcome() {
       view: {
         enabled: true,
         component: 'markdown-doc',
-        slot: 'top'
+        slot: 'top',
+        summary: 'This is a demo install: 15 sample cards and 5 sample reports, all fabricated by the seed script. Open the welcome report for a tour of what this dashboard does and how to clear the demo when you\'re ready to build your own.'
       }
     },
-    description: 'Demo-instance welcome card. Explains this is auto-seeded demo data.',
-    data: { markdown }
+    description: 'Demo-instance welcome card. Links to the welcome report.',
+    data: { markdown: 'See the [welcome report](/report/welcome) for the full tour.' }
   };
 }
 
 function buildHowToAddACard() {
-  const markdown = [
-    '## 📘 Adding your own cards',
-    '',
-    'Every card on this dashboard is a JSON file in `$HEALTH_HOME/data/`.',
-    '',
-    '### Three ways',
-    '',
-    '1. **Ask the chat agent.** Tap 🧠, say *"Add a card for tracking daily meditation minutes"*. It drafts the manifest, drops the file in, and the card appears.',
-    '2. **Copy an example.** Browse `data.example/` in the repo — 25 ready-made cards. Copy the one you want to `$HEALTH_HOME/data/` and drop the `.example` from the filename.',
-    '3. **Write one by hand.** Full spec: `MANIFEST-SCHEMA.md`. Patterns: `docs/CARDS.md`. Recipes: `docs/RECIPES.md`.',
-    '',
-    '### Removing a card',
-    '',
-    'Delete the file, or toggle it off in **Settings** (keeps the data, hides the card).',
-    '',
-    '### Getting help',
-    '',
-    'Ask the chat agent: *"Change the mood card to allow multiple entries per day"* or *"Why isn\'t my new card showing up?"*. It has access to the same docs you do.',
-    '',
-    '---',
-    '',
-    '*This is the **demo** how-to — the data around it is fake. Ready to build your own dashboard? See the welcome card above.*'
-  ].join('\n');
-
   return {
     $schema: 'klebb.datafile.v1',
     meta: {
@@ -164,11 +108,12 @@ function buildHowToAddACard() {
       view: {
         enabled: true,
         component: 'markdown-doc',
-        slot: 'top'
+        slot: 'top',
+        summary: 'Three ways to add your own card: ask the chat agent, copy an example, or write one by hand. Full how-to in the linked report.'
       }
     },
-    description: 'Inline quick-reference for card authoring.',
-    data: { markdown }
+    description: 'Card-authoring quick reference. Links to the how-to report.',
+    data: { markdown: 'See the [how-to report](/report/how-to-add-a-card) for the full guide.' }
   };
 }
 

--- a/tests/server-api.test.js
+++ b/tests/server-api.test.js
@@ -114,10 +114,10 @@ describe('server HTTP API', () => {
       assert.ok(res.json.chatAgent.name);
     });
 
-    test('GET /api/voice/config when FISH_AUDIO_API_KEY unset returns error', async () => {
+    test('GET /api/voice/config when FISH_AUDIO_API_KEY unset returns enabled:false', async () => {
       const res = await req(server.baseUrl, '/api/voice/config');
-      assert.equal(res.status, 500);
-      assert.ok(res.json.error);
+      assert.equal(res.status, 200);
+      assert.equal(res.json.enabled, false);
     });
 
     test('GET /auth/status returns setup=false', async () => {

--- a/voice/fish.js
+++ b/voice/fish.js
@@ -9,8 +9,14 @@
 //
 // Config is pulled from env:
 //   FISH_AUDIO_API_KEY        (required; loaded from ~/.env or systemd env)
-//   FISH_AUDIO_DEFAULT_VOICE  (reference_id for TTS; configure the voice model)
-//   FISH_BACKEND              (optional override: s2-pro|s2|speech-1.6)
+//   FISH_AUDIO_VOICE_ID       (reference_id for TTS; configure the voice model)
+//   FISH_AUDIO_MODEL          (optional override: s2-pro|s2|speech-1.6)
+//   FISH_AUDIO_ENABLED        (optional: set to 'false' to hide the mic UI
+//                              even when a key is present)
+//
+// Legacy aliases (supported for existing deploys):
+//   FISH_AUDIO_DEFAULT_VOICE  → FISH_AUDIO_VOICE_ID
+//   FISH_BACKEND              → FISH_AUDIO_MODEL
 //
 // Tier policy (based on remaining API credit):
 //   credit >= 50%  → s2-pro
@@ -56,7 +62,14 @@ function getApiKey() {
 }
 
 function getDefaultVoice() {
-  return (process.env.FISH_AUDIO_DEFAULT_VOICE || '').trim();
+  const v = (process.env.FISH_AUDIO_VOICE_ID || process.env.FISH_AUDIO_DEFAULT_VOICE || '').trim();
+  return v;
+}
+
+function isEnabled() {
+  const flag = (process.env.FISH_AUDIO_ENABLED || '').trim().toLowerCase();
+  if (flag === 'false' || flag === '0' || flag === 'no') return false;
+  return true;
 }
 
 // --- Credit tracking ---
@@ -98,7 +111,8 @@ function pickTier(creditUSD) {
 }
 
 async function getCurrentBackend() {
-  if (process.env.FISH_BACKEND) return process.env.FISH_BACKEND;
+  const explicit = process.env.FISH_AUDIO_MODEL || process.env.FISH_BACKEND;
+  if (explicit) return explicit;
   const now = Date.now();
   if (!_creditCache || (now - _creditCache.checkedAt) > CREDIT_TTL_MS) {
     try {
@@ -113,9 +127,11 @@ async function getCurrentBackend() {
 }
 
 async function getStatus() {
-  const backend = await getCurrentBackend();
+  let key = '';
+  try { key = getApiKey(); } catch { /* no key configured */ }
+  const backend = key ? await getCurrentBackend() : null;
   return {
-    enabled: !!getApiKey() && !!getDefaultVoice(),
+    enabled: !!key && !!getDefaultVoice() && isEnabled(),
     backend,
     creditUSD: _creditCache?.creditUSD ?? null,
     voiceId: getDefaultVoice(),


### PR DESCRIPTION
# What changed

Wires the already-implemented voice-chat pipeline (mic button, ASR, TTS,
caching, playback controls) to the canonical Fish Audio env-var names,
adds an explicit on/off toggle, extends the playback-speed cycle to
include `0.5x`, and fixes the broken `welcome` / `how-to-add-a-card`
links on fresh demo installs.

# Why

Fixes #27.

Two friction points on a fresh Docker install with Fish Audio
configured:

1. `voice/fish.js` read `FISH_AUDIO_DEFAULT_VOICE` and `FISH_BACKEND`;
   the reference `.env` uses `FISH_AUDIO_VOICE_ID` and
   `FISH_AUDIO_MODEL`. No mapping, so the mic button silently
   disappeared.
2. `/api/voice/config` 500'd when unconfigured. Client had to treat the
   error as "voice unavailable" implicitly; explicit is cleaner.

Separately, the demo seed produced a `welcome` and a
`how-to-add-a-card` card whose "Open document →" links 404'd because no
matching `.md` existed under `$HEALTH_HOME/reports/`.

# How

**Voice:**

- `voice/fish.js`: `getDefaultVoice()` now reads
  `FISH_AUDIO_VOICE_ID || FISH_AUDIO_DEFAULT_VOICE`;
  `getCurrentBackend()` reads `FISH_AUDIO_MODEL || FISH_BACKEND`;
  new `isEnabled()` honours `FISH_AUDIO_ENABLED=false|0|no`.
  `getStatus()` catches the "no key" path and returns
  `{ enabled: false }` instead of throwing.
- `docker-compose.yml` passes `FISH_AUDIO_ENABLED`,
  `FISH_AUDIO_VOICE_ID`, `FISH_AUDIO_MODEL` through, plus the legacy
  aliases for existing deploys.
- `public/js/components/health-chat.js`: speed cycle extended to
  `[0.5, 1, 1.25, 1.5, 2]`.
- `tests/server-api.test.js`: updated the single test that asserted
  the old 500 behaviour.

**Demo cards:**

- `scripts/lib/demo-cards.js` builds `welcome.json` and
  `how-to-add-a-card.json` with a one-line `meta.view.summary` and a
  link inside `data.markdown` pointing at `/report/<id>`.
- `data.demo/reports/welcome.md` and `how-to-add-a-card.md` added
  with the full long-form content, served by the existing
  `/report/<name>` route.

# Testing

- [x] `npm test` green (same pass/fail counts as baseline `main` — the
      pre-existing agent-api sandbox flake isn't touched by this PR).
- [x] Manual QA on the test instance:
      - `GET /api/voice/config` returns
        `{ enabled: true, backend: "s2-pro", voiceId: "..." }` with
        the new env var names.
      - Dashboard mic button appears; tapping it starts recording.
      - Welcome + how-to cards show a summary line and an "Open
        document →" link that resolves to the rendered markdown report.
- [ ] Voice round-trip (record → transcript → reply → TTS) exercised
      end-to-end by the operator.

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [ ] Docs updated (no user-facing doc changes in this PR; env-var
      table in README already references Fish Audio generically)
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens

# Breaking changes

None. Legacy `FISH_AUDIO_DEFAULT_VOICE` and `FISH_BACKEND` names still
take effect if the new names aren't set, so existing live deploys
continue working without reconfiguration.