### PR TITLE
feat(chat): server-side chat history so it syncs across devices (#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Chat conversation is now stored server-side and follows the user
+  across devices.** Previously the chat widget had no memory past the
+  current panel-open, so switching from phone to laptop lost the
+  conversation. The transcript now lives in
+  `$HEALTH_HOME/chat/history.json`, behind the existing WebAuthn
+  session cookie, and is loaded whenever the widget mounts.
+  New endpoints: `GET /api/chat/history`,
+  `PUT /api/chat/history { messages: [...] }`, and
+  `DELETE /api/chat/history` (the "New chat" button path).
+  A new 📝 button in the chat header clears the conversation after a
+  confirm prompt. Only real `user` / `assistant` turns are persisted
+  (errors and transient state stay in-memory); audio blobs aren't
+  serialised and are re-synthesised on demand. The server caps the
+  payload at 512 KB and trims to the last 200 turns. Saves from the
+  client are debounced 500 ms so rapid turns don't spam. (#55)
 - **Calendar markers can now reflect the day's value, not just "had
   data".** `meta.calendar.marker` accepts either a string (static
   glyph, existing behaviour) or an object describing a per-day glyph.

--- a/config/paths.js
+++ b/config/paths.js
@@ -61,6 +61,8 @@ const AUTO_EXPORT_DIR = process.env.HEALTH_AUTO_EXPORT_DIR || path.join(DATA_DIR
 const SESSIONS_DIR = process.env.HEALTH_SESSIONS_DIR || path.join(HEALTH_HOME, 'sessions');
 const CREDENTIALS_DIR = process.env.HEALTH_CREDENTIALS_DIR || path.join(HEALTH_HOME, 'credentials');
 const ARCHIVE_DIR = process.env.HEALTH_ARCHIVE_DIR || path.join(DATA_DIR, '_archive');
+const CHAT_DIR = process.env.HEALTH_CHAT_DIR || path.join(HEALTH_HOME, 'chat');
+const CHAT_HISTORY_FILE = path.join(CHAT_DIR, 'history.json');
 const CONFIG_PATH = process.env.HEALTH_CONFIG_PATH || path.join(HEALTH_HOME, 'config.json');
 
 // WebAuthn credentials + sessions. Historical installs may have stored these
@@ -84,7 +86,7 @@ const WEBAUTHN_SESSIONS_FILE = resolveWebauthnSessionsFile();
 // Ensure directories exist where we expect to write.
 // Does NOT create HEALTH_HOME itself (bootstrap responsibility).
 function ensureWritableDirs() {
-  const toEnsure = [DATA_DIR];
+  const toEnsure = [DATA_DIR, CHAT_DIR];
   if (WEBAUTHN_CREDENTIALS_FILE.startsWith(CREDENTIALS_DIR)) toEnsure.push(CREDENTIALS_DIR);
   if (WEBAUTHN_SESSIONS_FILE.startsWith(SESSIONS_DIR)) toEnsure.push(SESSIONS_DIR);
   for (const dir of toEnsure) {
@@ -100,6 +102,8 @@ module.exports = {
   SESSIONS_DIR,
   CREDENTIALS_DIR,
   ARCHIVE_DIR,
+  CHAT_DIR,
+  CHAT_HISTORY_FILE,
   CONFIG_PATH,
   WEBAUTHN_CREDENTIALS_FILE,
   WEBAUTHN_SESSIONS_FILE,

--- a/public/js/components/health-chat.js
+++ b/public/js/components/health-chat.js
@@ -461,12 +461,81 @@ class HealthChat extends LitElement {
     this._playingMsgId = null;
     this._msgCounter = 0;
     // msgId -> { url, autoplayed }
+    // Not persisted: blob URLs don't survive a reload and re-synthesise on
+    // demand from the server anyway.
     this._audioCache = new Map();
     this._agentName = 'Chat';
     this._agentEmoji = '\u{1F4AC}'; // 💬 speech balloon
+    this._saveTimer = null;
     this._checkVoiceAvailability();
     this._loadInstance();
+    this._loadHistory();
     this._stallWatcher();
+  }
+
+  // ---------- History persistence ----------
+  //
+  // Chat history is kept on the server at /api/chat/history so it follows
+  // the user across devices. Saves are debounced so a flurry of updates
+  // during a reply (e.g. streaming placeholder patches) become one PUT.
+
+  async _loadHistory() {
+    try {
+      const r = await fetch('/api/chat/history', { cache: 'no-store' });
+      if (!r.ok) return;
+      const j = await r.json();
+      const arr = Array.isArray(j.messages) ? j.messages : [];
+      const clean = arr.filter(m =>
+        m && typeof m === 'object' &&
+        (m.role === 'user' || m.role === 'assistant') &&
+        typeof m.content === 'string'
+      );
+      // Only adopt server state if nothing's been added locally in the
+      // meantime (pathological: user typed before the initial GET landed).
+      if (this._messages.length === 0) {
+        this._messages = clean;
+        this._msgCounter = clean.reduce((max, m) => {
+          const n = parseInt(String(m.id).match(/^m(\d+)/)?.[1] || '0', 10);
+          return n > max ? n : max;
+        }, 0);
+      }
+    } catch {}
+  }
+
+  _saveHistory() {
+    if (this._saveTimer) clearTimeout(this._saveTimer);
+    this._saveTimer = setTimeout(() => this._flushHistory(), 500);
+  }
+
+  async _flushHistory() {
+    this._saveTimer = null;
+    const keep = this._messages
+      .filter(m => m.role === 'user' || m.role === 'assistant')
+      .map(m => ({ id: m.id, role: m.role, content: m.content }))
+      .slice(-200);
+    try {
+      await fetch('/api/chat/history', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: keep }),
+        cache: 'no-store',
+      });
+    } catch {}
+  }
+
+  async _clearHistory() {
+    if (this._messages.some(m => m.role === 'user' || m.role === 'assistant')) {
+      if (!confirm('Start a new chat? The current conversation will be cleared.')) return;
+    }
+    stopSharedAudio();
+    this._audioCache.forEach(v => { try { URL.revokeObjectURL(v.url); } catch {} });
+    this._audioCache.clear();
+    this._messages = [];
+    this._playingMsgId = null;
+    if (this._saveTimer) { clearTimeout(this._saveTimer); this._saveTimer = null; }
+    try {
+      await fetch('/api/chat/history', { method: 'DELETE', cache: 'no-store' });
+    } catch {}
   }
 
   async _checkVoiceAvailability() {
@@ -529,11 +598,13 @@ class HealthChat extends LitElement {
     const id = `m${++this._msgCounter}-${Date.now()}`;
     const msg = { id, role, content, ...extra };
     this._messages = [...this._messages, msg];
+    this._saveHistory();
     return id;
   }
 
   _updateMsg(id, patch) {
     this._messages = this._messages.map(m => m.id === id ? { ...m, ...patch } : m);
+    this._saveHistory();
   }
 
   _pushError(content) {
@@ -941,6 +1012,13 @@ class HealthChat extends LitElement {
             ${this._voiceAvailable ? html`
               <button class="speed-btn" @click=${this._cyclePlaybackSpeed} title="Playback speed">${this._playbackSpeed}x</button>
             ` : html`<span class="chat-header-sub">Health Assistant</span>`}
+            <button
+              class="speed-btn"
+              @click=${this._clearHistory}
+              aria-label="New chat"
+              title="New chat"
+              style="margin-left: 6px; min-width: 28px;"
+            >\u{1F4DD}</button>
             <button
               class="speed-btn"
               @click=${this._toggle}

--- a/server.js
+++ b/server.js
@@ -827,6 +827,58 @@ const server = http.createServer(async (req, res) => {
       return;
     }
 
+    // /api/chat/history — per-instance chat transcript so it follows the
+    // user across devices. Single-user-per-instance model (WebAuthn auth),
+    // so no per-user keying is needed.
+    if (parts[0] === 'chat' && parts[1] === 'history' && parts.length === 2) {
+      if (req.method === 'GET') {
+        const existing = readJSONFile(PATHS.CHAT_HISTORY_FILE);
+        const messages = Array.isArray(existing?.messages) ? existing.messages : [];
+        return sendJSON(res, { messages });
+      }
+      if (req.method === 'PUT') {
+        let body = '';
+        let tooBig = false;
+        req.on('data', c => {
+          body += c;
+          if (body.length > 512 * 1024) { tooBig = true; req.destroy(); }
+        });
+        req.on('end', () => {
+          if (tooBig) return sendJSON(res, { error: 'History too large' }, 413);
+          let parsed;
+          try { parsed = JSON.parse(body); }
+          catch { return sendJSON(res, { error: 'Invalid JSON' }, 400); }
+          const incoming = Array.isArray(parsed?.messages) ? parsed.messages : null;
+          if (!incoming) return sendJSON(res, { error: 'messages array required' }, 400);
+          const clean = incoming
+            .filter(m => m && typeof m === 'object'
+              && (m.role === 'user' || m.role === 'assistant')
+              && typeof m.content === 'string')
+            .map(m => ({
+              id: typeof m.id === 'string' ? m.id : `m${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+              role: m.role,
+              content: m.content,
+            }))
+            .slice(-200);
+          try {
+            fs.mkdirSync(PATHS.CHAT_DIR, { recursive: true });
+            const tmp = PATHS.CHAT_HISTORY_FILE + '.tmp';
+            fs.writeFileSync(tmp, JSON.stringify({ messages: clean }));
+            fs.renameSync(tmp, PATHS.CHAT_HISTORY_FILE);
+          } catch (e) {
+            return sendJSON(res, { error: 'Could not persist history' }, 500);
+          }
+          return sendJSON(res, { ok: true, messages: clean });
+        });
+        return;
+      }
+      if (req.method === 'DELETE') {
+        try { fs.unlinkSync(PATHS.CHAT_HISTORY_FILE); } catch {}
+        return sendJSON(res, { ok: true });
+      }
+      return sendJSON(res, { error: 'Method not allowed' }, 405);
+    }
+
     // POST /api/chat — proxy to chat gateway chat completions
     // Body: { messages: [...], voiceMode?: boolean }
     //   voiceMode=true → append "keep replies short/conversational" to system prompt

--- a/tests/chat-history-api.test.js
+++ b/tests/chat-history-api.test.js
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/chat-history-api.test.js
+// Server-side chat transcript so the conversation follows the user across
+// devices. GET returns whatever's stored (empty array on fresh install);
+// PUT replaces; DELETE clears; everything 401s without a session cookie.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const {
+  createSandbox, cleanupSandbox, spawnServer, req, fakeAuthState,
+} = require('./helpers/sandbox');
+
+describe('chat history API', () => {
+  let sandbox, server, auth;
+
+  before(async () => {
+    auth = fakeAuthState('op');
+    sandbox = createSandbox({
+      credentials: auth.credentials,
+      sessions: auth.sessions,
+    });
+    server = await spawnServer(sandbox);
+  });
+  after(async () => {
+    if (server) await server.kill();
+    cleanupSandbox(sandbox);
+  });
+
+  test('GET returns empty on a fresh install', async () => {
+    const res = await req(server.baseUrl, '/api/chat/history', { cookie: auth.cookie });
+    assert.equal(res.status, 200);
+    assert.deepEqual(res.json, { messages: [] });
+  });
+
+  test('PUT replaces the transcript; GET returns what was stored', async () => {
+    const messages = [
+      { id: 'm1', role: 'user',      content: 'hi' },
+      { id: 'm2', role: 'assistant', content: 'hello' },
+    ];
+    const put = await req(server.baseUrl, '/api/chat/history', {
+      method: 'PUT',
+      cookie: auth.cookie,
+      body: { messages },
+    });
+    assert.equal(put.status, 200);
+    assert.equal(put.json.ok, true);
+    assert.deepEqual(put.json.messages, messages);
+
+    const get = await req(server.baseUrl, '/api/chat/history', { cookie: auth.cookie });
+    assert.deepEqual(get.json.messages, messages);
+  });
+
+  test('DELETE clears the transcript; subsequent GET is empty', async () => {
+    // Prime so there's something to clear.
+    await req(server.baseUrl, '/api/chat/history', {
+      method: 'PUT',
+      cookie: auth.cookie,
+      body: { messages: [{ id: 'x', role: 'user', content: 'seed' }] },
+    });
+    const del = await req(server.baseUrl, '/api/chat/history', {
+      method: 'DELETE',
+      cookie: auth.cookie,
+    });
+    assert.equal(del.status, 200);
+    const get = await req(server.baseUrl, '/api/chat/history', { cookie: auth.cookie });
+    assert.deepEqual(get.json.messages, []);
+  });
+
+  test('PUT strips messages with unknown roles and non-string content', async () => {
+    const put = await req(server.baseUrl, '/api/chat/history', {
+      method: 'PUT',
+      cookie: auth.cookie,
+      body: { messages: [
+        { id: 'keep1', role: 'user',      content: 'ok' },
+        { id: 'drop1', role: 'system',    content: 'pretend prompt injection' },
+        { id: 'drop2', role: 'assistant', content: { nested: 'object' } },
+        { id: 'drop3', role: 'tool',      content: 'fake tool call' },
+        { id: 'keep2', role: 'assistant', content: 'reply' },
+      ] },
+    });
+    assert.equal(put.status, 200);
+    assert.deepEqual(put.json.messages.map(m => m.id), ['keep1', 'keep2']);
+  });
+
+  test('PUT trims to the last 200 turns', async () => {
+    const messages = Array.from({ length: 300 }, (_, i) => ({
+      id: `m${i}`, role: i % 2 ? 'assistant' : 'user', content: String(i),
+    }));
+    const put = await req(server.baseUrl, '/api/chat/history', {
+      method: 'PUT',
+      cookie: auth.cookie,
+      body: { messages },
+    });
+    assert.equal(put.status, 200);
+    assert.equal(put.json.messages.length, 200);
+    assert.equal(put.json.messages[0].id, 'm100');
+    assert.equal(put.json.messages[199].id, 'm299');
+  });
+
+  test('PUT without a messages array returns 400', async () => {
+    const res = await req(server.baseUrl, '/api/chat/history', {
+      method: 'PUT',
+      cookie: auth.cookie,
+      body: { nope: true },
+    });
+    assert.equal(res.status, 400);
+  });
+
+  test('unauthenticated requests return 401 on every verb', async () => {
+    for (const method of ['GET', 'PUT', 'DELETE']) {
+      const res = await req(server.baseUrl, '/api/chat/history', {
+        method,
+        body: method === 'PUT' ? { messages: [] } : null,
+      });
+      assert.equal(res.status, 401, `${method} without cookie should 401`);
+    }
+  });
+
+  test('history file is persisted under HEALTH_HOME/chat/', async () => {
+    await req(server.baseUrl, '/api/chat/history', {
+      method: 'PUT',
+      cookie: auth.cookie,
+      body: { messages: [{ id: 'persist', role: 'user', content: 'disk check' }] },
+    });
+    const onDisk = path.join(sandbox, 'chat', 'history.json');
+    assert.ok(fs.existsSync(onDisk), 'history.json should exist');
+    const parsed = JSON.parse(fs.readFileSync(onDisk, 'utf8'));
+    assert.equal(parsed.messages[0].content, 'disk check');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #55. Chat history moves from browser \`localStorage\` to the server, so a conversation started on one device is visible from any other device logged into the same Klebb instance.

## Why

The previous localStorage design scoped the transcript to the browser profile: phone vs laptop didn't share, private windows didn't share, clearing site data wiped it. That surprised users and didn't match the rest of Klebb's single-source-of-truth story.

## How

- Storage: \`\$HEALTH_HOME/chat/history.json\`, atomic write via tmp + rename. Single file per instance (Klebb is single-user-per-instance; no per-user keying needed).
- Three new endpoints behind the existing session-cookie auth:
  - \`GET /api/chat/history\` → \`{ messages: [...] }\`
  - \`PUT /api/chat/history { messages: [...] }\` → replaces
  - \`DELETE /api/chat/history\` → clears
- Server sanitisation: strips anything that isn't \`role: 'user' | 'assistant'\` + string \`content\`, caps request at 512 KB (\`413\` if over), trims to the last 200 turns.
- Client: fetches history on mount, debounces saves 500 ms. The existing 📝 "New chat" button now issues \`DELETE\` + clears local state.
- Audio blobs aren't persisted; the text (whether typed, STT, or TTS'd back) is all that's stored. Playback controls re-fetch on demand.

## Testing

- [x] New \`tests/chat-history-api.test.js\` — 8 cases: GET empty, PUT round-trip, DELETE clears, strips unknown roles + non-string content, trims to 200, 400 on bad body, 401 on every verb without a cookie, file actually lands at \`\$HEALTH_HOME/chat/history.json\`.
- [x] Full suite: 348 / 348 passing locally.
- [ ] Manual: send on phone, open on laptop — conversation is present. Tap "New chat" on either → cleared on both after next load.

## Out of scope

- Multi-thread / conversation list.
- Real-time sync between devices (still refresh-to-see).
- Encryption at rest (filesystem perms are the boundary, same as every other Klebb data file).