### PR TITLE
fix(chat): threshold marker prompt says 'rules' (not 'bands')

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Threshold calendar markers work again when written by the chat
+  agent.** The \`DEFAULT_HEALTH_SYSTEM_PROMPT\` was telling agents to
+  use \`"bands": [...]\` for threshold-marker rules; the renderer
+  reads \`spec.rules\` (as the other docs all say). Agents wrote
+  \`bands\`, the renderer found no \`rules\`, and fell back to the
+  card's static emoji on every day with a reading. Prompt now matches
+  the renderer and docs; the renderer also accepts the legacy
+  \`bands\` alias so manifests written during the buggy window keep
+  working. (#70)
 - **generic-card tolerates a bare string \`display\` and the chat-agent
   prompt steers away from authoring one.** Klebbius (and any other
   agent using \`create_manifest\`) was writing

--- a/config/env.js
+++ b/config/env.js
@@ -251,7 +251,7 @@ Each input carries \`key\`, \`label\`, \`required\`, \`default\`, \`help\`, plus
 - Static emoji: \`"marker": "💊"\`
 - \`{ "type":"field-emoji", "field":"mood" }\` — emoji pulled from row data
 - \`{ "type":"trend-arrow", "field":"kg", "goodDirection":"down" }\`
-- \`{ "type":"threshold", "field":"systolic", "bands":[{"max":120,"emoji":"✅"},...] }\`
+- \`{ "type":"threshold", "field":"systolic", "rules":[{"max":120,"emoji":"✅"},...] }\`
 - \`{ "type":"template", "template":"{kg:round(1)}kg" }\`
 
 ### meta.reports config by renderer

--- a/public/js/lib/calendar-marker.esm.js
+++ b/public/js/lib/calendar-marker.esm.js
@@ -112,14 +112,21 @@ export function resolveMarker(spec, ctx) {
     }
 
     case 'threshold': {
-      if (!spec.field || !Array.isArray(spec.rules) || !row) {
+      // Accept `rules` (canonical, matches docs) or `bands` (legacy
+      // alias; see #70 — an early system-prompt revision told agents
+      // to use `bands`, so manifests written during that window carry
+      // the old key).
+      const rules = Array.isArray(spec.rules) ? spec.rules
+        : Array.isArray(spec.bands) ? spec.bands
+        : null;
+      if (!spec.field || !rules || !row) {
         return spec.fallback || fallback;
       }
       const v = getValue(row, spec.field);
       if (v === null || v === undefined || v === '') {
         return spec.fallback || fallback;
       }
-      for (const rule of spec.rules) {
+      for (const rule of rules) {
         if (!rule || typeof rule !== 'object') continue;
         if ('eq' in rule) {
           if (String(v) === String(rule.eq)) return rule.emoji || spec.fallback || fallback;

--- a/public/js/lib/calendar-marker.js
+++ b/public/js/lib/calendar-marker.js
@@ -146,14 +146,21 @@
       }
 
       case 'threshold': {
-        if (!spec.field || !Array.isArray(spec.rules) || !row) {
+        // Accept `rules` (canonical, matches docs) or `bands` (legacy
+        // alias; see #70 — an early system-prompt revision told agents
+        // to use `bands`, so manifests written during that window carry
+        // the old key).
+        const rules = Array.isArray(spec.rules) ? spec.rules
+          : Array.isArray(spec.bands) ? spec.bands
+          : null;
+        if (!spec.field || !rules || !row) {
           return spec.fallback || fallback;
         }
         const v = getValue(row, spec.field);
         if (v === null || v === undefined || v === '') {
           return spec.fallback || fallback;
         }
-        for (const rule of spec.rules) {
+        for (const rule of rules) {
           if (!rule || typeof rule !== 'object') continue;
           if ('eq' in rule) {
             if (String(v) === String(rule.eq)) return rule.emoji || spec.fallback || fallback;

--- a/tests/calendar-marker.test.js
+++ b/tests/calendar-marker.test.js
@@ -291,6 +291,34 @@ describe('resolveMarker', () => {
       const bad = { type: 'threshold', field: 'kg', fallback: '•' };
       assert.equal(resolveMarker(bad, { row: { kg: 80 } }), '•');
     });
+
+    test('legacy `bands` key is accepted as an alias for `rules` (see #70)', () => {
+      const legacy = {
+        type: 'threshold',
+        field: 'systolic',
+        bands: [
+          { max: 119, emoji: '🟢' },
+          { max: 129, emoji: '🟡' },
+          { max: 139, emoji: '🟠' },
+          { max: 999, emoji: '🔴' },
+        ],
+        fallback: '•',
+      };
+      assert.equal(resolveMarker(legacy, { row: { systolic: 110 } }), '🟢');
+      assert.equal(resolveMarker(legacy, { row: { systolic: 135 } }), '🟠');
+      assert.equal(resolveMarker(legacy, { row: { systolic: 160 } }), '🔴');
+    });
+
+    test('`rules` wins over `bands` when both are present', () => {
+      const both = {
+        type: 'threshold',
+        field: 'kg',
+        rules: [{ max: 100, emoji: '✅' }],
+        bands: [{ max: 100, emoji: '❌' }],
+        fallback: '•',
+      };
+      assert.equal(resolveMarker(both, { row: { kg: 80 } }), '✅');
+    });
   });
 
   describe('template', () => {

--- a/tests/config-defaults.test.js
+++ b/tests/config-defaults.test.js
@@ -219,6 +219,14 @@ describe('config/env.js defaults', () => {
       assert.ok(p.includes(marker), `prompt should mention marker type "${marker}"`);
     }
 
+    // Threshold marker: the rules-array key is "rules", NOT "bands"
+    // (renderer at public/js/lib/calendar-marker.js reads spec.rules).
+    // Guards against the #70 typo regressing.
+    const thresholdLine = p.split('\n').find(l => l.includes('"threshold"'));
+    assert.ok(thresholdLine, 'prompt should illustrate the threshold marker');
+    assert.match(thresholdLine, /"rules"\s*:/, 'threshold marker example should use "rules":');
+    assert.doesNotMatch(thresholdLine, /"bands"\s*:/, 'threshold marker example must NOT use "bands":');
+
     // Escape-hatch sentinel: agents need to know unknown renderers are OK
     assert.ok(/persist/i.test(p), 'prompt should describe the ad-hoc persistence escape hatch');
 


### PR DESCRIPTION
## Summary

Fixes the threshold calendar-marker mismatch that was making days with readings show the static card emoji (🩺) instead of the colour-coded clinical-band emoji on a Blood Pressure card created by Klebbius.

## Root cause

Single-key typo in the system prompt shipped in #62.

- `public/js/lib/calendar-marker.js:149,156` — renderer reads `spec.rules`.
- `MANIFEST-SCHEMA.md`, `docs/CARDS.md`, `docs/RECIPES.md` — all document `rules`.
- `config/env.js:254` (the system prompt) — said `bands`.

The agent wrote `"bands": [...]`, the renderer found no `rules`, fell through to `spec.fallback || fallback`, used the card's static emoji.

## Fix

1. Prompt: `bands` → `rules` in the threshold cheat-sheet.
2. Renderer (CJS + ESM twin): accept `spec.bands` as a legacy alias for `spec.rules`. Protects existing manifests written from the buggy prompt (the BP card on klebbtest), and the test run confirms both keys now produce the same output. Precedence: `rules` wins when both are present.
3. Tests: prompt-content assertion (`rules` present, `bands` absent in the threshold line) guards against regression. Two renderer cases in `tests/calendar-marker.test.js` exercise the alias + precedence.

## Test plan

- [x] `npm test` — 389/390 (pre-existing `no-personal-refs` failure unrelated, unchanged).
- [x] Local tests: new renderer cases + prompt guard pass.
- [ ] Live: deploy to klebbtest, visit Calendar on the date the user logged a BP reading. Expect the colour-coded emoji (✅/🟡/🟠/🔴 per systolic band), not 🩺.

Fixes #70