### PR TITLE
fix(renderer): treat bounds-less threshold rule as a catch-all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Changed
 
+- **Threshold rules without bounds now act as a catch-all.** Previously
+  a rule with no \`min\`, \`max\`, or \`eq\` was silently skipped, so
+  the natural way to write "anything else" (a bare \`{emoji}\` as the
+  last rule, matching the CSS / switch-default pattern) produced no
+  marker. Agents and users both wrote this pattern unprompted; the BP
+  card on klebbtest showed 🩺 on readings over 140 because the
+  catch-all \`{emoji:"🔴"}\` was ignored. Now a bounds-less rule
+  matches any non-null value at the field — put it last. Applies to
+  both \`display.thresholds\` (Today headline colouring) and
+  \`meta.calendar.marker.{type:"threshold"}\` (calendar glyph). The
+  old workaround of \`{max:999, emoji:"..."}\` still works. Docs,
+  Recipe 11c, the system prompt, and \`data.example/bp.example.json\`
+  all updated to use the catch-all form. (#73)
 - **"New chat" button clears immediately, no confirmation prompt.**
   The 📝 button in the chat widget used to pop a `confirm()` dialog
   whenever the transcript had any messages. The button label is clear

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Changed
+
+- **"New chat" button clears immediately, no confirmation prompt.**
+  The 📝 button in the chat widget used to pop a `confirm()` dialog
+  whenever the transcript had any messages. The button label is clear
+  enough on its own; the extra step was friction. (#72)
+
 ### Fixed
 
 - **Threshold calendar markers work again when written by the chat

--- a/MANIFEST-SCHEMA.md
+++ b/MANIFEST-SCHEMA.md
@@ -227,7 +227,7 @@ phase labels.
     { "max": 119, "emoji": "🟢" },
     { "max": 129, "emoji": "🟡" },
     { "max": 139, "emoji": "🟠" },
-    { "max": 999, "emoji": "🔴" }
+    { "emoji": "🔴" }
   ],
   "fallback": "•"
 }
@@ -237,10 +237,13 @@ phase labels.
 - `rules` (array, required): each rule is
   `{ min?, max?, eq?, emoji }`. Rules iterate top-to-bottom; the
   first rule whose field exists and satisfies the matcher wins.
-- Matchers: `min <= row[field] <= max` (both optional, at least one
-  required), or `row[field]` stringly-equals `eq`.
+- Matchers: `min <= row[field] <= max` (either bound optional), or
+  `row[field]` stringly-equals `eq`, or — if the rule declares no
+  `min`, `max`, or `eq` — it's a **catch-all** that matches any
+  non-null value. Put a catch-all last to paint the "anything else"
+  colour rather than falling through to `fallback`.
 - `fallback` (string, optional): glyph when no rule matches or the
-  field is missing.
+  field is missing. Typically unnecessary if you include a catch-all.
 
 **`type: "template"`** — render a template string against the day's
 row using the same mini-language as `view.display.template`. Great

--- a/config/env.js
+++ b/config/env.js
@@ -251,7 +251,7 @@ Each input carries \`key\`, \`label\`, \`required\`, \`default\`, \`help\`, plus
 - Static emoji: \`"marker": "💊"\`
 - \`{ "type":"field-emoji", "field":"mood" }\` — emoji pulled from row data
 - \`{ "type":"trend-arrow", "field":"kg", "goodDirection":"down" }\`
-- \`{ "type":"threshold", "field":"systolic", "rules":[{"max":120,"emoji":"✅"},...] }\`
+- \`{ "type":"threshold", "field":"systolic", "rules":[{"max":120,"emoji":"✅"},{"max":140,"emoji":"🟠"},{"emoji":"🔴"}] }\` — each rule is \`{min?, max?, eq?, emoji}\`. A rule with no bounds is a catch-all; use it as the last entry for "anything else".
 - \`{ "type":"template", "template":"{kg:round(1)}kg" }\`
 
 ### meta.reports config by renderer

--- a/data.example/bp.example.json
+++ b/data.example/bp.example.json
@@ -37,7 +37,6 @@
           },
           {
             "ifField": "systolic",
-            "max": 999,
             "colour": "#ff3333",
             "label": "Stage 2"
           }
@@ -93,7 +92,7 @@
           { "max": 119, "emoji": "🟢" },
           { "max": 129, "emoji": "🟡" },
           { "max": 139, "emoji": "🟠" },
-          { "max": 999, "emoji": "🔴" }
+          { "emoji": "🔴" }
         ],
         "fallback": "💓"
       }

--- a/docs/CARDS.md
+++ b/docs/CARDS.md
@@ -314,7 +314,7 @@ temp, SpO₂) or discrete phase labels (`"loading"` / `"maintenance"` /
       { "max": 119, "emoji": "🟢" },
       { "max": 129, "emoji": "🟡" },
       { "max": 139, "emoji": "🟠" },
-      { "max": 999, "emoji": "🔴" }
+      { "emoji": "🔴" }
     ],
     "fallback": "•"
   }
@@ -323,9 +323,13 @@ temp, SpO₂) or discrete phase labels (`"loading"` / `"maintenance"` /
 
 Rules iterate top-to-bottom, first match wins. Each rule is one of:
 
-- `{ min, max, emoji }` — numeric bands (both bounds optional, at
-  least one required). `min <= row[field] <= max`.
+- `{ min, max, emoji }` — numeric bands (either bound optional).
+  `min <= row[field] <= max`.
 - `{ eq, emoji }` — exact string match, for categorical values.
+- `{ emoji }` with no `min`/`max`/`eq` — **catch-all**. Matches any
+  non-null value at the field. Put it last; paints "anything that
+  didn't match the explicit bands above" without falling through to
+  `fallback`.
 
 This mirrors `display.thresholds` from the generic-card renderer, so
 if you already have threshold rules colour-coding the Today card you

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -80,7 +80,7 @@ cholesterol ratios, fasting glucose).
           { "ifField": "systolic", "max": 119, "colour": "#44ff88", "label": "Optimal" },
           { "ifField": "systolic", "max": 129, "colour": "#aaaa44", "label": "Elevated" },
           { "ifField": "systolic", "max": 139, "colour": "#ff7733", "label": "Stage 1" },
-          { "ifField": "systolic", "max": 999, "colour": "#ff3333", "label": "Stage 2" }
+          { "ifField": "systolic",              "colour": "#ff3333", "label": "Stage 2" }
         ]
       }
     },
@@ -604,7 +604,7 @@ so order rules narrow-to-wide just like `display.thresholds`.
       { "max": 119, "emoji": "🟢" },
       { "max": 129, "emoji": "🟡" },
       { "max": 139, "emoji": "🟠" },
-      { "max": 999, "emoji": "🔴" }
+      { "emoji": "🔴" }
     ],
     "fallback": "•"
   }
@@ -612,8 +612,10 @@ so order rules narrow-to-wide just like `display.thresholds`.
 ```
 
 **Key bits:**
-- Each rule is `{ min?, max?, emoji }` (at least one bound) or
-  `{ eq, emoji }` for exact string match.
+- Each rule is `{ min?, max?, emoji }` (numeric band; either bound
+  optional), `{ eq, emoji }` (exact string match), or `{ emoji }` on
+  its own (catch-all — matches anything not caught by the rules above;
+  put it last).
 - Rules are evaluated top-to-bottom; first match wins. Cascade
   narrowest-first.
 - `fallback` shows when no rule matches or the field is missing.

--- a/public/js/components/health-chat.js
+++ b/public/js/components/health-chat.js
@@ -524,9 +524,6 @@ class HealthChat extends LitElement {
   }
 
   async _clearHistory() {
-    if (this._messages.some(m => m.role === 'user' || m.role === 'assistant')) {
-      if (!confirm('Start a new chat? The current conversation will be cleared.')) return;
-    }
     stopSharedAudio();
     this._audioCache.forEach(v => { try { URL.revokeObjectURL(v.url); } catch {} });
     this._audioCache.clear();

--- a/public/js/lib/calendar-marker.esm.js
+++ b/public/js/lib/calendar-marker.esm.js
@@ -132,11 +132,15 @@ export function resolveMarker(spec, ctx) {
           if (String(v) === String(rule.eq)) return rule.emoji || spec.fallback || fallback;
           continue;
         }
+        // Bounds-less rule = catch-all (matches any value). Put it last
+        // as the "anything else" emoji for the field.
+        if (!('min' in rule) && !('max' in rule)) {
+          return rule.emoji || spec.fallback || fallback;
+        }
         const n = Number(v);
         if (Number.isNaN(n)) continue;
         if ('min' in rule && n < Number(rule.min)) continue;
         if ('max' in rule && n > Number(rule.max)) continue;
-        if (!('min' in rule) && !('max' in rule)) continue;
         return rule.emoji || spec.fallback || fallback;
       }
       return spec.fallback || fallback;

--- a/public/js/lib/calendar-marker.js
+++ b/public/js/lib/calendar-marker.js
@@ -166,11 +166,15 @@
             if (String(v) === String(rule.eq)) return rule.emoji || spec.fallback || fallback;
             continue;
           }
+          // Bounds-less rule = catch-all (matches any value). Put it
+          // last as the "anything else" emoji for the field.
+          if (!('min' in rule) && !('max' in rule)) {
+            return rule.emoji || spec.fallback || fallback;
+          }
           const n = Number(v);
           if (Number.isNaN(n)) continue;
           if ('min' in rule && n < Number(rule.min)) continue;
           if ('max' in rule && n > Number(rule.max)) continue;
-          if (!('min' in rule) && !('max' in rule)) continue;
           return rule.emoji || spec.fallback || fallback;
         }
         return spec.fallback || fallback;

--- a/public/js/lib/display-template.esm.js
+++ b/public/js/lib/display-template.esm.js
@@ -106,11 +106,13 @@ export function evaluateThresholds(row, thresholds) {
       if (String(v) === String(rule.eq)) return rule;
       continue;
     }
+    // Bounds-less rule = catch-all (matches any value at this field).
+    // Put it last as a fallback for values that missed every specific band.
+    if (!('min' in rule) && !('max' in rule)) return rule;
     const n = Number(v);
     if (Number.isNaN(n)) continue;
     if ('min' in rule && n < Number(rule.min)) continue;
     if ('max' in rule && n > Number(rule.max)) continue;
-    if (!('min' in rule) && !('max' in rule)) continue;
     return rule;
   }
   return null;

--- a/public/js/lib/display-template.js
+++ b/public/js/lib/display-template.js
@@ -154,11 +154,14 @@
         if (String(v) === String(rule.eq)) return rule;
         continue;
       }
+      // Bounds-less rule = catch-all (matches any value at this field).
+      // Put it last in the list as a fallback for values that missed
+      // every specific band above.
+      if (!('min' in rule) && !('max' in rule)) return rule;
       const n = Number(v);
       if (Number.isNaN(n)) continue;
       if ('min' in rule && n < Number(rule.min)) continue;
       if ('max' in rule && n > Number(rule.max)) continue;
-      if (!('min' in rule) && !('max' in rule)) continue;
       return rule;
     }
     return null;

--- a/tests/calendar-marker.test.js
+++ b/tests/calendar-marker.test.js
@@ -309,6 +309,25 @@ describe('resolveMarker', () => {
       assert.equal(resolveMarker(legacy, { row: { systolic: 160 } }), '🔴');
     });
 
+    test('bounds-less rule acts as a catch-all (see #73)', () => {
+      const bp = {
+        type: 'threshold',
+        field: 'systolic',
+        rules: [
+          { max: 120, emoji: '✅' },
+          { max: 130, emoji: '🟡' },
+          { max: 140, emoji: '🟠' },
+          { emoji: '🔴' },                  // catch-all for >140
+        ],
+        fallback: '•',
+      };
+      assert.equal(resolveMarker(bp, { row: { systolic: 110 } }), '✅');
+      assert.equal(resolveMarker(bp, { row: { systolic: 125 } }), '🟡');
+      assert.equal(resolveMarker(bp, { row: { systolic: 135 } }), '🟠');
+      assert.equal(resolveMarker(bp, { row: { systolic: 190 } }), '🔴');
+      assert.equal(resolveMarker(bp, { row: { systolic: 250 } }), '🔴');
+    });
+
     test('`rules` wins over `bands` when both are present', () => {
       const both = {
         type: 'threshold',

--- a/tests/display-thresholds-and-trend.test.js
+++ b/tests/display-thresholds-and-trend.test.js
@@ -81,13 +81,23 @@ describe('evaluateThresholds', () => {
     assert.equal(evaluateThresholds(null, bpRules), null);
   });
 
-  test('rule without any min/max/eq/ifField is ignored', () => {
+  test('rule without ifField is ignored', () => {
     const rules = [
       { label: 'wrong' },                  // no ifField
-      { ifField: 'x' },                    // no bounds
       { ifField: 'x', min: 5, max: 10, label: 'right' },
     ];
     assert.equal(evaluateThresholds({ x: 7 }, rules).label, 'right');
+  });
+
+  test('bounds-less rule (no min/max/eq) acts as a catch-all', () => {
+    const rules = [
+      { ifField: 'x', max: 10, label: 'low' },
+      { ifField: 'x', min: 20, label: 'high' },
+      { ifField: 'x', label: 'middle' },      // catch-all: 10 < x < 20
+    ];
+    assert.equal(evaluateThresholds({ x: 5  }, rules).label, 'low');
+    assert.equal(evaluateThresholds({ x: 15 }, rules).label, 'middle');
+    assert.equal(evaluateThresholds({ x: 25 }, rules).label, 'high');
   });
 
   test('accepts field alias (backwards compat)', () => {


### PR DESCRIPTION
## Summary

Fixes threshold markers and headline colouring on readings that fall outside every explicit numeric band.

A rule with no `min`, `max`, or `eq` now matches any non-null value at the field — the natural "anything else" catch-all. Applies equally to `display.thresholds` and `meta.calendar.marker.{type:"threshold"}`.

## Why

Live exposure on klebbtest: the BP card's readings of 190 and 200 systolic showed 🩺 instead of 🔴 because the catch-all `{emoji:"🔴"}` rule was silently skipped. Agents and humans both wrote bare-emoji catch-alls unprompted — it's the natural pattern (CSS `default`, OpenAPI `default`, switch-default, etc.). The old workaround was `{max: 999, emoji: "🔴"}`; it still works, but the catch-all form is the tidier expression.

## How

- `public/js/lib/calendar-marker.js` + `.esm.js` — threshold case: a rule with no bounds returns its emoji. Short-circuit before the numeric coercion so non-numeric values also match.
- `public/js/lib/display-template.js` + `.esm.js` — same change for the `display.thresholds` matcher.
- Docs refreshed (`MANIFEST-SCHEMA.md`, `docs/CARDS.md`, `docs/RECIPES.md`) to prefer the catch-all form and document it explicitly.
- System prompt updated: the threshold cheat-sheet now shows `{"emoji":"🔴"}` as the last rule.
- `data.example/bp.example.json` updated to use the catch-all form for both `display.thresholds` (Stage 2) and the calendar threshold marker.
- Tests: existing "no bounds = skipped" case in `tests/display-thresholds-and-trend.test.js` replaced with a catch-all assertion; new matching case added to `tests/calendar-marker.test.js`.

## Test plan

- [x] `npm test` — 391/392 green (pre-existing unrelated `no-personal-refs` failure; `chat-proxy-reset` is mildly flaky under full-suite load, passes in isolation).
- [x] Calendar-marker + display-thresholds assertions cover the new catch-all semantics end-to-end.
- [ ] Live on klebbtest: visit Calendar on the dates the user logged systolic 190 and 200 — expect 🔴 after deploy. Lower-band days should continue to render ✅ / 🟡 / 🟠 correctly.

Fixes #73