### PR TITLE
feat(server): POST /api/health-auto-export/<type> ingest endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **`POST /api/health-auto-export/<type>` ingest endpoint.** Lets an
+  external caller (typically an iOS Shortcut) push health metrics into
+  Klebb. Off by default: the endpoint returns 501 until
+  `HEALTH_AUTO_EXPORT_TOKEN` is set. When configured, the caller
+  supplies `Authorization: Bearer <token>` and a canonical JSON body
+  of the form `{ date, metrics: {...} }`. Supported types are `sleep`
+  (metrics: `hours`, `stages.{core,rem,deep,awake}`, `bedTime`,
+  `wakeTime`) and `activity` (metrics: `steps`, `activeEnergy`,
+  `exerciseMinutes`, `standHours`). The handler archives the raw
+  payload under `$HEALTH_HOME/data/auto-export/<type>/<date>.json`
+  (mirroring the predecessor layout) and fans each recognised metric
+  out to its own atomic `klebb.datafile.v1` card: `sleep-hours`,
+  `sleep-stages`, `sleep-bed-wake`, `steps`, `active-energy`,
+  `exercise-minutes`, `stand-hours`. Missing target manifests are
+  created on first write from a baked-in template. Re-posting the
+  same date is idempotent: only that date's row is overwritten in
+  each affected card. Partial writes merge on the same date (a
+  follow-up POST carrying only `wakeTime` preserves a previously
+  posted `bedTime`). Unknown metric keys are silently ignored so the
+  payload shape can grow without breaking older clients. (#94)
 - **Expand/collapse toggle for the chat panel.** A new header button
   (\`⤡\` / \`⤢\`) flips between the default 380px-wide panel and an
   expanded variant (\`min(720px, 100vw - 40px)\` wide, up to 900px

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ COPY --chown=klebb:klebb server.js ./
 COPY --chown=klebb:klebb auth ./auth
 COPY --chown=klebb:klebb chat ./chat
 COPY --chown=klebb:klebb config ./config
+COPY --chown=klebb:klebb health-auto-export ./health-auto-export
 COPY --chown=klebb:klebb manifests ./manifests
 COPY --chown=klebb:klebb public ./public
 COPY --chown=klebb:klebb scripts ./scripts

--- a/config/env.js
+++ b/config/env.js
@@ -117,6 +117,12 @@ function getSessionSecret() {
 // --- Feature flags ---
 const DEBUG_LOG = process.env.HEALTH_DEBUG === '1';
 
+// --- Health Auto Export ingest (optional) ---
+// When set, enables POST /api/health-auto-export/<type>. The caller (an iOS
+// Shortcut, typically) must send Authorization: Bearer <HEALTH_AUTO_EXPORT_TOKEN>.
+// When unset, the endpoint returns 501 so the feature is off by default.
+const HEALTH_AUTO_EXPORT_TOKEN = (process.env.HEALTH_AUTO_EXPORT_TOKEN || '').trim();
+
 // --- Health system prompt (used by chat proxy) ---
 //
 // Default prompt is generic and references whatever cards the registry
@@ -410,5 +416,6 @@ module.exports = {
   WEBAUTHN_ORIGIN,
   getSessionSecret,
   DEBUG_LOG,
+  HEALTH_AUTO_EXPORT_TOKEN,
   HEALTH_SYSTEM_PROMPT,
 };

--- a/health-auto-export/ingest.js
+++ b/health-auto-export/ingest.js
@@ -1,0 +1,366 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// health-auto-export/ingest.js
+//
+// Iphone Health Auto Export (HAE) ingest.
+//
+// Accepts a canonical, intuitive payload (NOT Apple's raw export JSON). The
+// caller (typically an iOS Shortcut) is expected to map HAE fields into this
+// canonical shape before posting; that mapping is trivial and keeps Klebb
+// decoupled from Apple's moving-target export format.
+//
+// Canonical shape:
+//   {
+//     "date": "YYYY-MM-DD",
+//     "metrics": {
+//       <metric-key>: <primitive or nested object>, ...
+//     }
+//   }
+//
+// For type="sleep" the recognised metric keys are:
+//   hours    (number)  -> fans out to sleep-hours card, row { date, hours }
+//   stages   (object { core, rem, deep, awake } in hours)
+//                      -> sleep-stages card, row { date, core, rem, deep, awake }
+//   bedTime  (string "HH:MM" or ISO) -> sleep-bed-wake card, row.bedTime
+//   wakeTime (string "HH:MM" or ISO) -> sleep-bed-wake card, row.wakeTime
+//
+// For type="activity" the recognised metric keys are:
+//   steps            (number)  -> steps card,           row { date, count }
+//   activeEnergy     (number)  -> active-energy card,   row { date, kcal }
+//   exerciseMinutes  (number)  -> exercise-minutes card, row { date, minutes }
+//   standHours       (number)  -> stand-hours card,     row { date, hours }
+//
+// Unknown metric keys are silently ignored so the shape can grow without
+// breaking older clients. Sparse payloads are fine: only the metrics present
+// produce writes.
+//
+// Behaviour per target card:
+//   - If the manifest exists, its data[] array is upserted by date (the
+//     existing row for that date is replaced; everything else is preserved,
+//     and the result is sorted by date ascending).
+//   - If the manifest does not exist, it is created from a minimal template
+//     baked in below (klebb.datafile.v1 + generic-card + sensible display
+//     config). A human can retrofit display / trends config later without
+//     touching the data.
+//
+// Idempotency: posting the same date twice overwrites only that date's row
+// in each affected card. All other dates are untouched.
+
+const fs = require('fs');
+const path = require('path');
+
+const TYPES = ['sleep', 'activity'];
+
+function isValidIsoDate(s) {
+  return typeof s === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(s);
+}
+
+function toNumber(v) {
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  if (typeof v === 'string' && v.trim() !== '') {
+    const n = Number(v);
+    if (Number.isFinite(n)) return n;
+  }
+  return null;
+}
+
+// Each key here produces zero or one target-card writes for a given payload.
+// A write is { targetId, row } where row carries `date` plus the card's
+// canonical fields.
+const FAN_OUT = {
+  sleep: {
+    hours: (date, v) => {
+      const n = toNumber(v);
+      if (n === null) return null;
+      return { targetId: 'sleep-hours', row: { date, hours: n } };
+    },
+    stages: (date, v) => {
+      if (!v || typeof v !== 'object') return null;
+      const row = { date };
+      let any = false;
+      for (const k of ['core', 'rem', 'deep', 'awake']) {
+        const n = toNumber(v[k]);
+        if (n !== null) { row[k] = n; any = true; }
+      }
+      return any ? { targetId: 'sleep-stages', row } : null;
+    },
+    bedTime:  (date, v) => timeFieldWrite('sleep-bed-wake', date, { bedTime:  v }),
+    wakeTime: (date, v) => timeFieldWrite('sleep-bed-wake', date, { wakeTime: v }),
+  },
+  activity: {
+    steps: (date, v) => {
+      const n = toNumber(v);
+      if (n === null) return null;
+      return { targetId: 'steps', row: { date, count: n } };
+    },
+    activeEnergy: (date, v) => {
+      const n = toNumber(v);
+      if (n === null) return null;
+      return { targetId: 'active-energy', row: { date, kcal: n } };
+    },
+    exerciseMinutes: (date, v) => {
+      const n = toNumber(v);
+      if (n === null) return null;
+      return { targetId: 'exercise-minutes', row: { date, minutes: n } };
+    },
+    standHours: (date, v) => {
+      const n = toNumber(v);
+      if (n === null) return null;
+      return { targetId: 'stand-hours', row: { date, hours: n } };
+    },
+  },
+};
+
+function timeFieldWrite(targetId, date, partial) {
+  const cleaned = {};
+  let any = false;
+  for (const [k, v] of Object.entries(partial)) {
+    if (typeof v === 'string' && v.trim().length > 0) {
+      cleaned[k] = v.trim();
+      any = true;
+    }
+  }
+  if (!any) return null;
+  return { targetId, row: { date, ...cleaned } };
+}
+
+// Minimal manifest templates used when a target doesn't exist on first write.
+// Kept intentionally spare: generic-card renderer, simple display template,
+// writeable disabled (ingest is the canonical writer), sensible description.
+const TEMPLATES = {
+  'sleep-hours': {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'sleep-hours',
+      label: 'Sleep',
+      emoji: '😴',
+      order: 30,
+      view: {
+        enabled: true,
+        component: 'generic-card',
+        display: { template: '{hours:round(1)}', unit: 'hrs', emptyHeadline: 'No sleep logged' },
+      },
+    },
+    description: 'Total sleep duration for the night, in hours. One entry per date. Populated by health-auto-export ingest.',
+    data: [],
+  },
+  'sleep-stages': {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'sleep-stages',
+      label: 'Sleep Stages',
+      emoji: '🌙',
+      order: 31,
+      view: {
+        enabled: true,
+        component: 'generic-card',
+        display: { template: '{deep:round(1)}h deep, {rem:round(1)}h REM', emptyHeadline: 'No stage data' },
+      },
+    },
+    description: 'Sleep stage durations in hours per date: core, rem, deep, awake. Populated by health-auto-export ingest.',
+    data: [],
+  },
+  'sleep-bed-wake': {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'sleep-bed-wake',
+      label: 'Bed/Wake',
+      emoji: '🛏️',
+      order: 33,
+      view: {
+        enabled: true,
+        component: 'generic-card',
+        display: { template: '{bedTime} to {wakeTime}', emptyHeadline: 'No times recorded' },
+      },
+    },
+    description: 'Bedtime and wake time for the night, as HH:MM strings. Populated by health-auto-export ingest.',
+    data: [],
+  },
+  'steps': {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'steps',
+      label: 'Steps',
+      emoji: '👣',
+      order: 70,
+      view: {
+        enabled: true,
+        component: 'generic-card',
+        display: { template: '{count}', unit: 'steps', emptyHeadline: 'No steps logged' },
+      },
+    },
+    description: 'Daily step count. One entry per date. Populated by health-auto-export ingest.',
+    data: [],
+  },
+  'active-energy': {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'active-energy',
+      label: 'Active Energy',
+      emoji: '🔥',
+      order: 71,
+      view: {
+        enabled: true,
+        component: 'generic-card',
+        display: { template: '{kcal}', unit: 'kcal', emptyHeadline: 'No energy logged' },
+      },
+    },
+    description: 'Active energy burned per day, in kilocalories. Populated by health-auto-export ingest.',
+    data: [],
+  },
+  'exercise-minutes': {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'exercise-minutes',
+      label: 'Exercise',
+      emoji: '🏃',
+      order: 73,
+      view: {
+        enabled: true,
+        component: 'generic-card',
+        display: { template: '{minutes}', unit: 'min', emptyHeadline: 'No exercise logged' },
+      },
+    },
+    description: 'Minutes of recorded exercise per day. Populated by health-auto-export ingest.',
+    data: [],
+  },
+  'stand-hours': {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'stand-hours',
+      label: 'Stand Hours',
+      emoji: '🧍',
+      order: 75,
+      view: {
+        enabled: true,
+        component: 'generic-card',
+        display: { template: '{hours}', unit: 'hrs', emptyHeadline: 'No stand hours logged' },
+      },
+    },
+    description: 'Number of hours containing at least one minute of standing activity. Populated by health-auto-export ingest.',
+    data: [],
+  },
+};
+
+// Validate an incoming payload before we act on it. Returns { ok, error, payload }.
+function validatePayload(type, body) {
+  if (!TYPES.includes(type)) {
+    return { ok: false, error: `unsupported type: ${type}` };
+  }
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return { ok: false, error: 'body must be a JSON object' };
+  }
+  if (!isValidIsoDate(body.date)) {
+    return { ok: false, error: 'body.date must be an ISO date (YYYY-MM-DD)' };
+  }
+  if (!body.metrics || typeof body.metrics !== 'object' || Array.isArray(body.metrics)) {
+    return { ok: false, error: 'body.metrics must be an object' };
+  }
+  return { ok: true, payload: { date: body.date, metrics: body.metrics } };
+}
+
+// Plan the fan-out for a validated payload WITHOUT touching disk or the
+// registry. Returns [{ targetId, row }, ...], which the caller then
+// applies. Pure; exported for unit tests.
+function planWrites(type, payload) {
+  const handlers = FAN_OUT[type];
+  const writes = [];
+  for (const [key, raw] of Object.entries(payload.metrics)) {
+    const fn = handlers[key];
+    if (typeof fn !== 'function') continue;
+    const w = fn(payload.date, raw);
+    if (w) writes.push(w);
+  }
+  return writes;
+}
+
+// Upsert one date's row into an array-shaped data block. Returns a new
+// array (the caller rewrites the whole data block via registry.writeData).
+function upsertRow(data, row) {
+  const existing = Array.isArray(data) ? data : [];
+  const withoutDate = existing.filter(r => !r || r.date !== row.date);
+  const merged = [...withoutDate];
+  // Merge with an existing row for that date only if THAT row carried
+  // different fields (e.g. bedTime written earlier, wakeTime now). This
+  // preserves partial writes across multiple POSTs for the same date.
+  const prior = existing.find(r => r && r.date === row.date) || null;
+  const finalRow = prior ? { ...prior, ...row } : { ...row };
+  merged.push(finalRow);
+  merged.sort((a, b) => (a.date || '').localeCompare(b.date || ''));
+  return merged;
+}
+
+// Archive the raw incoming payload at $AUTO_EXPORT_DIR/<type>/<date>.json.
+// Mirrors the predecessor app's behaviour so external tooling that reads
+// those files (or the existing GET /api/sleep/:date endpoints) keeps working.
+function archivePayload(autoExportDir, type, payload, body) {
+  const dir = path.join(autoExportDir, type);
+  fs.mkdirSync(dir, { recursive: true });
+  const target = path.join(dir, `${payload.date}.json`);
+  // We write the ORIGINAL body (what the caller sent), not the parsed
+  // payload, so archival is a true capture of what arrived.
+  const tmp = target + '.tmp';
+  fs.writeFileSync(tmp, JSON.stringify(body, null, 2));
+  fs.renameSync(tmp, target);
+  return target;
+}
+
+// Apply planned writes against the registry. Creates missing target
+// manifests from TEMPLATES on first write. Idempotent.
+function applyWrites(registry, writes) {
+  const applied = [];
+  for (const { targetId, row } of writes) {
+    const template = TEMPLATES[targetId];
+    if (!template) {
+      // Unknown target (should be impossible because FAN_OUT is closed).
+      continue;
+    }
+    const existing = registry.get(targetId);
+    if (!existing) {
+      // Create with a single-row data[] on first write. Clone so the
+      // template object isn't mutated across requests.
+      const manifest = JSON.parse(JSON.stringify(template));
+      manifest.data = [row];
+      registry.createManifest(manifest);
+    } else {
+      const nextData = upsertRow(existing.data, row);
+      registry.writeData(targetId, nextData);
+    }
+    applied.push(targetId);
+  }
+  return applied;
+}
+
+// Full end-to-end: validate, archive, fan out, apply. Returns either
+//   { ok: true, type, date, targets: [<id>, ...], archive: <abs path> }
+// or
+//   { ok: false, status, error }
+// The caller maps { ok: false } onto the HTTP response shape.
+function ingest({ type, body, autoExportDir, registry, rawBody = null }) {
+  const v = validatePayload(type, body);
+  if (!v.ok) {
+    return { ok: false, status: 400, error: v.error };
+  }
+  const writes = planWrites(type, v.payload);
+  const archive = archivePayload(autoExportDir, type, v.payload, rawBody ?? body);
+  const targets = applyWrites(registry, writes);
+  return {
+    ok: true,
+    type,
+    date: v.payload.date,
+    targets,
+    archive,
+  };
+}
+
+module.exports = {
+  TYPES,
+  FAN_OUT,
+  TEMPLATES,
+  validatePayload,
+  planWrites,
+  upsertRow,
+  archivePayload,
+  applyWrites,
+  ingest,
+};

--- a/server.js
+++ b/server.js
@@ -491,6 +491,68 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
+  // Health Auto Export ingest: POST /api/health-auto-export/<type>.
+  // Auth model is independent of the webapp session: a bearer token from
+  // HEALTH_AUTO_EXPORT_TOKEN, so an iOS Shortcut (or any external tool) can
+  // push data without owning a session cookie. Handled before the global
+  // session gate to avoid double-gating.
+  if (pathname.startsWith('/api/health-auto-export/') && req.method === 'POST') {
+    const type = pathname.slice('/api/health-auto-export/'.length);
+    if (!ENV.HEALTH_AUTO_EXPORT_TOKEN) {
+      res.writeHead(501, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'health-auto-export ingest is not configured on this instance' }));
+      return;
+    }
+    const auth = req.headers['authorization'] || '';
+    const ok = auth.startsWith('Bearer ') && auth.slice(7).trim() === ENV.HEALTH_AUTO_EXPORT_TOKEN;
+    if (!ok) {
+      res.writeHead(401, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'invalid or missing bearer token' }));
+      return;
+    }
+    if (!require('./health-auto-export/ingest').TYPES.includes(type)) {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: `unsupported type: ${type}` }));
+      return;
+    }
+    let body = '';
+    req.on('data', c => { body += c; });
+    req.on('end', () => {
+      let parsed;
+      try { parsed = JSON.parse(body || '{}'); }
+      catch {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'invalid JSON body' }));
+        return;
+      }
+      try {
+        const result = require('./health-auto-export/ingest').ingest({
+          type,
+          body: parsed,
+          rawBody: parsed,
+          autoExportDir: PATHS.AUTO_EXPORT_DIR,
+          registry,
+        });
+        if (!result.ok) {
+          res.writeHead(result.status || 400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: result.error }));
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          ok: true,
+          type: result.type,
+          date: result.date,
+          targets: result.targets,
+        }));
+      } catch (e) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: e.message || 'ingest failed' }));
+      }
+    });
+    return;
+  }
+
   // Handle auth routes first
   if (pathname.startsWith('/auth/')) {
     const result = await handleAuthRoutes(req, res, pathname);

--- a/tests/health-auto-export.ingest.test.js
+++ b/tests/health-auto-export.ingest.test.js
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/health-auto-export.ingest.test.js
+// End-to-end coverage of POST /api/health-auto-export/<type>.
+//
+// Spawns a real server against a sandbox HEALTH_HOME and exercises:
+//   - 501 when the token env is unset (feature off by default),
+//   - 401 on missing / wrong bearer,
+//   - 404 on unsupported type,
+//   - 400 on malformed body,
+//   - 200 happy path: archive file written + atomic target manifests
+//     created / upserted,
+//   - idempotency: re-posting the same date overwrites only that date,
+//   - partial writes (bedTime then wakeTime) merge on the same date,
+//   - existing manifests receive new rows without losing prior rows.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+const {
+  createSandbox, cleanupSandbox, spawnServer, req, fakeAuthState,
+} = require('./helpers/sandbox');
+
+const TOKEN = 'test-hae-token-1234567890';
+
+describe('POST /api/health-auto-export/<type>', () => {
+
+  describe('feature disabled (no token env)', () => {
+    let sandbox, server;
+    before(async () => {
+      sandbox = createSandbox();
+      server = await spawnServer(sandbox);  // no HEALTH_AUTO_EXPORT_TOKEN
+    });
+    after(async () => {
+      if (server) await server.kill();
+      cleanupSandbox(sandbox);
+    });
+
+    test('returns 501', async () => {
+      const res = await req(server.baseUrl, '/api/health-auto-export/sleep', {
+        method: 'POST',
+        body: { date: '2026-05-01', metrics: { hours: 7 } },
+      });
+      assert.equal(res.status, 501);
+    });
+  });
+
+  describe('feature enabled', () => {
+    let sandbox, server, auth;
+    const bearer = { 'Authorization': `Bearer ${TOKEN}` };
+
+    before(async () => {
+      auth = fakeAuthState('op');
+      sandbox = createSandbox({
+        credentials: auth.credentials,
+        sessions: auth.sessions,
+      });
+      server = await spawnServer(sandbox, { HEALTH_AUTO_EXPORT_TOKEN: TOKEN });
+    });
+    after(async () => {
+      if (server) await server.kill();
+      cleanupSandbox(sandbox);
+    });
+
+    test('401 without bearer', async () => {
+      const res = await req(server.baseUrl, '/api/health-auto-export/sleep', {
+        method: 'POST',
+        body: { date: '2026-05-01', metrics: { hours: 7 } },
+      });
+      assert.equal(res.status, 401);
+    });
+
+    test('401 with wrong bearer', async () => {
+      const res = await req(server.baseUrl, '/api/health-auto-export/sleep', {
+        method: 'POST',
+        headers: { 'Authorization': 'Bearer nope' },
+        body: { date: '2026-05-01', metrics: { hours: 7 } },
+      });
+      assert.equal(res.status, 401);
+    });
+
+    test('404 on unsupported type', async () => {
+      const res = await req(server.baseUrl, '/api/health-auto-export/bananas', {
+        method: 'POST',
+        headers: bearer,
+        body: { date: '2026-05-01', metrics: {} },
+      });
+      assert.equal(res.status, 404);
+    });
+
+    test('400 on malformed JSON body', async () => {
+      const res = await req(server.baseUrl, '/api/health-auto-export/sleep', {
+        method: 'POST',
+        headers: bearer,
+        body: '{not json',
+      });
+      assert.equal(res.status, 400);
+    });
+
+    test('400 on invalid date', async () => {
+      const res = await req(server.baseUrl, '/api/health-auto-export/sleep', {
+        method: 'POST',
+        headers: bearer,
+        body: { date: '5/1/2026', metrics: { hours: 7 } },
+      });
+      assert.equal(res.status, 400);
+    });
+
+    test('happy path: creates missing manifests + archive file', async () => {
+      const payload = {
+        date: '2026-05-01',
+        metrics: {
+          hours: 7.5,
+          stages: { core: 4.2, rem: 1.3, deep: 1.5, awake: 0.5 },
+          bedTime: '23:12',
+          wakeTime: '07:05',
+        },
+      };
+      const res = await req(server.baseUrl, '/api/health-auto-export/sleep', {
+        method: 'POST',
+        headers: bearer,
+        body: payload,
+      });
+      assert.equal(res.status, 200);
+      assert.equal(res.json.ok, true);
+      assert.equal(res.json.date, '2026-05-01');
+      assert.ok(res.json.targets.includes('sleep-hours'));
+      assert.ok(res.json.targets.includes('sleep-stages'));
+      assert.ok(res.json.targets.includes('sleep-bed-wake'));
+
+      // Archive file on disk
+      const archive = path.join(sandbox, 'data', 'auto-export', 'sleep', '2026-05-01.json');
+      assert.ok(fs.existsSync(archive), 'archive file should exist');
+      const archived = JSON.parse(fs.readFileSync(archive, 'utf8'));
+      assert.equal(archived.date, '2026-05-01');
+      assert.equal(archived.metrics.hours, 7.5);
+
+      // Target manifests exist and carry the row for this date
+      const sleepHours = await req(server.baseUrl, '/api/manifests/sleep-hours/data', { cookie: auth.cookie });
+      assert.equal(sleepHours.status, 200);
+      const row = sleepHours.json.data.find(r => r.date === '2026-05-01');
+      assert.equal(row.hours, 7.5);
+
+      const stages = await req(server.baseUrl, '/api/manifests/sleep-stages/data', { cookie: auth.cookie });
+      const stageRow = stages.json.data.find(r => r.date === '2026-05-01');
+      assert.equal(stageRow.core, 4.2);
+      assert.equal(stageRow.rem, 1.3);
+      assert.equal(stageRow.deep, 1.5);
+
+      const bedWake = await req(server.baseUrl, '/api/manifests/sleep-bed-wake/data', { cookie: auth.cookie });
+      const bwRow = bedWake.json.data.find(r => r.date === '2026-05-01');
+      assert.equal(bwRow.bedTime, '23:12');
+      assert.equal(bwRow.wakeTime, '07:05');
+
+      // Manifest file itself is a valid klebb.datafile.v1
+      const onDisk = JSON.parse(fs.readFileSync(path.join(sandbox, 'data', 'sleep-hours.json'), 'utf8'));
+      assert.equal(onDisk.$schema, 'klebb.datafile.v1');
+      assert.equal(onDisk.meta.id, 'sleep-hours');
+    });
+
+    test('second post for the same date overwrites only that date', async () => {
+      // First: post another date so we have at least two entries to keep.
+      await req(server.baseUrl, '/api/health-auto-export/sleep', {
+        method: 'POST',
+        headers: bearer,
+        body: { date: '2026-04-30', metrics: { hours: 6.0 } },
+      });
+      // Then overwrite the 2026-05-01 row.
+      const res = await req(server.baseUrl, '/api/health-auto-export/sleep', {
+        method: 'POST',
+        headers: bearer,
+        body: { date: '2026-05-01', metrics: { hours: 9.0 } },
+      });
+      assert.equal(res.status, 200);
+      const sleepHours = await req(server.baseUrl, '/api/manifests/sleep-hours/data', { cookie: auth.cookie });
+      const rows = sleepHours.json.data;
+      const may1 = rows.filter(r => r.date === '2026-05-01');
+      assert.equal(may1.length, 1, 'exactly one row for the reposted date');
+      assert.equal(may1[0].hours, 9.0);
+      const apr30 = rows.find(r => r.date === '2026-04-30');
+      assert.equal(apr30.hours, 6.0, 'earlier date untouched');
+    });
+
+    test('partial writes merge into one row per date', async () => {
+      // Post only bedTime.
+      await req(server.baseUrl, '/api/health-auto-export/sleep', {
+        method: 'POST',
+        headers: bearer,
+        body: { date: '2026-06-01', metrics: { bedTime: '22:30' } },
+      });
+      // Then only wakeTime.
+      await req(server.baseUrl, '/api/health-auto-export/sleep', {
+        method: 'POST',
+        headers: bearer,
+        body: { date: '2026-06-01', metrics: { wakeTime: '06:40' } },
+      });
+      const bedWake = await req(server.baseUrl, '/api/manifests/sleep-bed-wake/data', { cookie: auth.cookie });
+      const rows = bedWake.json.data.filter(r => r.date === '2026-06-01');
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0].bedTime, '22:30');
+      assert.equal(rows[0].wakeTime, '06:40');
+    });
+
+    test('activity payload fans out to four atomic cards', async () => {
+      const res = await req(server.baseUrl, '/api/health-auto-export/activity', {
+        method: 'POST',
+        headers: bearer,
+        body: {
+          date: '2026-05-01',
+          metrics: {
+            steps: 8421,
+            activeEnergy: 540,
+            exerciseMinutes: 42,
+            standHours: 11,
+          },
+        },
+      });
+      assert.equal(res.status, 200);
+      assert.ok(res.json.targets.includes('steps'));
+      assert.ok(res.json.targets.includes('active-energy'));
+      assert.ok(res.json.targets.includes('exercise-minutes'));
+      assert.ok(res.json.targets.includes('stand-hours'));
+
+      const steps = await req(server.baseUrl, '/api/manifests/steps/data', { cookie: auth.cookie });
+      assert.equal(steps.json.data.find(r => r.date === '2026-05-01').count, 8421);
+      const energy = await req(server.baseUrl, '/api/manifests/active-energy/data', { cookie: auth.cookie });
+      assert.equal(energy.json.data.find(r => r.date === '2026-05-01').kcal, 540);
+    });
+
+    test('sparse metrics produce only the relevant writes', async () => {
+      const res = await req(server.baseUrl, '/api/health-auto-export/activity', {
+        method: 'POST',
+        headers: bearer,
+        body: { date: '2026-05-02', metrics: { steps: 500 } },
+      });
+      assert.equal(res.status, 200);
+      assert.deepEqual(res.json.targets, ['steps']);
+    });
+
+    test('unknown metric keys are silently ignored (no writes, still ok)', async () => {
+      const res = await req(server.baseUrl, '/api/health-auto-export/sleep', {
+        method: 'POST',
+        headers: bearer,
+        body: { date: '2026-07-01', metrics: { nonsense: 1, moreNonsense: 'x' } },
+      });
+      assert.equal(res.status, 200);
+      assert.deepEqual(res.json.targets, []);
+      // No archive for missing-metric day? Actually, we archive regardless,
+      // so that raw captures still land. Check.
+      const archive = path.join(sandbox, 'data', 'auto-export', 'sleep', '2026-07-01.json');
+      assert.ok(fs.existsSync(archive), 'archive should capture even no-op payloads');
+    });
+
+    test('existing pre-seeded manifest is upserted, not recreated', async () => {
+      // The "steps" manifest was already created by an earlier test (activity).
+      // Re-post a new day and confirm BOTH rows end up in the same file.
+      await req(server.baseUrl, '/api/health-auto-export/activity', {
+        method: 'POST',
+        headers: bearer,
+        body: { date: '2026-05-03', metrics: { steps: 12345 } },
+      });
+      const steps = await req(server.baseUrl, '/api/manifests/steps/data', { cookie: auth.cookie });
+      const dates = steps.json.data.map(r => r.date);
+      assert.ok(dates.includes('2026-05-01'));
+      assert.ok(dates.includes('2026-05-03'));
+    });
+  });
+});

--- a/tests/health-auto-export.parser.test.js
+++ b/tests/health-auto-export.parser.test.js
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/health-auto-export.parser.test.js
+// Unit tests for the HAE ingest parser/fan-out. No filesystem, no registry.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+
+const {
+  TYPES, FAN_OUT, TEMPLATES,
+  validatePayload, planWrites, upsertRow,
+} = require(path.join(__dirname, '..', 'health-auto-export', 'ingest.js'));
+
+describe('health-auto-export ingest parser', () => {
+  describe('validatePayload', () => {
+    test('accepts a well-formed sleep payload', () => {
+      const v = validatePayload('sleep', { date: '2026-05-01', metrics: { hours: 7.5 } });
+      assert.equal(v.ok, true);
+      assert.equal(v.payload.date, '2026-05-01');
+      assert.deepEqual(v.payload.metrics, { hours: 7.5 });
+    });
+
+    test('rejects unsupported type', () => {
+      const v = validatePayload('bananas', { date: '2026-05-01', metrics: {} });
+      assert.equal(v.ok, false);
+      assert.match(v.error, /unsupported type/);
+    });
+
+    test('rejects non-object body', () => {
+      assert.equal(validatePayload('sleep', null).ok, false);
+      assert.equal(validatePayload('sleep', 'hello').ok, false);
+      assert.equal(validatePayload('sleep', [1, 2]).ok, false);
+    });
+
+    test('rejects bad date', () => {
+      assert.equal(validatePayload('sleep', { date: '5/1/26', metrics: {} }).ok, false);
+      assert.equal(validatePayload('sleep', { metrics: {} }).ok, false);
+    });
+
+    test('rejects missing/non-object metrics', () => {
+      assert.equal(validatePayload('sleep', { date: '2026-05-01' }).ok, false);
+      assert.equal(validatePayload('sleep', { date: '2026-05-01', metrics: [] }).ok, false);
+      assert.equal(validatePayload('sleep', { date: '2026-05-01', metrics: 'x' }).ok, false);
+    });
+  });
+
+  describe('planWrites (sleep)', () => {
+    const D = '2026-05-01';
+
+    test('hours metric fans out to sleep-hours', () => {
+      const writes = planWrites('sleep', { date: D, metrics: { hours: 7.5 } });
+      assert.equal(writes.length, 1);
+      assert.equal(writes[0].targetId, 'sleep-hours');
+      assert.deepEqual(writes[0].row, { date: D, hours: 7.5 });
+    });
+
+    test('stages metric fans out to sleep-stages with only present fields', () => {
+      const writes = planWrites('sleep', {
+        date: D,
+        metrics: { stages: { core: 4.2, rem: 1.3, deep: 1.5 } },
+      });
+      assert.equal(writes.length, 1);
+      assert.equal(writes[0].targetId, 'sleep-stages');
+      assert.deepEqual(writes[0].row, { date: D, core: 4.2, rem: 1.3, deep: 1.5 });
+    });
+
+    test('stages with zero recognised fields produces no write', () => {
+      const writes = planWrites('sleep', { date: D, metrics: { stages: { nap: 1 } } });
+      assert.equal(writes.length, 0);
+    });
+
+    test('bedTime + wakeTime both target sleep-bed-wake', () => {
+      const writes = planWrites('sleep', {
+        date: D,
+        metrics: { bedTime: '23:12', wakeTime: '07:05' },
+      });
+      assert.equal(writes.length, 2);
+      assert.ok(writes.every(w => w.targetId === 'sleep-bed-wake'));
+      assert.equal(writes[0].row.bedTime, '23:12');
+      assert.equal(writes[1].row.wakeTime, '07:05');
+    });
+
+    test('empty-string time fields are dropped', () => {
+      const writes = planWrites('sleep', {
+        date: D,
+        metrics: { bedTime: '   ', wakeTime: '07:05' },
+      });
+      assert.equal(writes.length, 1);
+      assert.equal(writes[0].row.wakeTime, '07:05');
+      assert.equal('bedTime' in writes[0].row, false);
+    });
+
+    test('unknown metric keys are silently ignored', () => {
+      const writes = planWrites('sleep', {
+        date: D,
+        metrics: { hours: 7, nonsense: 'ignored', x: { y: 1 } },
+      });
+      assert.equal(writes.length, 1);
+      assert.equal(writes[0].targetId, 'sleep-hours');
+    });
+
+    test('coerces numeric strings', () => {
+      const writes = planWrites('sleep', { date: D, metrics: { hours: '7.25' } });
+      assert.equal(writes[0].row.hours, 7.25);
+    });
+
+    test('non-numeric hours produces no write', () => {
+      const writes = planWrites('sleep', { date: D, metrics: { hours: 'many' } });
+      assert.equal(writes.length, 0);
+    });
+  });
+
+  describe('planWrites (activity)', () => {
+    const D = '2026-05-01';
+
+    test('steps + activeEnergy + exerciseMinutes + standHours all fan out', () => {
+      const writes = planWrites('activity', {
+        date: D,
+        metrics: {
+          steps: 8421,
+          activeEnergy: 540,
+          exerciseMinutes: 42,
+          standHours: 11,
+        },
+      });
+      const byTarget = Object.fromEntries(writes.map(w => [w.targetId, w.row]));
+      assert.equal(writes.length, 4);
+      assert.equal(byTarget.steps.count, 8421);
+      assert.equal(byTarget['active-energy'].kcal, 540);
+      assert.equal(byTarget['exercise-minutes'].minutes, 42);
+      assert.equal(byTarget['stand-hours'].hours, 11);
+    });
+
+    test('sparse payload produces sparse writes', () => {
+      const writes = planWrites('activity', { date: D, metrics: { steps: 500 } });
+      assert.equal(writes.length, 1);
+      assert.equal(writes[0].targetId, 'steps');
+    });
+  });
+
+  describe('upsertRow', () => {
+    test('inserts first row', () => {
+      const out = upsertRow([], { date: '2026-05-01', count: 1000 });
+      assert.deepEqual(out, [{ date: '2026-05-01', count: 1000 }]);
+    });
+
+    test('upserts same-date row, preserves others', () => {
+      const existing = [
+        { date: '2026-04-30', count: 900 },
+        { date: '2026-05-01', count: 1000 },
+        { date: '2026-05-02', count: 1200 },
+      ];
+      const out = upsertRow(existing, { date: '2026-05-01', count: 1500 });
+      assert.equal(out.length, 3);
+      assert.equal(out.find(r => r.date === '2026-05-01').count, 1500);
+      assert.equal(out.find(r => r.date === '2026-04-30').count, 900);
+      assert.equal(out.find(r => r.date === '2026-05-02').count, 1200);
+    });
+
+    test('merges with prior row on same date (partial writes)', () => {
+      const existing = [{ date: '2026-05-01', bedTime: '23:00' }];
+      const out = upsertRow(existing, { date: '2026-05-01', wakeTime: '07:00' });
+      assert.deepEqual(out[0], { date: '2026-05-01', bedTime: '23:00', wakeTime: '07:00' });
+    });
+
+    test('keeps result sorted ascending by date', () => {
+      const out = upsertRow(
+        [{ date: '2026-05-03', v: 3 }, { date: '2026-05-01', v: 1 }],
+        { date: '2026-05-02', v: 2 }
+      );
+      assert.deepEqual(out.map(r => r.date), ['2026-05-01', '2026-05-02', '2026-05-03']);
+    });
+
+    test('non-array prior data is treated as empty', () => {
+      const out = upsertRow(null, { date: '2026-05-01', v: 1 });
+      assert.deepEqual(out, [{ date: '2026-05-01', v: 1 }]);
+    });
+  });
+
+  describe('TEMPLATES', () => {
+    test('every fan-out targetId has a template', () => {
+      for (const type of TYPES) {
+        for (const key of Object.keys(FAN_OUT[type])) {
+          const out = FAN_OUT[type][key]('2026-05-01', type === 'sleep' && key === 'stages' ? { core: 1 } : (key.endsWith('Time') ? '07:00' : 5));
+          if (out) {
+            assert.ok(TEMPLATES[out.targetId], `missing template for target ${out.targetId}`);
+            assert.equal(TEMPLATES[out.targetId].$schema, 'klebb.datafile.v1');
+            assert.equal(TEMPLATES[out.targetId].meta.id, out.targetId);
+          }
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
# What changed

Adds a new HTTP ingest endpoint, \`POST /api/health-auto-export/<type>\`, that lets an external caller (an iOS Shortcut is the primary target, but anything that speaks HTTP will do) push health metrics into Klebb. Off by default: returns 501 until the operator sets \`HEALTH_AUTO_EXPORT_TOKEN\`.

# Why

The \`\$HEALTH_HOME/data/auto-export/\` directory has been a reserved sink for a while (config/paths.js:60, manifests/registry.js:27) with read-only legacy GET endpoints (server.js:777-793) but no writer, so there's no way for the iPhone Health Auto Export Shortcut to deliver data into Klebb. This PR fills that gap and is the ingest half of the \"Combination Cards\" feature (see #93 for the renderer); once this lands, the upcoming \`sleep-overview\` / \`activity-overview\` presets can be driven by real iPhone data rather than manual entry.

# How

- \`health-auto-export/ingest.js\` (new): validate -> archive raw payload -> plan writes -> apply writes. Pure where possible, so the parser/fan-out layer is fully unit-testable in Node with no filesystem or registry. Exports \`validatePayload\`, \`planWrites\`, \`upsertRow\`, \`archivePayload\`, \`applyWrites\`, \`ingest\` plus \`FAN_OUT\` and \`TEMPLATES\` tables so new metric types can be added by editing data tables instead of touching control flow.
- \`server.js\`: new handler placed **before** the global session gate. Its own bearer-token check means it doesn't piggyback on \`AGENT_API_TOKEN\` or the webapp cookie; ingest callers present their own bearer only. Keeps the handler thin (reading body, passing through to the ingest module).
- \`config/env.js\`: new \`HEALTH_AUTO_EXPORT_TOKEN\` env var. Feature is disabled entirely when unset.

## Payload shape

Canonical, intuitive JSON (not Apple's raw Health Auto Export format). The caller maps HAE fields to this shape before POSTing; that mapping is trivial and keeps Klebb decoupled from Apple's moving-target export format.

\`\`\`http
POST /api/health-auto-export/sleep
Authorization: Bearer <HEALTH_AUTO_EXPORT_TOKEN>
Content-Type: application/json

{
  \"date\": \"2026-05-01\",
  \"metrics\": {
    \"hours\": 7.5,
    \"stages\": { \"core\": 4.2, \"rem\": 1.3, \"deep\": 1.5, \"awake\": 0.5 },
    \"bedTime\": \"23:12\",
    \"wakeTime\": \"07:05\"
  }
}
\`\`\`

Supported types + their recognised metrics:
- **sleep**: \`hours\`, \`stages.{core,rem,deep,awake}\`, \`bedTime\`, \`wakeTime\`
- **activity**: \`steps\`, \`activeEnergy\`, \`exerciseMinutes\`, \`standHours\`

Unknown metric keys are silently ignored so the payload shape can grow without breaking older clients.

## Side-effects per request

1. Archives the raw payload at \`\$HEALTH_HOME/data/auto-export/<type>/<date>.json\` (mirrors predecessor layout; the legacy GET endpoints at server.js:777-793 keep working).
2. Fans each recognised metric out to an atomic \`klebb.datafile.v1\` card: \`sleep-hours\`, \`sleep-stages\`, \`sleep-bed-wake\`, \`steps\`, \`active-energy\`, \`exercise-minutes\`, \`stand-hours\`.
3. Missing target manifests are created on first write from a baked-in minimal template. A human can retrofit display / trends config later without touching the data.
4. Idempotent per date: re-posting the same date overwrites only that date's row in each affected card. Partial writes merge on the same date (a follow-up POST carrying only \`wakeTime\` preserves a previously posted \`bedTime\`).

## Response codes

| Status | Meaning |
|--------|---------|
| 200 | Ingested. Response \`{ok, type, date, targets: [<id>, ...]}\` |
| 400 | Malformed body, invalid date, non-object metrics |
| 401 | Missing / wrong bearer |
| 404 | Unsupported type |
| 501 | \`HEALTH_AUTO_EXPORT_TOKEN\` unset (feature disabled on this instance) |

# Testing

- [x] \`npm test\`: 427 tests, 426 pass, 1 fail. The lone failure is the pre-existing \`tests/no-personal-refs.test.js\` hitting gitignored operator files (\`.claude/\`, \`BRIEF-FOR-CC.md\`, \`CLAUDE.md\`, \`data/sessions/\`); reproduces on \`main\` and is unrelated to this PR.
- [x] Unit tests in \`tests/health-auto-export.parser.test.js\` (22 tests): payload validation across good/bad shapes; fan-out correctness for each supported metric including sparse stage objects, empty-string time fields, and numeric-string coercion; unknown-key silent ignore; \`upsertRow\` semantics (insert, overwrite, partial-merge, date-sort, null-prior tolerance); template/target-id coverage cross-check.
- [x] Integration tests in \`tests/health-auto-export.ingest.test.js\` (12 tests) against a spawned server + sandbox \`\$HEALTH_HOME\`: 501 when disabled, 401 without / with wrong bearer, 404 on unsupported type, 400 on malformed / invalid bodies, happy path (archive file written + target manifests created + rows retrievable via existing \`/api/manifests/:id/data\`), idempotency per date, partial-write merging, activity fan-out, sparse metrics producing sparse writes, and that a subsequent POST upserts an existing manifest rather than recreating it.
- [x] Manual QA: will run against a dev instance with the token set once #96 + #97 merge so the combination-card presets can be exercised end-to-end with real ingest data.

# Checklist

- [x] Commit messages follow the conventions in \`CONTRIBUTING.md\`
- [x] \`CHANGELOG.md\` updated under \`## Unreleased\`
- [x] Docs updated (CHANGELOG describes the full contract; the endpoint surface is compact enough that a dedicated doc isn't warranted yet — if we add file-drop ingest or more metric types later a \`docs/INGEST.md\` would make sense)
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Breaking changes

None. Existing endpoints are untouched. The new endpoint is off by default (returns 501 when the env var is unset), so no behaviour changes for instances that don't opt in.

Fixes #94