### PR TITLE
fix(chat): scroll to bottom when opening panel with history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Chat panel scrolls to the latest turn when reopened.** Opening the
+  panel with existing history used to leave the message list scrolled
+  to the top, so the user always had to flick down to see what they'd
+  just been talking about. Scroll-to-bottom now runs after the panel
+  paints, and re-runs once async history load completes if the user
+  managed to open the panel before the initial \`GET /api/chat/history\`
+  landed. (#80)
 - **Threshold calendar markers work again when written by the chat
   agent.** The \`DEFAULT_HEALTH_SYSTEM_PROMPT\` was telling agents to
   use \`"bands": [...]\` for threshold-marker rules; the renderer

--- a/public/js/components/health-chat.js
+++ b/public/js/components/health-chat.js
@@ -673,12 +673,28 @@ class HealthChat extends LitElement {
 
   _toggle() {
     this._open = !this._open;
-    // When opening, auto-focus the text input after render
+    // When opening, auto-focus the text input after render.
+    // Scroll-to-bottom is handled in updated() so it also fires after
+    // async history load races the panel open.
     if (this._open) {
-      requestAnimationFrame(() => {
+      this._pendingScrollToBottom = true;
+      this.updateComplete.then(() => {
         const input = this.shadowRoot?.querySelector('.chat-input');
         if (input && !this._recording) input.focus();
       });
+    }
+  }
+
+  updated(changed) {
+    // Pin to the latest turn when the panel opens. If history is still
+    // loading from the server at that moment, _messages will change
+    // shortly and we re-scroll then, clearing the flag afterwards.
+    if (this._open && this._pendingScrollToBottom) {
+      const container = this.shadowRoot?.querySelector('.chat-messages');
+      if (container) {
+        container.scrollTop = container.scrollHeight;
+        if (this._messages.length > 0) this._pendingScrollToBottom = false;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Opening the chat panel with existing conversation history left the message list scrolled to the top. The user had to flick down to see the most recent turn. This pins the scroll to the bottom on open.

Fixes #80.

## Why

History persists server-side (#54 groundwork already landed), so the common case is reopening an in-progress thread. Landing at the top makes that feel broken.

## How

- \`_toggle()\` sets \`_pendingScrollToBottom\` when opening.
- New \`updated()\` lifecycle hook scrolls \`.chat-messages\` to the bottom and clears the flag only once there's content. This covers the race where the panel opens before the async \`/api/chat/history\` GET returns: the re-render from that fetch re-runs \`updated()\` and scrolls again.
- No server change.

## Testing

- [x] \`npm test\` — 392/393 pass; the single fail is a pre-existing \`no-personal-refs\` hit on operator-brief files, unrelated to this branch.
- [ ] Manual: reopen a non-empty chat panel; verify the latest turn is visible without scrolling.
- [ ] Manual: reload the page and immediately tap to open; verify scroll still lands at bottom after history loads.
- [ ] Manual (mobile viewport): same as above.