### PR TITLE
fix(ui): compute today in local timezone, not UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
   now uses `minmax(0, 1fr)` instead of plain `1fr` so a card's
   min-content width can't expand its column. Per-card
   ellipsis / overflow then does its job. (#37)
+- **Modal prompts now fire correctly in UTC+ timezones.** Client-side
+  "today" was computed with `new Date().toISOString().slice(0, 10)`,
+  which always returns a UTC date. For users in e.g. AEST (UTC+10),
+  "today" silently rolled back to "yesterday" before 10:00 AM local
+  time, so `meta.prompt` cards (like the Mood modal) never fired on
+  first load of the day. All client date computations now go through
+  a shared `localToday()` helper that uses the device's local
+  timezone. (#36)
 - **`futureAllowed: false` (and `pastAllowed: false`) now actually
   block webapp writes.** Previously the ➕/✏️ button showed on every
   date and the `POST /api/manifests/:id/data` handler ignored the

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -19,6 +19,7 @@ import './components/eh-settings-view.js';    // /settings
 import './components/health-chat.js';
 import './components/eh-prompt-modal.js';
 import { checkPromptsForToday } from './lib/prompt-queue.js';
+import { localToday } from './lib/date-util.js';
 
 class HealthApp extends LitElement {
   static properties = {
@@ -102,7 +103,7 @@ class HealthApp extends LitElement {
     // Mark shown-today regardless of saved/dismissed — per spec, once shown
     // never reshow the same day even on cancel.
     try {
-      const today = new Date().toISOString().slice(0, 10);
+      const today = localToday();
       localStorage.setItem(`klebb-prompt-shown-${cardId}-${today}`, '1');
     } catch {}
     // Advance the queue.
@@ -299,7 +300,7 @@ class HealthApp extends LitElement {
       ${activePrompt ? html`
         <eh-prompt-modal
           .card=${activePrompt}
-          .date=${new Date().toISOString().slice(0, 10)}
+          .date=${localToday()}
           @eh-prompt-done=${this._onPromptDone}
         ></eh-prompt-modal>
       ` : ''}

--- a/public/js/components/eh-prompt-modal.js
+++ b/public/js/components/eh-prompt-modal.js
@@ -28,6 +28,7 @@
 //     in the queue.
 
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
+import { localToday } from '../lib/date-util.js';
 import './eh-input-form.js';
 
 export class EhPromptModal extends LitElement {
@@ -207,7 +208,7 @@ export class EhPromptModal extends LitElement {
       // the same pattern as eh-generic-card._save(). This keeps the modal
       // independent of the card's renderer but honours maxReadingsPerDay.
       const entry = { ...values };
-      if (!entry.date) entry.date = this.date || new Date().toISOString().slice(0, 10);
+      if (!entry.date) entry.date = this.date || localToday();
 
       // Fetch the current manifest (fresh — avoid stale writes if another
       // tab just wrote something).
@@ -251,7 +252,7 @@ export class EhPromptModal extends LitElement {
     if (!this.card) return html``;
     const meta = this.card.meta || {};
     const inputs = meta.writeable?.inputs || [];
-    const today = this.date || new Date().toISOString().slice(0, 10);
+    const today = this.date || localToday();
     return html`
       <dialog aria-modal="true" aria-label="${meta.label || 'Log entry'}">
         <div class="wrap">

--- a/public/js/lib/date-util.js
+++ b/public/js/lib/date-util.js
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// public/js/lib/date-util.js
+// Local-date helpers. `new Date().toISOString()` always returns UTC,
+// which silently rolls back to "yesterday" for UTC+ timezones in the
+// morning. These return YYYY-MM-DD in the device's local timezone.
+
+export function localDateStr(date) {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+export function localToday() {
+  return localDateStr(new Date());
+}

--- a/public/js/lib/prompt-queue.js
+++ b/public/js/lib/prompt-queue.js
@@ -18,10 +18,12 @@
 //     Returns full manifest objects ({ meta, data }) ready to pass to
 //     eh-prompt-modal.
 
+import { localToday } from './date-util.js';
+
 const STORAGE_PREFIX = 'klebb-prompt-shown-';
 
 function todayStr() {
-  return new Date().toISOString().slice(0, 10);
+  return localToday();
 }
 
 export function shownTodayKey(cardId, date = todayStr()) {

--- a/tests/date-util.test.js
+++ b/tests/date-util.test.js
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/date-util.test.js
+// Unit tests for public/js/lib/date-util.js — local-timezone date
+// helpers. The bug these fix: new Date().toISOString() returns UTC,
+// so in UTC+ timezones "today" rolled back to yesterday in the morning,
+// breaking the meta.prompt modal queue.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { localDateStr, localToday } from '../public/js/lib/date-util.js';
+
+test('localDateStr: formats a local Date as YYYY-MM-DD', () => {
+  const d = new Date(2026, 3, 25, 7, 0, 0); // 25 April 2026, local
+  assert.equal(localDateStr(d), '2026-04-25');
+});
+
+test('localDateStr: pads month and day', () => {
+  const d = new Date(2026, 0, 3, 0, 0, 0); // 3 January 2026, local
+  assert.equal(localDateStr(d), '2026-01-03');
+});
+
+test('localDateStr: returns local date even when UTC date differs', () => {
+  // 07:00 in Sydney (UTC+10) on 2026-04-25 is 21:00 on 2026-04-24 in UTC.
+  // Build a Date that represents that exact instant, then assert that
+  // localDateStr uses the runner's local zone (not UTC).
+  const instant = new Date('2026-04-24T21:00:00Z');
+  const expectedY = instant.getFullYear();
+  const expectedM = String(instant.getMonth() + 1).padStart(2, '0');
+  const expectedD = String(instant.getDate()).padStart(2, '0');
+  assert.equal(localDateStr(instant), `${expectedY}-${expectedM}-${expectedD}`);
+  // And explicitly verify it doesn't fall back to the UTC slice which
+  // would be '2026-04-24' regardless of runner timezone.
+  if (instant.getTimezoneOffset() < 0) {
+    // Runner is in a UTC+ zone — local date should be 2026-04-25, not UTC's 2026-04-24.
+    assert.equal(localDateStr(instant), '2026-04-25');
+    assert.notEqual(localDateStr(instant), instant.toISOString().slice(0, 10));
+  }
+});
+
+test('localToday: returns today in local timezone, YYYY-MM-DD format', () => {
+  const result = localToday();
+  assert.match(result, /^\d{4}-\d{2}-\d{2}$/);
+  const now = new Date();
+  assert.equal(result, localDateStr(now));
+});


### PR DESCRIPTION
# What changed

New shared helper module `public/js/lib/date-util.js` exposing
`localDateStr(date)` and `localToday()`, both returning a YYYY-MM-DD
string using the device's **local** timezone. Every client-side
place that previously used `new Date().toISOString().slice(0, 10)`
for a "today" string now routes through `localToday()`:

- `public/js/app.js` — prompt-modal `date` prop + localStorage key
  for the "shown today" dedupe
- `public/js/components/eh-prompt-modal.js` — default entry date
  + the rendered date line
- `public/js/lib/prompt-queue.js` — internal `todayStr()` helper
  that decides which prompts match today

# Why

Fixes #36.

`new Date().toISOString()` **always returns UTC**, regardless of the
device's timezone. For a user in AEST (UTC+10), local 09:00 is
23:00 UTC *yesterday*. So between local 00:00 and local 10:00,
`toISOString().slice(0, 10)` returned yesterday's date.

Consequence for the `meta.prompt` modal queue: the mood card (set
to prompt once per day) would check "did we already store an entry
for 'today' = yesterday-UTC", find yesterday's entry, conclude
"already logged today", and silently skip the modal for the first
10 hours of every day. Any other feature that keys off "today" on
the client had the same latent bug.

# How

- Introduce `localDateStr` / `localToday` in `public/js/lib/date-util.js`.
  These format a Date using `getFullYear()` / `getMonth()` /
  `getDate()` — all of which are local-timezone-aware on the JS
  Date object (unlike the `getUTC*` variants or `toISOString()`).
- Replace the four `toISOString().slice(0, 10)` call sites with
  `localToday()`. Server-side code is untouched: the server
  respects `TZ` (see PR #33) and already computes dates correctly.
- Add `tests/date-util.test.js` (4 tests) covering the happy path,
  zero-padding, and a targeted UTC-differs-from-local case that
  only asserts the divergent expected value when the test runner
  is in a UTC+ zone.

# Testing

- [x] `npm test` passes locally (67 relevant tests incl. 4 new).
- [x] Manual QA on the live test container from a UTC+10 device:
      mood modal now fires at 07:00 local as expected (previously
      silent until ~10:00 local).

# Checklist

- [x] Commit messages follow `CONTRIBUTING.md`
- [x] `CHANGELOG.md` updated under `## Unreleased`
- [x] Docs untouched (no schema or behaviour change)
- [x] No personal identifiers or hardcoded paths
- [x] No secrets

# Breaking changes

None. Client-side date strings now match the device's local date;
any localStorage entry written before this change under the UTC
key will still be read under the same UTC key until it naturally
ages out (keys include a date component). Nothing on disk or
server-side changes.