### PR TITLE
docs(cards): combination-card renderer + morning-dashboard recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Manifest schema: `meta.view.combines[]` for combination cards.**
+  New optional block on `meta.view` that lets a manifest declare it is
+  a composite view over several sibling manifests. Each entry binds a
+  `sourceId` with a `role` (`primary`, `secondary`, `annotation`,
+  `ring-segment`), plus optional `label`, `units`, `accessor` (dotted
+  path) and `colour`. Paired with `layout` (`stack` / `grid` / `ring`)
+  and an optional `skin` (`sleep-stages`, `activity-ring`), this is
+  the schema foundation for the forthcoming `combination-card`
+  renderer. Combination manifests typically carry `data: []` of their
+  own; values are resolved from sibling cards at render time.
+  Documentation only; no code changes. (#92)
 - **Expand/collapse toggle for the chat panel.** A new header button
   (\`⤡\` / \`⤢\`) flips between the default 380px-wide panel and an
   expanded variant (\`min(720px, 100vw - 40px)\` wide, up to 900px

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Docs: combination-card renderer + worked recipe.** `docs/CARDS.md`
+  grows a "combination-card renderer" section alongside the
+  generic-card and list-card sections, covering layouts (`stack` /
+  `grid` / `ring`), skins (`sleep-stages`, `activity-ring`), the role
+  vocabulary, the full `combines[]` entry shape, and the resolution
+  rules for missing sources / missing dates. `docs/RECIPES.md` adds
+  Recipe 12: a morning-dashboard example built out of existing
+  atomic cards with no new writeable surface. (#95)
 - **Manifest schema: `meta.view.combines[]` for combination cards.**
   New optional block on `meta.view` that lets a manifest declare it is
   a composite view over several sibling manifests. Each entry binds a

--- a/MANIFEST-SCHEMA.md
+++ b/MANIFEST-SCHEMA.md
@@ -141,6 +141,74 @@ label pill.
 `trendArrow` shows ↑/↓/→ next to the headline, comparing the current
 row to the most recent earlier entry on `field`.
 
+### `combines` (combination-card)
+
+Used by `component: "combination-card"` to compose a single card from
+several sibling manifests. The combination card reads each listed
+source's `data` at render time; it typically carries no `data` of its
+own (`data: []`).
+
+```json
+"meta": {
+  "view": {
+    "component": "combination-card",
+    "layout":    "stack",
+    "skin":      "sleep-stages",
+    "combines": [
+      {
+        "sourceId": "sleep-hours",
+        "role":     "primary",
+        "label":    "Asleep",
+        "units":    "h",
+        "accessor": "value",
+        "colour":   "#6366f1"
+      },
+      {
+        "sourceId": "sleep-stages",
+        "role":     "ring-segment",
+        "label":    "Deep",
+        "accessor": "stages.deep",
+        "colour":   "#3b82f6"
+      },
+      {
+        "sourceId": "mood",
+        "role":     "annotation"
+      }
+    ]
+  }
+}
+```
+
+Top-level view fields:
+
+| field | type | default | purpose |
+|-------|------|---------|---------|
+| `layout` | `"stack"` \| `"grid"` \| `"ring"` | `"stack"` | Overall arrangement of the combined metrics. |
+| `skin` | string \| null | null | Optional pixel-perfect visual preset. Current skins: `"sleep-stages"` (stacked horizontal bar of sleep stages), `"activity-ring"` (close-your-rings visual). |
+| `combines` | array | — | Required, non-empty. Each entry binds one sibling manifest into this card. |
+
+Each `combines[]` entry:
+
+| field | type | required | purpose |
+|-------|------|----------|---------|
+| `sourceId` | string | yes | `meta.id` of the source manifest to read from. |
+| `role` | `"primary"` \| `"secondary"` \| `"annotation"` \| `"ring-segment"` | yes | How this source contributes to the composed view. Renderers use role plus layout/skin to decide visual treatment. |
+| `label` | string | no | Override for the source's own label. Defaults to the source manifest's `meta.label`. |
+| `units` | string | no | Short suffix printed next to the value (e.g. `"h"`, `"kcal"`). |
+| `accessor` | string | no | Dotted path into the source's matched data entry (e.g. `"value"`, `"stages.deep"`). Defaults to the entry for the current date; if the entry is a primitive, it is used directly. |
+| `colour` | string | no | CSS colour for this entry's visual slot (bar segment, ring arc, threshold pill, etc). |
+
+Resolution rules:
+
+- The combination card matches each source's data for the view's
+  current date. If no entry exists for that date, the source is
+  considered empty (renderer decides whether to show "no data" or fall
+  back to the most recent prior entry; default is "no data").
+- Unknown `sourceId`, or a source whose file has been deleted,
+  surfaces inline in the card rather than failing the whole view.
+- The combination card emits no writes. To edit a displayed value the
+  user navigates to the atomic source card.
+
 ### `calendar` — month-grid marker config
 
 `meta.calendar` opts the card into the Calendar view. Each day cell in
@@ -400,6 +468,7 @@ Use one of these names in `meta.view.component` / `meta.trends.component`:
 | `table-list` | Tabular data |
 | `adherence-report` | Med adherence summary |
 | `greeting-banner` | Top-of-page greeting |
+| `combination-card` | Composite view over several sibling manifests (see `combines` config above) |
 
 Unknown renderer names fall back to `eh-unknown-card`, which shows an
 inline warning but keeps the dashboard running.

--- a/docs/CARDS.md
+++ b/docs/CARDS.md
@@ -632,6 +632,135 @@ is set automatically per row on create and isn't shown in the form.
 
 ---
 
+## The `combination-card` renderer: composite view over other cards
+
+`meta.view.component = "combination-card"` renders a single card whose
+content is pulled from several **other** manifests. Use this when a
+cluster of related metrics belongs in one visual unit (a sleep
+overview, an activity ring, a morning dashboard) without collapsing
+the underlying data into a single card's file.
+
+Source cards stay atomic and independently editable; the combination
+card is a **view** over them. It owns no data of its own and writes
+nothing; users edit values on the source cards directly.
+
+### Meta config
+
+```json
+"view": {
+  "enabled":   true,
+  "component": "combination-card",
+  "layout":    "stack",
+  "skin":      null,
+  "combines": [
+    {
+      "sourceId": "sleep-hours",
+      "role":     "primary",
+      "label":    "Asleep",
+      "units":    "hrs",
+      "accessor": "hours",
+      "colour":   "#6366f1"
+    },
+    {
+      "sourceId": "sleep-quality",
+      "role":     "secondary",
+      "label":    "Quality",
+      "accessor": "rating",
+      "units":    "/ 5"
+    },
+    {
+      "sourceId": "mood",
+      "role":     "annotation",
+      "label":    "Wake-ups",
+      "accessor": "wakeUps"
+    }
+  ]
+},
+"writeable": { "fromWebapp": false }
+```
+
+`data` in the manifest is typically `[]`. It is ignored by the
+renderer.
+
+### Layouts
+
+| `layout` | Shape |
+|----------|-------|
+| `stack`  | Vertical list of label / value rows. Sensible default for 2-5 metrics. |
+| `grid`   | CSS auto-fit grid of metric cells. Good for dense dashboards. |
+| `ring`   | Concentric SVG arcs driven by any entry with `role: "ring-segment"`. Arcs normalise to the largest value in the set. Secondary roles render as a legend alongside. |
+
+### Skins
+
+`skin` is an optional pixel-perfect visual override layered on top of
+the base layout. Current skins:
+
+| `skin` | Visual |
+|--------|--------|
+| `sleep-stages` | Stacked horizontal bar of `ring-segment` durations (core / REM / deep / awake). Renders below the stack layout. |
+| `activity-ring` | Apple-style close-your-rings visual. Use with `layout: "ring"`. |
+
+### Roles
+
+| `role` | Meaning |
+|--------|---------|
+| `primary` | The headline metric. In `stack` layout it takes the prominent value style. |
+| `secondary` | Supporting metrics; rendered smaller. |
+| `annotation` | Context the user glances at (mood, wake-up count, workout type). Smallest type. |
+| `ring-segment` | In `ring` layout drives one concentric arc; in a `sleep-stages` skin drives one bar segment. Ignored in plain `stack`. |
+
+### Entry fields
+
+Each `combines[]` entry:
+
+| field | Required | Meaning |
+|-------|----------|---------|
+| `sourceId` | yes | `meta.id` of the source manifest to read from. |
+| `role`     | yes | One of the four roles above. |
+| `label`    | no  | Override for the source's label. Defaults to the source manifest's `meta.label`. |
+| `units`    | no  | Short suffix printed next to the value (e.g. `"hrs"`, `"kcal"`). |
+| `accessor` | no  | Dotted path into the source's date-matched row, e.g. `"hours"` or `"stages.deep"`. Defaults to `row.value` if the row has a `value` field, otherwise `null`. |
+| `colour`   | no  | CSS colour for the entry's visual slot (bar segment, ring arc, side stripe). |
+
+### Resolution rules
+
+- The combination card looks up each source's data for the view's
+  current date.
+- If the source exists but has no row for that date: rendered as an
+  em dash in `stack` / `grid`; the arc stays at zero in `ring`.
+- If the source manifest doesn't exist at all: rendered as `"source
+  missing"` inline. The rest of the view keeps working.
+- The card automatically re-resolves when any source card fires
+  `manifest-data-changed` (the same event atomic cards use after an
+  edit), so source edits propagate without a full view reload.
+- Combination cards emit no writes. Add a writeable card of your own
+  for each metric you want to log.
+
+### Example presets
+
+Two ready-to-drop example manifests ship under `data.example/`:
+
+- `sleep-overview.example.json`: `stack` layout combining
+  `sleep-hours` (primary) + `sleep-quality` (secondary) + `mood`
+  wake-ups (annotation).
+- `activity-overview.example.json`: `ring` layout combining `steps`
+  + `active-minutes` as ring segments, `workouts.type` as annotation.
+
+Both run against the existing atomic example cards out of the box:
+copy the source manifests into `$HEALTH_HOME/data/`, then copy the
+combination manifest, and the composite card appears.
+
+### Differences from `generic-card` and `list-card`
+
+| Dimension | generic-card | list-card | combination-card |
+|------|-------------|-----------|------------------|
+| Data source | this card's `data[]` | this card's `data[]` | other cards' `data[]` by `sourceId` |
+| Writes | supported | supported | never |
+| Scope | one dated entry | full roster | one dated entry per source |
+| Editing | inline form | inline list editor | edit the source cards directly |
+
+---
+
 ## The `data` block
 
 Card-specific. The convention for most cards is an array of dated entries:

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -681,6 +681,78 @@ See `data.example/mood.example.json` (field-emoji),
 
 ---
 
+## Recipe 12: Morning dashboard from existing atomic cards
+
+**Want:** one card that shows last night's sleep, this morning's mood,
+and yesterday's step count side by side, without collapsing those
+metrics into a single card's data file.
+
+**Use:** `combination-card` with a `stack` layout and three
+`combines[]` entries pointing at existing atomic cards. No new
+writeable surface: you keep logging on the individual cards, the
+combination card just reads from them.
+
+```json
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "morning-dashboard",
+    "label": "Morning",
+    "emoji": "🌅",
+    "order": 10,
+    "view": {
+      "enabled": true,
+      "component": "combination-card",
+      "layout": "stack",
+      "combines": [
+        {
+          "sourceId": "sleep-hours",
+          "role": "primary",
+          "label": "Sleep",
+          "accessor": "hours",
+          "units": "hrs",
+          "colour": "#6366f1"
+        },
+        {
+          "sourceId": "mood",
+          "role": "secondary",
+          "label": "Mood",
+          "accessor": "mood",
+          "colour": "#a78bfa"
+        },
+        {
+          "sourceId": "steps",
+          "role": "annotation",
+          "label": "Steps yesterday",
+          "accessor": "count"
+        }
+      ]
+    }
+  },
+  "description": "Morning glance card. Reads sleep-hours, mood, and steps; edits happen on the source cards.",
+  "data": []
+}
+```
+
+**Behaviour notes:**
+
+- `accessor` is a dotted path into each source's date-matched row. If
+  your `mood` card stores `{ date, mood: 4, wakeUps: 1 }`, use
+  `"mood"`. For a nested field like `stages.deep`, just write
+  `"stages.deep"`.
+- Missing sources render as `"source missing"`; missing rows render
+  as an em dash. The card never fails the whole view.
+- Combination manifests do not take a `writeable` block because they
+  emit no writes. Log on the source cards; this card updates
+  automatically via the `manifest-data-changed` event.
+- For a more visual sleep overview (stacked stage bar) or an
+  activity ring, see `data.example/sleep-overview.example.json` and
+  `data.example/activity-overview.example.json`.
+
+**See:** [`CARDS.md`: combination-card renderer](CARDS.md#the-combination-card-renderer-composite-view-over-other-cards).
+
+---
+
 ## Next steps
 
 - For the full manifest spec (every field, every input type, every


### PR DESCRIPTION
# What changed

Adds user-facing documentation for the combination-card feature landed in #96 (schema) and #97 (renderer + presets). Two files touched, no code.

# Why

Without docs, the schema extension from #96 and the new renderer from #97 are invisible to anyone reading the repo cold. Operators / chat agents should be able to author a working combination manifest from the docs alone rather than reverse-engineering the example files.

# How

- \`docs/CARDS.md\` gains a new \"combination-card renderer\" section sitting alongside the existing \`generic-card\` and \`list-card\` sections. Covers:
  - the three v1 layouts (\`stack\` / \`grid\` / \`ring\`),
  - the two v1 skins (\`sleep-stages\`, \`activity-ring\`),
  - the role vocabulary (\`primary\` / \`secondary\` / \`annotation\` / \`ring-segment\`) and how each interacts with each layout,
  - the full \`combines[]\` entry shape with every optional field,
  - the resolution rules for missing sources, missing dates, and the auto-refresh behaviour on \`manifest-data-changed\`,
  - pointers to the two shipped presets in \`data.example/\`,
  - a side-by-side differences table (\`generic-card\` vs \`list-card\` vs \`combination-card\`) so readers can decide when to reach for which.
- \`docs/RECIPES.md\` adds Recipe 12: a worked \"morning dashboard\" example built from three existing atomic cards (\`sleep-hours\`, \`mood\`, \`steps\`) with no new writeable surface, demonstrating that a combination card is a pure view concern.
- \`CHANGELOG.md\` entry under \`## [Unreleased]\`.

# Testing

- [x] \`npm test\`: 393 tests, 392 pass, 1 fail. The lone failure is the pre-existing \`tests/no-personal-refs.test.js\` flagging gitignored operator files; unchanged from \`main\` and unrelated to this PR. Docs-only changes, so no new tests.
- [x] Manual: rendered the new CARDS.md section locally and confirmed headings / anchors match the Recipe 12 cross-reference.

# Checklist

- [x] Commit messages follow the conventions in \`CONTRIBUTING.md\`
- [x] \`CHANGELOG.md\` updated under \`## Unreleased\`
- [x] Docs updated (this PR IS the docs update)
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Breaking changes

None; documentation only.

# Stacking

Stacked on #96 (schema docs) so the new CARDS.md section can reference \`meta.view.combines[]\` without getting ahead of the canonical definition. GitHub will show the combined diff until #96 merges, after which this PR auto-rebases to the docs-only delta.

Fixes #95