### PR TITLE
feat(chat): clarify ambiguous card requests, suggest extras on create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,22 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Changed
 
+- **Chat agent asks for clarification only when a card request is
+  genuinely ambiguous, and offers optional extras after creating.**
+  Previously, "add a hydration card" would just produce a plain
+  generic-card with one number input and no follow-up. The system
+  prompt now tells the agent to (1) default to creating when defaults
+  are obvious (hydration, mood, steps etc. just ship), (2) ask ONE
+  focused question before creating only when a renderer-critical
+  choice is genuinely ambiguous (glucose = list vs generic?; weight =
+  kg vs lb if not already established?; dose-cadence cards need
+  schedule shape), and (3) always end a successful \`create_manifest\`
+  reply with a 2-3 item offer of tailored embellishments (trends
+  chart, calendar marker, headline thresholds, reports, extra inputs,
+  daily target/reminder). Picked extras apply via delete+recreate,
+  safe only right after initial creation before the card has user
+  data. (#81)
+
 - **Threshold rules without bounds now act as a catch-all.** Previously
   a rule with no \`min\`, \`max\`, or \`eq\` was silently skipped, so
   the natural way to write "anything else" (a bare \`{emoji}\` as the

--- a/config/env.js
+++ b/config/env.js
@@ -300,6 +300,32 @@ Call \`create_manifest\` with this \`manifest\` argument:
 }
 \`\`\`
 
+### Clarify before creating — only when required info is missing
+
+Default to just creating the card. Trivial asks with obvious defaults ("add a hydration card", "track my mood", "card for steps") have enough signal: pick a sensible renderer (\`generic-card\` or \`list-card\`), pick one or two natural inputs (e.g. hydration → \`ml\` number input; steps → \`count\` number input; mood → 1-5 rating), and call \`create_manifest\`.
+
+Ask ONE focused clarifying question BEFORE calling \`create_manifest\` only when a choice the renderer actually needs is genuinely ambiguous and can't be guessed. Examples of "genuinely ambiguous":
+- Multiple readings per day vs one (list-card vs generic-card) for a metric where either is plausible (e.g. "track my glucose" — could be CGM spot checks or a once-a-day fasting number).
+- The metric's unit is regional ("track my weight" → kg or lb? Only ask if the instance hasn't already established a unit via an existing card you can check with \`list_manifests\`.)
+- Schedule-shaped cards ("log my peptide doses") where you need the cadence (daily / weekly / phased) to fill \`meta.schedule\` correctly.
+
+Do NOT ask about optional embellishments before creating. Ship the card first, then suggest extras (see below). One question max; if still unsure, pick a reasonable default, create, and mention the assumption in the reply.
+
+### After creating — suggest 2-3 optional extras
+
+Once \`create_manifest\` succeeds, your reply MUST end with a short offer of optional embellishments the user didn't mention, tailored to the card you just made. Pick 2-3 from this list that actually fit (don't suggest a line chart for a checklist, don't suggest thresholds for a textarea):
+
+- **Trends chart:** \`meta.trends = {enabled:true, component:"line-chart", ...}\` — for any numeric card, so the user can see the metric over time.
+- **Calendar marker:** \`meta.calendar = {enabled:true, component:"day-marker", marker:...}\` — a static emoji, a threshold colour (green/amber/red), a trend arrow, or a template like \`"{kg}kg"\`.
+- **Thresholds on the Today headline:** \`meta.view.display.thresholds\` — colour the value green/amber/red against bands (great for BP, glucose, RHR, weight goals).
+- **Reports renderer:** \`meta.reports\` — \`table-list\` for history, \`adherence-report\` for schedules.
+- **Extra inputs:** a notes field, a time-of-day field, a tag/category select.
+- **A daily target or reminder prompt:** \`meta.prompt = {enabled:true, ...}\` if the user wants to be nudged.
+
+Offer them as a single short sentence or a 2-3 item bullet list, e.g. "Done. Want me to add a trends chart, a daily target, or a calendar marker?" — not a long menu. Never auto-add beyond what was asked.
+
+If the user picks one of your suggestions, apply it by calling \`delete_manifest(id)\` followed immediately by \`create_manifest\` with the augmented manifest. This is safe ONLY right after initial creation because the card has no user data yet. Do NOT use delete+recreate to modify an existing card that has data — tell the user that editing an existing card in place isn't supported yet and they'll need to add data-preserving tooling or accept the loss.
+
 ### Deletion
 
 Call \`delete_manifest\` with the card's id, e.g. \`delete_manifest("blood-pressure")\`. Returns \`{ok, id}\` on success; \`{error: "unknown manifest: ..."}\` if the id doesn't exist.


### PR DESCRIPTION
## Summary

System-prompt-only change. Teaches the chat agent to:

1. Default to creating the card when the request has obvious defaults (e.g. "add a hydration card").
2. Ask ONE focused question before \`create_manifest\` only when a renderer-critical choice is genuinely ambiguous (single vs list reading, regional unit not already established, dose-cadence schedule).
3. Always end a successful creation with a 2-3 item offer of optional embellishments (trends chart, calendar marker, headline thresholds, reports, extra inputs, daily target/reminder), tailored to the card just made.
4. Apply accepted extras via \`delete_manifest\` + \`create_manifest\` — called out as safe ONLY right after creation, before the card accumulates data, so the agent doesn't use the same trick to "edit" a populated card.

Fixes #81.

## Why

Live test of "create a card for hydration" revealed the agent was one-and-done: it made the card and said nothing more. That's a missed collaboration opportunity: most cards want a trend chart and calendar marker, and the agent is in the best position to suggest those at the moment the user is engaged with the new card.

## How

- \`config/env.js\`: two new subsections in \`DEFAULT_HEALTH_SYSTEM_PROMPT\` under "Creating and deleting cards" — "Clarify before creating — only when required info is missing" and "After creating — suggest 2-3 optional extras".
- No code changes; no tool changes; no server changes.
- Existing prompt / config tests still pass.

## Testing

- [x] \`npm test -- tests/chat-prompt-cards.test.js tests/config-defaults.test.js\` — 31/31 pass.
- [ ] Manual (klebbtest): "add a hydration card" — card should ship with sensible defaults and the reply should end with a short offer of extras.
- [ ] Manual: "track my glucose" — agent should ask whether spot-checks or a single fasting reading before creating.
- [ ] Manual: accept one of the suggested extras, confirm it applies via delete+recreate without data loss (there's no data yet).
- [ ] Manual: try to extend an older card the same way; agent should refuse the delete+recreate shortcut.