### PR TITLE
fix(tests): seed-demo expects 7 reports, not 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "webapp",
+  "name": "klebb",
   "version": "2.0.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "webapp",
+      "name": "klebb",
       "version": "2.0.0-dev",
-      "license": "MIT",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "@simplewebauthn/browser": "^13.3.0",
         "@simplewebauthn/server": "^13.3.0",

--- a/tests/seed-demo.test.js
+++ b/tests/seed-demo.test.js
@@ -155,13 +155,13 @@ describe('demo-cards generator', () => {
 // ---------------------------------------------------------------------------
 
 describe('runDemoSeed', () => {
-  test('writes 15 cards, 5 reports, and sentinel into empty HEALTH_HOME', () => {
+  test('writes 15 cards, 7 reports, and sentinel into empty HEALTH_HOME', () => {
     const sandbox = mkSandbox();
     try {
       const summary = runDemoSeed({ healthHome: sandbox });
       assert.equal(summary.cardsWritten.length, 15);
       assert.equal(summary.cardsSkipped.length, 0);
-      assert.equal(summary.reportsWritten.length, 5);
+      assert.equal(summary.reportsWritten.length, 7);
       assert.equal(summary.reportsSkipped.length, 0);
       assert.ok(summary.sentinelWritten);
 
@@ -171,7 +171,7 @@ describe('runDemoSeed', () => {
       assert.equal(dataFiles.length, 15);
       const reportFiles = fs.readdirSync(path.join(sandbox, 'reports'))
         .filter(f => f.endsWith('.md'));
-      assert.equal(reportFiles.length, 5);
+      assert.equal(reportFiles.length, 7);
       assert.ok(fs.existsSync(path.join(sandbox, SENTINEL_NAME)));
 
       // Every JSON file parses
@@ -207,7 +207,7 @@ describe('runDemoSeed', () => {
       assert.equal(summary2.cardsWritten.length, 0);
       assert.equal(summary2.cardsSkipped.length, 15);
       assert.equal(summary2.reportsWritten.length, 0);
-      assert.equal(summary2.reportsSkipped.length, 5);
+      assert.equal(summary2.reportsSkipped.length, 7);
     } finally {
       rmrf(sandbox);
     }
@@ -355,13 +355,16 @@ describe('runFirstBootDemoSeed', () => {
 // ---------------------------------------------------------------------------
 
 describe('data.demo/reports', () => {
-  test('ships exactly 5 markdown reports', () => {
+  test('ships 5 DEMO samples plus 2 onboarding reports', () => {
     const files = fs.readdirSync(REPORTS_SRC).filter(f => f.endsWith('.md'));
-    assert.equal(files.length, 5);
+    assert.equal(files.length, 7);
+    const demo = files.filter(f => f.startsWith('DEMO-'));
+    assert.equal(demo.length, 5);
   });
 
-  test('every report opens with a DEMO warning banner', () => {
-    const files = fs.readdirSync(REPORTS_SRC).filter(f => f.endsWith('.md'));
+  test('every DEMO-*.md opens with a DEMO warning banner', () => {
+    const files = fs.readdirSync(REPORTS_SRC)
+      .filter(f => f.endsWith('.md') && f.startsWith('DEMO-'));
     for (const f of files) {
       const body = fs.readFileSync(path.join(REPORTS_SRC, f), 'utf8');
       assert.ok(/DEMO/i.test(body), `${f}: no DEMO marker`);


### PR DESCRIPTION
## Summary

- Bump \`runDemoSeed\` + \`data.demo/reports\` test expectations from 5 to 7 now that the onboarding reports (\`welcome.md\`, \`how-to-add-a-card.md\`) ship alongside the five \`DEMO-*.md\` samples.
- Narrow the DEMO-banner check to \`DEMO-*.md\` — the onboarding reports deliberately use different framing.
- Drive-by: re-sync \`package-lock.json\` with \`package.json\` (\`klebb\` / AGPL-3.0-only). A fresh \`npm install\` normalises these; committing the resulting diff keeps the tree clean on clone.

## Why

CI's \`test\` workflow has been red on \`main\` since 2026-04-25 (commit 732ec96). The seed content changed in #28 but the assertions didn't move with it. Everything else in the 297-test suite passes.

## How

\`tests/seed-demo.test.js\` only. See diff for exact count bumps.

## Test plan

- [x] \`npm test\` — 297/297 pass locally
- [x] \`node scripts/seed-demo.js --dir /tmp/klebb-verify --dry-run\` reports 15 cards + 7 reports
- [ ] CI goes green on this branch

Fixes #29