### PR TITLE
feat(cards): flip sleep-hours/steps/active-minutes/workouts to ingest-only

### DIFF
--- a/data.example/active-minutes.example.json
+++ b/data.example/active-minutes.example.json
@@ -12,7 +12,7 @@
       "display": {
         "template": "{minutes}",
         "unit": "min",
-        "emptyHeadline": "No active minutes",
+        "emptyHeadline": "No activity data yet",
         "trendArrow": { "field": "minutes" },
         "thresholds": [
           { "ifField": "minutes", "max": 14, "colour": "#ff3333", "label": "Sedentary" },
@@ -30,16 +30,9 @@
       "unit": "min"
     },
     "writeable": {
-      "fromWebapp": true,
-      "todayAllowed": true,
-      "pastAllowed": true,
-      "futureAllowed": false,
-      "maxReadingsPerDay": 1,
-      "inputs": [
-        { "key": "minutes", "type": "number", "label": "Active minutes", "min": 0, "max": 1440, "step": 1, "required": true }
-      ]
+      "fromWebapp": false
     }
   },
-  "description": "Daily minutes of moderate-to-vigorous activity. WHO guideline is 150+ per WEEK (~22/day).",
+  "description": "Daily minutes of moderate-to-vigorous activity (Apple Exercise Time). WHO guideline is 150+ per WEEK (~22/day). Populated by the iPhone Health Auto Export webhook; see docs/HEALTH-AUTO-EXPORT.md. Often consumed by the Activity combination card rather than shown on its own.",
   "data": []
 }

--- a/data.example/sleep-hours.example.json
+++ b/data.example/sleep-hours.example.json
@@ -13,7 +13,7 @@
         "template": "{hours:round(1)}",
         "unit": "hrs",
         "secondary": "{note|}",
-        "emptyHeadline": "No sleep logged",
+        "emptyHeadline": "No sleep data yet",
         "trendArrow": { "field": "hours" },
         "thresholds": [
           { "ifField": "hours", "max": 5.9, "colour": "#ff3333", "label": "Too little" },
@@ -31,17 +31,9 @@
       "unit": "hrs"
     },
     "writeable": {
-      "fromWebapp": true,
-      "todayAllowed": true,
-      "pastAllowed": true,
-      "futureAllowed": false,
-      "maxReadingsPerDay": 1,
-      "inputs": [
-        { "key": "hours", "type": "number", "label": "Hours slept", "min": 0, "max": 16, "step": 0.25, "required": true },
-        { "key": "note", "type": "text", "label": "Note", "placeholder": "e.g. woken by cat" }
-      ]
+      "fromWebapp": false
     }
   },
-  "description": "Total sleep duration for the night. One entry per date. Optimal band is 7-9 hours.",
+  "description": "Total sleep duration for the night. One entry per date. Populated by the iPhone Health Auto Export webhook; see docs/HEALTH-AUTO-EXPORT.md. Often consumed by the Sleep combination card (data.example/sleep.example.json) rather than shown on its own.",
   "data": []
 }

--- a/data.example/steps.example.json
+++ b/data.example/steps.example.json
@@ -12,7 +12,7 @@
       "display": {
         "template": "{count}",
         "unit": "steps",
-        "emptyHeadline": "No steps logged",
+        "emptyHeadline": "No step data yet",
         "trendArrow": { "field": "count" },
         "thresholds": [
           { "ifField": "count", "max": 3999, "colour": "#ff3333", "label": "Sedentary" },
@@ -30,17 +30,9 @@
       "unit": "steps"
     },
     "writeable": {
-      "fromWebapp": true,
-      "todayAllowed": true,
-      "pastAllowed": true,
-      "futureAllowed": false,
-      "maxReadingsPerDay": 1,
-      "inputs": [
-        { "key": "count", "type": "number", "label": "Steps", "min": 0, "max": 100000, "step": 1, "required": true },
-        { "key": "source", "type": "text", "label": "Source", "placeholder": "e.g. iPhone, Fitbit" }
-      ]
+      "fromWebapp": false
     }
   },
-  "description": "Daily step count, typically pulled from a phone or wearable. One entry per day.",
+  "description": "Daily step count. Populated by the iPhone Health Auto Export webhook; see docs/HEALTH-AUTO-EXPORT.md. Often consumed by the Activity combination card (data.example/activity.example.json) rather than shown on its own.",
   "data": []
 }

--- a/data.example/workouts.example.json
+++ b/data.example/workouts.example.json
@@ -11,23 +11,14 @@
       "dateContext": "viewedDate",
       "display": {
         "template": "{trained?✅ Trained:❌ Rest}",
-        "secondary": "{notes|}",
-        "emptyHeadline": "Log a workout"
+        "secondary": "{type|}",
+        "emptyHeadline": "No workout data yet"
       }
     },
     "writeable": {
-      "fromWebapp": true,
-      "todayAllowed": true,
-      "pastAllowed": true,
-      "futureAllowed": false,
-      "maxReadingsPerDay": 1,
-      "inputs": [
-        { "key": "trained", "type": "checkbox", "label": "Trained today?", "default": false },
-        { "key": "type", "type": "select", "label": "Type", "options": ["Strength", "Cardio", "Mobility", "Sport", "Mixed"], "placeholder": "— pick —" },
-        { "key": "notes", "type": "textarea", "label": "Notes", "rows": 2, "placeholder": "optional" }
-      ]
+      "fromWebapp": false
     }
   },
-  "description": "Simple yes/no training tracker. When trained is true, the type field captures a coarse category. For detailed strength/cardio logging use a dedicated app; this card is for the adherence checkbox.",
+  "description": "Simple yes/no training tracker derived from iPhone workouts. When trained is true, the type field captures a coarse category. Populated by the Health Auto Export webhook; see docs/HEALTH-AUTO-EXPORT.md. Often consumed by the Activity combination card rather than shown on its own.",
   "data": []
 }


### PR DESCRIPTION
## Summary

Flips the four atomic manifests consumed by the combination cards
(#93) and populated by the upcoming HAE ingest webhook (#94) to
`writeable.fromWebapp: false`. Removes their manual-entry forms.

## Why

Those four cards will be populated automatically by the iPhone
Health Auto Export webhook. If we left manual entry on:

- Users would see the same number three ways on Today (combo card +
  atomic card + input form).
- Every HAE push would silently overwrite any hand-typed row.
- The "source of truth" question (iPhone vs human) would need a
  discriminator field the MVP deliberately doesn't ship.

Flipping these to ingest-only keeps the data model clean: HAE is
the only writer, the Sleep and Activity combo cards are the
primary read surface, the atomic cards still exist on disk + in
Settings so users can disable them or swap in a dedicated renderer
later.

## How

Per manifest:

- `writeable.fromWebapp: false`; `inputs[]` dropped.
- `emptyHeadline` reworded from `"Log a workout"` / `"No steps
  logged"` style prompts to `"No data yet"` — reads as "waiting for
  export", not "please type something".
- `description` updated to point at the upcoming
  `docs/HEALTH-AUTO-EXPORT.md` and name the consuming combo card.
- `workouts.secondary` template switched from `{notes|}` to
  `{type|}` because `notes` was only ever set by the hand-entry
  form; `type` is what HAE's fan-out fills.

The underlying data shape is unchanged, so operator instances with
pre-existing rows keep rendering — this is purely a UI-surface
flip.

## Testing checklist

- [x] `npm test` — 392/393 passing (same pre-existing
  `no-personal-refs` failure that fails identically on `main`).
- [x] `tests/example-manifests.test.js` passes for all four files.
- [ ] Manual: drop these four examples into a dev instance with
  `fromWebapp: false`, confirm they still render read-only rows of
  whatever's in `data` and no ✏️/➕ button appears.

## Out of scope

- Live-data migration: operator prod instances carry real-data
  copies of these manifests that may include hand-typed rows.
  Those files aren't touched; they keep whatever `writeable` flag
  the operator set.
- Reinstating manual entry alongside ingest with a `source` field.

Closes #100  ·  enables #94