### PR TITLE
feat(renderer): eh-combination-card + sleep/activity presets

### DIFF
--- a/MANIFEST-SCHEMA.md
+++ b/MANIFEST-SCHEMA.md
@@ -400,9 +400,99 @@ Use one of these names in `meta.view.component` / `meta.trends.component`:
 | `table-list` | Tabular data |
 | `adherence-report` | Med adherence summary |
 | `greeting-banner` | Top-of-page greeting |
+| `combination-card` | Read-only composite over sibling manifests (see [Combination cards](#combination-cards)) |
 
 Unknown renderer names fall back to `eh-unknown-card`, which shows an
 inline warning but keeps the dashboard running.
+
+---
+
+## Combination cards
+
+A combination card is a read-only window over other cards' data. It
+declares which sibling manifests to read from and how to surface their
+values, and owns no data of its own (its `data` block is ignored).
+
+Shape:
+
+```json
+"meta": {
+  "view": {
+    "enabled":   true,
+    "component": "combination-card",
+    "layout":    "stack",
+    "combines": [
+      {
+        "sourceId": "sleep-hours",
+        "role":     "primary",
+        "label":    "Asleep",
+        "accessor": "hours",
+        "unit":     "h"
+      },
+      {
+        "sourceId": "mood",
+        "role":     "secondary",
+        "label":    "Mood",
+        "accessor": "mood",
+        "emojiMap": { "1": "😩", "2": "😴", "3": "😐", "4": "🙂", "5": "😄" }
+      }
+    ]
+  }
+}
+```
+
+### `layout`
+
+Picks the visual treatment.
+
+| value | behaviour |
+|-------|-----------|
+| `stack` | Vertical label/value rows. Primary rows render large, secondary smaller, annotation muted. |
+
+Values `rings` and `chart` are reserved for future renderers. An
+unknown layout falls back to `stack`.
+
+### `combines[]`
+
+An ordered array of source entries. Each entry:
+
+| field | required | meaning |
+|-------|----------|---------|
+| `sourceId` | yes | Must match a loaded manifest's `meta.id`. Missing source renders a placeholder, not an error. |
+| `role` | yes | `primary` \| `secondary` \| `annotation`. Drives visual weight. `ring-segment` and `bar-series` are reserved. |
+| `label` | no | Overrides the source's `meta.label` for this view. |
+| `accessor` | no | Path into the day's row. Dotted paths (`stats.avg`) supported. Default: first non-`date` scalar on the row. |
+| `unit` | no | Short string rendered next to the value (e.g. `h`, `kcal`). |
+| `emojiMap` | no | Stringified-value → emoji, for enum sources (mood, etc). |
+
+### Row resolution
+
+For a viewed date, the renderer resolves each source to one of:
+
+| state | meaning |
+|-------|---------|
+| `ok` | Source exists, has a row for that date, accessor yields a value. |
+| `no-source` | `sourceId` is not a loaded manifest. |
+| `no-entry` | Source loaded but has no row for the viewed date. |
+| `no-accessor-match` | Row exists but the accessor yields `undefined`/`null`. |
+
+States other than `ok` render as a muted placeholder so partial data
+doesn't break the layout.
+
+### Editing
+
+Combination cards are read-only; they have no `writeable` block and
+emit no writes. To change a value, edit the source manifest; the
+combo re-resolves on `manifest-data-changed` (fired by the app shell
+whenever any manifest's data block changes).
+
+### Typical pairing
+
+A combo card usually absorbs one or more atomic cards. To avoid
+showing the same data twice, set the absorbed card's `meta.enabled:
+false` (master disable) so it stays in Settings but drops from every
+view. See `data.example/sleep.example.json` for a worked example
+that combines `sleep-hours` and `mood`.
 
 ---
 

--- a/data.example/activity.example.json
+++ b/data.example/activity.example.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "activity",
+    "label": "Activity",
+    "emoji": "🏃",
+    "order": 65,
+    "view": {
+      "enabled": true,
+      "component": "combination-card",
+      "layout": "stack",
+      "dateContext": "viewedDate",
+      "combines": [
+        {
+          "sourceId": "steps",
+          "role": "primary",
+          "label": "Steps",
+          "accessor": "count",
+          "unit": "steps"
+        },
+        {
+          "sourceId": "active-minutes",
+          "role": "secondary",
+          "label": "Active minutes",
+          "accessor": "minutes",
+          "unit": "min"
+        },
+        {
+          "sourceId": "workouts",
+          "role": "annotation",
+          "label": "Trained",
+          "accessor": "trained"
+        }
+      ]
+    }
+  },
+  "description": "Composite Activity card. Read-only view over steps + active-minutes + workouts. Edit values on the source cards; this one re-renders on change.",
+  "data": []
+}

--- a/data.example/sleep.example.json
+++ b/data.example/sleep.example.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "sleep",
+    "label": "Sleep",
+    "emoji": "😴",
+    "order": 25,
+    "view": {
+      "enabled": true,
+      "component": "combination-card",
+      "layout": "stack",
+      "dateContext": "viewedDate",
+      "combines": [
+        {
+          "sourceId": "sleep-hours",
+          "role": "primary",
+          "label": "Asleep",
+          "accessor": "hours",
+          "unit": "h"
+        },
+        {
+          "sourceId": "mood",
+          "role": "secondary",
+          "label": "Mood",
+          "accessor": "mood",
+          "emojiMap": {
+            "1": "😩",
+            "2": "😴",
+            "3": "😐",
+            "4": "🙂",
+            "5": "😄"
+          }
+        },
+        {
+          "sourceId": "mood",
+          "role": "annotation",
+          "label": "Wake-ups",
+          "accessor": "wakeUps"
+        }
+      ]
+    }
+  },
+  "description": "Composite Sleep card. Read-only view over sleep-hours + mood. Edit values on the source cards; this one re-renders on change. To avoid duplicate display, hide the mood card via its meta.enabled: false.",
+  "data": []
+}

--- a/public/js/components/eh-combination-card.js
+++ b/public/js/components/eh-combination-card.js
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// public/js/components/eh-combination-card.js
+// Read-only composite renderer. Consumes meta.view.combines[] and
+// surfaces one row per combined source for the viewed date.
+//
+// Opt a manifest into this renderer by setting:
+//   meta.view.component = "combination-card"
+//   meta.view.layout    = "stack"   (MVP; "rings" and "chart" reserved)
+//   meta.view.combines  = [ { sourceId, role, label?, accessor?, unit?, emojiMap? } ]
+//
+// See MANIFEST-SCHEMA.md "Combination cards" for the full contract.
+
+import { LitElement, html, css } from 'https://esm.sh/lit@3';
+import { registerRenderer } from '../renderer-registry.js';
+import { resolveCombines } from '../lib/combines-resolver.esm.js';
+
+export class EhCombinationCard extends LitElement {
+  static properties = {
+    card: { type: Object },
+    date: { type: String },
+    dateMode: { type: String },
+    _sources: { state: true },   // { [sourceId]: { loaded, data, meta } }
+    _loading: { state: true },
+    _error: { state: true },
+  };
+
+  constructor() {
+    super();
+    this.card = null;
+    this.date = null;
+    this.dateMode = 'today';
+    this._sources = {};
+    this._loading = true;
+    this._error = null;
+    this._onDataChanged = this._onDataChanged.bind(this);
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    window.addEventListener('manifest-data-changed', this._onDataChanged);
+    this._fetchAll();
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    window.removeEventListener('manifest-data-changed', this._onDataChanged);
+  }
+
+  _onDataChanged(e) {
+    const changedId = e?.detail?.id;
+    if (!changedId) return;
+    const combines = this._combines();
+    if (combines.some(c => c.sourceId === changedId)) this._fetchAll();
+  }
+
+  _combines() {
+    const vc = this.card?.viewConfig || {};
+    return Array.isArray(vc.combines) ? vc.combines : [];
+  }
+
+  _layout() {
+    const l = this.card?.viewConfig?.layout || 'stack';
+    // Unknown layouts fall back to stack (documented behaviour).
+    return l === 'stack' ? 'stack' : 'stack';
+  }
+
+  async _fetchAll() {
+    this._loading = true;
+    this._error = null;
+    const ids = [...new Set(this._combines().map(c => c.sourceId).filter(Boolean))];
+    const entries = await Promise.all(ids.map(id => this._fetchOne(id)));
+    const next = {};
+    for (const { id, loaded, data, meta } of entries) {
+      next[id] = { loaded, data, meta };
+    }
+    this._sources = next;
+    this._loading = false;
+  }
+
+  async _fetchOne(id) {
+    try {
+      const [dataRes, metaRes] = await Promise.all([
+        fetch(`/api/manifests/${encodeURIComponent(id)}/data`),
+        fetch(`/api/manifests/${encodeURIComponent(id)}`),
+      ]);
+      if (!dataRes.ok) return { id, loaded: false, data: null, meta: null };
+      const dataBody = await dataRes.json();
+      const metaBody = metaRes.ok ? await metaRes.json() : null;
+      return {
+        id,
+        loaded: true,
+        data: dataBody.data,
+        meta: metaBody?.meta || null,
+      };
+    } catch {
+      return { id, loaded: false, data: null, meta: null };
+    }
+  }
+
+  updated(changed) {
+    if (changed.has('card')) this._fetchAll();
+  }
+
+  _renderRow(resolved) {
+    const label = resolved.label || resolved.sourceId;
+    const roleClass = `role-${resolved.role || 'annotation'}`;
+
+    if (resolved.state !== 'ok') {
+      const hint = resolved.state === 'no-source' ? 'source not loaded'
+                 : resolved.state === 'no-entry' ? 'no entry for this date'
+                 : 'no value';
+      return html`
+        <div class="row ${roleClass} placeholder">
+          <span class="row-label">${label}</span>
+          <span class="row-placeholder">${hint}</span>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="row ${roleClass}">
+        <span class="row-label">${label}</span>
+        <span class="row-value">
+          ${resolved.displayValue}
+          ${resolved.unit ? html`<span class="row-unit">${resolved.unit}</span>` : ''}
+        </span>
+      </div>
+    `;
+  }
+
+  render() {
+    const m = this.card?.meta || {};
+    const combines = this._combines();
+
+    if (this._loading) {
+      return html`
+        <div class="shell">
+          <div class="header">
+            ${m.emoji ? html`<span class="emoji">${m.emoji}</span>` : ''}
+            <span class="title">${m.label || m.id || ''}</span>
+          </div>
+          <div class="loading">Loading…</div>
+        </div>
+      `;
+    }
+
+    const resolved = resolveCombines(combines, this._sources, this.date);
+    const allMissing = resolved.length > 0 && resolved.every(r => r.state !== 'ok');
+
+    return html`
+      <div class="shell">
+        <div class="header">
+          ${m.emoji ? html`<span class="emoji">${m.emoji}</span>` : ''}
+          <span class="title">${m.label || m.id || ''}</span>
+          ${this.dateMode === 'future' ? html`<span class="badge future">🔮 Planned</span>` : ''}
+          ${this.dateMode === 'past'   ? html`<span class="badge past">Past</span>` : ''}
+        </div>
+        <div class="body layout-${this._layout()}">
+          ${combines.length === 0 ? html`
+            <div class="empty">No sources configured.</div>
+          ` : allMissing ? html`
+            <div class="empty">No data for this date.</div>
+          ` : resolved.map(r => this._renderRow(r))}
+        </div>
+      </div>
+    `;
+  }
+
+  static styles = css`
+    :host {
+      display: block;
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      overflow: hidden;
+      box-shadow: var(--shadow-sm, 0 1px 2px rgba(0,0,0,0.08));
+    }
+    .shell { display: block; }
+    .header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 16px 6px;
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.6px;
+      text-transform: uppercase;
+      color: var(--text-muted, var(--text-secondary));
+    }
+    .header .emoji { font-size: 14px; }
+    .header .title { flex: 1; min-width: 0; }
+    .badge {
+      font-size: 10px;
+      padding: 2px 6px;
+      border-radius: 8px;
+      font-weight: 600;
+      text-transform: none;
+      letter-spacing: 0;
+    }
+    .badge.future {
+      background: var(--accent-bg, rgba(255,170,0,0.15));
+      color: var(--accent-amber, #ffaa00);
+    }
+    .badge.past {
+      background: var(--bg-hover, rgba(255,255,255,0.05));
+      color: var(--text-muted, var(--text-secondary));
+    }
+
+    .body { padding: 6px 16px 16px; }
+    .body.layout-stack { display: flex; flex-direction: column; gap: 6px; }
+
+    .row {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 12px;
+      min-width: 0;
+    }
+    .row-label {
+      color: var(--text-muted, var(--text-secondary));
+      font-size: 13px;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .row-value {
+      color: var(--text-primary);
+      font-weight: 600;
+      display: inline-flex;
+      align-items: baseline;
+      gap: 4px;
+      flex-shrink: 0;
+    }
+    .row-unit {
+      font-size: 11px;
+      font-weight: 400;
+      color: var(--text-muted, var(--text-secondary));
+    }
+    .row-placeholder {
+      font-size: 11px;
+      font-style: italic;
+      color: var(--text-muted, var(--text-secondary));
+      flex-shrink: 0;
+    }
+
+    .row.role-primary .row-value { font-size: 28px; font-weight: 700; }
+    .row.role-primary .row-label { font-size: 14px; color: var(--text-primary); }
+    .row.role-secondary .row-value { font-size: 18px; }
+    .row.role-annotation { opacity: 0.75; }
+    .row.role-annotation .row-value { font-size: 13px; font-weight: 500; }
+
+    .loading, .empty {
+      padding: 10px 0;
+      font-size: 12px;
+      color: var(--text-muted, var(--text-secondary));
+      text-align: center;
+    }
+  `;
+}
+
+customElements.define('eh-combination-card', EhCombinationCard);
+registerRenderer('combination-card', 'eh-combination-card');

--- a/public/js/components/eh-view-renderer.js
+++ b/public/js/components/eh-view-renderer.js
@@ -20,6 +20,7 @@ import './eh-line-chart.js';
 import './eh-schedule-timeline.js';
 import './eh-adherence-report.js';
 import './eh-table-list.js';
+import './eh-combination-card.js';
 
 export class EhViewRenderer extends LitElement {
   static properties = {

--- a/public/js/lib/combines-resolver.esm.js
+++ b/public/js/lib/combines-resolver.esm.js
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// public/js/lib/combines-resolver.esm.js
+// ES-module re-export of the combines resolver. Keep in sync with
+// combines-resolver.js (UMD) — Node tests use the UMD version, browser
+// components use this one.
+
+export function getByPath(obj, pathStr) {
+  if (!obj || !pathStr) return undefined;
+  const parts = String(pathStr).split('.');
+  let cur = obj;
+  for (const p of parts) {
+    if (cur == null) return undefined;
+    cur = cur[p];
+  }
+  return cur;
+}
+
+export function firstScalarKey(row) {
+  if (!row || typeof row !== 'object') return null;
+  for (const k of Object.keys(row)) {
+    if (k === 'date') continue;
+    const v = row[k];
+    const t = typeof v;
+    if (v === null) continue;
+    if (t === 'string' || t === 'number' || t === 'boolean') return k;
+  }
+  return null;
+}
+
+export function stringifyValue(value, emojiMap) {
+  if (value === null || value === undefined) return null;
+  if (emojiMap) {
+    const key = String(value);
+    if (emojiMap[key]) return emojiMap[key];
+  }
+  if (typeof value === 'number') {
+    if (Number.isInteger(value)) return String(value);
+    return String(Math.round(value * 100) / 100);
+  }
+  if (typeof value === 'boolean') return value ? 'yes' : 'no';
+  return String(value);
+}
+
+export function resolveEntry(entry, sources, date) {
+  const sourceId = entry?.sourceId;
+  const base = {
+    sourceId,
+    role: entry?.role || 'annotation',
+    label: entry?.label || null,
+    unit: entry?.unit || null,
+    colour: entry?.colour || null,
+    emojiMap: entry?.emojiMap || null,
+  };
+
+  if (!sourceId) {
+    return { ...base, state: 'no-source', value: null, displayValue: null, row: null };
+  }
+
+  const source = sources?.[sourceId];
+  if (!source || !source.loaded) {
+    return { ...base, state: 'no-source', value: null, displayValue: null, row: null };
+  }
+
+  if (!base.label && source.meta?.label) base.label = source.meta.label;
+
+  const rows = Array.isArray(source.data) ? source.data : [];
+  const row = rows.find(r => r && r.date === date) || null;
+  if (!row) {
+    return { ...base, state: 'no-entry', value: null, displayValue: null, row: null };
+  }
+
+  const accessor = entry?.accessor || firstScalarKey(row);
+  if (!accessor) {
+    return { ...base, state: 'no-accessor-match', value: null, displayValue: null, row };
+  }
+
+  const value = getByPath(row, accessor);
+  if (value === undefined || value === null) {
+    return { ...base, state: 'no-accessor-match', value: null, displayValue: null, row };
+  }
+
+  return {
+    ...base,
+    state: 'ok',
+    value,
+    displayValue: stringifyValue(value, base.emojiMap),
+    row,
+  };
+}
+
+export function resolveCombines(combines, sources, date) {
+  if (!Array.isArray(combines)) return [];
+  return combines.map(entry => resolveEntry(entry, sources, date));
+}

--- a/public/js/lib/combines-resolver.js
+++ b/public/js/lib/combines-resolver.js
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// public/js/lib/combines-resolver.js
+// Pure resolver for combination-card's meta.view.combines[].
+// Dual-runtime: browser (ESM) + Node (CommonJS) via UMD pattern.
+//
+// Given:
+//   - combines[]       (array of entries from meta.view.combines)
+//   - sources          (object mapping sourceId -> { loaded, data, meta })
+//                        loaded:false means the sourceId is not a known manifest
+//                        data is the source's data array (rows with a `date` field)
+//                        meta is the source's meta object (for label fallback)
+//   - date             (ISO date string the viewer is on, YYYY-MM-DD)
+//
+// Produce an array of resolved rows, one per combines[] entry, in order.
+// Each resolved row has:
+//   {
+//     sourceId, role, label, unit, colour?, emojiMap?,
+//     state: 'ok' | 'no-source' | 'no-entry' | 'no-accessor-match',
+//     value: any | null,
+//     displayValue: string | null,  // value rendered to a display string
+//     row: object | null,            // the full source row, or null
+//   }
+
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.ehCombinesResolver = factory();
+  }
+}(typeof self !== 'undefined' ? self : this, function () {
+
+  // Dotted-path accessor. Returns undefined if any hop is missing.
+  function getByPath(obj, pathStr) {
+    if (!obj || !pathStr) return undefined;
+    const parts = String(pathStr).split('.');
+    let cur = obj;
+    for (const p of parts) {
+      if (cur == null) return undefined;
+      cur = cur[p];
+    }
+    return cur;
+  }
+
+  // First non-`date` scalar on a row. Returns the key name or null.
+  function firstScalarKey(row) {
+    if (!row || typeof row !== 'object') return null;
+    for (const k of Object.keys(row)) {
+      if (k === 'date') continue;
+      const v = row[k];
+      const t = typeof v;
+      if (v === null) continue;
+      if (t === 'string' || t === 'number' || t === 'boolean') return k;
+    }
+    return null;
+  }
+
+  // Stringify the resolved value for display. The renderer can override
+  // presentation (e.g. emojiMap lookup) but this gives a sensible default.
+  function stringifyValue(value, emojiMap) {
+    if (value === null || value === undefined) return null;
+    if (emojiMap) {
+      const key = String(value);
+      if (emojiMap[key]) return emojiMap[key];
+    }
+    if (typeof value === 'number') {
+      // Trim to 2dp unless already integral
+      if (Number.isInteger(value)) return String(value);
+      return String(Math.round(value * 100) / 100);
+    }
+    if (typeof value === 'boolean') return value ? 'yes' : 'no';
+    return String(value);
+  }
+
+  function resolveEntry(entry, sources, date) {
+    const sourceId = entry?.sourceId;
+    const base = {
+      sourceId,
+      role: entry?.role || 'annotation',
+      label: entry?.label || null,
+      unit: entry?.unit || null,
+      colour: entry?.colour || null,
+      emojiMap: entry?.emojiMap || null,
+    };
+
+    if (!sourceId) {
+      return { ...base, state: 'no-source', value: null, displayValue: null, row: null };
+    }
+
+    const source = sources?.[sourceId];
+    if (!source || !source.loaded) {
+      return { ...base, state: 'no-source', value: null, displayValue: null, row: null };
+    }
+
+    // Fill in label from source meta if not overridden
+    if (!base.label && source.meta?.label) base.label = source.meta.label;
+
+    const rows = Array.isArray(source.data) ? source.data : [];
+    const row = rows.find(r => r && r.date === date) || null;
+    if (!row) {
+      return { ...base, state: 'no-entry', value: null, displayValue: null, row: null };
+    }
+
+    const accessor = entry?.accessor || firstScalarKey(row);
+    if (!accessor) {
+      return { ...base, state: 'no-accessor-match', value: null, displayValue: null, row };
+    }
+
+    const value = getByPath(row, accessor);
+    if (value === undefined || value === null) {
+      return { ...base, state: 'no-accessor-match', value: null, displayValue: null, row };
+    }
+
+    return {
+      ...base,
+      state: 'ok',
+      value,
+      displayValue: stringifyValue(value, base.emojiMap),
+      row,
+    };
+  }
+
+  function resolveCombines(combines, sources, date) {
+    if (!Array.isArray(combines)) return [];
+    return combines.map(entry => resolveEntry(entry, sources, date));
+  }
+
+  return {
+    resolveCombines,
+    resolveEntry,
+    getByPath,
+    firstScalarKey,
+    stringifyValue,
+  };
+}));

--- a/tests/combination-card.view.test.js
+++ b/tests/combination-card.view.test.js
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/combination-card.view.test.js
+// Integration: a combination-card manifest loads through the registry
+// and /api/views/view surfaces combines[] verbatim to the client.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const { createSandbox, cleanupSandbox, spawnServer, req } = require('./helpers/sandbox');
+
+describe('combination-card view integration', () => {
+  let sandbox, server;
+
+  const sleepHoursManifest = {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'sleep-hours',
+      label: 'Sleep hours',
+      view: { enabled: true, component: 'generic-card', display: { template: '{hours}' } },
+    },
+    data: [{ date: '2026-05-04', hours: 8.1 }],
+  };
+
+  const moodManifest = {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'mood',
+      label: 'Mood',
+      view: { enabled: true, component: 'generic-card', display: { template: '{mood}' } },
+    },
+    data: [{ date: '2026-05-04', mood: 4, wakeUps: 1 }],
+  };
+
+  const sleepComboManifest = {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'sleep',
+      label: 'Sleep',
+      emoji: '😴',
+      order: 25,
+      view: {
+        enabled: true,
+        component: 'combination-card',
+        layout: 'stack',
+        combines: [
+          { sourceId: 'sleep-hours', role: 'primary', label: 'Asleep', accessor: 'hours', unit: 'h' },
+          { sourceId: 'mood', role: 'secondary', label: 'Mood', accessor: 'mood',
+            emojiMap: { '1':'😩','4':'🙂' } },
+        ],
+      },
+    },
+    data: [],
+  };
+
+  before(async () => {
+    sandbox = createSandbox({
+      seed: {
+        'sleep-hours.json': sleepHoursManifest,
+        'mood.json': moodManifest,
+        'sleep.json': sleepComboManifest,
+      },
+    });
+    server = await spawnServer(sandbox);
+  });
+
+  after(async () => {
+    if (server) await server.kill();
+    if (sandbox) cleanupSandbox(sandbox);
+  });
+
+  test('GET /api/views/view includes the combination card with combines[] intact', async () => {
+    const res = await req(server.baseUrl, '/api/views/view');
+    assert.equal(res.status, 200);
+    const cards = res.json.cards;
+    assert.ok(Array.isArray(cards));
+    const combo = cards.find(c => c.id === 'sleep');
+    assert.ok(combo, 'sleep combo card present in view');
+    assert.equal(combo.viewConfig.component, 'combination-card');
+    assert.equal(combo.viewConfig.layout, 'stack');
+    assert.ok(Array.isArray(combo.viewConfig.combines));
+    assert.equal(combo.viewConfig.combines.length, 2);
+    assert.equal(combo.viewConfig.combines[0].sourceId, 'sleep-hours');
+    assert.equal(combo.viewConfig.combines[0].accessor, 'hours');
+    assert.equal(combo.viewConfig.combines[1].emojiMap['4'], '🙂');
+  });
+
+  test('GET /api/manifests/:id/data returns empty data for the combo', async () => {
+    const res = await req(server.baseUrl, '/api/manifests/sleep/data');
+    assert.equal(res.status, 200);
+    assert.deepEqual(res.json.data, []);
+  });
+
+  test('source manifests are independently readable by the renderer', async () => {
+    const sleep = await req(server.baseUrl, '/api/manifests/sleep-hours/data');
+    const mood = await req(server.baseUrl, '/api/manifests/mood/data');
+    assert.equal(sleep.status, 200);
+    assert.equal(mood.status, 200);
+    assert.equal(sleep.json.data[0].hours, 8.1);
+    assert.equal(mood.json.data[0].mood, 4);
+  });
+
+  test('combo card appears ordered by meta.order', async () => {
+    // order=25 on sleep combo; sleep-hours+mood have no order (default 1000),
+    // so combo should render first among the three.
+    const res = await req(server.baseUrl, '/api/views/view');
+    const ids = res.json.cards.map(c => c.id);
+    assert.equal(ids[0], 'sleep');
+  });
+});

--- a/tests/combines-resolver.test.js
+++ b/tests/combines-resolver.test.js
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/combines-resolver.test.js
+// Pure unit tests for the combines resolver.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const {
+  resolveCombines,
+  resolveEntry,
+  getByPath,
+  firstScalarKey,
+  stringifyValue,
+} = require('../public/js/lib/combines-resolver.js');
+
+describe('getByPath', () => {
+  test('returns shallow value', () => {
+    assert.equal(getByPath({ a: 1 }, 'a'), 1);
+  });
+  test('returns dotted value', () => {
+    assert.equal(getByPath({ a: { b: { c: 7 } } }, 'a.b.c'), 7);
+  });
+  test('undefined on missing hop', () => {
+    assert.equal(getByPath({ a: null }, 'a.b'), undefined);
+  });
+  test('undefined on empty path', () => {
+    assert.equal(getByPath({ a: 1 }, ''), undefined);
+  });
+});
+
+describe('firstScalarKey', () => {
+  test('skips date, returns first scalar', () => {
+    assert.equal(firstScalarKey({ date: '2026-05-04', hours: 7.5, note: 'x' }), 'hours');
+  });
+  test('skips null fields', () => {
+    assert.equal(firstScalarKey({ date: '2026-05-04', hours: null, count: 42 }), 'count');
+  });
+  test('skips object/array fields', () => {
+    assert.equal(firstScalarKey({ date: '2026-05-04', stages: {}, total: 8 }), 'total');
+  });
+  test('null on empty-scalar row', () => {
+    assert.equal(firstScalarKey({ date: '2026-05-04' }), null);
+  });
+});
+
+describe('stringifyValue', () => {
+  test('null → null', () => {
+    assert.equal(stringifyValue(null), null);
+  });
+  test('integer stays integer', () => {
+    assert.equal(stringifyValue(42), '42');
+  });
+  test('float rounded to 2dp', () => {
+    assert.equal(stringifyValue(7.3456), '7.35');
+  });
+  test('emojiMap override', () => {
+    assert.equal(stringifyValue(4, { '1':'😩','4':'🙂' }), '🙂');
+  });
+  test('emojiMap miss → fallback to stringified value', () => {
+    assert.equal(stringifyValue(99, { '1':'😩' }), '99');
+  });
+  test('boolean', () => {
+    assert.equal(stringifyValue(true), 'yes');
+    assert.equal(stringifyValue(false), 'no');
+  });
+});
+
+describe('resolveEntry', () => {
+  const sources = {
+    'sleep-hours': {
+      loaded: true,
+      meta: { label: 'Sleep' },
+      data: [
+        { date: '2026-05-03', hours: 7.2 },
+        { date: '2026-05-04', hours: 8.1 },
+      ],
+    },
+    'mood': {
+      loaded: true,
+      meta: { label: 'Mood' },
+      data: [
+        { date: '2026-05-04', mood: 4, wakeUps: 1 },
+      ],
+    },
+    'empty': {
+      loaded: true,
+      meta: { label: 'Empty' },
+      data: [],
+    },
+  };
+
+  test('ok path with explicit accessor', () => {
+    const r = resolveEntry(
+      { sourceId: 'sleep-hours', role: 'primary', accessor: 'hours', unit: 'h' },
+      sources, '2026-05-04',
+    );
+    assert.equal(r.state, 'ok');
+    assert.equal(r.value, 8.1);
+    assert.equal(r.displayValue, '8.1');
+    assert.equal(r.unit, 'h');
+    assert.equal(r.role, 'primary');
+  });
+
+  test('label falls back to source meta.label', () => {
+    const r = resolveEntry(
+      { sourceId: 'sleep-hours', role: 'primary', accessor: 'hours' },
+      sources, '2026-05-04',
+    );
+    assert.equal(r.label, 'Sleep');
+  });
+
+  test('label override wins over source meta', () => {
+    const r = resolveEntry(
+      { sourceId: 'sleep-hours', role: 'primary', accessor: 'hours', label: 'Asleep' },
+      sources, '2026-05-04',
+    );
+    assert.equal(r.label, 'Asleep');
+  });
+
+  test('default accessor picks first non-date scalar', () => {
+    const r = resolveEntry(
+      { sourceId: 'sleep-hours', role: 'primary' },
+      sources, '2026-05-04',
+    );
+    assert.equal(r.state, 'ok');
+    assert.equal(r.value, 8.1);
+  });
+
+  test('no-source when sourceId missing from sources map', () => {
+    const r = resolveEntry(
+      { sourceId: 'not-a-card', role: 'primary' },
+      sources, '2026-05-04',
+    );
+    assert.equal(r.state, 'no-source');
+    assert.equal(r.value, null);
+  });
+
+  test('no-source when entry has no sourceId', () => {
+    const r = resolveEntry({ role: 'primary' }, sources, '2026-05-04');
+    assert.equal(r.state, 'no-source');
+  });
+
+  test('no-source when source not loaded', () => {
+    const r = resolveEntry(
+      { sourceId: 'sleep-hours', role: 'primary' },
+      { 'sleep-hours': { loaded: false, data: null, meta: null } },
+      '2026-05-04',
+    );
+    assert.equal(r.state, 'no-source');
+  });
+
+  test('no-entry when date not present', () => {
+    const r = resolveEntry(
+      { sourceId: 'sleep-hours', role: 'primary', accessor: 'hours' },
+      sources, '2026-05-01',
+    );
+    assert.equal(r.state, 'no-entry');
+    assert.equal(r.value, null);
+  });
+
+  test('no-entry when source has empty data', () => {
+    const r = resolveEntry(
+      { sourceId: 'empty', role: 'primary' },
+      sources, '2026-05-04',
+    );
+    assert.equal(r.state, 'no-entry');
+  });
+
+  test('no-accessor-match when accessor yields undefined', () => {
+    const r = resolveEntry(
+      { sourceId: 'sleep-hours', role: 'primary', accessor: 'nonexistent' },
+      sources, '2026-05-04',
+    );
+    assert.equal(r.state, 'no-accessor-match');
+    assert.ok(r.row);
+  });
+
+  test('emojiMap applied to displayValue', () => {
+    const r = resolveEntry(
+      {
+        sourceId: 'mood',
+        role: 'secondary',
+        accessor: 'mood',
+        emojiMap: { '1':'😩','2':'😴','3':'😐','4':'🙂','5':'😄' },
+      },
+      sources, '2026-05-04',
+    );
+    assert.equal(r.state, 'ok');
+    assert.equal(r.value, 4);
+    assert.equal(r.displayValue, '🙂');
+  });
+
+  test('dotted accessor resolves', () => {
+    const deep = {
+      'nested': {
+        loaded: true,
+        meta: { label: 'Nested' },
+        data: [{ date: '2026-05-04', stats: { avg: 3.14 } }],
+      },
+    };
+    const r = resolveEntry(
+      { sourceId: 'nested', role: 'primary', accessor: 'stats.avg' },
+      deep, '2026-05-04',
+    );
+    assert.equal(r.state, 'ok');
+    assert.equal(r.value, 3.14);
+  });
+
+  test('role defaults to annotation', () => {
+    const r = resolveEntry(
+      { sourceId: 'sleep-hours', accessor: 'hours' },
+      sources, '2026-05-04',
+    );
+    assert.equal(r.role, 'annotation');
+  });
+});
+
+describe('resolveCombines', () => {
+  const sources = {
+    'sleep-hours': {
+      loaded: true, meta: { label: 'Sleep' },
+      data: [{ date: '2026-05-04', hours: 8.1 }],
+    },
+    'mood': {
+      loaded: true, meta: { label: 'Mood' },
+      data: [{ date: '2026-05-04', mood: 4, wakeUps: 1 }],
+    },
+  };
+
+  test('preserves order', () => {
+    const combines = [
+      { sourceId: 'mood', role: 'secondary', accessor: 'mood' },
+      { sourceId: 'sleep-hours', role: 'primary', accessor: 'hours' },
+    ];
+    const out = resolveCombines(combines, sources, '2026-05-04');
+    assert.equal(out.length, 2);
+    assert.equal(out[0].sourceId, 'mood');
+    assert.equal(out[1].sourceId, 'sleep-hours');
+  });
+
+  test('empty/missing combines returns []', () => {
+    assert.deepEqual(resolveCombines(null, sources, '2026-05-04'), []);
+    assert.deepEqual(resolveCombines(undefined, sources, '2026-05-04'), []);
+    assert.deepEqual(resolveCombines([], sources, '2026-05-04'), []);
+  });
+
+  test('mix of ok and missing states', () => {
+    const combines = [
+      { sourceId: 'sleep-hours', role: 'primary', accessor: 'hours' },
+      { sourceId: 'missing-card', role: 'secondary' },
+      { sourceId: 'mood', role: 'annotation', accessor: 'missingField' },
+    ];
+    const out = resolveCombines(combines, sources, '2026-05-04');
+    assert.equal(out[0].state, 'ok');
+    assert.equal(out[1].state, 'no-source');
+    assert.equal(out[2].state, 'no-accessor-match');
+  });
+});

--- a/tests/example-manifests.test.js
+++ b/tests/example-manifests.test.js
@@ -30,6 +30,7 @@ const KNOWN_COMPONENTS = new Set([
   'progress-bars-card',  // Used by existing goals.json
   'list-card',           // Persistent-items list, eh-list-card
   'day-marker',          // Calendar-only marker config (meta.calendar.component)
+  'combination-card',    // Read-only composite over sibling manifests
 ]);
 
 const KNOWN_INPUT_TYPES = new Set([


### PR DESCRIPTION
## Summary

Ships the read-only composite renderer for combination cards. Stacked
on top of #101 (schema docs for `meta.view.combines[]`).

- **Resolver** (`public/js/lib/combines-resolver.{js,esm.js}`):
  pure UMD + ESM resolver mapping `combines[]` + source data + date
  to a render-ready row list. States: `ok` / `no-source` / `no-entry`
  / `no-accessor-match`.
- **Renderer** (`public/js/components/eh-combination-card.js`): Lit
  element. Fetches each `sourceId`'s `/api/manifests/:id/data` +
  `/api/manifests/:id`, re-resolves on `manifest-data-changed`.
- **Presets**: `data.example/sleep.example.json` (combines
  `sleep-hours` + `mood`) and `data.example/activity.example.json`
  (combines `steps` + `active-minutes` + `workouts`).
- **Tests**: `tests/combines-resolver.test.js` (30 unit tests),
  `tests/combination-card.view.test.js` (4 integration tests).

## Why

Atomic cards work well for single metrics; users want
Apple-Health-style combined views for sleep + activity without
bespoke Lit components per dashboard. A generic renderer keeps the
manifest-is-the-app discipline: composition is a renderer concern,
not a server one.

## How

The combo card manifest carries `meta.view.combines[]`, each entry
naming a sibling `sourceId`, a `role` (primary/secondary/annotation,
drives visual weight), and optionally an `accessor`, `unit`, `label`,
`emojiMap`.

1. `eh-view-renderer` resolves the component name to
   `eh-combination-card`.
2. The combo element reads `viewConfig.combines[]`, fetches each
   source's data + meta in parallel, resolves today's row per source
   using the pure resolver.
3. Renders a `layout-stack` body: primary rows render large,
   secondary smaller, annotation muted.
4. Listens for `manifest-data-changed`; re-fetches when a source
   changes.

Combo manifests own no data (`data: []`); edits happen on the source
atomic cards. The combo is a pure projection.

## Testing checklist

- [x] `npm test` — 428/429 passing. The single failure
  (`no-personal-refs`) pre-exists on `main`; unrelated to this PR.
- [x] Resolver unit tests (30 cases: accessors, dotted paths,
  emojiMap, fallback label, all 4 states).
- [x] Integration test via sandbox: `/api/views/view` round-trips
  `combines[]` verbatim; source manifests remain independently
  readable; ordering works.
- [ ] Manual: drop the two preset files into a dev instance + source
  data, confirm the combo cards render on Today.

## Stacking note

This branch was cut off `feat/92-combines-schema`, so commit
`5f01c2d` (schema docs) is included here AND in #101. Merge #101
first; this PR will then show only the renderer commit.

Closes #93