### PR TITLE
feat(chat): tool-calling agent loop so chat can invoke manifest endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Chat agent actually calls the manifest endpoints now.** #61 shipped
+  `POST /api/manifests` + `DELETE /api/manifests/:id` and taught the
+  system prompt about them, but the in-app agent (Klebbius) had no way
+  to make an HTTP call from inside a chat turn — the chat proxy just
+  forwarded `{model, messages}` to the gateway. This PR wires an
+  OpenAI-compatible tool-calling agent loop into `/api/chat` so the
+  model can call three new tools that dispatch directly into the
+  registry (no HTTP hop to self): `create_manifest(manifest)`,
+  `delete_manifest(id)`, and `list_manifests()`. The loop re-calls
+  the gateway on `finish_reason: "tool_calls"`, appending the
+  assistant turn + tool-result messages each iteration, capped at 5
+  iterations so a misbehaving model can't spin forever. Tool errors
+  (e.g. 409 duplicate id, 422 bad id) come back as the tool-result
+  content so the model can self-correct in the same chat turn; only
+  the final text reply reaches the widget. Tool rounds are not
+  persisted to chat history. System prompt is updated to name the
+  tools (the existing HTTP list stays as reference material for
+  external agents with `AGENT_API_TOKEN`). Verified end-to-end
+  against a live LiteLLM → Bedrock gateway. (#63)
 - **Chat agent can now create and delete cards directly.** Two new
   endpoints land alongside the existing manifest surface:
   `POST /api/manifests` creates a brand new card from a full manifest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Chat agent can now create and delete cards directly.** Two new
+  endpoints land alongside the existing manifest surface:
+  `POST /api/manifests` creates a brand new card from a full manifest
+  body (201 on success, 409 on duplicate id, 400/422 on validation
+  failure); `DELETE /api/manifests/:id` removes a card and unlinks its
+  file. Auth matches the rest of `/api/` (session cookie or bearer
+  token). The create endpoint is intentionally lenient: any JSON whose
+  `$schema` is `klebb.datafile.v1` and whose `meta.id` + `meta.label`
+  pass validation is accepted, so agents can ship cards with renderer
+  names that don't exist yet (they render as an unknown-card placeholder
+  and data persists). `DEFAULT_HEALTH_SYSTEM_PROMPT` is augmented with a
+  full authoring guide: every built-in renderer, every input type,
+  schedule shape, calendar marker type, `meta.reports` config, and two
+  worked examples. New example manifests cover the three renderers that
+  previously had no proof-by-example: `example-schedule-timeline`,
+  `example-adherence-report`, `example-table-list`.
+  `MANIFEST-SCHEMA.md`, `docs/CARDS.md`, and `docs/CHAT-AGENT.md`
+  document `meta.reports` per renderer, `meta.category`, and the new
+  endpoints. (#61)
+- **Masonry layout on the Today view.** Cards with short content
+  (Symptoms, Appointments) now pack upwards into gaps left by taller
+  neighbours on multi-column viewports, rather than waiting for the
+  tallest row-mate to finish before starting a new row. Reorder mode
+  keeps the grid layout because SortableJS misbehaves in column
+  layouts. (#59)
 - **Calendar markers can now reflect the day's value, not just "had
   data".** `meta.calendar.marker` accepts either a string (static
   glyph, existing behaviour) or an object describing a per-day glyph.

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ COPY --from=deps --chown=klebb:klebb /app/node_modules ./node_modules
 COPY --chown=klebb:klebb package.json ./
 COPY --chown=klebb:klebb server.js ./
 COPY --chown=klebb:klebb auth ./auth
+COPY --chown=klebb:klebb chat ./chat
 COPY --chown=klebb:klebb config ./config
 COPY --chown=klebb:klebb manifests ./manifests
 COPY --chown=klebb:klebb public ./public

--- a/MANIFEST-SCHEMA.md
+++ b/MANIFEST-SCHEMA.md
@@ -41,6 +41,10 @@ Klebb dashboard. For the human-friendly tour, see
                                       //   so inserts can use gaps (150, 250…)
   "enabled":  true,                   // optional bool, default true;
                                       //   false hides card from EVERY view
+  "category": "vitals",               // optional free-form grouping label;
+                                      //   pass-through (not used in core
+                                      //   layout today; surfaces as data
+                                      //   for agents and future filters)
   "view":     { ... },                // optional view config
   "trends":   { ... },                // optional trends config
   "calendar": { ... },                // optional calendar config
@@ -319,6 +323,64 @@ All support: `key` (required), `label`, `required`, `default`, `help`.
 
 ---
 
+## Reports config (`meta.reports`)
+
+The Reports view has its own small set of renderers geared at summarised
+or tabular output. Config shape depends on the renderer:
+
+### `adherence-report`
+
+Summarises scheduled-item adherence across a rolling window. Expects
+the card's `data` to follow the schedule-block shape (`{groups, items,
+items[].doses}` — see `medication-schedule.example.json` and
+`example-adherence-report.example.json`).
+
+```json
+"reports": {
+  "enabled": true,
+  "component": "adherence-report",
+  "showCompliance": true,     // optional, default true
+  "showInventory":  true      // optional
+}
+```
+
+### `schedule-timeline`
+
+Stacked timeline of scheduled items across a window. Typically shares
+the same `data` shape as `adherence-report`.
+
+```json
+"reports": {
+  "enabled": true,
+  "component": "schedule-timeline",
+  "windowDays": 14,           // window to display
+  "showPast":   true,
+  "showFuture": true
+}
+```
+
+### `table-list`
+
+Generic rowset-as-table, useful for blood panels, SNPs, lab results,
+and any ad-hoc tabular data. `data` is an array of row objects.
+
+```json
+"reports": {
+  "enabled": true,
+  "component": "table-list",
+  "columns": [
+    { "field": "date",   "header": "Date" },
+    { "field": "test",   "header": "Test" },
+    { "field": "result", "header": "Result", "format": "number" }
+  ],
+  "sort": { "field": "date", "dir": "desc" }
+}
+```
+
+See `data.example/example-*.example.json` for runnable versions of each.
+
+---
+
 ## Built-in renderers
 
 Use one of these names in `meta.view.component` / `meta.trends.component`:
@@ -441,3 +503,57 @@ changes will bump to v2 and ship a migration script.
 Non-breaking additions (new optional fields, new input types, new
 renderers) do NOT require a version bump — v1 manifests are
 forward-compatible as long as they don't rely on fields introduced later.
+
+---
+
+## HTTP API — create / delete cards
+
+In addition to the existing read + data-replace endpoints (see
+`docs/CHAT-AGENT.md`), two endpoints let callers author new cards
+without touching the filesystem directly:
+
+### `POST /api/manifests`
+
+Creates a brand new card. Body is a full manifest object. Auth matches
+the rest of the `/api/` surface (session cookie for the webapp, Bearer
+token via `AGENT_API_TOKEN` for agents).
+
+Required fields: `$schema === "klebb.datafile.v1"`, `meta.id` matching
+`/^[a-z0-9][a-z0-9._-]*$/` (max 64 chars, not in the reserved set
+`_archive`, `_virtual`, `_meta`, `auto-export`, `reports`, `index`),
+and `meta.label`. Everything else is pass-through.
+
+| Status | Meaning |
+|--------|---------|
+| 201 | Created. Response `{ok, id, source: "<filename>"}` |
+| 400 | Malformed: bad JSON body, wrong `$schema`, missing `meta.id`/`meta.label` |
+| 401 | No auth |
+| 409 | `meta.id` already in use (in-memory or on-disk) |
+| 422 | `meta.id` fails the sanitiser (bad chars, reserved name, path escape) |
+| 500 | Filesystem write failed |
+
+The endpoint is intentionally lenient: any renderer name is accepted,
+including ones not (yet) implemented. Unknown renderers fall through to
+`eh-unknown-card` until a real renderer ships — see "Ad-hoc manifests"
+below.
+
+### `DELETE /api/manifests/:id`
+
+Removes the card from the registry and deletes its file. Same auth
+model.
+
+| Status | Meaning |
+|--------|---------|
+| 200 | Removed. Response `{ok, id}` |
+| 401 | No auth |
+| 404 | Unknown id |
+| 500 | Unlink failed |
+
+### Ad-hoc manifests
+
+When an agent wants a renderer that doesn't exist yet, the
+recommendation is to POST anyway with the best-guess component name.
+The card persists; the renderer registry falls back to the unknown-card
+placeholder on the frontend; a human can retrofit a dedicated renderer
+later without migration. This is the supported path for extending the
+system without a code change.

--- a/chat/tools.js
+++ b/chat/tools.js
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// chat/tools.js
+// OpenAI-compatible tool schemas + dispatch for the Klebbius agent loop.
+// Tools call into the manifest registry directly — no HTTP hop back to
+// /api/manifests. Registry writes are sync atomic tmp+rename so this is
+// safe to do inline inside a chat request.
+
+const registry = require('../manifests/registry');
+
+const TOOL_DEFS = [
+  {
+    type: 'function',
+    function: {
+      name: 'create_manifest',
+      description:
+        "Create a new card on the user's dashboard. Pass a full klebb.datafile.v1 manifest object. Returns {ok, id, source} on success; validation errors come back as {error} — read the message and retry with a fixed manifest (e.g. pick a different id on 'duplicate id', sanitise bad chars on 'invalid id').",
+      parameters: {
+        type: 'object',
+        properties: {
+          manifest: {
+            type: 'object',
+            description:
+              'Full klebb.datafile.v1 manifest. Must include $schema, meta.id (matching /^[a-z0-9][a-z0-9._-]*$/), and meta.label. See the system prompt for the full field reference.',
+            additionalProperties: true,
+          },
+        },
+        required: ['manifest'],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'delete_manifest',
+      description:
+        'Delete a card and its manifest file. Only call after confirming intent with the user — data goes with the file. Prefer suggesting meta.enabled:false (hide without losing data) if the user is unsure.',
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'Manifest id, e.g. "blood-pressure".' },
+        },
+        required: ['id'],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'list_manifests',
+      description:
+        "Return a compact list of all cards currently on the user's dashboard. Useful to re-check state mid-conversation (e.g. after you just created a card, or before proposing an id to check it's not taken).",
+      parameters: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+    },
+  },
+];
+
+// Execute a single tool_call from an assistant response. Always returns a
+// string (stringified JSON) — both success and failure paths. The string
+// becomes the `content` of the matching {role:"tool"} message on the next
+// gateway request.
+function dispatchToolCall(tc) {
+  const name = tc.function?.name;
+  let args = {};
+  try {
+    args = JSON.parse(tc.function?.arguments || '{}');
+  } catch (e) {
+    return JSON.stringify({ error: 'invalid JSON in tool arguments: ' + e.message });
+  }
+  try {
+    switch (name) {
+      case 'create_manifest': {
+        const result = registry.createManifest(args.manifest);
+        return JSON.stringify({ ok: true, ...result });
+      }
+      case 'delete_manifest': {
+        const result = registry.deleteManifest(args.id);
+        return JSON.stringify({ ok: true, ...result });
+      }
+      case 'list_manifests': {
+        const rows = registry.list().map(c => ({
+          id: c.id,
+          label: c.meta?.label || c.id,
+          description: (c.description || '').split('\n')[0].slice(0, 200),
+          enabled: c.meta?.enabled !== false,
+        }));
+        return JSON.stringify({ cards: rows });
+      }
+      default:
+        return JSON.stringify({ error: 'unknown tool: ' + name });
+    }
+  } catch (e) {
+    return JSON.stringify({ error: e.message || String(e) });
+  }
+}
+
+module.exports = { TOOL_DEFS, dispatchToolCall };

--- a/config/env.js
+++ b/config/env.js
@@ -147,9 +147,150 @@ The data layout is card-specific — rely on each manifest's \`meta\` and \`desc
 - \`GET /api/manifests/:id\` → full manifest (meta + data)
 - \`GET /api/manifests/:id/data\` → just the data block
 - \`POST /api/manifests/:id/data\` with \`{ data: [...] }\` → replace data
+- \`POST /api/manifests\` with a full manifest body → create a brand new card (201; 409 if id exists)
+- \`DELETE /api/manifests/:id\` → remove a card and its file (200; 404 if missing)
 - \`GET /api/views/today\` / \`/trends\` / \`/reports\` / \`/calendar\` → cards enabled for that view
 
 All requests require \`Authorization: Bearer <AGENT_API_TOKEN>\` when that env var is set.
+
+## Creating and deleting cards
+
+You are the primary way the user creates new cards. When they describe a tracker, dashboard tile, or anything "I want to log X" → design a manifest and POST it. Don't print JSON and ask them to save a file; just create it.
+
+### Minimum required fields
+
+\`\`\`
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "blood-pressure",      // match /^[a-z0-9][a-z0-9._-]*$/, max 64 chars
+    "label": "Blood Pressure"
+  },
+  "data": []                     // any shape; may be [] or {} or omitted
+}
+\`\`\`
+
+Everything else is optional pass-through. The endpoint is lenient: if the renderer you want doesn't exist yet, POST the manifest anyway with your best-guess \`meta.view.component\` — unknown components render as a placeholder card, and the data persists. This is the ad-hoc escape hatch. Use it freely; a human can retrofit a real renderer later.
+
+### Full manifest shape
+
+\`\`\`
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "blood-pressure",
+    "label": "Blood Pressure",
+    "emoji": "🩺",
+    "order": 500,                // sparse: 100, 200, 300…
+    "enabled": true,             // master off-switch
+    "category": "vitals",        // free-form grouping label
+    "view":      { "enabled": true, "component": "<renderer>", ...config },
+    "trends":    { "enabled": true, "component": "line-chart", ...config },
+    "calendar":  { "enabled": true, "component": "day-marker", "marker": ... },
+    "reports":   { "enabled": true, "component": "<reports renderer>", ...config },
+    "writeable": {
+      "fromWebapp": true,
+      "todayAllowed": true,
+      "pastAllowed":  false,
+      "futureAllowed":false,
+      "maxReadingsPerDay": 1,
+      "inputs": [ { "key":"...", "label":"...", "type":"...", ... } ]
+    },
+    "prompt":   { "enabled": false, "mode": "modal", "whenMissing": true }
+  },
+  "description": "Free text for future agents about this file's data shape.",
+  "data": []
+}
+\`\`\`
+
+### Known renderers (meta.view.component)
+
+- \`generic-card\` — single latest value + delta; data is \`[{date, <field>...}]\`. Pairs with \`meta.view.display\` template.
+- \`list-card\` — persistent chronological list of entries; data is \`[{date, ...fields}]\`.
+- \`checklist-card\` — tickable daily items; data \`{items:[{id,doses:[...]}]}\`-ish.
+- \`schedule-card\` — scheduled doses/events with recurrence; data tracks check-offs.
+- \`schedule-timeline\` — stacked timeline across a window; reads \`meta.schedule\`.
+- \`markdown-doc\` — renders markdown; data \`{markdown:"..."}\`.
+- \`line-chart\` — time-series chart (aliases: \`area-chart\`, \`bar-chart\`); data \`[{date,value}]\` or rows keyed via \`meta.trends.field\`/\`series\`.
+- \`table-list\` — arbitrary rowset as a table; columns via \`meta.reports.columns\`.
+- \`adherence-report\` — % adherence report over a window.
+- \`greeting-banner\` — top-of-today banner; uses \`meta.view.slot:"top"\`.
+- \`day-marker\` — calendar-only marker renderer (used in \`meta.calendar.component\`).
+
+Unknown renderer names render as placeholders but the manifest still saves. This is on purpose.
+
+### Input types (meta.writeable.inputs[*].type)
+
+\`number\`, \`stepper\`, \`text\`, \`textarea\`, \`select\`, \`emoji-picker\`, \`colour\` (alias \`color\`), \`checkbox\`, \`date\`, \`time\`, \`rating\`.
+
+Each input carries \`key\`, \`label\`, \`required\`, \`default\`, \`help\`, plus per-type options (\`min\`/\`max\`/\`step\`/\`placeholder\`/\`options\`/\`emojis\` etc.).
+
+### Schedule shapes (meta.schedule or per-item schedule)
+
+- \`{ "type":"daily", "times_per_day":N }\`
+- \`{ "type":"weekly", "on_days":["Mon","Wed"] }\`
+- \`{ "type":"every_n_days", "interval_days":3, "start_date":"YYYY-MM-DD" }\`
+- \`{ "type":"on_off", "on_days":["Mon","Tue"], "off_days":["Sat","Sun"] }\`
+- \`{ "type":"phased", "loading":{"days":[...],"duration_weeks":N}, "maintenance":{"days":[...]} }\`
+- \`{ "type":"as_needed" }\`
+
+### Calendar marker types (meta.calendar.marker)
+
+- Static emoji: \`"marker": "💊"\`
+- \`{ "type":"field-emoji", "field":"mood" }\` — emoji pulled from row data
+- \`{ "type":"trend-arrow", "field":"kg", "goodDirection":"down" }\`
+- \`{ "type":"threshold", "field":"systolic", "bands":[{"max":120,"emoji":"✅"},...] }\`
+- \`{ "type":"template", "template":"{kg:round(1)}kg" }\`
+
+### meta.reports config by renderer
+
+- \`adherence-report\`: \`{ enabled, component:"adherence-report", showCompliance?, showInventory? }\`
+- \`schedule-timeline\`: \`{ enabled, component:"schedule-timeline", windowDays, showPast?, showFuture? }\`
+- \`table-list\`: \`{ enabled, component:"table-list", columns:[{field,header,format?}], sort:{field,dir} }\`
+
+### Example 1 — structured (blood pressure)
+
+\`\`\`
+POST /api/manifests
+{
+  "$schema":"klebb.datafile.v1",
+  "meta":{
+    "id":"blood-pressure","label":"Blood Pressure","emoji":"🩺","order":550,
+    "view":{"enabled":true,"component":"list-card","primaryField":"systolic","secondaryTemplate":"{systolic}/{diastolic} mmHg"},
+    "trends":{"enabled":true,"component":"line-chart","series":[{"field":"systolic","label":"Systolic"},{"field":"diastolic","label":"Diastolic"}]},
+    "writeable":{"fromWebapp":true,"todayAllowed":true,"pastAllowed":true,
+      "inputs":[
+        {"key":"systolic","label":"Systolic","type":"number","min":60,"max":220,"required":true},
+        {"key":"diastolic","label":"Diastolic","type":"number","min":40,"max":140,"required":true}
+      ]}
+  },
+  "description":"Home BP readings. Take morning + evening; log both values.",
+  "data":[]
+}
+\`\`\`
+
+### Example 2 — ad-hoc (renderer not yet implemented)
+
+\`\`\`
+POST /api/manifests
+{
+  "$schema":"klebb.datafile.v1",
+  "meta":{
+    "id":"sleep-architecture","label":"Sleep Architecture","emoji":"🌙",
+    "view":{"enabled":true,"component":"sleep-stages-sunburst","legend":true}
+  },
+  "description":"Overnight sleep-stage breakdown. Renderer not yet implemented — placeholder until one ships.",
+  "data":{"stages":[{"name":"REM","pct":22},{"name":"Deep","pct":18},{"name":"Light","pct":50},{"name":"Awake","pct":10}]}
+}
+\`\`\`
+
+### Deletion
+
+\`\`\`
+DELETE /api/manifests/blood-pressure  →  { "ok": true, "id": "blood-pressure" }
+\`\`\`
+
+Only delete a card after confirming intent with the user — manifest files contain their data history and the delete removes it. If in doubt, set \`meta.enabled:false\` instead (hides the card without losing data).
 
 ## Workflow
 

--- a/config/env.js
+++ b/config/env.js
@@ -141,7 +141,17 @@ Each card file is a v2 manifest:
 
 The data layout is card-specific — rely on each manifest's \`meta\` and \`description\` fields, not hardcoded knowledge.
 
-## HTTP API (when configured as an external agent)
+## Tools you can call
+
+You, ${CHAT_AGENT_NAME}, are embedded in the dashboard itself. You act by calling tools — never by printing JSON and asking the user to save a file, and never by describing an HTTP request as prose.
+
+- \`create_manifest(manifest)\` → create a new card on the dashboard. Pass the full manifest object. Returns \`{ok, id, source}\` on success. Validation errors come back as \`{error: "..."}\` — read the message and retry with a corrected manifest (e.g. pick a different id on "duplicate id", sanitise chars on "invalid id: format").
+- \`delete_manifest(id)\` → remove a card and its file. Only call after confirming intent with the user. If the user is unsure, prefer suggesting they hide it via meta.enabled:false (no tool for that today; tell them where the Settings toggle is).
+- \`list_manifests()\` → current card list. Useful mid-conversation after a create, or to check an id isn't already taken before proposing one.
+
+## HTTP API (reference for external agents)
+
+External agents running outside this app (with \`AGENT_API_TOKEN\`) hit these endpoints directly. You do NOT use them — you call the tools above. The list is reference material so you can answer user questions about the API surface.
 
 - \`GET /api/manifests\` → list all cards
 - \`GET /api/manifests/:id\` → full manifest (meta + data)
@@ -151,11 +161,11 @@ The data layout is card-specific — rely on each manifest's \`meta\` and \`desc
 - \`DELETE /api/manifests/:id\` → remove a card and its file (200; 404 if missing)
 - \`GET /api/views/today\` / \`/trends\` / \`/reports\` / \`/calendar\` → cards enabled for that view
 
-All requests require \`Authorization: Bearer <AGENT_API_TOKEN>\` when that env var is set.
+All external requests require \`Authorization: Bearer <AGENT_API_TOKEN>\` when that env var is set.
 
 ## Creating and deleting cards
 
-You are the primary way the user creates new cards. When they describe a tracker, dashboard tile, or anything "I want to log X" → design a manifest and POST it. Don't print JSON and ask them to save a file; just create it.
+You are the primary way the user creates new cards. When they describe a tracker, dashboard tile, or anything "I want to log X" → design a manifest and call \`create_manifest\`. Don't print JSON and ask them to save a file; just create it. If the tool returns \`{error: "..."}\`, read it and retry with a corrected manifest in the same turn.
 
 ### Minimum required fields
 
@@ -250,8 +260,9 @@ Each input carries \`key\`, \`label\`, \`required\`, \`default\`, \`help\`, plus
 
 ### Example 1 — structured (blood pressure)
 
+Call \`create_manifest\` with this \`manifest\` argument:
+
 \`\`\`
-POST /api/manifests
 {
   "$schema":"klebb.datafile.v1",
   "meta":{
@@ -271,8 +282,9 @@ POST /api/manifests
 
 ### Example 2 — ad-hoc (renderer not yet implemented)
 
+Call \`create_manifest\` with this \`manifest\` argument:
+
 \`\`\`
-POST /api/manifests
 {
   "$schema":"klebb.datafile.v1",
   "meta":{
@@ -286,11 +298,9 @@ POST /api/manifests
 
 ### Deletion
 
-\`\`\`
-DELETE /api/manifests/blood-pressure  →  { "ok": true, "id": "blood-pressure" }
-\`\`\`
+Call \`delete_manifest\` with the card's id, e.g. \`delete_manifest("blood-pressure")\`. Returns \`{ok, id}\` on success; \`{error: "unknown manifest: ..."}\` if the id doesn't exist.
 
-Only delete a card after confirming intent with the user — manifest files contain their data history and the delete removes it. If in doubt, set \`meta.enabled:false\` instead (hides the card without losing data).
+Only delete a card after confirming intent with the user — manifest files contain their data history and the delete removes it. If in doubt, suggest hiding the card via \`meta.enabled:false\` (toggled in Settings) instead of deleting.
 
 ## Workflow
 

--- a/data.example/example-adherence-report.example.json
+++ b/data.example/example-adherence-report.example.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "example-adherence-report",
+    "label": "Example: Adherence Report",
+    "emoji": "✅",
+    "category": "example",
+    "order": 9200,
+    "reports": {
+      "enabled": true,
+      "component": "adherence-report",
+      "showCompliance": true,
+      "showInventory": true
+    }
+  },
+  "description": "Demonstrates the adherence-report renderer. Reads items[].doses[] from a schedule-shaped data block and computes % compliance over a rolling window. Each dose row is {scheduledDate, takenAt}; leave takenAt null to represent a missed dose. Not shown on Today or Trends — the card only surfaces under the Reports view.",
+  "data": {
+    "groups": [
+      {
+        "id": "daily-meds",
+        "label": "Daily medications",
+        "items": ["morning-dose", "evening-dose"]
+      }
+    ],
+    "items": [
+      {
+        "name": "morning-dose",
+        "dose": "1 tablet",
+        "schedule": { "frequency": "daily", "times_per_day": 1 },
+        "cycles": [{ "type": "on", "start": "2026-04-01", "end": "2026-12-31" }],
+        "doses": [
+          { "scheduledDate": "2026-04-25", "takenAt": "2026-04-25T08:00:00+10:00" },
+          { "scheduledDate": "2026-04-26", "takenAt": "2026-04-26T08:04:00+10:00" },
+          { "scheduledDate": "2026-04-27", "takenAt": null },
+          { "scheduledDate": "2026-04-28", "takenAt": "2026-04-28T08:11:00+10:00" },
+          { "scheduledDate": "2026-04-29", "takenAt": "2026-04-29T07:58:00+10:00" },
+          { "scheduledDate": "2026-04-30", "takenAt": "2026-04-30T08:03:00+10:00" }
+        ]
+      },
+      {
+        "name": "evening-dose",
+        "dose": "1 tablet",
+        "schedule": { "frequency": "daily", "times_per_day": 1 },
+        "cycles": [{ "type": "on", "start": "2026-04-01", "end": "2026-12-31" }],
+        "doses": [
+          { "scheduledDate": "2026-04-25", "takenAt": "2026-04-25T20:10:00+10:00" },
+          { "scheduledDate": "2026-04-26", "takenAt": null },
+          { "scheduledDate": "2026-04-27", "takenAt": "2026-04-27T20:20:00+10:00" },
+          { "scheduledDate": "2026-04-28", "takenAt": "2026-04-28T20:15:00+10:00" },
+          { "scheduledDate": "2026-04-29", "takenAt": "2026-04-29T20:05:00+10:00" },
+          { "scheduledDate": "2026-04-30", "takenAt": null }
+        ]
+      }
+    ]
+  }
+}

--- a/data.example/example-schedule-timeline.example.json
+++ b/data.example/example-schedule-timeline.example.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "example-schedule-timeline",
+    "label": "Example: Schedule Timeline",
+    "emoji": "📅",
+    "category": "example",
+    "order": 9100,
+    "trends": {
+      "enabled": true,
+      "component": "schedule-timeline",
+      "groupBy": "groups",
+      "itemsPath": "items"
+    },
+    "reports": {
+      "enabled": true,
+      "component": "schedule-timeline",
+      "windowDays": 14,
+      "showPast": true,
+      "showFuture": true
+    }
+  },
+  "description": "Demonstrates the schedule-timeline renderer: a stacked weekly timeline with two grouped scheduled items, one daily and one weekly. Drops doses[] rows to mark check-offs (scheduledDate + takenAt); omit takenAt to record a missed dose. The timeline renders across the window configured in meta.reports (windowDays).",
+  "data": {
+    "groups": [
+      {
+        "id": "morning",
+        "label": "Morning routine",
+        "items": ["vitamin-d", "cold-shower"]
+      }
+    ],
+    "items": [
+      {
+        "name": "vitamin-d",
+        "dose": "5000 IU",
+        "schedule": { "frequency": "daily", "times_per_day": 1 },
+        "cycles": [{ "type": "on", "start": "2026-04-01", "end": "2026-12-31" }],
+        "doses": [
+          { "scheduledDate": "2026-04-28", "takenAt": "2026-04-28T07:12:00+10:00" },
+          { "scheduledDate": "2026-04-29", "takenAt": "2026-04-29T07:04:00+10:00" },
+          { "scheduledDate": "2026-04-30", "takenAt": null }
+        ]
+      },
+      {
+        "name": "cold-shower",
+        "dose": "3 min",
+        "schedule": { "frequency": "weekly", "on_days": ["Mon", "Wed", "Fri"] },
+        "cycles": [{ "type": "on", "start": "2026-04-01", "end": "2026-12-31" }],
+        "doses": [
+          { "scheduledDate": "2026-04-28", "takenAt": "2026-04-28T07:30:00+10:00" }
+        ]
+      }
+    ]
+  }
+}

--- a/data.example/example-table-list.example.json
+++ b/data.example/example-table-list.example.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "example-table-list",
+    "label": "Example: Table List",
+    "emoji": "📋",
+    "category": "example",
+    "order": 9300,
+    "reports": {
+      "enabled": true,
+      "component": "table-list",
+      "columns": [
+        { "field": "date",   "header": "Date" },
+        { "field": "test",   "header": "Test" },
+        { "field": "result", "header": "Result" },
+        { "field": "unit",   "header": "Unit" }
+      ],
+      "sort": { "field": "date", "dir": "desc" }
+    }
+  },
+  "description": "Demonstrates the table-list renderer under the Reports view. Useful for ad-hoc tabular data: blood panels, SNP reports, lab results, etc. Rows are free-form objects; columns are declared in meta.reports.columns. Each row object's keys should match the declared `field` names.",
+  "data": [
+    { "date": "2026-04-29", "test": "HbA1c",       "result": 5.2,  "unit": "%" },
+    { "date": "2026-04-29", "test": "Fasting glucose", "result": 4.8,  "unit": "mmol/L" },
+    { "date": "2026-04-29", "test": "LDL-C",       "result": 2.4,  "unit": "mmol/L" },
+    { "date": "2026-04-29", "test": "HDL-C",       "result": 1.6,  "unit": "mmol/L" },
+    { "date": "2026-04-29", "test": "Triglycerides", "result": 0.9, "unit": "mmol/L" },
+    { "date": "2026-01-15", "test": "HbA1c",       "result": 5.3,  "unit": "%" }
+  ]
+}

--- a/docs/CARDS.md
+++ b/docs/CARDS.md
@@ -86,6 +86,13 @@ The master kill-switch. When `false`, the card is hidden from **every** view
 The data stays in the file; only visibility is suppressed. Toggle via the
 Settings page, or just edit the file yourself.
 
+### `meta.category` (optional)
+
+Free-form grouping label (e.g. `"vitals"`, `"health"`, `"example"`). Used
+by a handful of example manifests and surfaced as data for agents and
+future filters, but not wired into the core layout today. Pass-through:
+the registry stores whatever you give it.
+
 ### `meta.prompt` (optional, default: no prompt)
 
 Turns the card into a **modal-prompt** on app open. Once per day per card,
@@ -166,6 +173,56 @@ Fields:
 
 Same shape as `meta.view`. Typical use: `component: "line-chart"` with `xKey`
 and `yKey` pointing into the data rows.
+
+### `meta.reports` — the Reports view config
+
+Opts the card into the Reports view. Three renderers live here, each
+with its own config. See `MANIFEST-SCHEMA.md` for the full spec; a
+quick tour:
+
+**`adherence-report`** — % adherence for scheduled items (reads
+`data.items[].doses[]`):
+
+```json
+"reports": {
+  "enabled": true,
+  "component": "adherence-report",
+  "showCompliance": true,
+  "showInventory":  true
+}
+```
+
+**`schedule-timeline`** — stacked timeline of scheduled items:
+
+```json
+"reports": {
+  "enabled": true,
+  "component": "schedule-timeline",
+  "windowDays": 14,
+  "showPast": true,
+  "showFuture": true
+}
+```
+
+**`table-list`** — rowset-as-table; rows are free-form objects. Useful
+for blood panels, SNPs, anything ad-hoc:
+
+```json
+"reports": {
+  "enabled": true,
+  "component": "table-list",
+  "columns": [
+    { "field": "date",   "header": "Date" },
+    { "field": "test",   "header": "Test" },
+    { "field": "result", "header": "Result", "format": "number" }
+  ],
+  "sort": { "field": "date", "dir": "desc" }
+}
+```
+
+Runnable examples live at `data.example/example-adherence-report.example.json`,
+`data.example/example-schedule-timeline.example.json`, and
+`data.example/example-table-list.example.json`.
 
 ### `meta.calendar` — Calendar view config
 

--- a/docs/CHAT-AGENT.md
+++ b/docs/CHAT-AGENT.md
@@ -71,9 +71,11 @@ authenticates with a bearer token instead of a WebAuthn session cookie.
 | Method | Path | Purpose |
 |--------|------|---------|
 | `GET` | `/api/manifests` | List all cards |
+| `POST` | `/api/manifests` | Create a new card from a full manifest body |
 | `GET` | `/api/manifests/:id` | Fetch full manifest |
 | `GET` | `/api/manifests/:id/data` | Fetch just the data block |
 | `POST` | `/api/manifests/:id/data` | Replace the data block |
+| `DELETE` | `/api/manifests/:id` | Remove the card and its file |
 | `POST` | `/api/manifests/reorder` | Reassign `meta.order` across cards |
 | `GET` | `/api/views/:view` | List cards for a view |
 | `GET` | `/api/settings/cards` | List all cards with enable state |
@@ -123,6 +125,64 @@ The registry validates `$schema` and core `meta.*` fields, but does **not**
 impose a schema on the `data` block. Whatever you write is what gets read
 back. This keeps card authorship flexible but means agents must honour the
 per-card convention (typically `{ date: "YYYY-MM-DD", ...fields }` rows).
+
+### Creating and deleting cards
+
+Agents can author brand new cards without filesystem access. `POST
+/api/manifests` takes a full manifest body and writes it to
+`$HEALTH_HOME/data/<meta.id>.json`:
+
+```http
+POST /api/manifests
+Authorization: Bearer $KLEBB_AGENT_TOKEN
+Content-Type: application/json
+
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "blood-pressure",
+    "label": "Blood Pressure",
+    "emoji": "🩺",
+    "view":      { "enabled": true, "component": "list-card" },
+    "writeable": {
+      "fromWebapp": true, "todayAllowed": true, "pastAllowed": true,
+      "inputs": [
+        {"key":"systolic","label":"Systolic","type":"number","required":true},
+        {"key":"diastolic","label":"Diastolic","type":"number","required":true}
+      ]
+    }
+  },
+  "description": "Home BP readings.",
+  "data": []
+}
+```
+
+| Status | Meaning |
+|--------|---------|
+| 201 | Created (`{ok, id, source}`) |
+| 400 | Malformed: bad JSON, wrong `$schema`, missing `meta.id`/`meta.label` |
+| 401 | No auth |
+| 409 | `meta.id` already in use |
+| 422 | `meta.id` fails the sanitiser (format / reserved / path escape) |
+| 500 | Filesystem write failed |
+
+`meta.id` must match `/^[a-z0-9][a-z0-9._-]*$/`, max 64 chars, and not
+be one of the reserved names (`_archive`, `_virtual`, `_meta`,
+`auto-export`, `reports`, `index`). Everything else is pass-through —
+unknown renderer names are accepted on purpose; they render as a
+placeholder card until a matching renderer ships. See
+`MANIFEST-SCHEMA.md` for the full field reference.
+
+Deletion mirrors the create path:
+
+```http
+DELETE /api/manifests/blood-pressure
+Authorization: Bearer $KLEBB_AGENT_TOKEN
+```
+
+Returns `{ok, id}` on success, 404 if the id is unknown. The file is
+unlinked; any data it contained is gone. Prefer `meta.enabled:false`
+if you only want to hide the card.
 
 ### Disabled cards still accept writes
 

--- a/manifests/registry.js
+++ b/manifests/registry.js
@@ -19,6 +19,14 @@ const PATHS = require('../config/paths');
 const SUPPORTED_SCHEMAS = ['klebb.datafile.v1'];
 const RESERVED_DIR_PREFIX = '_';
 
+// Id sanitisation rules — shared between the create endpoint and any caller
+// that wants to validate a manifest shape without hitting disk.
+const ID_PATTERN = /^[a-z0-9][a-z0-9._-]*$/;
+const ID_MAX_LENGTH = 64;
+const RESERVED_IDS = new Set([
+  '_archive', '_virtual', '_meta', 'auto-export', 'reports', 'index',
+]);
+
 let _entries = new Map();   // id -> { meta, description, schema, data, source, version }
 let _errors = [];           // [{file, error}]
 let _watcher = null;
@@ -45,6 +53,48 @@ function _scanDir(dir) {
   return found;
 }
 
+// Validate the shape of a parsed manifest object. Shared by the on-disk load
+// path (`_parse`) and the HTTP create endpoint. Structural failures throw
+// with a prefix the server handler maps to 400/422:
+//   "missing $schema" / "unsupported $schema:" / "missing meta" / "missing
+//   meta.id" / "missing meta.label"          -> 400
+//   "invalid id: format" / "invalid id: reserved"  -> 422
+// `opts.strictId` applies the id-format sanitiser (filename-safe, reserved
+// names, length). Load-time validation is lenient about id format so legacy
+// files keep loading; the create path sets strictId:true.
+function validateManifestShape(parsed, opts = {}) {
+  const { strictId = false } = opts;
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('missing $schema');
+  }
+  const schema = parsed.$schema;
+  if (!schema) throw new Error('missing $schema');
+  if (!SUPPORTED_SCHEMAS.includes(schema)) {
+    throw new Error(`unsupported $schema: ${schema}`);
+  }
+  if (!parsed.meta || typeof parsed.meta !== 'object' || Array.isArray(parsed.meta)) {
+    throw new Error('missing meta block');
+  }
+  if (!parsed.meta.id || typeof parsed.meta.id !== 'string') {
+    throw new Error('missing meta.id');
+  }
+  if (strictId) {
+    if (parsed.meta.id.length > ID_MAX_LENGTH) {
+      throw new Error('invalid id: format (too long)');
+    }
+    if (!ID_PATTERN.test(parsed.meta.id)) {
+      throw new Error('invalid id: format (must match /^[a-z0-9][a-z0-9._-]*$/)');
+    }
+    if (RESERVED_IDS.has(parsed.meta.id)) {
+      throw new Error('invalid id: reserved name');
+    }
+  }
+  if (!parsed.meta.label || typeof parsed.meta.label !== 'string') {
+    throw new Error('missing meta.label');
+  }
+  return parsed;
+}
+
 function _parse(filepath) {
   let raw;
   try {
@@ -58,26 +108,24 @@ function _parse(filepath) {
   } catch (e) {
     return { error: `invalid JSON: ${e.message}` };
   }
+  // Silently skip legacy shapes that pre-date the manifest schema.
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    // Bare arrays / primitives are legacy non-manifest data files. Skip silently.
     return { skip: 'legacy format (not a manifest object)' };
   }
-  const schema = parsed.$schema;
-  if (!schema) {
-    // Not a manifest file — legacy data. Skip silently.
+  if (!parsed.$schema) {
     return { skip: 'no $schema' };
   }
-  if (!SUPPORTED_SCHEMAS.includes(schema)) {
-    return { error: `unsupported $schema: ${schema}` };
-  }
-  if (!parsed.meta || typeof parsed.meta !== 'object') {
-    return { error: 'missing meta block' };
-  }
-  if (!parsed.meta.id || typeof parsed.meta.id !== 'string') {
-    return { error: 'meta.id required' };
-  }
-  if (!parsed.meta.label || typeof parsed.meta.label !== 'string') {
-    return { error: 'meta.label required' };
+  try {
+    validateManifestShape(parsed);
+  } catch (e) {
+    // Translate internal messages to the legacy error strings callers + tests
+    // expect. Keeps backwards-compatible error text.
+    const msg = e.message;
+    if (msg.startsWith('unsupported $schema')) return { error: msg };
+    if (msg === 'missing meta block') return { error: 'missing meta block' };
+    if (msg === 'missing meta.id') return { error: 'meta.id required' };
+    if (msg === 'missing meta.label') return { error: 'meta.label required' };
+    return { error: msg };
   }
   return { manifest: parsed };
 }
@@ -314,6 +362,69 @@ function _hasRenderableData(entry, viewName) {
   return true;
 }
 
+// Create a brand-new manifest from a caller-supplied object. Writes it to
+// $HEALTH_HOME/data/<meta.id>.json atomically and populates the in-memory
+// cache so the card is visible immediately (the fs.watch reload will
+// converge later, idempotently). Throws with a prefix the HTTP handler
+// maps to a status code:
+//   "missing *" / "unsupported $schema:"  -> 400
+//   "invalid id: *"                        -> 422
+//   "duplicate id: *"                      -> 409
+// Pass-through: every other field (meta.view, meta.writeable, meta.reports,
+// meta.schedule, data, description, etc.) is stored verbatim. Unknown
+// renderer names are allowed on purpose — the frontend falls back to
+// eh-unknown-card so the card still persists and a human can retrofit.
+function createManifest(manifestObj) {
+  const parsed = validateManifestShape(manifestObj, { strictId: true });
+  const id = parsed.meta.id;
+  if (_entries.has(id)) {
+    throw new Error(`duplicate id: ${id}`);
+  }
+  const targetPath = path.join(PATHS.DATA_DIR, id + '.json');
+  // Defence-in-depth: ID_PATTERN already blocks path separators, but
+  // double-check the resolved path doesn't escape DATA_DIR.
+  const resolved = path.resolve(targetPath);
+  const dataDirResolved = path.resolve(PATHS.DATA_DIR);
+  if (!resolved.startsWith(dataDirResolved + path.sep)) {
+    throw new Error('invalid id: path escapes data dir');
+  }
+  if (fs.existsSync(targetPath)) {
+    // A file exists on disk that wasn't in _entries — likely a parse error
+    // on load. Don't overwrite it silently.
+    throw new Error(`duplicate id: file already exists on disk`);
+  }
+  const tmp = targetPath + '.tmp';
+  fs.writeFileSync(tmp, JSON.stringify(parsed, null, 2));
+  fs.renameSync(tmp, targetPath);
+  _entries.set(id, {
+    meta: parsed.meta,
+    description: parsed.description || null,
+    schema: parsed.schema || null,
+    data: parsed.data === undefined ? null : parsed.data,
+    source: targetPath,
+    version: parsed.$schema,
+  });
+  return { id, source: targetPath };
+}
+
+// Remove a manifest's file and drop its entry from the cache. Throws if the
+// id is unknown (map to 404 in the handler).
+function deleteManifest(id) {
+  const entry = _entries.get(id);
+  if (!entry) throw new Error(`unknown manifest: ${id}`);
+  try {
+    fs.unlinkSync(entry.source);
+  } catch (e) {
+    // If the file's already gone, drop the cache entry anyway so we
+    // converge to the right state.
+    if (e.code !== 'ENOENT') {
+      throw new Error(`delete failed: ${e.message}`);
+    }
+  }
+  _entries.delete(id);
+  return { id, removed: entry.source };
+}
+
 module.exports = {
   init,
   reload,
@@ -326,4 +437,7 @@ module.exports = {
   isMasterEnabled,
   setMasterEnabled,
   reorderByIds,
+  createManifest,
+  deleteManifest,
+  validateManifestShape,
 };

--- a/server.js
+++ b/server.js
@@ -14,6 +14,7 @@ const { convertDateKeyedToArray } = require('./scripts/migrate-date-keyed-to-arr
 const { runFirstBootDemoSeed } = require('./scripts/seed-demo');
 const voice = require('./voice/fish');
 const voiceCache = require('./voice/cache');
+const { TOOL_DEFS, dispatchToolCall } = require('./chat/tools');
 
 // chat endpoint config (env-driven; see config/env.js)
 const CHAT_ENDPOINT_URL = ENV.CHAT_ENDPOINT_URL;
@@ -237,6 +238,104 @@ function extractJsonReply(raw) {
     } catch {}
   }
   return null;
+}
+
+// POST one chat-completions payload to the configured gateway and return the
+// parsed JSON response. Promise rejects with a typed Error so the caller can
+// map to the right HTTP status:
+//   'gateway_unavailable: <msg>'  -> 502
+//   'gateway_timeout'             -> 504
+//   'gateway_parse: <msg>'        -> 500
+// Preserves the existing transport options (no keep-alive, self-signed TLS
+// tolerated, 180s per-hop timeout).
+function callGateway({ messages, tools }) {
+  return new Promise((resolve, reject) => {
+    if (!CHAT_ENDPOINT) return reject(new Error('gateway_unavailable: CHAT_ENDPOINT_URL not set'));
+    const body = { model: CHAT_MODEL, messages };
+    if (tools && tools.length) {
+      body.tools = tools;
+      body.tool_choice = 'auto';
+    }
+    const payload = JSON.stringify(body);
+    const options = {
+      hostname: CHAT_ENDPOINT.hostname,
+      port: CHAT_ENDPOINT.port,
+      path: CHAT_ENDPOINT.path,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${CHAT_API_KEY}`,
+        'Content-Length': Buffer.byteLength(payload),
+        'Connection': 'close',
+      },
+      rejectUnauthorized: false,
+      agent: false,
+    };
+    const proxyReq = CHAT_ENDPOINT.transport.request(options, (proxyRes) => {
+      let data = '';
+      proxyRes.on('data', c => data += c);
+      proxyRes.on('end', () => {
+        try { resolve(JSON.parse(data)); }
+        catch (e) { reject(new Error('gateway_parse: ' + e.message)); }
+      });
+    });
+    proxyReq.on('error', (e) => reject(new Error('gateway_unavailable: ' + e.message)));
+    proxyReq.setTimeout(180000, () => {
+      proxyReq.destroy();
+      reject(new Error('gateway_timeout'));
+    });
+    proxyReq.write(payload);
+    proxyReq.end();
+  });
+}
+
+// Run the OpenAI-compatible tool-calling loop. Each iteration:
+//   1. call the gateway with current messages (+ TOOL_DEFS)
+//   2. if finish_reason is 'tool_calls', execute each tool_call, append the
+//      assistant turn and one {role:"tool"} per call, loop.
+//   3. otherwise, return the assistant's text as the final reply.
+// Caps at MAX_ITERS to keep a misbehaving model from looping forever; if we
+// hit the cap we return the last text we saw (or a fallback).
+async function runAgentLoop({ systemPrompt, userMessages }) {
+  const MAX_ITERS = 5;
+  const messages = [{ role: 'system', content: systemPrompt }, ...userMessages];
+  let lastAssistantText = '';
+  for (let i = 0; i < MAX_ITERS; i++) {
+    const gw = await callGateway({ messages, tools: TOOL_DEFS });
+    const choice = gw.choices?.[0];
+    const msg = choice?.message || {};
+    const finish = choice?.finish_reason;
+
+    if (typeof msg.content === 'string' && msg.content.trim()) {
+      lastAssistantText = msg.content;
+    }
+
+    if (finish === 'tool_calls' && Array.isArray(msg.tool_calls) && msg.tool_calls.length) {
+      // Preserve tool_calls on the round-trip; Bedrock/LiteLLM rejects the
+      // next turn if the assistant message is missing them.
+      messages.push({
+        role: 'assistant',
+        content: msg.content || '',
+        tool_calls: msg.tool_calls,
+      });
+      for (const tc of msg.tool_calls) {
+        messages.push({
+          role: 'tool',
+          tool_call_id: tc.id,
+          name: tc.function?.name,
+          content: dispatchToolCall(tc),
+        });
+      }
+      continue;
+    }
+
+    return { finalText: msg.content || lastAssistantText || '', cappedOut: false };
+  }
+  return {
+    finalText: lastAssistantText ||
+      "I wasn't able to finish that in one turn — please re-ask or be more specific.",
+    cappedOut: true,
+  };
 }
 
 // Synthesise the legacy injection-log.json shape { 'YYYY-MM-DD': { 'PeptideName': { taken: true, time: ISO } } }
@@ -1011,68 +1110,35 @@ Original system prompt follows:
             return sendJSON(res, { error: 'Chat endpoint not configured' }, 503);
           }
 
-          const payload = JSON.stringify({
-            model: CHAT_MODEL,
-            messages: fullMessages,
-          });
-
-          const options = {
-            hostname: CHAT_ENDPOINT.hostname,
-            port: CHAT_ENDPOINT.port,
-            path: CHAT_ENDPOINT.path,
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'Authorization': `Bearer ${CHAT_API_KEY}`,
-              'Content-Length': Buffer.byteLength(payload),
-              'Connection': 'close',
-            },
-            rejectUnauthorized: false, // self-signed TLS tolerated; endpoint trust is operator's call
-            agent: false, // disable keep-alive — stale pooled connections hang on some endpoints
-          };
-
-          const proxyReq = CHAT_ENDPOINT.transport.request(options, (proxyRes) => {
-            let data = '';
-            proxyRes.on('data', c => data += c);
-            proxyRes.on('end', () => {
-              try {
-                const result = JSON.parse(data);
-                const rawReply = result.choices?.[0]?.message?.content || '';
-                if (voiceMode) {
-                  // Parse { speak, display } JSON. The model is instructed to
-                  // output nothing but the JSON object; handle stray text + code
-                  // fences defensively.
-                  const parsed = extractJsonReply(rawReply);
-                  if (parsed && (parsed.speak || parsed.display)) {
-                    const speak = (parsed.speak || parsed.display || '').trim();
-                    const display = (parsed.display || parsed.speak || '').trim();
-                    return sendJSON(res, { reply: display, speak });
-                  }
-                  // Fallback if the model didn't produce JSON: use the raw text
-                  // for both (with light emoji stripping for speak)
-                  const speak = rawReply.replace(/\p{Extended_Pictographic}/gu, '').trim();
-                  return sendJSON(res, { reply: rawReply || 'No response', speak });
+          runAgentLoop({ systemPrompt, userMessages: messages })
+            .then(({ finalText }) => {
+              if (voiceMode) {
+                const parsedReply = extractJsonReply(finalText);
+                if (parsedReply && (parsedReply.speak || parsedReply.display)) {
+                  const speak = (parsedReply.speak || parsedReply.display || '').trim();
+                  const display = (parsedReply.display || parsedReply.speak || '').trim();
+                  return sendJSON(res, { reply: display, speak });
                 }
-                sendJSON(res, { reply: rawReply || 'No response' });
-              } catch (e) {
-                console.error('Chat parse error:', e.message);
-                sendJSON(res, { error: 'Failed to parse response' }, 500);
+                const speak = finalText.replace(/\p{Extended_Pictographic}/gu, '').trim();
+                return sendJSON(res, { reply: finalText || 'No response', speak });
               }
+              sendJSON(res, { reply: finalText || 'No response' });
+            })
+            .catch((e) => {
+              const msg = e.message || String(e);
+              if (msg.startsWith('gateway_timeout')) {
+                console.error('Chat gateway timeout');
+                if (!res.headersSent) sendJSON(res, { error: 'Request timed out' }, 504);
+                return;
+              }
+              if (msg.startsWith('gateway_unavailable')) {
+                console.error('Chat proxy error:', msg);
+                if (!res.headersSent) sendJSON(res, { error: 'Gateway unavailable' }, 502);
+                return;
+              }
+              console.error('Chat parse error:', msg);
+              if (!res.headersSent) sendJSON(res, { error: 'Failed to parse response' }, 500);
             });
-          });
-
-          proxyReq.on('error', (e) => {
-            console.error('Chat proxy error:', e.message);
-            if (!res.headersSent) sendJSON(res, { error: 'Gateway unavailable' }, 502);
-          });
-
-          proxyReq.setTimeout(180000, () => {
-            proxyReq.destroy();
-            if (!res.headersSent) sendJSON(res, { error: 'Request timed out' }, 504);
-          });
-
-          proxyReq.write(payload);
-          proxyReq.end();
         } catch (e) {
           sendJSON(res, { error: 'Invalid request' }, 400);
         }

--- a/server.js
+++ b/server.js
@@ -431,6 +431,50 @@ const server = http.createServer(async (req, res) => {
       return sendJSON(res, { entries: registry.list(), errors: registry.errors() });
     }
 
+    // POST /api/manifests — create a brand new card from a full manifest body.
+    // Lenient on purpose: any JSON whose $schema, meta.id, meta.label satisfy
+    // the load path's contract is accepted. Unknown renderer names are allowed
+    // (ad-hoc escape hatch) and render as eh-unknown-card until a matching
+    // renderer exists. Auth is already enforced globally at the top of the
+    // request handler.
+    if (parts[0] === 'manifests' && parts.length === 1 && req.method === 'POST') {
+      let body = '';
+      req.on('data', c => body += c);
+      req.on('end', () => {
+        let parsed;
+        try { parsed = JSON.parse(body || '{}'); }
+        catch { return sendJSON(res, { error: 'invalid JSON body' }, 400); }
+        try {
+          const result = registry.createManifest(parsed);
+          return sendJSON(res, {
+            ok: true,
+            id: result.id,
+            source: path.basename(result.source),
+          }, 201);
+        } catch (e) {
+          const msg = e.message || 'create failed';
+          const status = /^duplicate id/.test(msg) ? 409
+            : /^invalid id/.test(msg) ? 422
+            : /^(missing |unsupported \$schema)/.test(msg) ? 400
+            : 500;
+          return sendJSON(res, { error: msg }, status);
+        }
+      });
+      return;
+    }
+
+    // DELETE /api/manifests/:id — remove a card + its file.
+    if (parts[0] === 'manifests' && parts.length === 2 && req.method === 'DELETE') {
+      const id = parts[1];
+      if (!registry.get(id)) return send404(res, 'manifest not found');
+      try {
+        const result = registry.deleteManifest(id);
+        return sendJSON(res, { ok: true, id: result.id });
+      } catch (e) {
+        return sendJSON(res, { error: e.message || 'delete failed' }, 500);
+      }
+    }
+
     // GET /api/views/:viewName — cards that opt into a named view
     if (parts[0] === 'views' && parts.length === 2 && req.method === 'GET') {
       const viewName = parts[1];

--- a/tests/chat-tool-use.test.js
+++ b/tests/chat-tool-use.test.js
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/chat-tool-use.test.js
+// End-to-end coverage of the tool-calling agent loop in /api/chat.
+// A scripted stub gateway pops one response per request and captures the
+// full outbound body each time, so we can assert:
+//   - tool_calls from the first response trigger a follow-up request that
+//     contains the assistant's tool_calls message + a {role:"tool"} reply
+//   - the tool's result (from registry.createManifest etc.) is the content
+//     of that tool-role message
+//   - errors from the registry become tool-visible {error:"..."} strings
+//     the model can self-correct against
+//   - a runaway model is capped at MAX_ITERS iterations
+//   - voice mode still JSON-extracts the final text only
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+const { createSandbox, cleanupSandbox, spawnServer, req } = require('./helpers/sandbox');
+
+// Scripted stub gateway. Starts an HTTP server; each POST pops the next
+// response from the queue and captures the request body. Exhausted queue
+// → 500 so tests fail loudly rather than silently hanging.
+function startStubGateway() {
+  const responseQueue = [];
+  const capturedRequests = [];
+  const server = http.createServer((request, response) => {
+    let body = '';
+    request.on('data', c => { body += c; });
+    request.on('end', () => {
+      try { capturedRequests.push(JSON.parse(body)); }
+      catch { capturedRequests.push(null); }
+      const next = responseQueue.shift();
+      if (!next) {
+        response.writeHead(500, { 'Content-Type': 'application/json' });
+        response.end(JSON.stringify({ error: 'stub queue exhausted' }));
+        return;
+      }
+      response.writeHead(200, { 'Content-Type': 'application/json' });
+      response.end(JSON.stringify(next));
+    });
+  });
+  return new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => {
+      const port = server.address().port;
+      resolve({
+        port,
+        close: () => new Promise(r => server.close(r)),
+        pushResponse: (r) => responseQueue.push(r),
+        pushResponses: (rs) => rs.forEach(r => responseQueue.push(r)),
+        getRequests: () => capturedRequests.slice(),
+        reset: () => { responseQueue.length = 0; capturedRequests.length = 0; },
+      });
+    });
+  });
+}
+
+function toolCallResponse({ name, args, id = 'call_1' }) {
+  return {
+    choices: [{
+      finish_reason: 'tool_calls',
+      message: {
+        role: 'assistant',
+        content: '',
+        tool_calls: [{
+          id,
+          type: 'function',
+          function: { name, arguments: JSON.stringify(args) },
+        }],
+      },
+    }],
+  };
+}
+
+function stopResponse(content) {
+  return {
+    choices: [{
+      finish_reason: 'stop',
+      message: { role: 'assistant', content },
+    }],
+  };
+}
+
+describe('chat proxy tool-calling agent loop', () => {
+  let sandbox, server, gateway;
+
+  before(async () => {
+    gateway = await startStubGateway();
+    sandbox = createSandbox();
+    server = await spawnServer(sandbox, {
+      CHAT_ENDPOINT_URL: `http://127.0.0.1:${gateway.port}/v1/chat/completions`,
+      CHAT_API_KEY: 'stub-token',
+      CHAT_MODEL: 'stub-model',
+    });
+  });
+  after(async () => {
+    if (server) await server.kill();
+    if (gateway) await gateway.close();
+    cleanupSandbox(sandbox);
+  });
+
+  test('A — happy-path create_manifest tool call', async () => {
+    gateway.reset();
+    const manifest = {
+      $schema: 'klebb.datafile.v1',
+      meta: { id: 'tool-test-a', label: 'Tool Test A' },
+      data: [],
+    };
+    gateway.pushResponses([
+      toolCallResponse({ name: 'create_manifest', args: { manifest }, id: 'call_a' }),
+      stopResponse('Done — created Tool Test A.'),
+    ]);
+
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'Create a Tool Test A card.' }] },
+    });
+
+    assert.equal(res.status, 200);
+    assert.equal(res.json.reply, 'Done — created Tool Test A.');
+    assert.ok(!res.json.error, 'no error on happy path');
+
+    // Stub saw exactly two requests
+    const reqs = gateway.getRequests();
+    assert.equal(reqs.length, 2, `stub should have seen 2 requests, got ${reqs.length}`);
+
+    // First request carries tools
+    assert.ok(Array.isArray(reqs[0].tools), 'first request should include tools');
+    assert.ok(reqs[0].tools.some(t => t.function?.name === 'create_manifest'),
+      'tools list should include create_manifest');
+
+    // Second request preserves the tool_calls assistant turn AND includes a
+    // tool-role message with the registry result.
+    const msgs = reqs[1].messages;
+    const assistantWithToolCalls = msgs.find(m => m.role === 'assistant' && Array.isArray(m.tool_calls));
+    assert.ok(assistantWithToolCalls, 'second request should include the original tool_calls assistant turn');
+    assert.equal(assistantWithToolCalls.tool_calls[0].id, 'call_a');
+
+    const toolMsg = msgs.find(m => m.role === 'tool');
+    assert.ok(toolMsg, 'second request should include a tool-role message');
+    assert.equal(toolMsg.tool_call_id, 'call_a');
+    assert.match(toolMsg.content, /"ok":true/);
+    assert.match(toolMsg.content, /"id":"tool-test-a"/);
+
+    // Manifest file hit the disk
+    const onDisk = path.join(sandbox, 'data', 'tool-test-a.json');
+    assert.ok(fs.existsSync(onDisk), 'manifest file should exist on disk');
+  });
+
+  test('B — error feedback on delete of unknown id', async () => {
+    gateway.reset();
+    gateway.pushResponses([
+      toolCallResponse({ name: 'delete_manifest', args: { id: 'does-not-exist' }, id: 'call_b' }),
+      stopResponse("That card does not exist — nothing to delete."),
+    ]);
+
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'Delete does-not-exist.' }] },
+    });
+
+    assert.equal(res.status, 200);
+    assert.equal(res.json.reply, 'That card does not exist — nothing to delete.');
+    assert.ok(!res.json.error, 'errors are fed back to the model, not raised to the user');
+
+    const reqs = gateway.getRequests();
+    assert.equal(reqs.length, 2);
+    const toolMsg = reqs[1].messages.find(m => m.role === 'tool');
+    assert.match(toolMsg.content, /"error":"unknown manifest: does-not-exist"/);
+  });
+
+  test('C — runaway loop capped at MAX_ITERS (5) with a graceful reply', async () => {
+    gateway.reset();
+    // Pre-seed the queue with many tool_calls so it never terminates naturally
+    for (let i = 0; i < 20; i++) {
+      gateway.pushResponse(toolCallResponse({
+        name: 'list_manifests',
+        args: {},
+        id: 'call_loop_' + i,
+      }));
+    }
+
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'Spin forever.' }] },
+    });
+
+    assert.equal(res.status, 200, 'cap should yield 200, not 500/504');
+    assert.ok(typeof res.json.reply === 'string' && res.json.reply.length > 0,
+      'cap fallback should produce a non-empty reply');
+
+    const reqs = gateway.getRequests();
+    assert.equal(reqs.length, 5, `should stop at MAX_ITERS=5, got ${reqs.length}`);
+
+    // Server remains healthy
+    const followup = await req(server.baseUrl, '/healthz', { method: 'GET' });
+    assert.equal(followup.status, 200);
+  });
+
+  test('E — voice mode JSON extract on final text only', async () => {
+    gateway.reset();
+    const manifest = {
+      $schema: 'klebb.datafile.v1',
+      meta: { id: 'tool-test-e', label: 'Tool Test E' },
+      data: [],
+    };
+    gateway.pushResponses([
+      toolCallResponse({ name: 'create_manifest', args: { manifest }, id: 'call_e' }),
+      stopResponse('{"speak":"Created it.","display":"Created **Tool Test E**."}'),
+    ]);
+
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: {
+        messages: [{ role: 'user', content: 'Create Tool Test E.' }],
+        voiceMode: true,
+      },
+    });
+
+    assert.equal(res.status, 200);
+    assert.equal(res.json.reply, 'Created **Tool Test E**.');
+    assert.equal(res.json.speak, 'Created it.');
+  });
+});

--- a/tests/config-defaults.test.js
+++ b/tests/config-defaults.test.js
@@ -191,6 +191,37 @@ describe('config/env.js defaults', () => {
     assert.ok(env.HEALTH_SYSTEM_PROMPT.length > 100);
     assert.ok(env.HEALTH_SYSTEM_PROMPT.includes('health assistant'));
   });
+
+  test('default system prompt advertises the create/delete endpoints + the full renderer + input surface', () => {
+    const env = freshEnv();
+    const p = env.HEALTH_SYSTEM_PROMPT;
+
+    // Endpoints (so the agent knows what to call)
+    assert.ok(p.includes('POST /api/manifests'), 'should advertise POST /api/manifests');
+    assert.ok(p.includes('DELETE /api/manifests/:id'), 'should advertise DELETE /api/manifests/:id');
+
+    // Every built-in renderer name, so the agent picks correctly
+    for (const renderer of [
+      'generic-card', 'list-card', 'checklist-card', 'schedule-card',
+      'schedule-timeline', 'markdown-doc', 'line-chart', 'table-list',
+      'adherence-report', 'greeting-banner',
+    ]) {
+      assert.ok(p.includes(renderer), `prompt should list renderer "${renderer}"`);
+    }
+
+    // Schedule shapes
+    for (const type of ['daily', 'weekly', 'every_n_days', 'on_off', 'phased', 'as_needed']) {
+      assert.ok(p.includes(type), `prompt should mention schedule type "${type}"`);
+    }
+
+    // Marker types (so the calendar integration is discoverable)
+    for (const marker of ['field-emoji', 'trend-arrow', 'threshold', 'template']) {
+      assert.ok(p.includes(marker), `prompt should mention marker type "${marker}"`);
+    }
+
+    // Escape-hatch sentinel: agents need to know unknown renderers are OK
+    assert.ok(/persist/i.test(p), 'prompt should describe the ad-hoc persistence escape hatch');
+  });
 });
 
 describe('config/env.js env overrides', () => {

--- a/tests/manifest-registry.test.js
+++ b/tests/manifest-registry.test.js
@@ -321,6 +321,195 @@ describe('manifest registry', () => {
     }
   });
 
+  // --- createManifest / deleteManifest ---
+
+  test('createManifest writes the file + populates list()', () => {
+    const sandbox = createSandbox();
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      const result = registry.createManifest({
+        $schema: 'klebb.datafile.v1',
+        meta: { id: 'bp', label: 'Blood Pressure', view: { enabled: true, component: 'list-card' } },
+        data: [{ date: '2026-04-20', systolic: 120, diastolic: 80 }],
+      });
+      assert.equal(result.id, 'bp');
+      assert.ok(fs.existsSync(path.join(sandbox, 'data', 'bp.json')));
+      const list = registry.list();
+      assert.equal(list.length, 1);
+      assert.equal(list[0].id, 'bp');
+      assert.equal(list[0].meta.label, 'Blood Pressure');
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('createManifest rejects duplicate id (already in registry)', () => {
+    const sandbox = createSandbox({
+      seed: {
+        'bp.json': {
+          $schema: 'klebb.datafile.v1',
+          meta: { id: 'bp', label: 'BP' },
+          data: [],
+        },
+      },
+    });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      assert.throws(
+        () => registry.createManifest({
+          $schema: 'klebb.datafile.v1',
+          meta: { id: 'bp', label: 'BP Again' },
+          data: [],
+        }),
+        /duplicate id: bp/,
+      );
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('createManifest rejects when a file already exists on disk (parse error, not in registry)', () => {
+    const sandbox = createSandbox();
+    // Pre-write a broken file so it fails to parse and never lands in _entries
+    fs.writeFileSync(path.join(sandbox, 'data', 'bp.json'), '{broken');
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      assert.throws(
+        () => registry.createManifest({
+          $schema: 'klebb.datafile.v1',
+          meta: { id: 'bp', label: 'BP' },
+          data: [],
+        }),
+        /duplicate id: file already exists on disk/,
+      );
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('createManifest rejects invalid id formats', () => {
+    const sandbox = createSandbox();
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      for (const badId of ['../hack', 'Blood Pressure', 'blood pressure', 'UPPER', '-leading-dash', '.leading-dot']) {
+        assert.throws(
+          () => registry.createManifest({
+            $schema: 'klebb.datafile.v1',
+            meta: { id: badId, label: 'X' },
+            data: [],
+          }),
+          /invalid id/,
+          `id "${badId}" should be rejected`,
+        );
+      }
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('createManifest rejects reserved ids', () => {
+    const sandbox = createSandbox();
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      for (const reserved of ['_archive', 'reports', 'index', 'auto-export']) {
+        assert.throws(
+          () => registry.createManifest({
+            $schema: 'klebb.datafile.v1',
+            meta: { id: reserved, label: 'X' },
+            data: [],
+          }),
+          /invalid id/,
+          `id "${reserved}" should be reserved`,
+        );
+      }
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('createManifest rejects missing $schema / meta.id / meta.label', () => {
+    const sandbox = createSandbox();
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      assert.throws(
+        () => registry.createManifest({ meta: { id: 'x', label: 'X' } }),
+        /missing \$schema/,
+      );
+      assert.throws(
+        () => registry.createManifest({ $schema: 'klebb.datafile.v1', meta: { label: 'X' } }),
+        /missing meta\.id/,
+      );
+      assert.throws(
+        () => registry.createManifest({ $schema: 'klebb.datafile.v1', meta: { id: 'x' } }),
+        /missing meta\.label/,
+      );
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('createManifest accepts ad-hoc unknown renderer names (escape hatch)', () => {
+    const sandbox = createSandbox();
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      const result = registry.createManifest({
+        $schema: 'klebb.datafile.v1',
+        meta: {
+          id: 'sleep-arch',
+          label: 'Sleep Architecture',
+          view: { enabled: true, component: 'sleep-stages-sunburst' },
+        },
+        data: { stages: [{ name: 'REM', pct: 22 }] },
+      });
+      assert.equal(result.id, 'sleep-arch');
+      const entry = registry.get('sleep-arch');
+      assert.equal(entry.meta.view.component, 'sleep-stages-sunburst');
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('deleteManifest removes the file and drops the entry', () => {
+    const sandbox = createSandbox({
+      seed: {
+        'bp.json': {
+          $schema: 'klebb.datafile.v1',
+          meta: { id: 'bp', label: 'BP' },
+          data: [],
+        },
+      },
+    });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      assert.equal(registry.list().length, 1);
+      registry.deleteManifest('bp');
+      assert.equal(registry.list().length, 0);
+      assert.equal(registry.get('bp'), null);
+      assert.ok(!fs.existsSync(path.join(sandbox, 'data', 'bp.json')));
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('deleteManifest unknown id throws', () => {
+    const sandbox = createSandbox();
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      assert.throws(() => registry.deleteManifest('nonexistent'), /unknown manifest/);
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
   test('one broken file does not stop siblings from loading', () => {
     const sandbox = createSandbox({
       seed: {

--- a/tests/manifests-create-api.test.js
+++ b/tests/manifests-create-api.test.js
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/manifests-create-api.test.js
+// End-to-end coverage of POST /api/manifests (create) and DELETE
+// /api/manifests/:id (delete) against a live spawned server + sandbox
+// HEALTH_HOME.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const {
+  createSandbox, cleanupSandbox, spawnServer, req, fakeAuthState,
+} = require('./helpers/sandbox');
+
+describe('POST /api/manifests + DELETE /api/manifests/:id', () => {
+  let sandbox, server, auth;
+
+  before(async () => {
+    auth = fakeAuthState('op');
+    sandbox = createSandbox({
+      credentials: auth.credentials,
+      sessions: auth.sessions,
+    });
+    server = await spawnServer(sandbox);
+  });
+  after(async () => {
+    if (server) await server.kill();
+    cleanupSandbox(sandbox);
+  });
+
+  test('401 without auth', async () => {
+    const res = await req(server.baseUrl, '/api/manifests', {
+      method: 'POST',
+      body: {
+        $schema: 'klebb.datafile.v1',
+        meta: { id: 'noauth', label: 'NoAuth' },
+        data: [],
+      },
+    });
+    assert.equal(res.status, 401);
+  });
+
+  test('201 happy path; GET round-trips the body; file lives on disk', async () => {
+    const body = {
+      $schema: 'klebb.datafile.v1',
+      meta: {
+        id: 'blood-pressure',
+        label: 'Blood Pressure',
+        emoji: '🩺',
+        view: { enabled: true, component: 'list-card' },
+      },
+      description: 'Home BP readings.',
+      data: [{ date: '2026-04-20', systolic: 120, diastolic: 80 }],
+    };
+    const post = await req(server.baseUrl, '/api/manifests', {
+      method: 'POST',
+      cookie: auth.cookie,
+      body,
+    });
+    assert.equal(post.status, 201);
+    assert.equal(post.json.ok, true);
+    assert.equal(post.json.id, 'blood-pressure');
+    assert.equal(post.json.source, 'blood-pressure.json');
+
+    const get = await req(server.baseUrl, '/api/manifests/blood-pressure', {
+      cookie: auth.cookie,
+    });
+    assert.equal(get.status, 200);
+    assert.equal(get.json.meta.label, 'Blood Pressure');
+    assert.equal(get.json.description, 'Home BP readings.');
+
+    const onDisk = path.join(sandbox, 'data', 'blood-pressure.json');
+    assert.ok(fs.existsSync(onDisk), 'manifest file should be on disk');
+  });
+
+  test('409 on duplicate id', async () => {
+    const res = await req(server.baseUrl, '/api/manifests', {
+      method: 'POST',
+      cookie: auth.cookie,
+      body: {
+        $schema: 'klebb.datafile.v1',
+        meta: { id: 'blood-pressure', label: 'Dup' },
+        data: [],
+      },
+    });
+    assert.equal(res.status, 409);
+    assert.match(res.json.error, /duplicate id/);
+  });
+
+  test('400 on invalid JSON body', async () => {
+    // req() stringifies object bodies; send a raw malformed string instead.
+    const res = await req(server.baseUrl, '/api/manifests', {
+      method: 'POST',
+      cookie: auth.cookie,
+      body: '{not valid',
+    });
+    assert.equal(res.status, 400);
+    assert.match(res.json.error, /invalid JSON/);
+  });
+
+  test('400 on missing $schema', async () => {
+    const res = await req(server.baseUrl, '/api/manifests', {
+      method: 'POST',
+      cookie: auth.cookie,
+      body: { meta: { id: 'noschema', label: 'No Schema' } },
+    });
+    assert.equal(res.status, 400);
+    assert.match(res.json.error, /\$schema/);
+  });
+
+  test('400 on missing meta.label', async () => {
+    const res = await req(server.baseUrl, '/api/manifests', {
+      method: 'POST',
+      cookie: auth.cookie,
+      body: {
+        $schema: 'klebb.datafile.v1',
+        meta: { id: 'no-label' },
+        data: [],
+      },
+    });
+    assert.equal(res.status, 400);
+    assert.match(res.json.error, /meta\.label/);
+  });
+
+  test('422 on invalid id format', async () => {
+    const res = await req(server.baseUrl, '/api/manifests', {
+      method: 'POST',
+      cookie: auth.cookie,
+      body: {
+        $schema: 'klebb.datafile.v1',
+        meta: { id: 'Bad Id With Spaces', label: 'Bad' },
+        data: [],
+      },
+    });
+    assert.equal(res.status, 422);
+    assert.match(res.json.error, /invalid id/);
+  });
+
+  test('422 on reserved id', async () => {
+    const res = await req(server.baseUrl, '/api/manifests', {
+      method: 'POST',
+      cookie: auth.cookie,
+      body: {
+        $schema: 'klebb.datafile.v1',
+        meta: { id: '_archive', label: 'Reserved' },
+        data: [],
+      },
+    });
+    assert.equal(res.status, 422);
+    assert.match(res.json.error, /invalid id/);
+  });
+
+  test('ad-hoc path: unknown renderer names are accepted (escape hatch)', async () => {
+    const res = await req(server.baseUrl, '/api/manifests', {
+      method: 'POST',
+      cookie: auth.cookie,
+      body: {
+        $schema: 'klebb.datafile.v1',
+        meta: {
+          id: 'sleep-arch',
+          label: 'Sleep Architecture',
+          view: { enabled: true, component: 'sleep-stages-sunburst' },
+        },
+        data: { stages: [{ name: 'REM', pct: 22 }] },
+      },
+    });
+    assert.equal(res.status, 201);
+
+    const get = await req(server.baseUrl, '/api/manifests/sleep-arch', {
+      cookie: auth.cookie,
+    });
+    assert.equal(get.status, 200);
+    assert.equal(get.json.meta.view.component, 'sleep-stages-sunburst');
+  });
+
+  test('DELETE removes the card; GET then 404s; file unlinked', async () => {
+    const del = await req(server.baseUrl, '/api/manifests/blood-pressure', {
+      method: 'DELETE',
+      cookie: auth.cookie,
+    });
+    assert.equal(del.status, 200);
+    assert.equal(del.json.ok, true);
+    assert.equal(del.json.id, 'blood-pressure');
+
+    const get = await req(server.baseUrl, '/api/manifests/blood-pressure', {
+      cookie: auth.cookie,
+    });
+    assert.equal(get.status, 404);
+
+    const onDisk = path.join(sandbox, 'data', 'blood-pressure.json');
+    assert.ok(!fs.existsSync(onDisk), 'manifest file should be gone');
+  });
+
+  test('DELETE unknown id → 404', async () => {
+    const res = await req(server.baseUrl, '/api/manifests/does-not-exist', {
+      method: 'DELETE',
+      cookie: auth.cookie,
+    });
+    assert.equal(res.status, 404);
+  });
+});


### PR DESCRIPTION
## Summary

Wires an OpenAI-compatible tool-calling agent loop into `/api/chat` so the in-app chat agent can actually create and delete cards. #61 shipped the REST endpoints and taught the system prompt about them, but the chat proxy had no tools wiring — the agent would compose the right JSON and then admit it couldn't send it anywhere (per the operator's live test).

Three tools, dispatched directly into the registry (no HTTP hop to self):

- `create_manifest(manifest)` → `registry.createManifest(args.manifest)`
- `delete_manifest(id)` → `registry.deleteManifest(args.id)`
- `list_manifests()` → compact projection of `registry.list()`

## Why

Klebbius can't be the primary card-authoring path if it can't call the endpoints. The REST API was only half the story.

## How

- **Loop:** `runAgentLoop` in `server.js` re-calls the gateway while `finish_reason === "tool_calls"`, appending the assistant turn (with `tool_calls` preserved — Bedrock rejects the round-trip otherwise) and one `{role:"tool", tool_call_id, name, content}` message per call. Capped at 5 iterations so a misbehaving model can't spin. Voice-mode JSON extract runs on the final text only.
- **Gateway helper:** `callGateway({messages, tools})` is a promise-returning version of the old `proxyReq = ... .request(...)` block. Same 180s timeout, same `agent:false`, same self-signed TLS tolerance. Rejects with typed errors (`gateway_unavailable`, `gateway_timeout`, `gateway_parse`) which the handler maps to 502/504/500.
- **Tools module:** new `chat/tools.js` exports `TOOL_DEFS` (OpenAI function-schema format) and a sync `dispatchToolCall(tc)`. Registry errors become the tool-result content so the model can self-correct.
- **System prompt:** rewritten to name the tools. The existing HTTP endpoint list is kept as reference material, re-labelled for "external agents running outside this app with `AGENT_API_TOKEN`". Both worked examples now say "call `create_manifest` with:" instead of "POST /api/manifests"; the JSON bodies are unchanged.
- **No widget changes.** Contract is preserved (`{reply, speak?, error?}`). Tool rounds never leak to the widget or to `/api/chat/history` (the widget already filters to user/assistant roles).

## Test plan

- [x] `npm test` — 387/388 green. The one failing test is the pre-existing `no-personal-refs` suite scanning gitignored files (`.claude/`, `BRIEF-FOR-CC.md`, `data/sessions/...`); not touched in this branch.
- [x] New `tests/chat-tool-use.test.js` covers:
  - Case A: happy-path `create_manifest` → stub returns `tool_calls`, server dispatches, second request to stub contains the preserved `tool_calls` assistant turn AND a matching `tool` message with `"ok":true` content; file on disk.
  - Case B: `delete_manifest` on an unknown id → tool-result is `"error":"unknown manifest: ..."`; widget receives a graceful reply, NOT an error.
  - Case C: runaway — stub always returns `tool_calls`; asserts exactly 5 iterations, 200 response with a fallback reply, server remains healthy.
  - Case E: voice mode — JSON-extract runs on the final `stop` turn only, intermediate tool rounds don't confuse the extractor.
- [x] Existing `tests/chat-prompt-cards.test.js` still passes unchanged (its stub returns plain text; loop exits on iteration 1).
- [x] Existing `tests/chat-endpoint-url.test.js`, `tests/chat-history-api.test.js`, `tests/chat-proxy-reset.test.js` all still green.
- [ ] Live smoke on klebbtest: ask the chat widget to create a resting-heart-rate card; expect a single assistant bubble confirming creation (not "save this file"); file on disk; card visible on Today.
- [ ] Live smoke: delete path. Ask to delete the card; expect confirmation; file gone.
- [ ] Live smoke: negative. Ask to delete a nonexistent card; expect graceful text reply, no 5xx.

Note: this branch is stacked on #62 (the REST endpoints + prompt groundwork). If #62 merges first this PR rebases cleanly on main; if ordering flips, GitHub will auto-update the base.

Fixes #63