### PR TITLE
fix(renderer): tolerate string meta.view.display in generic-card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **generic-card tolerates a bare string \`display\` and the chat-agent
+  prompt steers away from authoring one.** Klebbius (and any other
+  agent using \`create_manifest\`) was writing
+  \`"view": { "display": "{bpm} bpm" }\` where the renderer expected
+  \`"display": { "template": "{bpm} bpm" }\`. The card rendered blank
+  even when data was present, because the renderer read
+  \`display.template\` on a string. The renderer now treats a string
+  \`display\` as \`{template: <string>}\`; the system prompt also
+  spells out that \`meta.view.display\` is an object, never a string,
+  and lists the sub-keys (\`template\`, \`secondary\`, \`emptyHeadline\`,
+  etc.) explicitly. (#67)
 - **Cards with empty data no longer get auto-hidden from views.** The
   old rule "empty data hides the card" (to avoid ghost cards) made a
   fresh writeable card invisible to its owner before the first entry

--- a/config/env.js
+++ b/config/env.js
@@ -182,6 +182,8 @@ You are the primary way the user creates new cards. When they describe a tracker
 
 Everything else is optional pass-through. The endpoint is lenient: if the renderer you want doesn't exist yet, POST the manifest anyway with your best-guess \`meta.view.component\` — unknown components render as a placeholder card, and the data persists. This is the ad-hoc escape hatch. Use it freely; a human can retrofit a real renderer later.
 
+**Gotcha — \`meta.view.display\` is an object, never a string.** Use \`"display": {"template": "{bpm} bpm"}\`, NOT \`"display": "{bpm} bpm"\`. The object can carry \`template\`, \`secondary\`, \`emptyHeadline\`, \`emojiMap\`, \`thresholds\`, \`trendArrow\`, \`unit\`, and \`subtitle\`. A bare string won't render anything.
+
 ### Full manifest shape
 
 \`\`\`
@@ -215,7 +217,7 @@ Everything else is optional pass-through. The endpoint is lenient: if the render
 
 ### Known renderers (meta.view.component)
 
-- \`generic-card\` — single latest value + delta; data is \`[{date, <field>...}]\`. Pairs with \`meta.view.display\` template.
+- \`generic-card\` — single latest value + delta. Data is \`[{date, <field>...}]\`. Uses \`meta.view.display\` (object: \`{template, secondary?, emptyHeadline?, unit?, emojiMap?, thresholds?, trendArrow?}\`) to format the headline.
 - \`list-card\` — persistent chronological list of entries; data is \`[{date, ...fields}]\`.
 - \`checklist-card\` — tickable daily items; data \`{items:[{id,doses:[...]}]}\`-ish.
 - \`schedule-card\` — scheduled doses/events with recurrence; data tracks check-offs.

--- a/public/js/components/eh-generic-card.js
+++ b/public/js/components/eh-generic-card.js
@@ -50,7 +50,11 @@ export class EhGenericCard extends EhBaseCard {
   // Local aliases — don't shadow EhBaseCard's _meta getter
   _m() { return this.card?.meta || {}; }
   _vc() { return this.card?.viewConfig || {}; }
-  _display() { return this._vc().display || this._m().view?.display || {}; }
+  _display() {
+    const d = this._vc().display ?? this._m().view?.display;
+    if (typeof d === 'string') return { template: d };
+    return d || {};
+  }
   _dateContext() { return this._vc().dateContext || this._m().view?.dateContext || 'viewedDate'; }
 
   _entries() {

--- a/tests/config-defaults.test.js
+++ b/tests/config-defaults.test.js
@@ -221,6 +221,16 @@ describe('config/env.js defaults', () => {
 
     // Escape-hatch sentinel: agents need to know unknown renderers are OK
     assert.ok(/persist/i.test(p), 'prompt should describe the ad-hoc persistence escape hatch');
+
+    // generic-card display-shape gotcha: the prompt must warn that
+    // meta.view.display is an object, not a string. Otherwise the model
+    // writes "display": "{bpm} bpm" and the renderer silently produces
+    // an empty headline.
+    assert.ok(
+      /display.*object.*never.*string|never.*string.*display|display.*is an object/i.test(p),
+      'prompt should flag that meta.view.display is an object, not a string'
+    );
+    assert.ok(p.includes('template'), 'prompt should name the display.template sub-key');
   });
 });
 


### PR DESCRIPTION
## Summary

- `eh-generic-card._display()` now treats a bare-string `meta.view.display` as `{template: <string>}`.
- System prompt in `DEFAULT_HEALTH_SYSTEM_PROMPT` explicitly flags that `meta.view.display` is an object, names all valid sub-keys (`template`, `secondary`, `emptyHeadline`, `unit`, `emojiMap`, `thresholds`, `trendArrow`), and adds a "gotcha" paragraph.

## Why

Exposed on klebbtest: the user asked Klebbius for a resting-heart-rate card, Klebbius authored a manifest with `"display": "{bpm} bpm"` (string), logged a reading successfully (data on disk), but the card stayed blank because the renderer read `display.template` on a string. Silent-failure mode — worst kind.

Root cause: the prompt's renderer cheat-sheet said `generic-card ... Pairs with meta.view.display template.` — ambiguous enough that the LLM reasonably wrote the template directly into `display`.

## How

- `public/js/components/eh-generic-card.js` — three lines: normalise `display` to an object at the `_display` getter.
- `config/env.js` — expand the `generic-card` one-liner under "Known renderers" to list sub-keys; add a gotcha paragraph under "Full manifest shape".
- `tests/config-defaults.test.js` — assert the prompt contains the gotcha + names `template`.

## Test plan

- [x] `npm test` — 387/388 (pre-existing `no-personal-refs` failure unrelated, not touched).
- [x] Prompt assertion guards against future regressions of the warning.
- [ ] Live: deploy, ask Klebbius for a resting-heart-rate card, log a reading, confirm the value renders on the card immediately.

Fixes #67