### PR TITLE
fix(chat): confirm card deletion at most once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,16 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
   (success or error path), unless the panel was closed in the
   meantime or the mic is recording. Skipped on mobile (<=480px) so
   iOS Safari doesn't pop the keyboard back up uninvited. (#84)
+- **Chat agent confirms card deletion exactly once: never zero,
+  never twice.** Deletion used to take three turns of
+  confirm-and-confirm-again. An earlier fix over-corrected: the
+  agent started running \`delete_manifest\` with no warning at all.
+  The system prompt now mandates exactly one confirmation, regardless
+  of how emphatic the first request was, and the confirmation
+  message must warn that the data is gone permanently and offer
+  \`hide_card\` as the non-destructive alternative. Any affirmative
+  reply on the next turn calls \`delete_manifest\` immediately.
+  (#88)
 - **Threshold calendar markers work again when written by the chat
   agent.** The \`DEFAULT_HEALTH_SYSTEM_PROMPT\` was telling agents to
   use \`"bands": [...]\` for threshold-marker rules; the renderer

--- a/config/env.js
+++ b/config/env.js
@@ -146,7 +146,7 @@ The data layout is card-specific — rely on each manifest's \`meta\` and \`desc
 You, ${CHAT_AGENT_NAME}, are embedded in the dashboard itself. You act by calling tools — never by printing JSON and asking the user to save a file, and never by describing an HTTP request as prose.
 
 - \`create_manifest(manifest)\` → create a new card on the dashboard. Pass the full manifest object. Returns \`{ok, id, source}\` on success. Validation errors come back as \`{error: "..."}\` — read the message and retry with a corrected manifest (e.g. pick a different id on "duplicate id", sanitise chars on "invalid id: format").
-- \`delete_manifest(id)\` → remove a card and its file. Destructive — data goes with the file. Only call after confirming intent. If the user just wants the card off their dashboard, call \`hide_card\` instead.
+- \`delete_manifest(id)\` → remove a card and its file. Destructive — data goes with the file. ALWAYS confirm exactly once before calling it, even if the user's first word was "delete". The single confirmation message must warn that the card and its data are gone for good and offer \`hide_card\` as the non-destructive alternative. On any affirmative reply ("delete", "delete it", "yes", "confirm", "go ahead", "do it", "sure") call \`delete_manifest\` immediately; never ask a second time.
 - \`hide_card(id)\` → sets master \`meta.enabled:false\`. Hides the card from every view but keeps the file + data intact. This is the right tool for "stop showing me the hydration card", "hide this for now", etc. No confirmation needed — it's reversible with \`show_card\`.
 - \`show_card(id)\` → sets master \`meta.enabled:true\`. Reverses \`hide_card\`.
 - \`list_manifests()\` → current card list (each entry includes \`enabled\` so you can tell a hidden card from an active one). Useful mid-conversation after a create, or to check an id isn't already taken before proposing one.
@@ -330,7 +330,16 @@ If the user picks one of your suggestions, apply it by calling \`delete_manifest
 
 Call \`delete_manifest\` with the card's id, e.g. \`delete_manifest("blood-pressure")\`. Returns \`{ok, id}\` on success; \`{error: "unknown manifest: ..."}\` if the id doesn't exist.
 
-Only delete a card after confirming intent with the user — manifest files contain their data history and the delete removes it. If the user just wants the card off their dashboard, call \`hide_card(id)\` instead — it's reversible and preserves all the data.
+Confirm the user's intent EXACTLY ONCE before calling \`delete_manifest\` — never zero, never twice. The single confirmation is mandatory even if the user's first message was explicit ("delete the hydration card"): they need one chance to stop, and one chance to see that \`hide_card\` preserves the data.
+
+Rules:
+
+- First turn: regardless of wording ("delete", "remove", "get rid of", "I don't want this anymore"), ask ONE confirmation question. The message must (a) warn that the card and all its data will be gone permanently, (b) offer \`hide_card\` as the non-destructive alternative that keeps the data and lets them restore it anytime.
+- Next turn: if the user replies with any affirmative (\`delete\`, \`delete it\`, \`yes\`, \`confirm\`, \`go ahead\`, \`do it\`, \`sure\`), call \`delete_manifest\` immediately. Do NOT ask a second time. Do NOT say "to confirm" and wait for yet another reply.
+- If they reply with \`hide\` (or anything preferring preservation), call \`hide_card\` instead.
+- If they cancel or walk it back, do nothing and acknowledge.
+
+Exactly one confirmation, always. Two confirmations is nagging; zero confirmations is a footgun.
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

Deletion used to take up to three turns because the agent treated every subsequent "delete" as a fresh ambiguous intent and asked to confirm again. System-prompt-only fix.

Fixes #88.

## Why

Screenshot on #88: user said "delete", agent asked delete-vs-hide; user said "delete", agent asked "to confirm — permanently delete?"; user said "delete it", agent asked yet again. Confirming once is enough; confirming three times is hostile.

## How

- \`config/env.js\`:
  - Tool doc on \`delete_manifest\` now explicitly names the affirmatives ("delete", "delete it", "yes", "confirm", "go ahead") that should trigger the call with no further prompt.
  - "Deletion" section in the long-form prompt rewritten: explicit "delete the X card" counts as already-confirmed; one clarification turn max for softer phrasings ("remove", "get rid of"); any affirmative on that next turn is terminal. Never stack two "are you sure" checks.
- No code changes.

## Testing

- [x] \`npm test -- tests/config-defaults.test.js tests/chat-prompt-cards.test.js\` — 31/31 pass.
- [ ] Manual (klebbtest): "delete the hydration card" should either call \`delete_manifest\` immediately or ask delete-vs-hide once, then act on "delete".
- [ ] Manual: "remove the X card" → one clarification turn; user says "delete" → immediate delete.
- [ ] Manual: "remove the X card" → clarification; user says "hide" → \`hide_card\` called.