### PR TITLE
fix(chat): refocus input after reply lands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,13 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
   paints, and re-runs once async history load completes if the user
   managed to open the panel before the initial \`GET /api/chat/history\`
   landed. (#80)
+- **Chat text input keeps focus after a reply lands.** The input is
+  disabled while a request is in flight, so the browser drops focus
+  and the user had to click the box again to type the next message.
+  Focus is now returned to \`.chat-input\` after \`_sendText\` settles
+  (success or error path), unless the panel was closed in the
+  meantime or the mic is recording. Skipped on mobile (<=480px) so
+  iOS Safari doesn't pop the keyboard back up uninvited. (#84)
 - **Threshold calendar markers work again when written by the chat
   agent.** The \`DEFAULT_HEALTH_SYSTEM_PROMPT\` was telling agents to
   use \`"bands": [...]\` for threshold-marker rules; the renderer

--- a/public/js/components/health-chat.js
+++ b/public/js/components/health-chat.js
@@ -788,6 +788,15 @@ class HealthChat extends LitElement {
     this._loading = false;
     this._abortController = null;
     this._scrollToBottom();
+    // Input lost focus because it was disabled while loading. Put it
+    // back so the user can type the next message without re-clicking.
+    // Skip on mobile: touch keyboards re-opening uninvited is jarring.
+    this.updateComplete.then(() => {
+      if (!this._open || this._recording) return;
+      if (matchMedia('(max-width: 480px)').matches) return;
+      const input = this.shadowRoot?.querySelector('.chat-input');
+      if (input && !input.disabled) input.focus();
+    });
   }
 
   _handleKeydown(e) {


### PR DESCRIPTION
## Summary

After pressing Enter to send a chat message, the text input lost focus and the user had to click it again to type a reply. This puts focus back after the request settles.

Fixes #84.

## Why

\`.chat-input\` is \`:disabled\` while \`_loading\` is true (prevents double-sends). When the input re-enables after the reply, the browser has already moved focus to \`<body>\`, so the next keystroke goes nowhere. Annoying enough to re-type after every turn.

## How

- \`public/js/components/health-chat.js\`: after both the success and error paths of \`_sendText()\` settle, schedule \`updateComplete.then(...)\` to refocus \`.chat-input\`. Gate it: don't refocus if the panel has been closed, if the mic is recording, or on viewports ≤480px (touch keyboards popping up uninvited is jarring).

## Testing

- [x] \`npm test\` — same 391/393 pass as main (pre-existing \`no-personal-refs\` + flaky \`chat-proxy-reset\`, neither relevant here).
- [ ] Manual (klebbtest desktop): type → Enter; when the reply lands, type without clicking; confirm the keystrokes land in the input.
- [ ] Manual: trigger an error (e.g. kill the gateway briefly); confirm focus still returns after the error message.
- [ ] Manual (klebbtest iOS Safari): confirm focus does NOT return on mobile (no unexpected keyboard pop).
- [ ] Manual: close the panel before the reply arrives; confirm no focus attempt fires (guarded by \`!this._open\`).