### PR TITLE
fix(ui): cards overflow narrow-phone viewport via grid track blow-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Cards no longer overflow the viewport on narrow phones.** A card
+  whose content had a long unbreakable string (e.g. a supplement named
+  "Swisse Ultiboost Magnesium Glycinate" with `white-space: nowrap` on
+  the list row) could push its grid track wider than the viewport,
+  dragging every other card with it and clipping the right edge of the
+  Today page on iPhone 13 mini (375px). Fix: the view-renderer grid
+  now uses `minmax(0, 1fr)` instead of plain `1fr` so a card's
+  min-content width can't expand its column. Per-card
+  ellipsis / overflow then does its job. (#37)
 - **`futureAllowed: false` (and `pastAllowed: false`) now actually
   block webapp writes.** Previously the ➕/✏️ button showed on every
   date and the `POST /api/manifests/:id/data` handler ignored the

--- a/public/js/components/eh-view-renderer.js
+++ b/public/js/components/eh-view-renderer.js
@@ -75,18 +75,26 @@ export class EhViewRenderer extends LitElement {
     :host { display: block; }
     .grid {
       display: grid;
-      grid-template-columns: 1fr;
+      /* minmax(0, 1fr) — NOT plain 1fr. A plain 1fr track resolves to
+         minmax(auto, 1fr), which lets a card whose intrinsic min-content
+         is wider than its share (a long nowrap string inside a row) push
+         its track wider and drag every other card with it. This is the
+         root cause of the supplements card blowing the whole Today page
+         past the viewport on iPhone 13 mini. Pinning the track min to 0
+         forces children to shrink to fit and lets per-card overflow
+         handling (nowrap + ellipsis) do its job. */
+      grid-template-columns: minmax(0, 1fr);
       gap: 12px;
       margin-top: 6px;
     }
     @media (min-width: 768px) {
       .grid {
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
       }
     }
     @media (min-width: 1100px) {
       .grid {
-        grid-template-columns: 1fr 1fr 1fr;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
       }
     }
     .loading, .empty {


### PR DESCRIPTION
# What changed

Switch the `eh-view-renderer` grid from `grid-template-columns: 1fr`
to `grid-template-columns: minmax(0, 1fr)` on every breakpoint (1-col
portrait, 2-col landscape, 3-col desktop).

# Why

Fixes #37.

On iPhone 13 mini (CSS viewport 375px, portrait), the Today page
clipped every card's right edge — the schedule card's Inject
checkbox could not be tapped without rotating to landscape.
Pinch-zoom-out did not help because the page itself was laid out
wider than the viewport.

Bisecting the card list showed that disabling the supplements card
made the clipping disappear. The supplements card has list rows
like *"Swisse Ultiboost Magnesium Glycinate"* with
`white-space: nowrap`. That row's intrinsic min-content is ~434px.

Plain `1fr` is shorthand for `minmax(auto, 1fr)`. The `auto` min
says *"grow to fit min-content"*. So the single grid track grew
to ~434px, the grid container grew to 434px, `main` grew to 434px,
and every card in the column rendered 434px wide — 59px past the
viewport. The Trends and Reports views used the same grid rule
but had no renderers that emit long nowrap rows, so the latent bug
never surfaced there.

# How

Replace `1fr` tracks with `minmax(0, 1fr)` tracks. The `0` lower
bound forces children to shrink to fit their share of the grid
rather than pushing the track wider. Per-card overflow handling
(existing `nowrap` + `text-overflow: ellipsis` on `.item-name`
and `.item-sub` in `eh-checklist-card`) then does its job.

Nothing changes on viewports wide enough to accommodate a card's
min-content, so desktop and landscape rendering is untouched.

# Testing

- [x] `npm test` passes locally
- [x] Verified with a puppeteer-core harness emulating iPhone 13
      mini (viewport 375×812, DPR 3, touch, iOS Safari UA) against
      a sandboxed instance with the full demo seed plus a real
      supplements manifest. Measured:
  - **before:** every card `wrap_w = 468` in a 375px viewport,
    `documentElement.scrollWidth = 468` (page overflow)
  - **after:** every card `wrap_w = 351` in a 375px viewport,
    `documentElement.scrollWidth = 375` (no overflow)
- [x] Verified on the live test container (`klebbtest.axis...`) on
      an actual iPhone 13 mini in Safari and Brave — supplements
      card and all sibling cards now fit in portrait, Inject
      checkbox on the schedule card is tappable without rotating
      to landscape.

# Checklist

- [x] Commit messages follow `CONTRIBUTING.md`
- [x] `CHANGELOG.md` updated under `## Unreleased`
- [x] Docs untouched (behaviour/schema unchanged)
- [x] No personal identifiers or hardcoded paths
- [x] No secrets

# Breaking changes

None. This is a pure layout fix; no API, data shape, or behaviour
change on any viewport size.