### PR TITLE
feat(chat): hide_card + show_card tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Added
+
+- **Chat agent can hide and unhide cards.** Two new tools
+  (\`hide_card\`, \`show_card\`) wire the chat agent into the existing
+  \`registry.setMasterEnabled\` path, so "hide the hydration card"
+  actually works instead of being answered with "go to Settings". The
+  deletion guidance in the system prompt now steers the model toward
+  \`hide_card\` whenever the user just wants a card off their
+  dashboard, since it's reversible and preserves all logged data.
+  (#75)
+
 ### Changed
 
 - **Threshold rules without bounds now act as a catch-all.** Previously

--- a/chat/tools.js
+++ b/chat/tools.js
@@ -49,6 +49,38 @@ const TOOL_DEFS = [
   {
     type: 'function',
     function: {
+      name: 'hide_card',
+      description:
+        "Hide a card from every view (Today, Trends, Calendar, Reports) by setting meta.enabled:false. The card's manifest file and data are preserved — use this instead of delete_manifest when the user wants to stop seeing a card but might want it back. The card stays visible in Settings so the user can re-enable it.",
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'Manifest id.' },
+        },
+        required: ['id'],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'show_card',
+      description:
+        "Unhide a previously-hidden card by setting meta.enabled:true. Reverses hide_card. No-op if the card is already enabled.",
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'Manifest id.' },
+        },
+        required: ['id'],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
       name: 'list_manifests',
       description:
         "Return a compact list of all cards currently on the user's dashboard. Useful to re-check state mid-conversation (e.g. after you just created a card, or before proposing an id to check it's not taken).",
@@ -82,6 +114,14 @@ function dispatchToolCall(tc) {
       case 'delete_manifest': {
         const result = registry.deleteManifest(args.id);
         return JSON.stringify({ ok: true, ...result });
+      }
+      case 'hide_card': {
+        registry.setMasterEnabled(args.id, false);
+        return JSON.stringify({ ok: true, id: args.id, enabled: false });
+      }
+      case 'show_card': {
+        registry.setMasterEnabled(args.id, true);
+        return JSON.stringify({ ok: true, id: args.id, enabled: true });
       }
       case 'list_manifests': {
         const rows = registry.list().map(c => ({

--- a/config/env.js
+++ b/config/env.js
@@ -146,8 +146,10 @@ The data layout is card-specific — rely on each manifest's \`meta\` and \`desc
 You, ${CHAT_AGENT_NAME}, are embedded in the dashboard itself. You act by calling tools — never by printing JSON and asking the user to save a file, and never by describing an HTTP request as prose.
 
 - \`create_manifest(manifest)\` → create a new card on the dashboard. Pass the full manifest object. Returns \`{ok, id, source}\` on success. Validation errors come back as \`{error: "..."}\` — read the message and retry with a corrected manifest (e.g. pick a different id on "duplicate id", sanitise chars on "invalid id: format").
-- \`delete_manifest(id)\` → remove a card and its file. Only call after confirming intent with the user. If the user is unsure, prefer suggesting they hide it via meta.enabled:false (no tool for that today; tell them where the Settings toggle is).
-- \`list_manifests()\` → current card list. Useful mid-conversation after a create, or to check an id isn't already taken before proposing one.
+- \`delete_manifest(id)\` → remove a card and its file. Destructive — data goes with the file. Only call after confirming intent. If the user just wants the card off their dashboard, call \`hide_card\` instead.
+- \`hide_card(id)\` → sets master \`meta.enabled:false\`. Hides the card from every view but keeps the file + data intact. This is the right tool for "stop showing me the hydration card", "hide this for now", etc. No confirmation needed — it's reversible with \`show_card\`.
+- \`show_card(id)\` → sets master \`meta.enabled:true\`. Reverses \`hide_card\`.
+- \`list_manifests()\` → current card list (each entry includes \`enabled\` so you can tell a hidden card from an active one). Useful mid-conversation after a create, or to check an id isn't already taken before proposing one.
 
 ## HTTP API (reference for external agents)
 
@@ -302,7 +304,7 @@ Call \`create_manifest\` with this \`manifest\` argument:
 
 Call \`delete_manifest\` with the card's id, e.g. \`delete_manifest("blood-pressure")\`. Returns \`{ok, id}\` on success; \`{error: "unknown manifest: ..."}\` if the id doesn't exist.
 
-Only delete a card after confirming intent with the user — manifest files contain their data history and the delete removes it. If in doubt, suggest hiding the card via \`meta.enabled:false\` (toggled in Settings) instead of deleting.
+Only delete a card after confirming intent with the user — manifest files contain their data history and the delete removes it. If the user just wants the card off their dashboard, call \`hide_card(id)\` instead — it's reversible and preserves all the data.
 
 ## Workflow
 

--- a/tests/chat-tool-use.test.js
+++ b/tests/chat-tool-use.test.js
@@ -149,6 +149,58 @@ describe('chat proxy tool-calling agent loop', () => {
     assert.ok(fs.existsSync(onDisk), 'manifest file should exist on disk');
   });
 
+  test('F — hide_card toggles master meta.enabled to false (see #75)', async () => {
+    gateway.reset();
+    // Seed a pre-existing card the agent will hide
+    const seedPath = path.join(sandbox, 'data', 'tool-test-f.json');
+    fs.writeFileSync(seedPath, JSON.stringify({
+      $schema: 'klebb.datafile.v1',
+      meta: {
+        id: 'tool-test-f',
+        label: 'Tool Test F',
+        view: { enabled: true, component: 'generic-card' },
+      },
+      data: [],
+    }, null, 2));
+    // Give fs.watch a beat to notice
+    await new Promise(r => setTimeout(r, 350));
+
+    gateway.pushResponses([
+      toolCallResponse({ name: 'hide_card', args: { id: 'tool-test-f' }, id: 'call_f' }),
+      stopResponse('Hidden.'),
+    ]);
+
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'Hide tool-test-f.' }] },
+    });
+
+    assert.equal(res.status, 200);
+    assert.equal(res.json.reply, 'Hidden.');
+
+    const reqs = gateway.getRequests();
+    const toolMsg = reqs[1].messages.find(m => m.role === 'tool');
+    assert.match(toolMsg.content, /"enabled":false/);
+
+    // File on disk now has meta.enabled: false
+    const afterHide = JSON.parse(fs.readFileSync(seedPath, 'utf8'));
+    assert.equal(afterHide.meta.enabled, false);
+
+    // Second round: show_card flips it back
+    gateway.reset();
+    gateway.pushResponses([
+      toolCallResponse({ name: 'show_card', args: { id: 'tool-test-f' }, id: 'call_f2' }),
+      stopResponse('Back.'),
+    ]);
+    const res2 = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'Show tool-test-f.' }] },
+    });
+    assert.equal(res2.status, 200);
+    const afterShow = JSON.parse(fs.readFileSync(seedPath, 'utf8'));
+    assert.equal(afterShow.meta.enabled, true);
+  });
+
   test('B — error feedback on delete of unknown id', async () => {
     gateway.reset();
     gateway.pushResponses([

--- a/tests/config-defaults.test.js
+++ b/tests/config-defaults.test.js
@@ -200,6 +200,11 @@ describe('config/env.js defaults', () => {
     assert.ok(p.includes('POST /api/manifests'), 'should advertise POST /api/manifests');
     assert.ok(p.includes('DELETE /api/manifests/:id'), 'should advertise DELETE /api/manifests/:id');
 
+    // Tools the agent can call (see #75)
+    for (const tool of ['create_manifest', 'delete_manifest', 'hide_card', 'show_card', 'list_manifests']) {
+      assert.ok(p.includes(tool), `prompt should name tool "${tool}"`);
+    }
+
     // Every built-in renderer name, so the agent picks correctly
     for (const renderer of [
       'generic-card', 'list-card', 'checklist-card', 'schedule-card',


### PR DESCRIPTION
## Summary

Two new tools for the chat agent: `hide_card(id)` flips `meta.enabled` to `false`, `show_card(id)` flips it back. Both dispatch directly to `registry.setMasterEnabled` (same underlying path as the existing `POST /api/settings/cards/:id/enable` + `/disable` endpoints).

## Why

Exposed on klebbtest: user asked "hide the hydration card" and the agent answered "I don't have a tool for that, go to Settings." The server already had the functionality; the tool wiring was just missing.

## How

- `chat/tools.js` — two new tool defs + dispatch cases. Sync calls, same pattern as create/delete.
- `config/env.js` — the "Tools you can call" list now names `hide_card` and `show_card`, and the Deletion paragraph steers the model toward `hide_card` when the user just wants the card off their dashboard (reversible, preserves data).
- `tests/chat-tool-use.test.js` — new case F: scripted stub drives `hide_card` → checks file on disk shows `meta.enabled:false`, then `show_card` → flips back.
- `tests/config-defaults.test.js` — assertion that the prompt names all five tools.

## Test plan

- [x] `npm test` — 392/393 green (pre-existing unrelated failure).
- [ ] Live on klebbtest: "hide the hydration card" → bubble confirms, card disappears from Today. "Show the hydration card" → reappears. File on disk reflects `meta.enabled` flipping.

Fixes #75