### PR TITLE
feat(chat): expand/collapse toggle for chat panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Expand/collapse toggle for the chat panel.** A new header button
+  (\`⤡\` / \`⤢\`) flips between the default 380px-wide panel and an
+  expanded variant (\`min(720px, 100vw - 40px)\` wide, up to 900px
+  tall on desktop). The preference lives in \`localStorage\` so it
+  sticks across sessions. On viewports ≤480px the width is already
+  pinned full-bleed, so expanding on mobile grows the message list
+  vertically only, clamped to \`100vh - 56px - safe-area\`; nothing
+  can overflow the screen. Toggling also re-pins the scroll to the
+  latest turn so the visible viewport doesn't suddenly show old
+  content after a resize. (#82)
 - **Chat bubbles render GFM markdown, including tables.** The widget
   was rolling its own ~25-line regex parser that covered bold / italic
   / inline code / bullets / paragraphs — enough for most replies, but

--- a/public/js/components/health-chat.js
+++ b/public/js/components/health-chat.js
@@ -111,6 +111,7 @@ class HealthChat extends LitElement {
     _playingMsgId: { state: true },
     _agentName: { state: true },
     _agentEmoji: { state: true },
+    _expanded: { state: true },
   };
 
   static styles = css`
@@ -206,6 +207,12 @@ class HealthChat extends LitElement {
       box-shadow: 0 -8px 32px rgba(0, 0, 0, 0.18);
       overflow: hidden;
     }
+    /* Expanded variant: wider on desktop, taller on phones.
+       Width is always clamped to the viewport so nothing can overflow. */
+    .chat-panel.expanded {
+      width: min(720px, calc(100vw - 40px));
+      max-height: min(900px, calc(100vh - 80px));
+    }
 
     .chat-header {
       padding: 14px 18px;
@@ -245,6 +252,10 @@ class HealthChat extends LitElement {
       gap: 10px;
       min-height: 200px;
       max-height: 360px;
+    }
+    /* In expanded mode, let the message list grow to fill the taller panel. */
+    .chat-panel.expanded .chat-messages {
+      max-height: calc(100vh - 220px);
     }
 
     .msg {
@@ -495,6 +506,17 @@ class HealthChat extends LitElement {
         max-height: calc(100vh - 56px - env(safe-area-inset-bottom, 0px));
         border-radius: 16px 16px 0 0;
       }
+      /* On mobile, width is already maxed; 'expanded' grows vertically.
+         The small-state max-height already clamps to the viewport, so
+         expanded on mobile just matches it; no overflow possible. */
+      .chat-panel.expanded {
+        width: 100vw;
+        max-width: 100vw;
+        max-height: calc(100vh - 56px - env(safe-area-inset-bottom, 0px));
+      }
+      .chat-panel.expanded .chat-messages {
+        max-height: calc(100vh - 200px - env(safe-area-inset-bottom, 0px));
+      }
       .fab { bottom: 14px; right: 14px; width: 50px; height: 50px; font-size: 20px; }
     }
 
@@ -529,6 +551,7 @@ class HealthChat extends LitElement {
     this._audioCache = new Map();
     this._agentName = 'Chat';
     this._agentEmoji = '\u{1F4AC}'; // 💬 speech balloon
+    this._expanded = localStorage.getItem('klebb-chat-expanded') === '1';
     this._saveTimer = null;
     this._checkVoiceAvailability();
     this._loadInstance();
@@ -958,6 +981,14 @@ class HealthChat extends LitElement {
     }
   }
 
+  _toggleExpanded() {
+    this._expanded = !this._expanded;
+    localStorage.setItem('klebb-chat-expanded', this._expanded ? '1' : '0');
+    // Pin to the latest turn after resize so the visible viewport
+    // doesn't suddenly show old content when the panel grows.
+    this._pendingScrollToBottom = true;
+  }
+
   _cyclePlaybackSpeed() {
     const speeds = [0.5, 1, 1.25, 1.5, 2];
     const idx = speeds.indexOf(this._playbackSpeed);
@@ -1037,13 +1068,21 @@ class HealthChat extends LitElement {
     const askName = this._agentName || 'Chat';
     return html`
       ${this._open ? html`
-        <div class="chat-panel">
+        <div class="chat-panel ${this._expanded ? 'expanded' : ''}">
           <div class="chat-header">
             <span class="chat-header-icon">${this._agentEmoji}</span>
             <span class="chat-header-text">${this._agentName}</span>
             ${this._voiceAvailable ? html`
               <button class="speed-btn" @click=${this._cyclePlaybackSpeed} title="Playback speed">${this._playbackSpeed}x</button>
             ` : html`<span class="chat-header-sub">Health Assistant</span>`}
+            <button
+              class="speed-btn"
+              @click=${this._toggleExpanded}
+              aria-label=${this._expanded ? 'Shrink chat' : 'Expand chat'}
+              aria-pressed=${this._expanded}
+              title=${this._expanded ? 'Shrink' : 'Expand'}
+              style="margin-left: 6px; min-width: 28px;"
+            >${this._expanded ? '\u2922' : '\u2921'}</button>
             <button
               class="speed-btn"
               @click=${this._clearHistory}


### PR DESCRIPTION
## Summary

Adds a header button that toggles the chat panel between its default size and a larger variant, with the preference persisted in \`localStorage\`.

Fixes #82.

## Why

The default 380px panel is tight for long replies (especially markdown tables and multi-paragraph assistant output). Rather than make it bigger by default and eat screen real estate on a pocket viewport, offer a per-user toggle.

## How

- \`public/js/components/health-chat.js\`:
  - New reactive \`_expanded\` state, initialised from \`localStorage.getItem('klebb-chat-expanded')\`.
  - New \`_toggleExpanded()\` handler; writes to \`localStorage\` and schedules a scroll-to-bottom so the visible viewport doesn't land on old content after resize.
  - New header button between the speed/new-chat/close buttons. Uses \`⤡\` / \`⤢\` glyphs; full \`aria-label\` + \`aria-pressed\`.
  - CSS:
    - Default \`.chat-panel\` unchanged (380px × \`min(640px, 100vh - 80px)\`).
    - \`.chat-panel.expanded\` on desktop: \`width: min(720px, 100vw - 40px); max-height: min(900px, 100vh - 80px)\`.
    - \`.chat-panel.expanded .chat-messages\` lifts the 360px message-list cap to \`calc(100vh - 220px)\` so the list actually fills the panel.
    - Mobile (\`@media (max-width: 480px)\`) already pins width full-bleed; \`.chat-panel.expanded\` in that block reasserts the same width and adjusts the message-list cap. No way to overflow the screen.
- No server change, no new deps.

## Testing

- [x] \`npm test\` — 391/393 pass; the two fails are pre-existing (\`no-personal-refs\` hygiene test on operator-brief files; \`chat-proxy-reset\` flaky race test, passes in isolation). Neither touches chat UI code.
- [x] Booted server locally and confirmed the updated JS is served (9 hits for \`_expanded\` in the delivered bundle).
- [ ] Manual (klebbtest desktop): click the new ⤡/⤢ header button; verify the panel grows/shrinks, preference sticks across reload.
- [ ] Manual (klebbtest desktop, narrow window ~500px): confirm \`min(720px, 100vw - 40px)\` clamps correctly.
- [ ] Manual (klebbtest iOS Safari): confirm expand grows vertically only, safe-area inset preserved, no off-screen overflow.
- [ ] Manual: open the panel with existing history in expanded mode; confirm scroll still lands at bottom.