### PR TITLE
docs(schema): document meta.view.combines[] for combination cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Manifest schema: `meta.view.combines[]` for combination cards.**
+  New optional block on `meta.view` that lets a manifest declare it is
+  a composite view over several sibling manifests. Each entry binds a
+  `sourceId` with a `role` (`primary`, `secondary`, `annotation`,
+  `ring-segment`), plus optional `label`, `units`, `accessor` (dotted
+  path) and `colour`. Paired with `layout` (`stack` / `grid` / `ring`)
+  and an optional `skin` (`sleep-stages`, `activity-ring`), this is
+  the schema foundation for the forthcoming `combination-card`
+  renderer. Combination manifests typically carry `data: []` of their
+  own; values are resolved from sibling cards at render time.
+  Documentation only; no code changes. (#92)
 - **Expand/collapse toggle for the chat panel.** A new header button
   (\`⤡\` / \`⤢\`) flips between the default 380px-wide panel and an
   expanded variant (\`min(720px, 100vw - 40px)\` wide, up to 900px

--- a/MANIFEST-SCHEMA.md
+++ b/MANIFEST-SCHEMA.md
@@ -141,6 +141,74 @@ label pill.
 `trendArrow` shows ↑/↓/→ next to the headline, comparing the current
 row to the most recent earlier entry on `field`.
 
+### `combines` (combination-card)
+
+Used by `component: "combination-card"` to compose a single card from
+several sibling manifests. The combination card reads each listed
+source's `data` at render time; it typically carries no `data` of its
+own (`data: []`).
+
+```json
+"meta": {
+  "view": {
+    "component": "combination-card",
+    "layout":    "stack",
+    "skin":      "sleep-stages",
+    "combines": [
+      {
+        "sourceId": "sleep-hours",
+        "role":     "primary",
+        "label":    "Asleep",
+        "units":    "h",
+        "accessor": "value",
+        "colour":   "#6366f1"
+      },
+      {
+        "sourceId": "sleep-stages",
+        "role":     "ring-segment",
+        "label":    "Deep",
+        "accessor": "stages.deep",
+        "colour":   "#3b82f6"
+      },
+      {
+        "sourceId": "mood",
+        "role":     "annotation"
+      }
+    ]
+  }
+}
+```
+
+Top-level view fields:
+
+| field | type | default | purpose |
+|-------|------|---------|---------|
+| `layout` | `"stack"` \| `"grid"` \| `"ring"` | `"stack"` | Overall arrangement of the combined metrics. |
+| `skin` | string \| null | null | Optional pixel-perfect visual preset. Current skins: `"sleep-stages"` (stacked horizontal bar of sleep stages), `"activity-ring"` (close-your-rings visual). |
+| `combines` | array | — | Required, non-empty. Each entry binds one sibling manifest into this card. |
+
+Each `combines[]` entry:
+
+| field | type | required | purpose |
+|-------|------|----------|---------|
+| `sourceId` | string | yes | `meta.id` of the source manifest to read from. |
+| `role` | `"primary"` \| `"secondary"` \| `"annotation"` \| `"ring-segment"` | yes | How this source contributes to the composed view. Renderers use role plus layout/skin to decide visual treatment. |
+| `label` | string | no | Override for the source's own label. Defaults to the source manifest's `meta.label`. |
+| `units` | string | no | Short suffix printed next to the value (e.g. `"h"`, `"kcal"`). |
+| `accessor` | string | no | Dotted path into the source's matched data entry (e.g. `"value"`, `"stages.deep"`). Defaults to the entry for the current date; if the entry is a primitive, it is used directly. |
+| `colour` | string | no | CSS colour for this entry's visual slot (bar segment, ring arc, threshold pill, etc). |
+
+Resolution rules:
+
+- The combination card matches each source's data for the view's
+  current date. If no entry exists for that date, the source is
+  considered empty (renderer decides whether to show "no data" or fall
+  back to the most recent prior entry; default is "no data").
+- Unknown `sourceId`, or a source whose file has been deleted,
+  surfaces inline in the card rather than failing the whole view.
+- The combination card emits no writes. To edit a displayed value the
+  user navigates to the atomic source card.
+
 ### `calendar` — month-grid marker config
 
 `meta.calendar` opts the card into the Calendar view. Each day cell in
@@ -400,6 +468,7 @@ Use one of these names in `meta.view.component` / `meta.trends.component`:
 | `table-list` | Tabular data |
 | `adherence-report` | Med adherence summary |
 | `greeting-banner` | Top-of-page greeting |
+| `combination-card` | Composite view over several sibling manifests (see `combines` config above) |
 
 Unknown renderer names fall back to `eh-unknown-card`, which shows an
 inline warning but keeps the dashboard running.


### PR DESCRIPTION
# What changed

Documents a new optional \`meta.view.combines[]\` block on \`klebb.datafile.v1\` manifests. This is the schema foundation for the upcoming \`combination-card\` renderer (#93) and is intentionally docs-only; no code changes.

# Why

Klebb manifests are strictly atomic today: one file, one card, one data stream. There's no documented way for a card to express that it is a composite view over other cards' data. The schema had a dormant \`meta.view.source\` hint at MANIFEST-SCHEMA.md:97 but nothing beyond that.

The forthcoming \`eh-combination-card\` renderer (#93) and HAE ingest endpoint (#94) both need a stable schema contract to build against, so this lands first.

# How

- New section in \`MANIFEST-SCHEMA.md\` covering \`meta.view.combines[]\`: the array entry shape (\`sourceId\`, \`role\`, optional \`label\` / \`units\` / \`accessor\` / \`colour\`), the surrounding \`layout\` + \`skin\` fields, and the resolution rules (per-date matching, unknown-sourceId behaviour, read-only semantics).
- New row in the built-in renderer table for \`combination-card\`.
- \`CHANGELOG.md\` entry under \`## [Unreleased]\` / \`### Added\`.

The \`role\` vocabulary (\`primary\` / \`secondary\` / \`annotation\` / \`ring-segment\`) is intentionally small: it lets a renderer decide visual treatment via role + layout + optional \`skin\`, without the schema needing to know about specific visualisations.

# Testing

- [x] \`npm test\` passes locally, with one pre-existing unrelated failure on \`tests/no-personal-refs.test.js\` that flags gitignored files (\`.claude/\`, \`BRIEF-FOR-CC.md\`, \`CLAUDE.md\`, \`data/sessions/\`). Not introduced by this PR; reproducible on \`main\`.
- [x] No new tests needed — this PR is pure documentation.
- [x] Manual QA: N/A (docs only).

# Checklist

- [x] Commit messages follow the conventions in \`CONTRIBUTING.md\`
- [x] \`CHANGELOG.md\` updated under \`## Unreleased\`
- [x] Docs updated (\`MANIFEST-SCHEMA.md\` is the change)
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Breaking changes

None. \`combines[]\` is purely additive and only meaningful when \`meta.view.component === "combination-card"\`. Existing atomic manifests are unaffected.

Fixes #92