### PR TITLE
fix(chat): guard /api/chat against upstream RST crash (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Chat no longer hangs for 60s and returns "Failed to connect" when
+  the gateway closes its TCP socket abruptly after a successful
+  response.** The `/api/chat` proxy's `error` and `timeout` handlers
+  unconditionally called `sendJSON` on the client response, so an
+  upstream RST arriving after the reply had already been flushed would
+  trigger `ERR_HTTP_HEADERS_SENT` and crash the Node process. Docker
+  would then restart the container, the next chat request would land
+  on a half-started server, and the browser would eventually time out
+  with "Failed to connect". Both handlers now guard with
+  `res.headersSent` before writing. (#41)
 - **Cards no longer overflow the viewport on narrow phones.** A card
   whose content had a long unbreakable string (e.g. a supplement named
   "Swisse Ultiboost Magnesium Glycinate" with `white-space: nowrap` on

--- a/server.js
+++ b/server.js
@@ -943,12 +943,12 @@ Original system prompt follows:
 
           proxyReq.on('error', (e) => {
             console.error('Chat proxy error:', e.message);
-            sendJSON(res, { error: 'Gateway unavailable' }, 502);
+            if (!res.headersSent) sendJSON(res, { error: 'Gateway unavailable' }, 502);
           });
 
           proxyReq.setTimeout(180000, () => {
             proxyReq.destroy();
-            sendJSON(res, { error: 'Request timed out' }, 504);
+            if (!res.headersSent) sendJSON(res, { error: 'Request timed out' }, 504);
           });
 
           proxyReq.write(payload);

--- a/tests/chat-proxy-reset.test.js
+++ b/tests/chat-proxy-reset.test.js
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/chat-proxy-reset.test.js
+// Regression: if the chat gateway sends a complete response and then RSTs the
+// TCP socket, the proxy must still deliver the reply to the client and must
+// not crash the server by trying to write a 502 on an already-ended response.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const net = require('net');
+const { createSandbox, cleanupSandbox, spawnServer, req } = require('./helpers/sandbox');
+
+function startResetGateway() {
+  const body = JSON.stringify({
+    choices: [{ message: { role: 'assistant', content: 'ack' } }],
+  });
+  const server = net.createServer((socket) => {
+    let buf = '';
+    socket.on('data', (chunk) => {
+      buf += chunk.toString('binary');
+      const headerEnd = buf.indexOf('\r\n\r\n');
+      if (headerEnd === -1) return;
+      const headers = buf.slice(0, headerEnd);
+      const m = headers.match(/Content-Length:\s*(\d+)/i);
+      const need = m ? parseInt(m[1], 10) : 0;
+      const have = Buffer.byteLength(buf.slice(headerEnd + 4), 'binary');
+      if (have < need) return;
+      const response =
+        'HTTP/1.1 200 OK\r\n' +
+        'Content-Type: application/json\r\n' +
+        `Content-Length: ${Buffer.byteLength(body)}\r\n` +
+        'Connection: close\r\n' +
+        '\r\n' +
+        body;
+      socket.write(response, () => {
+        // Force a TCP RST after the response bytes are flushed. This is the
+        // exact shape observed live: gateway returns 200 + body then the
+        // socket is reset, firing 'error' on the client's ClientRequest.
+        try { socket.resetAndDestroy(); }
+        catch { socket.destroy(); }
+      });
+    });
+    socket.on('error', () => {});
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve({
+        port: server.address().port,
+        close: () => new Promise((r) => server.close(r)),
+      });
+    });
+  });
+}
+
+function makeCard(id) {
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: { id, label: id, emoji: '.', view: { enabled: true, component: 'generic-card' } },
+    description: id,
+    data: [],
+  };
+}
+
+describe('chat proxy survives upstream RST after successful response', () => {
+  let sandbox, server, gateway;
+
+  before(async () => {
+    gateway = await startResetGateway();
+    sandbox = createSandbox({ seed: { 'w.json': makeCard('w') } });
+    server = await spawnServer(sandbox, {
+      CHAT_GATEWAY_HOST: '127.0.0.1',
+      CHAT_GATEWAY_PORT: String(gateway.port),
+      CHAT_GATEWAY_TLS: 'false',
+      CHAT_GATEWAY_TOKEN: 'stub',
+      CHAT_GATEWAY_MODEL: 'stub',
+    });
+  });
+  after(async () => {
+    if (server) await server.kill();
+    if (gateway) await gateway.close();
+    cleanupSandbox(sandbox);
+  });
+
+  test('client receives reply and server stays up after upstream RST', async () => {
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'hi' }] },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.json?.reply, 'ack');
+
+    // Server is still alive on a follow-up request.
+    await new Promise((r) => setTimeout(r, 100));
+    const res2 = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'again' }] },
+    });
+    assert.equal(res2.status, 200);
+    assert.equal(res2.json?.reply, 'ack');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #41. A successful chat response followed by an upstream TCP RST was crashing the Node process via `ERR_HTTP_HEADERS_SENT`, causing Docker to restart the container and the next chat request to dead-end with "Failed to connect".

## Why

Observed live on the test instance. The \`/api/chat\` proxy's \`error\` and \`timeout\` handlers wrote the 502/504 JSON to the client response unconditionally. When the upstream gateway sent a complete 200 + body and then reset the socket (self-managed TLS endpoint with \`Connection: close\` does this routinely), the sequence was:

1. \`proxyRes.on('end')\` → \`sendJSON(res, { reply })\` → client response ended.
2. Upstream RST fires \`proxyReq.on('error')\` → \`sendJSON(res, { error: 'Gateway unavailable' }, 502)\`.
3. \`res.writeHead\` on an already-ended response → \`ERR_HTTP_HEADERS_SENT\` → Node exits.
4. Docker restarts the container; nginx logs \`upstream prematurely closed connection\` and the browser eventually gives up (499 after the client-side 120s timeout).

## How

Guard both handlers with \`res.headersSent\` before writing. Also add a regression test: a stub gateway that writes a full 200 + body then calls \`socket.resetAndDestroy()\` — reproduces the live shape exactly.

## Testing

- [x] New test \`tests/chat-proxy-reset.test.js\` passes.
- [x] Existing \`tests/chat-prompt-cards.test.js\` still passes.
- [x] Full suite runs clean locally (one unrelated env-dependent test flakes on port collisions when run in parallel; passes in isolation).
- [ ] Manual: chat against the live gateway on the test instance, confirm no crash, confirm reply arrives.