### PR TITLE
feat(chat): require writeable.inputs on every writeable card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
   daily target/reminder). Picked extras apply via delete+recreate,
   safe only right after initial creation before the card has user
   data. (#81)
+- **Chat agent ships every writeable card with a full \`inputs\`
+  array.** Klebbius was creating writeable list-cards with the
+  \`writeable\` booleans set but no \`inputs\`. Result: Edit mode on a
+  list-card row showed only the primary-field text box — the
+  per-row three-dot button for secondary fields never appeared
+  because there were no secondaries to render. Prompt now demands
+  that every manifest with \`meta.writeable.fromWebapp:true\` carry
+  a non-empty \`meta.writeable.inputs\` array covering every field
+  the description mentions, and for list-card also set
+  \`meta.view.display.primaryField\`. A new worked example (full
+  appointments manifest) is in the prompt. (#90)
 
 - **Threshold rules without bounds now act as a catch-all.** Previously
   a rule with no \`min\`, \`max\`, or \`eq\` was silently skipped, so

--- a/config/env.js
+++ b/config/env.js
@@ -186,6 +186,8 @@ Everything else is optional pass-through. The endpoint is lenient: if the render
 
 **Gotcha — \`meta.view.display\` is an object, never a string.** Use \`"display": {"template": "{bpm} bpm"}\`, NOT \`"display": "{bpm} bpm"\`. The object can carry \`template\`, \`secondary\`, \`emptyHeadline\`, \`emojiMap\`, \`thresholds\`, \`trendArrow\`, \`unit\`, and \`subtitle\`. A bare string won't render anything.
 
+**Gotcha — writeable cards MUST declare \`meta.writeable.inputs\`.** If \`meta.writeable.fromWebapp: true\` is set, the manifest MUST carry a non-empty \`meta.writeable.inputs\` array that covers every field the card's \`description\` mentions. Without inputs, the edit-form is a primary-field-only stub and the per-row three-dot button (which opens secondary-field editing on list-card) never appears. Concretely: if the description says "Array of {date, type, location, status, followUp, note}", the manifest must declare inputs for all of those keys. For \`list-card\` also set \`meta.view.display.primaryField\` to the key whose value is the row title (e.g. \`"name"\`) so the renderer knows which input is primary vs secondary.
+
 ### Full manifest shape
 
 \`\`\`
@@ -284,7 +286,36 @@ Call \`create_manifest\` with this \`manifest\` argument:
 }
 \`\`\`
 
-### Example 2 — ad-hoc (renderer not yet implemented)
+### Example 2 — list-card with full inputs (appointments)
+
+Call \`create_manifest\` with this \`manifest\` argument. Note: every field named in the \`description\` has a matching input, and \`meta.view.display.primaryField\` tells the renderer which input is the row title.
+
+\`\`\`
+{
+  "$schema":"klebb.datafile.v1",
+  "meta":{
+    "id":"appointments","label":"Appointments","emoji":"🗓️","order":700,
+    "view":{"enabled":true,"component":"list-card","dateContext":"exact-date",
+      "display":{"primaryField":"name","secondaryTemplate":"{date} — {location}","emptyMessage":"No appointments."}},
+    "calendar":{"enabled":true,"component":"day-marker","marker":"🗓️"},
+    "writeable":{"fromWebapp":true,"pastAllowed":true,"todayAllowed":true,"futureAllowed":true,
+      "inputs":[
+        {"key":"name","label":"Name","type":"text","required":true,"placeholder":"e.g. GP annual review"},
+        {"key":"date","label":"Date","type":"date"},
+        {"key":"time","label":"Time","type":"time"},
+        {"key":"location","label":"Location","type":"text"},
+        {"key":"type","label":"Type","type":"select","options":["GP","Specialist","Imaging","Pathology","Dental","Allied health","Telehealth","Other"]},
+        {"key":"status","label":"Status","type":"select","options":["Scheduled","Completed","Cancelled","Rescheduled","No-show"]},
+        {"key":"followUp","label":"Follow-up","type":"text"},
+        {"key":"note","label":"Notes","type":"textarea"}
+      ]}
+  },
+  "description":"Medical/health appointments. Primary field: name. Per-row fields: name, date, time, location, type, status, followUp, note.",
+  "data":[]
+}
+\`\`\`
+
+### Example 3 — ad-hoc (renderer not yet implemented)
 
 Call \`create_manifest\` with this \`manifest\` argument:
 


### PR DESCRIPTION
## Summary

System-prompt-only fix. Requires the chat agent to ship a non-empty \`meta.writeable.inputs\` array on every manifest that sets \`meta.writeable.fromWebapp: true\`, and for list-card also requires \`meta.view.display.primaryField\`.

Fixes #90.

## Why

Klebbius was creating writeable list-cards with the writeable booleans set but no \`inputs\`. Result on the klebbtest Appointments card: Edit mode showed only the primary-field text input; the per-row three-dot button (\`eh-list-card.js:550\`) never rendered because \`secondaryInputs.length === 0\`. User had no way to capture date/location/status/notes — despite the manifest's \`description\` explicitly naming those keys.

## How

- \`config/env.js\`: new Gotcha paragraph in \`DEFAULT_HEALTH_SYSTEM_PROMPT\` spelling out the inputs requirement and the \`primaryField\` rule; new "Example 2 — list-card with full inputs (appointments)" worked example; old ad-hoc example renumbered to 3.
- No code changes.

## Testing

- [x] \`npm test -- tests/config-defaults.test.js tests/chat-prompt-cards.test.js\` — 31/31 pass.
- [x] Live klebbtest appointments manifest hand-patched with the same input shape: three-dot button renders, all 8 fields editable.
- [ ] Manual: ask Klebbius to create a new list-card (e.g. "add an allergies card"). Verify the manifest ships with inputs, \`primaryField\` set, and the edit UI exposes all declared fields via the three-dot menu.