### PR TITLE
fix(voice): install ffmpeg in Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Voice notes now work in the Docker image.** The runtime container
+  was missing `ffmpeg`, which the server shells out to for transcoding
+  browser audio (WebM/Opus/MP4) into the 16 kHz mono WAV that Fish ASR
+  reliably accepts. Recording a voice note returned "audio transcode
+  failed; spawn ffmpeg ENOENT". `ffmpeg` is now installed in the
+  runtime stage. Bare-metal deploys were unaffected because ffmpeg
+  already existed on the host. (#57)
 - **Chat no longer aborts an in-flight reply on every momentary tab
   switch.** The visibility-change watcher used to abort any pending
   `/api/chat` request the instant the tab became visible again,

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,12 @@ LABEL org.opencontainers.image.title="Klebb" \
 #   ca-certificates — HTTPS trust anchors for outbound calls (chat gateway, Fish Audio)
 #   tini            — proper PID 1 so SIGTERM reaches Node cleanly
 #   gosu            — privilege drop from root -> klebb in the entrypoint
+#   ffmpeg          — transcode browser voice-note audio to 16 kHz mono WAV for Fish ASR
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates \
       tini \
       gosu \
+      ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 # Non-root runtime user


### PR DESCRIPTION
## Summary

- Voice notes in the chat widget failed in Docker with `spawn ffmpeg ENOENT`.
- The runtime Dockerfile now installs `ffmpeg` alongside `ca-certificates`, `tini`, and `gosu`.

## Why

`server.js` spawns `ffmpeg` to transcode arbitrary incoming browser audio (WebM/Opus/MP4) into 16 kHz mono WAV before handing it to Fish ASR, which in practice only reliably accepts WAV. The runtime stage never installed ffmpeg, so the first voice note in any containerised deploy returned `audio transcode failed; spawn ffmpeg ENOENT`. Bare-metal systemd hosts happened to have ffmpeg installed independently, which is why this bug only showed up on Docker.

## How

Add `ffmpeg` to the `apt-get install` list in the runtime stage of `Dockerfile`, with a comment matching the style of the other runtime deps.

## Testing

- [ ] `docker build -t klebb-test .` succeeds.
- [ ] `docker run --rm klebb-test ffmpeg -version` prints a version banner.
- [ ] Hit the test instance's chat widget, record a voice note, confirm transcription returns (no ENOENT).

Fixes #57