### PR TITLE
feat(config): global TZ config, default UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Added
+
+- **Timezone is now an explicit, documented config knob.** The container
+  image defaults to `TZ=UTC`; operators can override via the `TZ` env
+  var with any IANA zone (e.g. `Australia/Sydney`). The active zone is
+  logged in the boot banner. Node honours `TZ` natively, so this
+  affects every Date the app constructs (demo seed anchor, card entry
+  dates, sentinel timestamps, log output). See the Timezone note in
+  `docs/DEPLOY.md`. (#32)
+
 ### Changed
 
 - **Voice chat env vars renamed; legacy names still accepted.**

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,8 @@ RUN chmod 0755 /usr/local/bin/docker-entrypoint.sh
 ENV NODE_ENV=production \
     PORT=10002 \
     HOST=0.0.0.0 \
-    HEALTH_HOME=/data
+    HEALTH_HOME=/data \
+    TZ=UTC
 
 EXPOSE 10002
 

--- a/config/env.js
+++ b/config/env.js
@@ -28,6 +28,12 @@ function paths() {
 const PORT = parseInt(process.env.PORT || process.env.HEALTH_PORT || '8080', 10);
 const HOST = process.env.HOST || '0.0.0.0';
 
+// --- Timezone ---
+// Node honours process.env.TZ natively for every Date construction. We
+// surface it here only so the boot banner can log the active zone and
+// tests have something to assert against. Default is UTC.
+const TZ = process.env.TZ || 'UTC';
+
 // --- Branding ---
 const INSTANCE_NAME = process.env.HEALTH_INSTANCE_NAME || 'Klebb';
 
@@ -144,6 +150,7 @@ const HEALTH_SYSTEM_PROMPT = (() => {
 module.exports = {
   PORT,
   HOST,
+  TZ,
   INSTANCE_NAME,
   CHAT_GATEWAY_HOST,
   CHAT_GATEWAY_PORT,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,13 @@ services:
       HEALTH_HOME: /data
       PORT: "10002"
       HOST: "0.0.0.0"
+      # --- Timezone ---
+      # Server-wide timezone. Affects every Date the app constructs: demo
+      # seed anchor, card entry dates, sentinel timestamps, chat agent
+      # "today" prompts, log output. Default UTC. Set to your IANA zone
+      # (e.g. Australia/Sydney, America/Los_Angeles, Europe/London) if
+      # you want on-screen dates to match your local calendar.
+      TZ: "${TZ:-UTC}"
       # --- Branding ---
       HEALTH_INSTANCE_NAME: "${HEALTH_INSTANCE_NAME:-Klebb}"
       HEALTH_RP_NAME: "${HEALTH_RP_NAME:-Klebb}"

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -62,6 +62,11 @@ HEALTH_ORIGIN=https://health.example.com
 PORT=8080
 HOST=127.0.0.1
 
+# Timezone (IANA zone; default UTC if unset)
+# Set this to your local zone if you want card dates, demo seed
+# entries, and log timestamps to match your wall clock.
+# TZ=Australia/Sydney
+
 # Optional: chat agent (chat gateway)
 # CHAT_GATEWAY_HOST=localhost
 # CHAT_GATEWAY_PORT=8787

--- a/server.js
+++ b/server.js
@@ -1149,7 +1149,7 @@ Original system prompt follows:
 });
 
 server.listen(PORT, HOST, () => {
-  console.log(`Health dashboard running at http://${HOST}:${PORT}`);
+  console.log(`Health dashboard running at http://${HOST}:${PORT} (TZ=${ENV.TZ})`);
 
   // First-boot demo seed. Runs only when HEALTH_HOME has no .klebb-seeded
   // sentinel AND data/ is empty AND KLEBB_SKIP_DEMO_SEED is not set.

--- a/tests/config-defaults.test.js
+++ b/tests/config-defaults.test.js
@@ -29,7 +29,8 @@ function freshEnv(overrides = {}) {
     k === 'SESSION_SECRET' ||
     k === 'AGENT_API_TOKEN' ||
     k === 'PORT' ||
-    k === 'HOST'
+    k === 'HOST' ||
+    k === 'TZ'
   );
   for (const k of strip) delete process.env[k];
   // Need HEALTH_HOME set so paths.js doesn't blow up — point at /tmp to avoid
@@ -103,6 +104,11 @@ describe('config/env.js defaults', () => {
     assert.equal(env.PORT, 8080);
   });
 
+  test('TZ defaults to UTC', () => {
+    const env = freshEnv();
+    assert.equal(env.TZ, 'UTC');
+  });
+
   test('no default value references "Axis", "Eddy", "Onyx", or "Chuck"', () => {
     const env = freshEnv();
     const serialised = JSON.stringify({
@@ -167,5 +173,10 @@ describe('config/env.js env overrides', () => {
   test('HEALTH_SYSTEM_PROMPT env var wins', () => {
     const env = freshEnv({ HEALTH_SYSTEM_PROMPT: 'You are a pirate.' });
     assert.equal(env.HEALTH_SYSTEM_PROMPT, 'You are a pirate.');
+  });
+
+  test('TZ env var wins over default', () => {
+    const env = freshEnv({ TZ: 'Australia/Sydney' });
+    assert.equal(env.TZ, 'Australia/Sydney');
   });
 });


### PR DESCRIPTION
## Summary

- Default \`TZ=UTC\` in the Dockerfile so container behaviour doesn't drift with the base image.
- Expose \`TZ\` in \`docker-compose.yml\` with an IANA-zone comment.
- Log the active zone in the boot banner (\`Health dashboard running at ... (TZ=UTC)\`).
- Document it in \`docs/DEPLOY.md\`.
- Test the default + the override.

## Why

Node reads \`process.env.TZ\` natively for every Date construction. We just weren't surfacing it as a supported config. That left operators (and #25) guessing why fresh-install card dates anchor on UTC instead of their wall clock. No date-handling code changes; set \`TZ\` to your IANA zone and every Date the app constructs uses it: demo seed anchor, card entries, sentinel timestamps, logs, chat-agent \"what's today\" prompts.

## How

- \`Dockerfile\`: \`ENV TZ=UTC\` added to the runtime stage's env block.
- \`docker-compose.yml\`: new \`TZ: \"\${TZ:-UTC}\"\` line with a comment block pointing operators at their local IANA zone.
- \`config/env.js\`: export \`TZ\` (defaulting to \`UTC\`). Used only for boot logging + tests; the runtime still relies on Node's native handling.
- \`server.js\`: boot banner now prints the TZ.
- \`docs/DEPLOY.md\`: commented \`TZ=Australia/Sydney\` example in the environment-file section.
- \`tests/config-defaults.test.js\`: \`TZ\` added to the sanitised env list; new default-and-override assertions.

## Test plan

- [x] \`node --test tests/config-defaults.test.js\` — 22/22 pass
- [x] Boot with \`TZ=UTC\` (default) prints \`(TZ=UTC)\`
- [x] \`node -e \"process.env.TZ='Australia/Sydney'; console.log(require('./config/env').TZ)\"\` prints \`Australia/Sydney\`
- [ ] CI \`test\` (Node 20 + 22)
- [ ] CI \`Build and publish container\` completes

Fixes #32
Closes #25