### PR TITLE
fix(chat): keep short tab-flicker replies, abort only after 3s background (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Calendar markers can now reflect the day's value, not just "had
+  data".** `meta.calendar.marker` accepts either a string (static
+  glyph, existing behaviour) or an object describing a per-day glyph.
+  Two kinds ship: `type: "field-emoji"` picks a glyph from an
+  `emojiMap` keyed by a field value on that day's row (e.g. mood 1..5
+  → 😩😴😐🙂😄); `type: "trend-arrow"` compares the day's reading to
+  the previous one and renders ⬆️/⬇️/➡️ (e.g. weight vs previous
+  reading). The resolver is type-discriminated so new kinds can ship
+  without a schema bump. `mood.example.json` and `weight.example.json`
+  demonstrate both. See `docs/CARDS.md` (§ `meta.calendar`) and
+  `docs/RECIPES.md` (Recipe 11). (#43)
 - **Timezone is now an explicit, documented config knob.** The container
   image defaults to `TZ=UTC`; operators can override via the `TZ` env
   var with any IANA zone (e.g. `Australia/Sydney`). The active zone is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Chat no longer aborts an in-flight reply on every momentary tab
+  switch.** The visibility-change watcher used to abort any pending
+  `/api/chat` request the instant the tab became visible again,
+  showing "Connection interrupted — send again" even for a
+  sub-second flicker. It now records when the tab went hidden and
+  only aborts if the tab was actually backgrounded for 3+ seconds
+  (long enough for mobile OSes to freeze the TCP socket). Brief
+  flickers leave the reply to arrive normally. The companion
+  `/api/config` keep-alive nudge has been removed: it never
+  actually rescued the chat socket, since it was a separate HTTP
+  request to a different endpoint. (#45)
 - **Chat no longer hangs for 60s and returns "Failed to connect" when
   the gateway closes its TCP socket abruptly after a successful
   response.** The `/api/chat` proxy's `error` and `timeout` handlers

--- a/MANIFEST-SCHEMA.md
+++ b/MANIFEST-SCHEMA.md
@@ -137,6 +137,85 @@ label pill.
 `trendArrow` shows ↑/↓/→ next to the headline, comparing the current
 row to the most recent earlier entry on `field`.
 
+### `calendar` — month-grid marker config
+
+`meta.calendar` opts the card into the Calendar view. Each day cell in
+the grid can carry up to three glyphs (capped with `+N` overflow); a
+card contributes one glyph per day it has data for.
+
+```json
+"calendar": {
+  "enabled": true,
+  "component": "day-marker",
+  "marker": "💊"
+}
+```
+
+Fields:
+- `enabled` (bool): include in Calendar. Default `false` (absent = not
+  in Calendar).
+- `component` (string): always `"day-marker"` today. Reserved for
+  future cell renderers.
+- `marker` (string | object): the glyph shown on days this card has
+  data. See below.
+
+#### `marker` — what glyph to show
+
+**Static string** — same glyph every logged day:
+
+```json
+"marker": "💊"
+```
+
+If `marker` is absent, the card's `meta.emoji` is used instead.
+
+**`type: "field-emoji"`** — pick the glyph from an emoji map keyed by a
+field value on that day's row:
+
+```json
+"marker": {
+  "type":      "field-emoji",
+  "field":     "mood",
+  "emojiMap":  { "1": "😩", "2": "😴", "3": "😐", "4": "🙂", "5": "😄" },
+  "fallback":  "🙂"
+}
+```
+
+- `field` (string, required): field on the day's row to read. Dotted
+  paths work (`stats.mood`).
+- `emojiMap` (object, required): `stringifiedValue -> emoji`.
+- `fallback` (string, optional): glyph when the row is missing, the
+  field is empty, or the value isn't in the map. Defaults to the card's
+  `meta.emoji` then `•`.
+
+**`type: "trend-arrow"`** — compare the day's row to the most recent
+earlier entry with a numeric value on `field`, render up/down/flat:
+
+```json
+"marker": {
+  "type":     "trend-arrow",
+  "field":    "kg",
+  "up":       "⬆️",
+  "down":     "⬇️",
+  "flat":     "➡️",
+  "fallback": "⚖️"
+}
+```
+
+- `field` (string, required): numeric field to compare. Dotted paths
+  work.
+- `up`, `down`, `flat` (string, optional): direction glyphs. Defaults:
+  `⬆️` / `⬇️` / `➡️`.
+- `fallback` (string, optional): glyph for the very first entry (no
+  previous to compare), non-numeric values, or missing field.
+
+#### Multiple entries per day
+
+If a card allows `maxReadingsPerDay > 1`, the **latest entry wins** for
+the day's marker (last by array index for array data; last by `takenAt`
+for `items[].doses[]` shapes). Earlier same-day entries are ignored by
+the calendar.
+
 ### `writeable`
 
 ```json

--- a/data.example/mood.example.json
+++ b/data.example/mood.example.json
@@ -24,6 +24,22 @@
         }
       }
     },
+    "calendar": {
+      "enabled": true,
+      "component": "day-marker",
+      "marker": {
+        "type": "field-emoji",
+        "field": "mood",
+        "emojiMap": {
+          "1": "😩",
+          "2": "😴",
+          "3": "😐",
+          "4": "🙂",
+          "5": "😄"
+        },
+        "fallback": "🙂"
+      }
+    },
     "writeable": {
       "fromWebapp": true,
       "pastAllowed": true,

--- a/data.example/weight.example.json
+++ b/data.example/weight.example.json
@@ -35,6 +35,18 @@
       ],
       "yAxisLabel": "kg"
     },
+    "calendar": {
+      "enabled": true,
+      "component": "day-marker",
+      "marker": {
+        "type": "trend-arrow",
+        "field": "kg",
+        "up": "⬆️",
+        "down": "⬇️",
+        "flat": "➡️",
+        "fallback": "⚖️"
+      }
+    },
     "writeable": {
       "fromWebapp": true,
       "pastAllowed": true,

--- a/docs/CARDS.md
+++ b/docs/CARDS.md
@@ -167,6 +167,99 @@ Fields:
 Same shape as `meta.view`. Typical use: `component: "line-chart"` with `xKey`
 and `yKey` pointing into the data rows.
 
+### `meta.calendar` — Calendar view config
+
+Opts the card into the Calendar view. The Calendar is a month grid
+where each day cell shows up to three emoji glyphs, one per card that
+has data for that day. Think of it as an at-a-glance "what did I log
+when" map.
+
+```json
+"calendar": {
+  "enabled":   true,
+  "component": "day-marker",
+  "marker":    "💊"
+}
+```
+
+Fields:
+- `enabled` (bool): include in Calendar. Default `false`.
+- `component` (string): `"day-marker"` is the only renderer today.
+- `marker` (string | object): which glyph to show. Three forms:
+
+**1. Static glyph** — the simplest. Same emoji every day the card has
+data for:
+
+```json
+"calendar": { "enabled": true, "component": "day-marker", "marker": "💊" }
+```
+
+If you omit `marker`, the card's `meta.emoji` is used.
+
+**2. `field-emoji`** — the glyph changes per day based on a field
+value. Great for categorical data where each value maps to its own
+emoji:
+
+```json
+"calendar": {
+  "enabled":   true,
+  "component": "day-marker",
+  "marker": {
+    "type":     "field-emoji",
+    "field":    "mood",
+    "emojiMap": { "1": "😩", "2": "😴", "3": "😐", "4": "🙂", "5": "😄" },
+    "fallback": "🙂"
+  }
+}
+```
+
+The resolver reads `row[field]` for that day, stringifies it, and looks
+it up in `emojiMap`. Missing / unmapped values fall through to
+`fallback` (or the card's `meta.emoji`, or `•`).
+
+**3. `trend-arrow`** — the glyph shows direction of change. Great for
+numeric metrics where you care about whether today's reading went up
+or down compared to the previous reading:
+
+```json
+"calendar": {
+  "enabled":   true,
+  "component": "day-marker",
+  "marker": {
+    "type":     "trend-arrow",
+    "field":    "kg",
+    "up":       "⬆️",
+    "down":     "⬇️",
+    "flat":     "➡️",
+    "fallback": "⚖️"
+  }
+}
+```
+
+- Compares today's `row[field]` to the most recent earlier row that
+  has a numeric value at the same field.
+- First entry ever (no previous) uses `fallback`.
+- `up` / `down` / `flat` default to `⬆️` / `⬇️` / `➡️` if omitted.
+
+**Where the day's row comes from.** The calendar flattens a card's
+`data` into `date -> row`:
+- Array of `{ date, ... }` rows: the last entry for each date wins.
+- Date-keyed object (`{ "2026-04-20": { ... } }`): the value is the row.
+- `items[].doses[]` (medication-schedule shape): the dose with the
+  latest `takenAt` for that day wins. Untaken doses (`takenAt: null`)
+  don't count.
+
+**Multiple entries per day.** When `maxReadingsPerDay > 1`, the latest
+same-day entry is the one the marker resolves against. Earlier
+same-day readings are still stored — just not reflected in the
+calendar glyph.
+
+**Extension space.** The marker object is discriminated by `type`; new
+kinds can ship without a schema bump. The roadmap includes
+`type: "threshold"` (range-to-emoji mirroring `display.thresholds`) and
+`type: "template"` (reuse the `{key:emoji}` mini-language). Until
+those land, the three forms above cover the common cases.
+
 ### `meta.writeable` — input form config
 
 ```json

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -470,6 +470,139 @@ time, skin redness).
 
 ---
 
+## Recipe 11 — Calendar marker that reflects the day's value
+
+For cards where you want the **month-grid calendar** to show more than
+just "had data". Two common patterns:
+
+### 11a — Field-driven emoji (mood, energy, stress)
+
+Add a `calendar` block to any card whose data has a categorical field.
+The marker resolver reads that field on the day's row and looks it up
+in an emoji map.
+
+```json
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "mood",
+    "label": "Mood",
+    "emoji": "🙂",
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{mood:emoji}",
+        "emojiMap": { "mood": { "1": "😩", "2": "😴", "3": "😐", "4": "🙂", "5": "😄" } }
+      }
+    },
+    "calendar": {
+      "enabled":   true,
+      "component": "day-marker",
+      "marker": {
+        "type":     "field-emoji",
+        "field":    "mood",
+        "emojiMap": { "1": "😩", "2": "😴", "3": "😐", "4": "🙂", "5": "😄" },
+        "fallback": "🙂"
+      }
+    },
+    "writeable": {
+      "fromWebapp": true,
+      "maxReadingsPerDay": 1,
+      "inputs": [
+        { "key": "mood", "type": "emoji-picker", "label": "Mood",
+          "emojis": ["😩", "😴", "😐", "🙂", "😄"],
+          "emitIndex": true, "required": true, "autoSubmit": true }
+      ]
+    }
+  },
+  "data": []
+}
+```
+
+**Key bits:**
+- `marker.field` — which field on the day's row to read (`mood` here).
+- `marker.emojiMap` — stringified-value to emoji. The view's own
+  `display.emojiMap` isn't reused; keep them in sync if you want the
+  calendar and the Today card to agree.
+- `marker.fallback` — glyph when the field is missing or unmapped.
+
+**Variations:**
+- Energy 1-5: sub in different emoji (`😴`/`😌`/`🙂`/`💪`/`🔥`).
+- Sleep quality: map `poor`/`ok`/`great` strings to `🌧️`/`⛅`/`☀️`.
+
+### 11b — Trend arrow (weight, HRV, RHR)
+
+For numeric metrics where you care about direction of change between
+consecutive entries. The resolver compares today's value to the most
+recent earlier entry's value at the same field.
+
+```json
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "weight",
+    "label": "Weight",
+    "emoji": "⚖️",
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": { "template": "{kg:round(1)}", "unit": "kg", "trendArrow": { "field": "kg" } }
+    },
+    "calendar": {
+      "enabled":   true,
+      "component": "day-marker",
+      "marker": {
+        "type":     "trend-arrow",
+        "field":    "kg",
+        "up":       "⬆️",
+        "down":     "⬇️",
+        "flat":     "➡️",
+        "fallback": "⚖️"
+      }
+    },
+    "writeable": {
+      "fromWebapp": true,
+      "maxReadingsPerDay": 1,
+      "inputs": [
+        { "key": "kg", "type": "number", "label": "Weight (kg)",
+          "min": 0, "max": 500, "step": 0.1, "required": true }
+      ]
+    }
+  },
+  "data": []
+}
+```
+
+**Key bits:**
+- `marker.field` — numeric field to compare. Dotted paths work for
+  nested shapes (`readings.kg`).
+- `up`/`down`/`flat` are optional; defaults are `⬆️`/`⬇️`/`➡️`.
+- `fallback` shows on the very first entry (no previous) or when the
+  current / previous value isn't numeric.
+
+**Variations:**
+- Invert semantics: for sleep hours, "up" is good — swap glyph colours
+  by picking different emoji (`💤`/`😵`/`➡️`).
+- Apply to HRV, steps, resting heart rate, grip strength — any
+  numeric daily reading.
+
+### Keeping it simple: static marker
+
+If you don't want per-day dynamics, the original shape still works:
+
+```json
+"calendar": { "enabled": true, "component": "day-marker", "marker": "💊" }
+```
+
+Every day the card has data gets the same glyph. `marker` can also be
+omitted, in which case the card's `meta.emoji` is used.
+
+See `data.example/mood.example.json` (field-emoji) and
+`data.example/weight.example.json` (trend-arrow).
+
+---
+
 ## Next steps
 
 - For the full manifest spec (every field, every input type, every

--- a/public/js/components/eh-calendar-view.js
+++ b/public/js/components/eh-calendar-view.js
@@ -5,13 +5,16 @@
 // whose meta.calendar.enabled is true AND which have data on that date.
 //
 // Data fetching strategy: on mount, fetch every card from /api/manifests
-// whose meta.calendar.enabled===true. Extract the dates that card has
-// data for (heuristic per data shape). Build a map: date -> [{id, marker, tooltip}].
+// whose meta.calendar.enabled===true. Extract that card's dated rows
+// (heuristic per data shape), then resolve each day's marker per the
+// card's meta.calendar.marker config (string, field-emoji, or
+// trend-arrow). Build a map: date -> [{id, marker, tooltip}].
 //
 // Navigation: < [Month Year] > with prev/next arrows and a "This month" shortcut.
 // Click a day -> navigate to /day/YYYY-MM-DD.
 
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
+import { extractDatedRows, resolveMarker } from '../lib/calendar-marker.esm.js';
 
 const DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 const MONTH_NAMES = ['January','February','March','April','May','June','July','August','September','October','November','December'];
@@ -63,12 +66,17 @@ export class EhCalendarView extends LitElement {
       for (const entry of fetched) {
         if (!entry) continue;
         const cal = entry.meta.calendar;
-        const marker = cal.marker || entry.meta.emoji || '•';
-        const dates = this._extractDates(entry.data);
-        for (const date of dates) {
+        const spec = cal.marker ?? entry.meta.emoji ?? '•';
+        const fallback = entry.meta.emoji || '•';
+        const dated = extractDatedRows(entry.data);
+        // Sorted ascending — trend-arrow needs this to find the previous row.
+        const sortedRows = Array.from(dated.values())
+          .filter(r => r && r.date)
+          .sort((a, b) => String(a.date).localeCompare(String(b.date)));
+        for (const [date, row] of dated) {
+          const marker = resolveMarker(spec, { date, row, sortedRows, fallback });
           if (!markers.has(date)) markers.set(date, []);
-          const existing = markers.get(date);
-          existing.push({
+          markers.get(date).push({
             id: entry.id,
             marker,
             tooltip: `${entry.meta.label || entry.id}`,
@@ -81,36 +89,6 @@ export class EhCalendarView extends LitElement {
     } finally {
       this._loading = false;
     }
-  }
-
-  // Try to find which dates a data block has entries for.
-  // Handles: arrays of {date}, objects keyed by date, items with doses[].
-  _extractDates(data) {
-    const dates = new Set();
-    if (!data) return dates;
-    if (Array.isArray(data)) {
-      for (const e of data) {
-        if (e && typeof e.date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(e.date)) dates.add(e.date);
-      }
-    } else if (typeof data === 'object') {
-      // Object keyed by date (mood, notes)
-      for (const k of Object.keys(data)) {
-        if (/^\d{4}-\d{2}-\d{2}$/.test(k)) dates.add(k);
-      }
-      // Items with doses[] (peptides)
-      if (Array.isArray(data.items)) {
-        for (const item of data.items) {
-          if (Array.isArray(item.doses)) {
-            for (const d of item.doses) {
-              if (d.takenAt && typeof d.scheduledDate === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(d.scheduledDate)) {
-                dates.add(d.scheduledDate);
-              }
-            }
-          }
-        }
-      }
-    }
-    return dates;
   }
 
   _shiftMonth(delta) {

--- a/public/js/components/health-chat.js
+++ b/public/js/components/health-chat.js
@@ -493,18 +493,31 @@ class HealthChat extends LitElement {
   }
 
   _stallWatcher() {
-    // Recover from visibility-change connection stalls
+    // Only abort an in-flight reply if the tab was actually backgrounded
+    // long enough that the OS likely froze the socket. Brief flickers
+    // (swipe away + swipe back within a second or two) leave the
+    // connection alive and the reply is about to arrive; aborting on
+    // those just loses good replies for no reason.
+    //
+    // iOS Safari and Android Chrome start freezing background tabs
+    // within ~5s. A 3s floor is a safe threshold that catches real
+    // backgrounding while ignoring flickers.
+    let hiddenAt = null;
     document.addEventListener('visibilitychange', () => {
-      if (document.visibilityState === 'visible') {
-        fetch('/api/config', { cache: 'no-store' }).catch(() => {});
-        if (this._loading && this._abortController) {
-          this._abortController.abort();
-          this._abortController = null;
-          this._loading = false;
-          const last = this._messages[this._messages.length - 1];
-          if (last && last.role === 'user') {
-            this._pushError('Connection interrupted — send again');
-          }
+      if (document.visibilityState === 'hidden') {
+        hiddenAt = Date.now();
+        return;
+      }
+      const hiddenMs = hiddenAt ? Date.now() - hiddenAt : 0;
+      hiddenAt = null;
+      if (hiddenMs < 3000) return;
+      if (this._loading && this._abortController) {
+        this._abortController.abort();
+        this._abortController = null;
+        this._loading = false;
+        const last = this._messages[this._messages.length - 1];
+        if (last && last.role === 'user') {
+          this._pushError('Tab was backgrounded: reply was lost. Send again.');
         }
       }
     });

--- a/public/js/lib/calendar-marker.esm.js
+++ b/public/js/lib/calendar-marker.esm.js
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// public/js/lib/calendar-marker.esm.js
+// ES-module twin of calendar-marker.js. Keep in sync — Node tests use the
+// UMD version, browser components use this one.
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function isDateStr(s) { return typeof s === 'string' && DATE_RE.test(s); }
+
+export function getValue(row, keyPath) {
+  if (!row || typeof row !== 'object' || !keyPath) return undefined;
+  if (keyPath.indexOf('.') === -1) return row[keyPath];
+  let cur = row;
+  for (const part of keyPath.split('.')) {
+    if (cur === null || cur === undefined) return undefined;
+    cur = cur[part];
+  }
+  return cur;
+}
+
+export function extractDatedRows(data) {
+  const out = new Map();
+  if (!data) return out;
+
+  if (Array.isArray(data)) {
+    for (const row of data) {
+      if (row && isDateStr(row.date)) out.set(row.date, row);
+    }
+    return out;
+  }
+
+  if (typeof data !== 'object') return out;
+
+  for (const k of Object.keys(data)) {
+    if (isDateStr(k) && data[k] && typeof data[k] === 'object') {
+      out.set(k, data[k]);
+    }
+  }
+
+  if (Array.isArray(data.items)) {
+    for (const item of data.items) {
+      if (!item || !Array.isArray(item.doses)) continue;
+      for (const dose of item.doses) {
+        if (!dose || !isDateStr(dose.scheduledDate)) continue;
+        if (!dose.takenAt) continue;
+        const existing = out.get(dose.scheduledDate);
+        if (!existing || (dose.takenAt > (existing.takenAt || ''))) {
+          out.set(dose.scheduledDate, dose);
+        }
+      }
+    }
+  }
+
+  return out;
+}
+
+export function resolveMarker(spec, ctx) {
+  const fallback = (ctx && ctx.fallback) || '•';
+
+  if (spec == null) return fallback;
+  if (typeof spec === 'string') return spec || fallback;
+  if (typeof spec !== 'object') return fallback;
+
+  const row = (ctx && ctx.row) || null;
+
+  switch (spec.type) {
+    case 'field-emoji': {
+      if (!spec.field || !spec.emojiMap || !row) {
+        return spec.fallback || fallback;
+      }
+      const v = getValue(row, spec.field);
+      if (v === null || v === undefined || v === '') {
+        return spec.fallback || fallback;
+      }
+      const hit = spec.emojiMap[String(v)] ?? spec.emojiMap[v];
+      if (hit) return hit;
+      return spec.fallback || fallback;
+    }
+
+    case 'trend-arrow': {
+      if (!spec.field || !row) {
+        return spec.fallback || fallback;
+      }
+      const currentVal = getValue(row, spec.field);
+      const currentNum = Number(currentVal);
+      if (currentVal === null || currentVal === undefined || Number.isNaN(currentNum)) {
+        return spec.fallback || fallback;
+      }
+      const currentDate = ctx && ctx.date;
+      const sorted = (ctx && ctx.sortedRows) || [];
+      let prevNum = null;
+      for (let i = sorted.length - 1; i >= 0; i--) {
+        const r = sorted[i];
+        if (!r || !r.date || r.date >= currentDate) continue;
+        const pv = getValue(r, spec.field);
+        const pn = Number(pv);
+        if (pv === null || pv === undefined || Number.isNaN(pn)) continue;
+        prevNum = pn;
+        break;
+      }
+      if (prevNum === null) {
+        return spec.fallback || fallback;
+      }
+      if (currentNum > prevNum) return spec.up || '⬆️';
+      if (currentNum < prevNum) return spec.down || '⬇️';
+      return spec.flat || '➡️';
+    }
+
+    default:
+      return spec.fallback || fallback;
+  }
+}

--- a/public/js/lib/calendar-marker.js
+++ b/public/js/lib/calendar-marker.js
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// public/js/lib/calendar-marker.js
+// Resolve a calendar cell's marker for a given date from meta.calendar.marker.
+// Dual-runtime: browser (ESM) + Node (CommonJS) via UMD pattern.
+//
+// meta.calendar.marker shapes:
+//   "💊"                                  → same glyph every logged day
+//   { type: "field-emoji", field, emojiMap, fallback? }
+//   { type: "trend-arrow", field, up?, down?, flat?, fallback? }
+//
+// Public surface:
+//   extractDatedRows(data) -> Map<"YYYY-MM-DD", row>
+//     Flattens array-of-{date}, date-keyed object, and items[].doses[] shapes
+//     into one map. When a date has multiple rows, the latest wins
+//     (last by array index for arrays; last by takenAt for doses).
+//
+//   resolveMarker(spec, ctx) -> string
+//     ctx = { date, row, sortedRows, fallback }
+//     sortedRows is dated rows ascending by date; used by trend-arrow.
+//     fallback is the glyph to use if the spec yields nothing.
+
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.ehCalendarMarker = factory();
+  }
+}(typeof self !== 'undefined' ? self : this, function () {
+
+  const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+  function isDateStr(s) { return typeof s === 'string' && DATE_RE.test(s); }
+
+  function getValue(row, keyPath) {
+    if (!row || typeof row !== 'object' || !keyPath) return undefined;
+    if (keyPath.indexOf('.') === -1) return row[keyPath];
+    let cur = row;
+    for (const part of keyPath.split('.')) {
+      if (cur === null || cur === undefined) return undefined;
+      cur = cur[part];
+    }
+    return cur;
+  }
+
+  // Flatten every known dated-row shape into Map<date, row>.
+  // On collision: later array entries win; for doses[], the dose with the
+  // most recent takenAt wins, or the last listed if no takenAt.
+  function extractDatedRows(data) {
+    const out = new Map();
+    if (!data) return out;
+
+    if (Array.isArray(data)) {
+      for (const row of data) {
+        if (row && isDateStr(row.date)) out.set(row.date, row);
+      }
+      return out;
+    }
+
+    if (typeof data !== 'object') return out;
+
+    // Date-keyed object (e.g. legacy notes)
+    for (const k of Object.keys(data)) {
+      if (isDateStr(k) && data[k] && typeof data[k] === 'object') {
+        out.set(k, data[k]);
+      }
+    }
+
+    // items[].doses[] shape (peptides / medication-schedule)
+    if (Array.isArray(data.items)) {
+      for (const item of data.items) {
+        if (!item || !Array.isArray(item.doses)) continue;
+        for (const dose of item.doses) {
+          if (!dose || !isDateStr(dose.scheduledDate)) continue;
+          if (!dose.takenAt) continue; // only count doses that were actually taken
+          const existing = out.get(dose.scheduledDate);
+          if (!existing || (dose.takenAt > (existing.takenAt || ''))) {
+            out.set(dose.scheduledDate, dose);
+          }
+        }
+      }
+    }
+
+    return out;
+  }
+
+  function resolveMarker(spec, ctx) {
+    const fallback = (ctx && ctx.fallback) || '•';
+
+    if (spec == null) return fallback;
+    if (typeof spec === 'string') return spec || fallback;
+    if (typeof spec !== 'object') return fallback;
+
+    const row = (ctx && ctx.row) || null;
+
+    switch (spec.type) {
+      case 'field-emoji': {
+        if (!spec.field || !spec.emojiMap || !row) {
+          return spec.fallback || fallback;
+        }
+        const v = getValue(row, spec.field);
+        if (v === null || v === undefined || v === '') {
+          return spec.fallback || fallback;
+        }
+        const hit = spec.emojiMap[String(v)] ?? spec.emojiMap[v];
+        if (hit) return hit;
+        return spec.fallback || fallback;
+      }
+
+      case 'trend-arrow': {
+        if (!spec.field || !row) {
+          return spec.fallback || fallback;
+        }
+        const currentVal = getValue(row, spec.field);
+        const currentNum = Number(currentVal);
+        if (currentVal === null || currentVal === undefined || Number.isNaN(currentNum)) {
+          return spec.fallback || fallback;
+        }
+        const currentDate = ctx && ctx.date;
+        const sorted = (ctx && ctx.sortedRows) || [];
+        // Find the most recent earlier entry that has a numeric value here.
+        let prevNum = null;
+        for (let i = sorted.length - 1; i >= 0; i--) {
+          const r = sorted[i];
+          if (!r || !r.date || r.date >= currentDate) continue;
+          const pv = getValue(r, spec.field);
+          const pn = Number(pv);
+          if (pv === null || pv === undefined || Number.isNaN(pn)) continue;
+          prevNum = pn;
+          break;
+        }
+        if (prevNum === null) {
+          return spec.fallback || fallback;
+        }
+        if (currentNum > prevNum) return spec.up || '⬆️';
+        if (currentNum < prevNum) return spec.down || '⬇️';
+        return spec.flat || '➡️';
+      }
+
+      default:
+        // Unknown type — render nothing special, just fall back.
+        return spec.fallback || fallback;
+    }
+  }
+
+  return { extractDatedRows, resolveMarker, getValue };
+}));

--- a/tests/calendar-marker.test.js
+++ b/tests/calendar-marker.test.js
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/calendar-marker.test.js
+// Pure-function tests for the calendar marker resolver used by the
+// Calendar view to pick a per-day glyph from a manifest's
+// meta.calendar.marker config.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+
+const { extractDatedRows, resolveMarker } =
+  require(path.join(__dirname, '..', 'public', 'js', 'lib', 'calendar-marker.js'));
+
+describe('extractDatedRows', () => {
+  test('empty / null input returns empty map', () => {
+    assert.equal(extractDatedRows(null).size, 0);
+    assert.equal(extractDatedRows(undefined).size, 0);
+    assert.equal(extractDatedRows([]).size, 0);
+    assert.equal(extractDatedRows({}).size, 0);
+  });
+
+  test('array of dated rows', () => {
+    const m = extractDatedRows([
+      { date: '2026-04-20', kg: 85 },
+      { date: '2026-04-21', kg: 86 },
+    ]);
+    assert.equal(m.size, 2);
+    assert.deepEqual(m.get('2026-04-20'), { date: '2026-04-20', kg: 85 });
+  });
+
+  test('array ignores rows with non-ISO date', () => {
+    const m = extractDatedRows([
+      { date: 'yesterday', kg: 1 },
+      { kg: 2 },
+      { date: '2026-04-20', kg: 3 },
+    ]);
+    assert.equal(m.size, 1);
+    assert.ok(m.has('2026-04-20'));
+  });
+
+  test('array collisions — later entry wins', () => {
+    const m = extractDatedRows([
+      { date: '2026-04-20', kg: 85 },
+      { date: '2026-04-20', kg: 86 },
+    ]);
+    assert.equal(m.get('2026-04-20').kg, 86);
+  });
+
+  test('date-keyed object', () => {
+    const m = extractDatedRows({
+      '2026-04-20': { mood: 4 },
+      '2026-04-21': { mood: 3 },
+      'not-a-date': { mood: 1 },
+    });
+    assert.equal(m.size, 2);
+    assert.equal(m.get('2026-04-20').mood, 4);
+  });
+
+  test('items[].doses[] — only taken doses count', () => {
+    const m = extractDatedRows({
+      items: [{
+        name: 'x',
+        doses: [
+          { scheduledDate: '2026-04-20', takenAt: '2026-04-20T08:00:00Z' },
+          { scheduledDate: '2026-04-21', takenAt: null },
+          { scheduledDate: '2026-04-22', takenAt: '2026-04-22T09:00:00Z' },
+        ],
+      }],
+    });
+    assert.equal(m.size, 2);
+    assert.ok(m.has('2026-04-20'));
+    assert.ok(m.has('2026-04-22'));
+    assert.ok(!m.has('2026-04-21'));
+  });
+
+  test('items[].doses[] — latest takenAt wins on same day', () => {
+    const m = extractDatedRows({
+      items: [{
+        name: 'x',
+        doses: [
+          { scheduledDate: '2026-04-20', takenAt: '2026-04-20T08:00:00Z', note: 'morning' },
+          { scheduledDate: '2026-04-20', takenAt: '2026-04-20T20:00:00Z', note: 'evening' },
+        ],
+      }],
+    });
+    assert.equal(m.get('2026-04-20').note, 'evening');
+  });
+});
+
+describe('resolveMarker', () => {
+  describe('static string', () => {
+    test('string spec returns string', () => {
+      assert.equal(resolveMarker('💊', {}), '💊');
+    });
+
+    test('empty string falls back', () => {
+      assert.equal(resolveMarker('', { fallback: '•' }), '•');
+    });
+
+    test('null / undefined spec falls back', () => {
+      assert.equal(resolveMarker(null, { fallback: '⚖️' }), '⚖️');
+      assert.equal(resolveMarker(undefined, { fallback: '⚖️' }), '⚖️');
+    });
+
+    test('no fallback — default to bullet', () => {
+      assert.equal(resolveMarker(null, {}), '•');
+    });
+  });
+
+  describe('field-emoji', () => {
+    const spec = {
+      type: 'field-emoji',
+      field: 'mood',
+      emojiMap: { '1': '😩', '2': '😴', '3': '😐', '4': '🙂', '5': '😄' },
+      fallback: '🙂',
+    };
+
+    test('resolves numeric value', () => {
+      const r = resolveMarker(spec, { row: { mood: 4 } });
+      assert.equal(r, '🙂');
+    });
+
+    test('resolves string value', () => {
+      const r = resolveMarker(spec, { row: { mood: '5' } });
+      assert.equal(r, '😄');
+    });
+
+    test('missing field returns spec.fallback', () => {
+      const r = resolveMarker(spec, { row: { wakeUps: 1 } });
+      assert.equal(r, '🙂');
+    });
+
+    test('unmapped value returns spec.fallback', () => {
+      const r = resolveMarker(spec, { row: { mood: 99 } });
+      assert.equal(r, '🙂');
+    });
+
+    test('no emojiMap returns fallback', () => {
+      const r = resolveMarker(
+        { type: 'field-emoji', field: 'mood', fallback: 'X' },
+        { row: { mood: 4 } }
+      );
+      assert.equal(r, 'X');
+    });
+
+    test('dotted-path field', () => {
+      const r = resolveMarker(
+        { type: 'field-emoji', field: 'stats.mood', emojiMap: { '4': '🙂' } },
+        { row: { stats: { mood: 4 } } }
+      );
+      assert.equal(r, '🙂');
+    });
+  });
+
+  describe('trend-arrow', () => {
+    const spec = {
+      type: 'trend-arrow',
+      field: 'kg',
+      up: '⬆️',
+      down: '⬇️',
+      flat: '➡️',
+      fallback: '•',
+    };
+
+    const rows = [
+      { date: '2026-04-18', kg: 85.0 },
+      { date: '2026-04-19', kg: 85.5 },
+      { date: '2026-04-20', kg: 85.5 },
+      { date: '2026-04-21', kg: 85.0 },
+    ];
+
+    test('up arrow when value increased', () => {
+      const r = resolveMarker(spec, {
+        date: '2026-04-19', row: rows[1], sortedRows: rows,
+      });
+      assert.equal(r, '⬆️');
+    });
+
+    test('flat arrow when value unchanged', () => {
+      const r = resolveMarker(spec, {
+        date: '2026-04-20', row: rows[2], sortedRows: rows,
+      });
+      assert.equal(r, '➡️');
+    });
+
+    test('down arrow when value decreased', () => {
+      const r = resolveMarker(spec, {
+        date: '2026-04-21', row: rows[3], sortedRows: rows,
+      });
+      assert.equal(r, '⬇️');
+    });
+
+    test('first entry (no previous) returns fallback', () => {
+      const r = resolveMarker(spec, {
+        date: '2026-04-18', row: rows[0], sortedRows: rows,
+      });
+      assert.equal(r, '•');
+    });
+
+    test('skips rows missing the field', () => {
+      const withGaps = [
+        { date: '2026-04-18', kg: 85.0 },
+        { date: '2026-04-19' },             // gap
+        { date: '2026-04-20', kg: 84.0 },    // should compare to 85.0, not the gap
+      ];
+      const r = resolveMarker(spec, {
+        date: '2026-04-20', row: withGaps[2], sortedRows: withGaps,
+      });
+      assert.equal(r, '⬇️');
+    });
+
+    test('non-numeric current value returns fallback', () => {
+      const r = resolveMarker(spec, {
+        date: '2026-04-20', row: { date: '2026-04-20', kg: 'heavy' }, sortedRows: rows,
+      });
+      assert.equal(r, '•');
+    });
+
+    test('uses default arrows when none specified', () => {
+      const minimal = { type: 'trend-arrow', field: 'kg' };
+      const r = resolveMarker(minimal, {
+        date: '2026-04-19', row: rows[1], sortedRows: rows,
+      });
+      assert.equal(r, '⬆️');
+    });
+  });
+
+  describe('unknown type', () => {
+    test('falls back rather than throwing', () => {
+      const r = resolveMarker(
+        { type: 'not-a-thing', fallback: 'X' },
+        { row: {} }
+      );
+      assert.equal(r, 'X');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #45. Stops chat from throwing away good replies just because the tab briefly lost focus.

## Why

\`_stallWatcher\` aborted any in-flight \`/api/chat\` request on every \`visibilitychange\` back to visible, no matter how brief. That was defensive cover for the old server-crash bug (#41 / #42), but with the server now crash-proof the blanket abort just costs us replies on incidental tab flickers.

## How

- Track when the tab went hidden; on return, compute the duration.
- If \`hiddenMs < 3000\`: do nothing, let the reply arrive.
- If \`hiddenMs >= 3000\`: abort and show "Tab was backgrounded: reply was lost. Send again." — surfaces the dead-socket case instantly instead of waiting out the 120s fetch timeout.
- 3s is below the threshold where mobile OSes (iOS Safari, Android Chrome) start freezing background tabs, so real backgrounding is caught while flickers pass through.
- Dropped the \`fetch('/api/config')\` keep-alive nudge: a ping to a separate endpoint can't rescue the chat request's socket.

## Testing

- [x] Existing chat tests pass.
- [ ] Manual: on klebbtest, send a message, tab-switch briefly, tab back — reply should arrive.
- [ ] Manual: on klebbtest, send a message, lock phone for 10s, unlock — should see the new error message immediately instead of a 120s hang.