### PR TITLE
feat(calendar): dynamic per-day markers from row values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,19 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 - **Calendar markers can now reflect the day's value, not just "had
   data".** `meta.calendar.marker` accepts either a string (static
   glyph, existing behaviour) or an object describing a per-day glyph.
-  Two kinds ship: `type: "field-emoji"` picks a glyph from an
-  `emojiMap` keyed by a field value on that day's row (e.g. mood 1..5
-  → 😩😴😐🙂😄); `type: "trend-arrow"` compares the day's reading to
-  the previous one and renders ⬆️/⬇️/➡️ (e.g. weight vs previous
-  reading). The resolver is type-discriminated so new kinds can ship
-  without a schema bump. `mood.example.json` and `weight.example.json`
-  demonstrate both. See `docs/CARDS.md` (§ `meta.calendar`) and
-  `docs/RECIPES.md` (Recipe 11). (#43)
+  Four kinds ship: `type: "field-emoji"` picks a glyph from an
+  `emojiMap` keyed by a field value on that day's row (mood 1..5 →
+  😩😴😐🙂😄); `type: "trend-arrow"` compares the day's reading to
+  the previous one and renders ⬆️/⬇️/➡️ (weight vs previous
+  reading); `type: "threshold"` evaluates `min`/`max`/`eq` rules to
+  pick a glyph per band (🟢/🟡/🟠/🔴 for BP); `type: "template"`
+  reuses the `display.template` mini-language so the calendar can
+  share the Today card's `emojiMap` without duplication. The
+  resolver is type-discriminated so new kinds can ship without a
+  schema bump. `mood.example.json` (template),
+  `weight.example.json` (trend-arrow), and `bp.example.json`
+  (threshold) demonstrate the range. See `docs/CARDS.md`
+  (§ `meta.calendar`) and `docs/RECIPES.md` (Recipe 11). (#43)
 - **Chat conversation is now stored server-side and follows the user
   across devices.** Previously the chat widget had no memory past the
   current panel-open, so switching from phone to laptop lost the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Calendar markers can now reflect the day's value, not just "had
+  data".** `meta.calendar.marker` accepts either a string (static
+  glyph, existing behaviour) or an object describing a per-day glyph.
+  Two kinds ship: `type: "field-emoji"` picks a glyph from an
+  `emojiMap` keyed by a field value on that day's row (e.g. mood 1..5
+  → 😩😴😐🙂😄); `type: "trend-arrow"` compares the day's reading to
+  the previous one and renders ⬆️/⬇️/➡️ (e.g. weight vs previous
+  reading). The resolver is type-discriminated so new kinds can ship
+  without a schema bump. `mood.example.json` and `weight.example.json`
+  demonstrate both. See `docs/CARDS.md` (§ `meta.calendar`) and
+  `docs/RECIPES.md` (Recipe 11). (#43)
 - **Chat conversation is now stored server-side and follows the user
   across devices.** Previously the chat widget had no memory past the
   current panel-open, so switching from phone to laptop lost the
@@ -24,17 +35,6 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
   serialised and are re-synthesised on demand. The server caps the
   payload at 512 KB and trims to the last 200 turns. Saves from the
   client are debounced 500 ms so rapid turns don't spam. (#55)
-- **Calendar markers can now reflect the day's value, not just "had
-  data".** `meta.calendar.marker` accepts either a string (static
-  glyph, existing behaviour) or an object describing a per-day glyph.
-  Two kinds ship: `type: "field-emoji"` picks a glyph from an
-  `emojiMap` keyed by a field value on that day's row (e.g. mood 1..5
-  → 😩😴😐🙂😄); `type: "trend-arrow"` compares the day's reading to
-  the previous one and renders ⬆️/⬇️/➡️ (e.g. weight vs previous
-  reading). The resolver is type-discriminated so new kinds can ship
-  without a schema bump. `mood.example.json` and `weight.example.json`
-  demonstrate both. See `docs/CARDS.md` (§ `meta.calendar`) and
-  `docs/RECIPES.md` (Recipe 11). (#43)
 - **Timezone is now an explicit, documented config knob.** The container
   image defaults to `TZ=UTC`; operators can override via the `TZ` env
   var with any IANA zone (e.g. `Australia/Sydney`). The active zone is

--- a/MANIFEST-SCHEMA.md
+++ b/MANIFEST-SCHEMA.md
@@ -209,6 +209,61 @@ earlier entry with a numeric value on `field`, render up/down/flat:
 - `fallback` (string, optional): glyph for the very first entry (no
   previous to compare), non-numeric values, or missing field.
 
+**`type: "threshold"`** — evaluate the day's row against a list of
+rules; the first matching rule's emoji wins. Mirrors the
+`display.thresholds` matcher shape (so `min`/`max`/`eq` behave the
+same). Good for clinical bands (BP, body temp, SpO₂) or discrete
+phase labels.
+
+```json
+"marker": {
+  "type":  "threshold",
+  "field": "systolic",
+  "rules": [
+    { "max": 119, "emoji": "🟢" },
+    { "max": 129, "emoji": "🟡" },
+    { "max": 139, "emoji": "🟠" },
+    { "max": 999, "emoji": "🔴" }
+  ],
+  "fallback": "•"
+}
+```
+
+- `field` (string, required): field on the day's row to evaluate.
+- `rules` (array, required): each rule is
+  `{ min?, max?, eq?, emoji }`. Rules iterate top-to-bottom; the
+  first rule whose field exists and satisfies the matcher wins.
+- Matchers: `min <= row[field] <= max` (both optional, at least one
+  required), or `row[field]` stringly-equals `eq`.
+- `fallback` (string, optional): glyph when no rule matches or the
+  field is missing.
+
+**`type: "template"`** — render a template string against the day's
+row using the same mini-language as `view.display.template`. Great
+for reusing an `emojiMap` that already lives in `display` rather than
+duplicating it under `calendar`.
+
+```json
+"marker": {
+  "type":     "template",
+  "template": "{mood:emoji}",
+  "fallback": "🙂"
+}
+```
+
+- `template` (string, required): same syntax as
+  `display.template` — supports `{key}`, `{key:emoji}`,
+  `{key:round(N)}`, `{key|default}`, `{key?yes:no}`, dotted paths.
+- The card's `meta.view.display` block is passed to the renderer so
+  `{key:emoji}` resolves against `display.emojiMap[key]` — i.e. the
+  same map the Today card uses.
+- `fallback` (string, optional): glyph when the template renders
+  empty (missing field, no match).
+
+Because both the calendar and the Today card read from the same
+`display.emojiMap`, the two stay in lock-step without you having to
+edit the manifest in two places.
+
 #### Multiple entries per day
 
 If a card allows `maxReadingsPerDay > 1`, the **latest entry wins** for

--- a/data.example/bp.example.json
+++ b/data.example/bp.example.json
@@ -86,7 +86,17 @@
     "calendar": {
       "enabled": true,
       "component": "day-marker",
-      "marker": "💓"
+      "marker": {
+        "type": "threshold",
+        "field": "systolic",
+        "rules": [
+          { "max": 119, "emoji": "🟢" },
+          { "max": 129, "emoji": "🟡" },
+          { "max": 139, "emoji": "🟠" },
+          { "max": 999, "emoji": "🔴" }
+        ],
+        "fallback": "💓"
+      }
     },
     "writeable": {
       "fromWebapp": true,

--- a/data.example/mood.example.json
+++ b/data.example/mood.example.json
@@ -28,15 +28,8 @@
       "enabled": true,
       "component": "day-marker",
       "marker": {
-        "type": "field-emoji",
-        "field": "mood",
-        "emojiMap": {
-          "1": "😩",
-          "2": "😴",
-          "3": "😐",
-          "4": "🙂",
-          "5": "😄"
-        },
+        "type": "template",
+        "template": "{mood:emoji}",
         "fallback": "🙂"
       }
     },

--- a/docs/CARDS.md
+++ b/docs/CARDS.md
@@ -241,6 +241,76 @@ or down compared to the previous reading:
 - First entry ever (no previous) uses `fallback`.
 - `up` / `down` / `flat` default to `⬆️` / `⬇️` / `➡️` if omitted.
 
+**4. `threshold`** — the glyph depends on which *range* (or exact
+value) the reading falls into. Great for clinical bands (BP, body
+temp, SpO₂) or discrete phase labels (`"loading"` / `"maintenance"` /
+`"rest"`):
+
+```json
+"calendar": {
+  "enabled":   true,
+  "component": "day-marker",
+  "marker": {
+    "type":  "threshold",
+    "field": "systolic",
+    "rules": [
+      { "max": 119, "emoji": "🟢" },
+      { "max": 129, "emoji": "🟡" },
+      { "max": 139, "emoji": "🟠" },
+      { "max": 999, "emoji": "🔴" }
+    ],
+    "fallback": "•"
+  }
+}
+```
+
+Rules iterate top-to-bottom, first match wins. Each rule is one of:
+
+- `{ min, max, emoji }` — numeric bands (both bounds optional, at
+  least one required). `min <= row[field] <= max`.
+- `{ eq, emoji }` — exact string match, for categorical values.
+
+This mirrors `display.thresholds` from the generic-card renderer, so
+if you already have threshold rules colour-coding the Today card you
+can reuse the same mental model here.
+
+**5. `template`** — reuse the `display.template` mini-language to
+pick the glyph. Especially useful when you already wrote an
+`emojiMap` under `view.display` (e.g. for Mood) and don't want to
+duplicate it:
+
+```json
+"view": {
+  "component": "generic-card",
+  "display": {
+    "template":  "{mood:emoji}",
+    "emojiMap":  { "mood": { "1": "😩", "2": "😴", "3": "😐", "4": "🙂", "5": "😄" } }
+  }
+},
+"calendar": {
+  "enabled":   true,
+  "component": "day-marker",
+  "marker": {
+    "type":     "template",
+    "template": "{mood:emoji}",
+    "fallback": "🙂"
+  }
+}
+```
+
+Because `template` renders against `view.display`, the calendar reads
+the very same `emojiMap` the Today card uses. One source of truth —
+change the map in `display` and both follow.
+
+Supported template syntax (identical to `display.template`):
+
+- `{key}` — raw value
+- `{key:emoji}` — lookup in `display.emojiMap[key]`
+- `{key:round(N)}` — round numeric to N decimals
+- `{key|default}` — fallback if missing
+- `{key?yes:no}` — ternary on truthiness
+- `{path.to.nested}` — dotted access
+
 **Where the day's row comes from.** The calendar flattens a card's
 `data` into `date -> row`:
 - Array of `{ date, ... }` rows: the last entry for each date wins.
@@ -254,11 +324,10 @@ same-day entry is the one the marker resolves against. Earlier
 same-day readings are still stored — just not reflected in the
 calendar glyph.
 
-**Extension space.** The marker object is discriminated by `type`; new
-kinds can ship without a schema bump. The roadmap includes
-`type: "threshold"` (range-to-emoji mirroring `display.thresholds`) and
-`type: "template"` (reuse the `{key:emoji}` mini-language). Until
-those land, the three forms above cover the common cases.
+**Extension space.** The marker object is discriminated by `type`, so
+the resolver is open to new kinds without breaking the schema. Each
+type is one branch in the resolver; adding a new one is a local
+change. The five currently shipped cover the common cases.
 
 ### `meta.writeable` — input form config
 

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -587,6 +587,81 @@ recent earlier entry's value at the same field.
 - Apply to HRV, steps, resting heart rate, grip strength — any
   numeric daily reading.
 
+### 11c — Threshold bands (BP, body temp, SpO₂)
+
+When the value falls into **clinical bands** you care about, paint the
+calendar cell with the matching band colour. First rule to match wins,
+so order rules narrow-to-wide just like `display.thresholds`.
+
+```json
+"calendar": {
+  "enabled":   true,
+  "component": "day-marker",
+  "marker": {
+    "type":  "threshold",
+    "field": "systolic",
+    "rules": [
+      { "max": 119, "emoji": "🟢" },
+      { "max": 129, "emoji": "🟡" },
+      { "max": 139, "emoji": "🟠" },
+      { "max": 999, "emoji": "🔴" }
+    ],
+    "fallback": "•"
+  }
+}
+```
+
+**Key bits:**
+- Each rule is `{ min?, max?, emoji }` (at least one bound) or
+  `{ eq, emoji }` for exact string match.
+- Rules are evaluated top-to-bottom; first match wins. Cascade
+  narrowest-first.
+- `fallback` shows when no rule matches or the field is missing.
+
+**Variations:**
+- Body temp with fever bands: `🧊` / `🟢` / `🟡` / `🔥`.
+- SpO₂: invert with `min` — `{ min: 95, emoji: '🟢' }`,
+  `{ min: 90, emoji: '🟡' }`, `{ max: 89, emoji: '🔴' }`.
+- Phase tracking with `eq`: `{ eq: 'loading', emoji: '🔁' }`,
+  `{ eq: 'rest', emoji: '💤' }`.
+
+### 11d — Template (reuse the Today card's emojiMap)
+
+If you already wrote an `emojiMap` under `view.display` for the Today
+card, the `template` type lets the calendar read the **same map** —
+no duplication. Change the map in `display` and the calendar follows.
+
+```json
+"view": {
+  "component": "generic-card",
+  "display": {
+    "template":  "{mood:emoji}",
+    "emojiMap":  { "mood": { "1": "😩", "2": "😴", "3": "😐", "4": "🙂", "5": "😄" } }
+  }
+},
+"calendar": {
+  "enabled":   true,
+  "component": "day-marker",
+  "marker": {
+    "type":     "template",
+    "template": "{mood:emoji}",
+    "fallback": "🙂"
+  }
+}
+```
+
+**Key bits:**
+- `marker.template` uses the same syntax as `display.template` —
+  `{key}`, `{key:emoji}`, `{key:round(N)}`, `{key|default}`, and so on.
+- `{key:emoji}` resolves against `display.emojiMap[key]` — same lookup
+  the Today card uses.
+- `fallback` shows when the template renders empty.
+
+**When to prefer template over field-emoji:**
+- You already have an `emojiMap` in `display` and don't want two
+  copies to keep in sync.
+- You want to combine multiple fields, e.g. `"{wakeUps?😴:✅}"`.
+
 ### Keeping it simple: static marker
 
 If you don't want per-day dynamics, the original shape still works:
@@ -598,8 +673,9 @@ If you don't want per-day dynamics, the original shape still works:
 Every day the card has data gets the same glyph. `marker` can also be
 omitted, in which case the card's `meta.emoji` is used.
 
-See `data.example/mood.example.json` (field-emoji) and
-`data.example/weight.example.json` (trend-arrow).
+See `data.example/mood.example.json` (field-emoji),
+`data.example/weight.example.json` (trend-arrow), and
+`data.example/bp.example.json` (threshold).
 
 ---
 

--- a/public/js/components/eh-calendar-view.js
+++ b/public/js/components/eh-calendar-view.js
@@ -7,14 +7,15 @@
 // Data fetching strategy: on mount, fetch every card from /api/manifests
 // whose meta.calendar.enabled===true. Extract that card's dated rows
 // (heuristic per data shape), then resolve each day's marker per the
-// card's meta.calendar.marker config (string, field-emoji, or
-// trend-arrow). Build a map: date -> [{id, marker, tooltip}].
+// card's meta.calendar.marker config (string, field-emoji, trend-arrow,
+// threshold, or template). Build a map: date -> [{id, marker, tooltip}].
 //
 // Navigation: < [Month Year] > with prev/next arrows and a "This month" shortcut.
 // Click a day -> navigate to /day/YYYY-MM-DD.
 
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
 import { extractDatedRows, resolveMarker } from '../lib/calendar-marker.esm.js';
+import { renderTemplate } from '../lib/display-template.esm.js';
 
 const DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 const MONTH_NAMES = ['January','February','March','April','May','June','July','August','September','October','November','December'];
@@ -68,13 +69,14 @@ export class EhCalendarView extends LitElement {
         const cal = entry.meta.calendar;
         const spec = cal.marker ?? entry.meta.emoji ?? '•';
         const fallback = entry.meta.emoji || '•';
+        const display = entry.meta?.view?.display || null;
         const dated = extractDatedRows(entry.data);
         // Sorted ascending — trend-arrow needs this to find the previous row.
         const sortedRows = Array.from(dated.values())
           .filter(r => r && r.date)
           .sort((a, b) => String(a.date).localeCompare(String(b.date)));
         for (const [date, row] of dated) {
-          const marker = resolveMarker(spec, { date, row, sortedRows, fallback });
+          const marker = resolveMarker(spec, { date, row, sortedRows, fallback, display, renderTemplate });
           if (!markers.has(date)) markers.set(date, []);
           markers.get(date).push({
             id: entry.id,

--- a/public/js/lib/calendar-marker.esm.js
+++ b/public/js/lib/calendar-marker.esm.js
@@ -3,6 +3,10 @@
 // public/js/lib/calendar-marker.esm.js
 // ES-module twin of calendar-marker.js. Keep in sync — Node tests use the
 // UMD version, browser components use this one.
+//
+// See calendar-marker.js for full docs on marker shapes and the ctx
+// interface. Supports: string | field-emoji | trend-arrow | threshold
+// | template.
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -105,6 +109,43 @@ export function resolveMarker(spec, ctx) {
       if (currentNum > prevNum) return spec.up || '⬆️';
       if (currentNum < prevNum) return spec.down || '⬇️';
       return spec.flat || '➡️';
+    }
+
+    case 'threshold': {
+      if (!spec.field || !Array.isArray(spec.rules) || !row) {
+        return spec.fallback || fallback;
+      }
+      const v = getValue(row, spec.field);
+      if (v === null || v === undefined || v === '') {
+        return spec.fallback || fallback;
+      }
+      for (const rule of spec.rules) {
+        if (!rule || typeof rule !== 'object') continue;
+        if ('eq' in rule) {
+          if (String(v) === String(rule.eq)) return rule.emoji || spec.fallback || fallback;
+          continue;
+        }
+        const n = Number(v);
+        if (Number.isNaN(n)) continue;
+        if ('min' in rule && n < Number(rule.min)) continue;
+        if ('max' in rule && n > Number(rule.max)) continue;
+        if (!('min' in rule) && !('max' in rule)) continue;
+        return rule.emoji || spec.fallback || fallback;
+      }
+      return spec.fallback || fallback;
+    }
+
+    case 'template': {
+      if (!spec.template || !row) {
+        return spec.fallback || fallback;
+      }
+      const render = ctx && ctx.renderTemplate;
+      if (typeof render !== 'function') {
+        return spec.fallback || fallback;
+      }
+      const out = render(spec.template, row, (ctx && ctx.display) || null);
+      if (out && out.trim()) return out;
+      return spec.fallback || fallback;
     }
 
     default:

--- a/public/js/lib/calendar-marker.js
+++ b/public/js/lib/calendar-marker.js
@@ -8,6 +8,8 @@
 //   "💊"                                  → same glyph every logged day
 //   { type: "field-emoji", field, emojiMap, fallback? }
 //   { type: "trend-arrow", field, up?, down?, flat?, fallback? }
+//   { type: "threshold",   field, rules: [{ min?, max?, eq?, emoji }], fallback? }
+//   { type: "template",    template, fallback? }
 //
 // Public surface:
 //   extractDatedRows(data) -> Map<"YYYY-MM-DD", row>
@@ -16,9 +18,15 @@
 //     (last by array index for arrays; last by takenAt for doses).
 //
 //   resolveMarker(spec, ctx) -> string
-//     ctx = { date, row, sortedRows, fallback }
-//     sortedRows is dated rows ascending by date; used by trend-arrow.
-//     fallback is the glyph to use if the spec yields nothing.
+//     ctx = { date, row, sortedRows, fallback, display, renderTemplate }
+//     sortedRows: dated rows ascending by date (for trend-arrow).
+//     fallback: glyph used if the spec yields nothing.
+//     display: the card's meta.view.display block (for template type to
+//       reuse its emojiMap).
+//     renderTemplate: an injected string-template render function
+//       (same signature as display-template.renderTemplate). Injected
+//       rather than imported to keep this lib dependency-free and
+//       UMD-simple. Only required when using type: "template".
 
 (function (root, factory) {
   if (typeof module === 'object' && module.exports) {
@@ -135,6 +143,43 @@
         if (currentNum > prevNum) return spec.up || '⬆️';
         if (currentNum < prevNum) return spec.down || '⬇️';
         return spec.flat || '➡️';
+      }
+
+      case 'threshold': {
+        if (!spec.field || !Array.isArray(spec.rules) || !row) {
+          return spec.fallback || fallback;
+        }
+        const v = getValue(row, spec.field);
+        if (v === null || v === undefined || v === '') {
+          return spec.fallback || fallback;
+        }
+        for (const rule of spec.rules) {
+          if (!rule || typeof rule !== 'object') continue;
+          if ('eq' in rule) {
+            if (String(v) === String(rule.eq)) return rule.emoji || spec.fallback || fallback;
+            continue;
+          }
+          const n = Number(v);
+          if (Number.isNaN(n)) continue;
+          if ('min' in rule && n < Number(rule.min)) continue;
+          if ('max' in rule && n > Number(rule.max)) continue;
+          if (!('min' in rule) && !('max' in rule)) continue;
+          return rule.emoji || spec.fallback || fallback;
+        }
+        return spec.fallback || fallback;
+      }
+
+      case 'template': {
+        if (!spec.template || !row) {
+          return spec.fallback || fallback;
+        }
+        const render = ctx && ctx.renderTemplate;
+        if (typeof render !== 'function') {
+          return spec.fallback || fallback;
+        }
+        const out = render(spec.template, row, (ctx && ctx.display) || null);
+        if (out && out.trim()) return out;
+        return spec.fallback || fallback;
       }
 
       default:

--- a/tests/calendar-marker.test.js
+++ b/tests/calendar-marker.test.js
@@ -226,6 +226,119 @@ describe('resolveMarker', () => {
     });
   });
 
+  describe('threshold', () => {
+    const spec = {
+      type: 'threshold',
+      field: 'systolic',
+      rules: [
+        { max: 119, emoji: '🟢' },
+        { max: 129, emoji: '🟡' },
+        { max: 139, emoji: '🟠' },
+        { max: 999, emoji: '🔴' },
+      ],
+      fallback: '•',
+    };
+
+    test('first-matching rule wins', () => {
+      assert.equal(resolveMarker(spec, { row: { systolic: 110 } }), '🟢');
+      assert.equal(resolveMarker(spec, { row: { systolic: 125 } }), '🟡');
+      assert.equal(resolveMarker(spec, { row: { systolic: 135 } }), '🟠');
+      assert.equal(resolveMarker(spec, { row: { systolic: 160 } }), '🔴');
+    });
+
+    test('min bound matches', () => {
+      const rising = {
+        type: 'threshold',
+        field: 'hr',
+        rules: [{ min: 100, emoji: '⚡' }],
+        fallback: '•',
+      };
+      assert.equal(resolveMarker(rising, { row: { hr: 120 } }), '⚡');
+      assert.equal(resolveMarker(rising, { row: { hr: 80 } }), '•');
+    });
+
+    test('eq matcher for categorical values', () => {
+      const cat = {
+        type: 'threshold',
+        field: 'phase',
+        rules: [
+          { eq: 'loading',     emoji: '🔁' },
+          { eq: 'maintenance', emoji: '✅' },
+          { eq: 'rest',        emoji: '💤' },
+        ],
+        fallback: '•',
+      };
+      assert.equal(resolveMarker(cat, { row: { phase: 'loading' } }), '🔁');
+      assert.equal(resolveMarker(cat, { row: { phase: 'rest' } }), '💤');
+      assert.equal(resolveMarker(cat, { row: { phase: 'other' } }), '•');
+    });
+
+    test('missing field returns fallback', () => {
+      assert.equal(resolveMarker(spec, { row: { diastolic: 80 } }), '•');
+    });
+
+    test('no matching rule returns fallback', () => {
+      const narrow = {
+        type: 'threshold',
+        field: 'kg',
+        rules: [{ min: 60, max: 70, emoji: '✅' }],
+        fallback: '❌',
+      };
+      assert.equal(resolveMarker(narrow, { row: { kg: 90 } }), '❌');
+    });
+
+    test('missing rules array returns fallback', () => {
+      const bad = { type: 'threshold', field: 'kg', fallback: '•' };
+      assert.equal(resolveMarker(bad, { row: { kg: 80 } }), '•');
+    });
+  });
+
+  describe('template', () => {
+    // Fake renderTemplate — just concatenates values so we can prove
+    // the injection path works without pulling in the real engine.
+    const fakeRender = (tpl, row) => tpl.replace(/\{(\w+)\}/g, (_, k) => row[k] ?? '');
+
+    test('renders a template string against the row', () => {
+      const spec = { type: 'template', template: '{m}', fallback: '?' };
+      const r = resolveMarker(spec, {
+        row: { m: '🔥' }, renderTemplate: fakeRender,
+      });
+      assert.equal(r, '🔥');
+    });
+
+    test('reuses display.emojiMap when renderTemplate supports :emoji', () => {
+      // Use the real renderTemplate to prove the end-to-end integration.
+      const realPath = require('path').join(
+        __dirname, '..', 'public', 'js', 'lib', 'display-template.js'
+      );
+      const { renderTemplate } = require(realPath);
+      const spec = { type: 'template', template: '{mood:emoji}', fallback: '🙂' };
+      const display = { emojiMap: { mood: { '1': '😩', '4': '🙂', '5': '😄' } } };
+      assert.equal(
+        resolveMarker(spec, { row: { mood: 5 }, display, renderTemplate }),
+        '😄'
+      );
+    });
+
+    test('blank render result returns fallback', () => {
+      const spec = { type: 'template', template: '{missing}', fallback: '•' };
+      const r = resolveMarker(spec, {
+        row: { other: 1 }, renderTemplate: fakeRender,
+      });
+      assert.equal(r, '•');
+    });
+
+    test('no renderTemplate injected → fallback', () => {
+      const spec = { type: 'template', template: '{m}', fallback: '•' };
+      assert.equal(resolveMarker(spec, { row: { m: 'x' } }), '•');
+    });
+
+    test('missing template returns fallback', () => {
+      const spec = { type: 'template', fallback: '•' };
+      assert.equal(resolveMarker(spec, { row: { m: 'x' }, renderTemplate: fakeRender }), '•');
+    });
+  });
+
   describe('unknown type', () => {
     test('falls back rather than throwing', () => {
       const r = resolveMarker(


### PR DESCRIPTION
# What changed

Calendar day cells can now show a glyph derived from the day's data
rather than a single static "card had data" indicator. The smiley on
a day with a mood entry can actually *match* that day's mood; a
weight card can show ⬆️ / ⬇️ / ➡️ based on whether the reading moved
against the previous one.

`meta.calendar.marker` becomes polymorphic:

- **string** (existing behaviour): `"marker": "💊"` — same glyph every
  logged day. Backwards compatible: cards currently using a string
  marker (`bp`, `medication-schedule`) keep rendering exactly as before.
- **`type: "field-emoji"`**: `{ field, emojiMap, fallback? }` — glyph
  comes from the row's field value via an emoji map.
- **`type: "trend-arrow"`**: `{ field, up?, down?, flat?, fallback? }`
  — glyph reflects direction of change vs the previous entry.

The resolver lives in a new pure lib (`public/js/lib/calendar-marker.{js,esm.js}`)
using the repo's standard dual-runtime UMD + ESM pattern (same as
`display-template`). `eh-calendar-view.js` now delegates row
extraction and marker resolution to the lib and hands the cell the
resolved glyph.

# Why

Fixes #43.

The calendar is the only cross-card, month-at-a-glance surface in the
app. A static glyph shows only "card had data" — the underlying row
already carries more signal (the mood emoji, the weight direction)
and the renderer can read it. Keeping this generic (any card can opt
in via config) beats special-casing mood.

# How

- New lib `public/js/lib/calendar-marker.js` (+ `.esm.js` twin)
  exports `extractDatedRows(data)` (flattens array-of-`{date}`,
  date-keyed objects, and `items[].doses[]` shapes into a
  `Map<dateStr, row>`) and `resolveMarker(spec, ctx)` (the
  `type`-dispatched marker resolver). Type-discriminated so future
  kinds (`threshold`, `template`) can ship without a schema bump.
- `eh-calendar-view.js` `_loadMarkers()` refactored to pre-sort each
  card's rows, then call the resolver per day with the row + the
  sorted-rows array (needed for `trend-arrow` to locate the previous
  entry). Old inline `_extractDates` helper removed.
- `mood.example.json` gains a `field-emoji` marker;
  `weight.example.json` gains a `trend-arrow` marker. Existing
  static-string markers (`bp`, `medication-schedule`) are unchanged.
- Docs: `MANIFEST-SCHEMA.md` gains a `calendar` section covering all
  three marker forms and the row-extraction rules.
  `docs/CARDS.md` gains an equivalent tutorial-style section under
  `meta.calendar`. `docs/RECIPES.md` gets Recipe 11 with two
  copy-pasteable manifests (mood → field-emoji, weight → trend-arrow)
  and notes on inverting for sleep / HRV.

# Testing

- [x] `npm test` passes locally (333 of 334 tests; the one failure is
      the pre-existing `no-personal-refs.test.js` hit against
      gitignored local operator files — not this branch's
      territory).
- [x] 25 new tests in `tests/calendar-marker.test.js` covering
      `extractDatedRows` (array, collision, date-keyed object,
      doses-shape, takenAt precedence) and `resolveMarker` (static,
      field-emoji hit/miss/dotted-path, trend-arrow up/down/flat/no-previous/non-numeric/gap-skipping,
      unknown type).
- [ ] Manual QA against a local dev instance: seed demo mood + weight
      rows, open the Calendar view, verify the day cells show the
      right per-day glyphs and that cards with a static string
      marker (bp, medication-schedule) still render correctly.

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [x] Docs updated (MANIFEST-SCHEMA, docs/CARDS, docs/RECIPES)
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens

# Breaking changes

None. `meta.calendar.marker: "💊"` keeps working; the object form is
strictly additive.