### PR TITLE
feat(ui): masonry layout for Today view cards

### DIFF
--- a/public/js/components/eh-view-renderer.js
+++ b/public/js/components/eh-view-renderer.js
@@ -97,6 +97,33 @@ export class EhViewRenderer extends LitElement {
         grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
       }
     }
+
+    /* Masonry layout via CSS multi-column. Used outside of reorder mode
+       so short cards pack upwards into the gaps left by taller cards
+       (e.g. Symptoms/Appointments filling space under Medication/Mood).
+       Reorder mode stays on grid because SortableJS misbehaves inside
+       column layouts. */
+    .masonry {
+      column-count: 1;
+      column-gap: 12px;
+      margin-top: 6px;
+    }
+    .masonry > * {
+      break-inside: avoid;
+      margin-bottom: 12px;
+      /* display:block on the wrapper so column layout treats it as one
+         unit rather than trying to split its contents. */
+      display: block;
+    }
+    .masonry > .slot-top {
+      column-span: all;
+    }
+    @media (min-width: 768px) {
+      .masonry { column-count: 2; }
+    }
+    @media (min-width: 1100px) {
+      .masonry { column-count: 3; }
+    }
     .loading, .empty {
       padding: 40px 20px;
       text-align: center;
@@ -516,7 +543,7 @@ export class EhViewRenderer extends LitElement {
       <div class="sr-live" aria-live="polite" aria-atomic="true">${this._ariaAnnouncement}</div>
       ${this._renderReorderBar()}
       ${this._renderErrorPill()}
-      <div class="grid">
+      <div class=${this._reorderMode ? 'grid' : 'masonry'}>
         ${this.cards.map(c => this._renderCard(c))}
       </div>
     `;


### PR DESCRIPTION
## Summary

Pack shorter cards upwards into gaps left by taller neighbours on multi-column viewports. Previously, Symptoms and Appointments landed in a second row that only began after the tallest first-row card (Schedule), leaving large blank areas below Medication Schedule and Mood.

## Why

CSS Grid rows equalise height, so a tall card in row 1 forces every other row-1 card to stretch and pushes follow-ups into a new row. Masonry packs each column independently, so short cards fill the gaps.

## How

- Added a `.masonry` container (CSS multi-column, `column-count` 1/2/3 responsive) alongside the existing `.grid`.
- `_reorderMode` still uses `.grid` because SortableJS doesn't play nice with column layouts.
- Top-slot cards (greeting banner) get `column-span: all` to stay full-width.
- `break-inside: avoid` on each card wrapper prevents splitting across columns.

## Testing

- [x] Verified on klebbtest via a side-channel rebuild: short cards pack upward correctly at all three breakpoints.
- [x] Drag-to-reorder still works (reorder mode swaps back to grid).
- [ ] Manual check: keyboard reorder still works.
- [ ] Manual check: top-slot cards (greeting banner) still full-width.

Fixes #59