### PR TITLE
feat(server): POST /api/health-auto-export HAE webhook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ COPY --chown=klebb:klebb manifests ./manifests
 COPY --chown=klebb:klebb public ./public
 COPY --chown=klebb:klebb scripts ./scripts
 COPY --chown=klebb:klebb voice ./voice
+COPY --chown=klebb:klebb health-auto-export ./health-auto-export
 # Demo seed content: markdown report templates copied at first-boot seed.
 # Card manifests are generated from scripts/lib/demo-cards.js (no static JSON
 # needed — dates are computed relative to seed time).

--- a/config/env.js
+++ b/config/env.js
@@ -114,6 +114,12 @@ function getSessionSecret() {
   return _sessionSecret;
 }
 
+// --- Health Auto Export ingest ---
+// When set, enables POST /api/health-auto-export for the iPhone HAE app's
+// webhook. Unset disables the endpoint entirely (returns 501). See
+// docs/HEALTH-AUTO-EXPORT.md for setup.
+const HEALTH_AUTO_EXPORT_TOKEN = (process.env.HEALTH_AUTO_EXPORT_TOKEN || '').trim() || null;
+
 // --- Feature flags ---
 const DEBUG_LOG = process.env.HEALTH_DEBUG === '1';
 
@@ -409,6 +415,7 @@ module.exports = {
   WEBAUTHN_RP_ID,
   WEBAUTHN_ORIGIN,
   getSessionSecret,
+  HEALTH_AUTO_EXPORT_TOKEN,
   DEBUG_LOG,
   HEALTH_SYSTEM_PROMPT,
 };

--- a/health-auto-export/ingest.js
+++ b/health-auto-export/ingest.js
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// health-auto-export/ingest.js
+// Parses iPhone Health Auto Export webhook payloads and upserts into
+// atomic klebb manifests.
+//
+// Payload shape (from the HAE app's "REST API" automation):
+//
+//   {
+//     "data": {
+//       "metrics":  [ { "name": "<metric>", "data": [ { date, qty, ... } ] }, ... ],
+//       "workouts": [ { "name", "start", "end", "duration", ... } ]
+//     }
+//   }
+//
+// Metrics the MVP cares about:
+//   sleep_analysis        -> sleep-hours  { date, hours }
+//   step_count            -> steps        { date, count }
+//   apple_exercise_time   -> active-minutes { date, minutes }
+//
+// Workouts array -> workouts { date, trained: true, type }
+//
+// Everything else in the payload is ignored but archived verbatim by the
+// caller; future follow-ups can add richer manifests without re-writing
+// the webhook plumbing.
+
+// --- Date helpers ---
+
+// HAE stamps dates like "2026-05-04 14:23:00 +1000". We only need the
+// calendar date for row keying; the timezone suffix is advisory.
+function toDate(stamp) {
+  if (!stamp || typeof stamp !== 'string') return null;
+  const m = stamp.match(/^(\d{4}-\d{2}-\d{2})/);
+  return m ? m[1] : null;
+}
+
+// --- Pure parser: payload -> { sleepRows, stepsRows, activeMinutesRows, workoutsRows } ---
+
+function parseHAEPayload(payload) {
+  const out = {
+    sleepRows: [],          // [{ date, hours, source? }]
+    stepsRows: [],          // [{ date, count }]
+    activeMinutesRows: [],  // [{ date, minutes }]
+    workoutsRows: [],       // [{ date, trained, type? }]
+  };
+
+  const data = payload?.data || payload || {};
+  const metrics = Array.isArray(data.metrics) ? data.metrics : [];
+
+  // Group metrics by name for targeted extraction.
+  const byName = {};
+  for (const m of metrics) {
+    if (m && typeof m.name === 'string' && Array.isArray(m.data)) {
+      byName[m.name] = m.data;
+    }
+  }
+
+  // Sleep: HAE's sleep_analysis rows carry an explicit per-night `asleep`
+  // or `totalSleep` field. We pick whichever is present, preferring the
+  // more inclusive value. One row per calendar date (last wins).
+  const sleepByDate = {};
+  for (const entry of byName.sleep_analysis || []) {
+    const date = toDate(entry.date || entry.sleepStart);
+    if (!date) continue;
+    const hours = Number(
+      entry.totalSleep ?? entry.asleep ?? entry.inBed ?? entry.qty
+    );
+    if (!Number.isFinite(hours)) continue;
+    sleepByDate[date] = { date, hours };
+    if (entry.source) sleepByDate[date].source = entry.source;
+  }
+  out.sleepRows = Object.values(sleepByDate);
+
+  // Steps: HAE sends per-sample entries with `qty`. Sum per calendar date.
+  const stepsByDate = {};
+  for (const entry of byName.step_count || []) {
+    const date = toDate(entry.date);
+    if (!date) continue;
+    const qty = Number(entry.qty);
+    if (!Number.isFinite(qty)) continue;
+    stepsByDate[date] = (stepsByDate[date] || 0) + qty;
+  }
+  out.stepsRows = Object.entries(stepsByDate)
+    .map(([date, count]) => ({ date, count: Math.round(count) }));
+
+  // Active minutes: each apple_exercise_time sample is one minute (qty=1).
+  // Sum per date.
+  const activeByDate = {};
+  for (const entry of byName.apple_exercise_time || []) {
+    const date = toDate(entry.date);
+    if (!date) continue;
+    const qty = Number(entry.qty);
+    if (!Number.isFinite(qty)) continue;
+    activeByDate[date] = (activeByDate[date] || 0) + qty;
+  }
+  out.activeMinutesRows = Object.entries(activeByDate)
+    .map(([date, minutes]) => ({ date, minutes: Math.round(minutes) }));
+
+  // Workouts: boolean "did the user train that day?" derived from the
+  // workouts[] array. Type = first workout's name.
+  const workoutsByDate = {};
+  for (const w of Array.isArray(data.workouts) ? data.workouts : []) {
+    const date = toDate(w.start || w.date);
+    if (!date) continue;
+    if (!workoutsByDate[date]) {
+      workoutsByDate[date] = { date, trained: true };
+      if (w.name) workoutsByDate[date].type = w.name;
+    }
+  }
+  out.workoutsRows = Object.values(workoutsByDate);
+
+  return out;
+}
+
+// --- Upsert: merge each new row into the target manifest by date ---
+
+// Merge newRows into existing (array of {date, ...}), replacing rows whose
+// `date` matches. Rows in newRows with no `date` are dropped.
+function mergeByDate(existing, newRows) {
+  const base = Array.isArray(existing) ? existing.slice() : [];
+  const byDate = new Map(base.filter(r => r && r.date).map(r => [r.date, r]));
+  for (const row of newRows) {
+    if (!row || !row.date) continue;
+    byDate.set(row.date, row);
+  }
+  return [...byDate.values()].sort((a, b) => String(a.date).localeCompare(String(b.date)));
+}
+
+// Upsert a single target manifest. If the manifest doesn't exist yet, create
+// it from the minimal template so the first push doesn't require the user
+// to pre-create files.
+function upsertOne(registry, id, rows, templateFn) {
+  if (!rows || rows.length === 0) return 0;
+  const existing = registry.get(id);
+  if (!existing) {
+    registry.createManifest(templateFn(rows));
+    return rows.length;
+  }
+  const existingRows = Array.isArray(existing.data) ? existing.data : [];
+  const merged = mergeByDate(existingRows, rows);
+  registry.writeData(id, merged);
+  return rows.length;
+}
+
+// Minimal templates used only when a target manifest is absent. Match the
+// shipped data.example/*.example.json shapes at a surface level; users can
+// edit freely after first creation.
+const TEMPLATES = {
+  'sleep-hours': rows => ({
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'sleep-hours', label: 'Sleep', emoji: '😴', order: 30,
+      view: { enabled: true, component: 'generic-card',
+              display: { template: '{hours:round(1)}', unit: 'hrs' } },
+      writeable: { fromWebapp: false },
+    },
+    description: 'Total sleep duration for the night. Populated by Health Auto Export.',
+    data: rows,
+  }),
+  'steps': rows => ({
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'steps', label: 'Steps', emoji: '👣', order: 70,
+      view: { enabled: true, component: 'generic-card',
+              display: { template: '{count}', unit: 'steps' } },
+      writeable: { fromWebapp: false },
+    },
+    description: 'Daily step count. Populated by Health Auto Export.',
+    data: rows,
+  }),
+  'active-minutes': rows => ({
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'active-minutes', label: 'Active Minutes', emoji: '⏱️', order: 74,
+      view: { enabled: true, component: 'generic-card',
+              display: { template: '{minutes}', unit: 'min' } },
+      writeable: { fromWebapp: false },
+    },
+    description: 'Daily active minutes (Apple Exercise Time). Populated by Health Auto Export.',
+    data: rows,
+  }),
+  'workouts': rows => ({
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'workouts', label: 'Workout Today', emoji: '🏋️', order: 72,
+      view: { enabled: true, component: 'generic-card',
+              display: { template: '{trained?✅ Trained:❌ Rest}', secondary: '{type|}' } },
+      writeable: { fromWebapp: false },
+    },
+    description: 'Simple yes/no training tracker. Populated by Health Auto Export.',
+    data: rows,
+  }),
+};
+
+// Apply a parsed payload to the registry. Returns per-target counts.
+function upsertInto(registry, parsed) {
+  const summary = {
+    'sleep-hours': upsertOne(registry, 'sleep-hours', parsed.sleepRows, TEMPLATES['sleep-hours']),
+    'steps': upsertOne(registry, 'steps', parsed.stepsRows, TEMPLATES['steps']),
+    'active-minutes': upsertOne(registry, 'active-minutes', parsed.activeMinutesRows, TEMPLATES['active-minutes']),
+    'workouts': upsertOne(registry, 'workouts', parsed.workoutsRows, TEMPLATES['workouts']),
+  };
+  return summary;
+}
+
+module.exports = {
+  toDate,
+  parseHAEPayload,
+  mergeByDate,
+  upsertInto,
+  TEMPLATES,
+};

--- a/server.js
+++ b/server.js
@@ -15,6 +15,7 @@ const { runFirstBootDemoSeed } = require('./scripts/seed-demo');
 const voice = require('./voice/fish');
 const voiceCache = require('./voice/cache');
 const { TOOL_DEFS, dispatchToolCall } = require('./chat/tools');
+const hae = require('./health-auto-export/ingest');
 
 // chat endpoint config (env-driven; see config/env.js)
 const CHAT_ENDPOINT_URL = ENV.CHAT_ENDPOINT_URL;
@@ -497,8 +498,14 @@ const server = http.createServer(async (req, res) => {
     if (result !== null) return;
   }
 
+  // The HAE webhook carries its own token (HEALTH_AUTO_EXPORT_TOKEN) and
+  // the handler enforces it. Let the request through the outer auth gate
+  // so the handler can respond with 501/401/200 as appropriate. No session
+  // cookie or AGENT_API_TOKEN is expected from the iPhone app.
+  const isHaeIngest = pathname === '/api/health-auto-export' && req.method === 'POST';
+
   // Redirect to setup or login if not authenticated
-  if (!isAuthenticated(req) && !isPublicPath(pathname)) {
+  if (!isAuthenticated(req) && !isHaeIngest && !isPublicPath(pathname)) {
     if (pathname.startsWith('/api/')) {
       res.writeHead(401, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -772,6 +779,58 @@ const server = http.createServer(async (req, res) => {
       const data = readJSONFile(path.join(DATA_DIR, 'info', `${parts[1]}.json`));
       if (data) return sendJSON(res, data);
       return send404(res);
+    }
+
+    // POST /api/health-auto-export — iPhone Health Auto Export webhook.
+    //
+    // Auth: Bearer <HEALTH_AUTO_EXPORT_TOKEN>. If the env var is unset, the
+    // endpoint returns 501 (feature off). If the header is wrong or
+    // missing, returns 401. Otherwise the raw payload is archived, parsed,
+    // and upserted into atomic manifests (sleep-hours, steps,
+    // active-minutes, workouts).
+    //
+    // Errors that occur AFTER auth passes are swallowed into a 200 with a
+    // warning so the iPhone app's retry loop doesn't spiral. The raw
+    // payload is always archived, so parse failures are debuggable later.
+    if (parts[0] === 'health-auto-export' && parts.length === 1 && req.method === 'POST') {
+      const token = ENV.HEALTH_AUTO_EXPORT_TOKEN;
+      if (!token) return sendJSON(res, { error: 'ingest disabled' }, 501);
+      const auth = req.headers['authorization'];
+      if (!auth || !auth.startsWith('Bearer ') || auth.slice(7).trim() !== token) {
+        return sendJSON(res, { error: 'unauthorised' }, 401);
+      }
+
+      let body = '';
+      req.on('data', c => body += c);
+      req.on('end', () => {
+        // Archive the raw payload unconditionally. Stamp carries
+        // milliseconds so rapid successive pushes don't clobber each
+        // other's archive file.
+        const rawDir = path.join(PATHS.AUTO_EXPORT_DIR, 'raw');
+        try { fs.mkdirSync(rawDir, { recursive: true }); } catch {}
+        const stamp = new Date().toISOString().replace(/[:.]/g, '');
+        const rawFile = path.join(rawDir, `${stamp}.json`);
+        try { fs.writeFileSync(rawFile, body); } catch (e) {
+          console.error('[hae] failed to archive raw payload:', e.message);
+        }
+
+        let payload;
+        try {
+          payload = JSON.parse(body);
+        } catch {
+          return sendJSON(res, { ok: true, warning: 'parse failed, raw saved' });
+        }
+
+        try {
+          const parsed = hae.parseHAEPayload(payload);
+          const summary = hae.upsertInto(registry, parsed);
+          return sendJSON(res, { ok: true, ingested: summary });
+        } catch (e) {
+          console.error('[hae] upsert failed:', e.message);
+          return sendJSON(res, { ok: true, warning: 'upsert failed, raw saved' });
+        }
+      });
+      return;
     }
 
     // Auto-export endpoints: sleep, workouts, vitals, activity

--- a/tests/health-auto-export.ingest.test.js
+++ b/tests/health-auto-export.ingest.test.js
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/health-auto-export.ingest.test.js
+// End-to-end ingest test: POST canned HAE payload, assert manifests upserted.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const { createSandbox, cleanupSandbox, spawnServer, req } = require('./helpers/sandbox');
+
+const CANNED_PAYLOAD = {
+  data: {
+    metrics: [
+      { name: 'sleep_analysis', data: [
+        { date: '2026-05-04 00:00:00 +1000', totalSleep: 7.8, inBed: 8.5,
+          asleep: 7.6, source: 'Apple Watch' },
+      ]},
+      { name: 'step_count', data: [
+        { date: '2026-05-04 08:00:00 +1000', qty: 3500 },
+        { date: '2026-05-04 15:00:00 +1000', qty: 4200 },
+      ]},
+      { name: 'apple_exercise_time', data: [
+        { date: '2026-05-04 09:00:00 +1000', qty: 1 },
+        { date: '2026-05-04 09:30:00 +1000', qty: 1 },
+        { date: '2026-05-04 16:00:00 +1000', qty: 1 },
+      ]},
+    ],
+    workouts: [
+      { name: 'Functional Strength Training',
+        start: '2026-05-04 11:00:00 +1000', duration: 1800 },
+    ],
+  },
+};
+
+describe('POST /api/health-auto-export', () => {
+  describe('with token unset', () => {
+    let sandbox, server;
+    before(async () => {
+      sandbox = createSandbox();
+      // Spawn WITHOUT the token env var
+      server = await spawnServer(sandbox, { HEALTH_AUTO_EXPORT_TOKEN: '' });
+    });
+    after(async () => { if (server) await server.kill(); if (sandbox) cleanupSandbox(sandbox); });
+
+    test('returns 501 when token unset', async () => {
+      const res = await req(server.baseUrl, '/api/health-auto-export', {
+        method: 'POST',
+        body: CANNED_PAYLOAD,
+      });
+      assert.equal(res.status, 501);
+      assert.equal(res.json.error, 'ingest disabled');
+    });
+  });
+
+  describe('with token set', () => {
+    let sandbox, server;
+    const TOKEN = 'test-hae-token-hex-123456789abcdef';
+
+    before(async () => {
+      sandbox = createSandbox();
+      server = await spawnServer(sandbox, { HEALTH_AUTO_EXPORT_TOKEN: TOKEN });
+    });
+    after(async () => { if (server) await server.kill(); if (sandbox) cleanupSandbox(sandbox); });
+
+    test('401 with no Authorization header', async () => {
+      const res = await req(server.baseUrl, '/api/health-auto-export', {
+        method: 'POST',
+        body: CANNED_PAYLOAD,
+      });
+      assert.equal(res.status, 401);
+    });
+
+    test('401 with wrong bearer', async () => {
+      const res = await req(server.baseUrl, '/api/health-auto-export', {
+        method: 'POST',
+        body: CANNED_PAYLOAD,
+        headers: { Authorization: 'Bearer not-the-right-token' },
+      });
+      assert.equal(res.status, 401);
+    });
+
+    test('200 with correct bearer + upserts four manifests', async () => {
+      const res = await req(server.baseUrl, '/api/health-auto-export', {
+        method: 'POST',
+        body: CANNED_PAYLOAD,
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      });
+      assert.equal(res.status, 200);
+      assert.equal(res.json.ok, true);
+      assert.equal(res.json.ingested['sleep-hours'], 1);
+      assert.equal(res.json.ingested.steps, 1);
+      assert.equal(res.json.ingested['active-minutes'], 1);
+      assert.equal(res.json.ingested.workouts, 1);
+
+      // Raw payload was archived
+      const rawDir = path.join(sandbox, 'data', 'auto-export', 'raw');
+      const files = fs.readdirSync(rawDir).filter(f => f.endsWith('.json'));
+      assert.ok(files.length >= 1, 'raw file was archived');
+
+      // Each atomic manifest exists on disk and carries the expected row
+      const sleepMan = JSON.parse(fs.readFileSync(
+        path.join(sandbox, 'data', 'sleep-hours.json'), 'utf8'));
+      assert.equal(sleepMan.data[0].date, '2026-05-04');
+      assert.equal(sleepMan.data[0].hours, 7.8);
+
+      const stepsMan = JSON.parse(fs.readFileSync(
+        path.join(sandbox, 'data', 'steps.json'), 'utf8'));
+      assert.equal(stepsMan.data[0].date, '2026-05-04');
+      assert.equal(stepsMan.data[0].count, 7700);
+
+      const activeMan = JSON.parse(fs.readFileSync(
+        path.join(sandbox, 'data', 'active-minutes.json'), 'utf8'));
+      assert.equal(activeMan.data[0].date, '2026-05-04');
+      assert.equal(activeMan.data[0].minutes, 3);
+
+      const workoutsMan = JSON.parse(fs.readFileSync(
+        path.join(sandbox, 'data', 'workouts.json'), 'utf8'));
+      assert.equal(workoutsMan.data[0].date, '2026-05-04');
+      assert.equal(workoutsMan.data[0].trained, true);
+    });
+
+    test('re-POSTing same date overwrites only that date', async () => {
+      // First push: 2026-05-04 with 7700 steps (from the previous test).
+      // Second push: 2026-05-05, new date.
+      const second = {
+        data: {
+          metrics: [
+            { name: 'step_count', data: [
+              { date: '2026-05-05 10:00:00 +1000', qty: 9001 },
+            ]},
+          ],
+        },
+      };
+      const res = await req(server.baseUrl, '/api/health-auto-export', {
+        method: 'POST',
+        body: second,
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      });
+      assert.equal(res.status, 200);
+
+      // Give the fs.watch reload a tick
+      await new Promise(r => setTimeout(r, 200));
+
+      const stepsMan = JSON.parse(fs.readFileSync(
+        path.join(sandbox, 'data', 'steps.json'), 'utf8'));
+      // Should still have both dates
+      const byDate = Object.fromEntries(stepsMan.data.map(r => [r.date, r.count]));
+      assert.equal(byDate['2026-05-04'], 7700, 'prior date row preserved');
+      assert.equal(byDate['2026-05-05'], 9001, 'new date row appended');
+    });
+
+    test('malformed JSON body: 200 + warning, raw archived', async () => {
+      const rawDir = path.join(sandbox, 'data', 'auto-export', 'raw');
+      const before = fs.readdirSync(rawDir).length;
+
+      const res = await req(server.baseUrl, '/api/health-auto-export', {
+        method: 'POST',
+        body: 'not json at all',
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      });
+      assert.equal(res.status, 200);
+      assert.equal(res.json.ok, true);
+      assert.ok(res.json.warning, 'warning present on parse failure');
+
+      const after = fs.readdirSync(rawDir).length;
+      assert.ok(after > before, 'raw file archived on parse failure');
+    });
+  });
+});

--- a/tests/health-auto-export.parser.test.js
+++ b/tests/health-auto-export.parser.test.js
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/health-auto-export.parser.test.js
+// Pure parser unit tests. No HTTP, no filesystem.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { parseHAEPayload, mergeByDate, toDate } = require('../health-auto-export/ingest.js');
+
+describe('toDate', () => {
+  test('extracts YYYY-MM-DD from HAE-style stamp', () => {
+    assert.equal(toDate('2026-05-04 14:23:00 +1000'), '2026-05-04');
+  });
+  test('handles a date-only string', () => {
+    assert.equal(toDate('2026-05-04'), '2026-05-04');
+  });
+  test('returns null for empty / undefined / malformed', () => {
+    assert.equal(toDate(null), null);
+    assert.equal(toDate(''), null);
+    assert.equal(toDate('not a date'), null);
+    assert.equal(toDate(42), null);
+  });
+});
+
+describe('parseHAEPayload', () => {
+  test('empty payload returns empty row sets', () => {
+    const r = parseHAEPayload({});
+    assert.deepEqual(r.sleepRows, []);
+    assert.deepEqual(r.stepsRows, []);
+    assert.deepEqual(r.activeMinutesRows, []);
+    assert.deepEqual(r.workoutsRows, []);
+  });
+
+  test('sleep_analysis -> sleep-hours rows', () => {
+    const r = parseHAEPayload({
+      data: {
+        metrics: [
+          { name: 'sleep_analysis', data: [
+            { date: '2026-05-04 00:00:00 +1000', totalSleep: 7.6, asleep: 7.3,
+              inBed: 8.1, source: 'Apple Watch' },
+          ]},
+        ],
+      },
+    });
+    assert.equal(r.sleepRows.length, 1);
+    assert.equal(r.sleepRows[0].date, '2026-05-04');
+    assert.equal(r.sleepRows[0].hours, 7.6);
+    assert.equal(r.sleepRows[0].source, 'Apple Watch');
+  });
+
+  test('sleep: falls back to asleep then inBed when totalSleep missing', () => {
+    const r = parseHAEPayload({ data: { metrics: [
+      { name: 'sleep_analysis', data: [
+        { date: '2026-05-04 00:00:00 +1000', asleep: 7.2, inBed: 8.0 },
+        { date: '2026-05-05 00:00:00 +1000', inBed: 9.0 },
+      ]},
+    ]}});
+    const byDate = Object.fromEntries(r.sleepRows.map(r => [r.date, r.hours]));
+    assert.equal(byDate['2026-05-04'], 7.2);
+    assert.equal(byDate['2026-05-05'], 9.0);
+  });
+
+  test('step_count: sums per-date samples', () => {
+    const r = parseHAEPayload({ data: { metrics: [
+      { name: 'step_count', data: [
+        { date: '2026-05-04 08:00:00 +1000', qty: 1200.5 },
+        { date: '2026-05-04 12:30:00 +1000', qty: 3200 },
+        { date: '2026-05-04 18:15:00 +1000', qty: 500.3 },
+        { date: '2026-05-05 09:00:00 +1000', qty: 2000 },
+      ]},
+    ]}});
+    const byDate = Object.fromEntries(r.stepsRows.map(r => [r.date, r.count]));
+    assert.equal(byDate['2026-05-04'], 4901);  // 1200.5 + 3200 + 500.3 = 4900.8 -> round 4901
+    assert.equal(byDate['2026-05-05'], 2000);
+  });
+
+  test('apple_exercise_time: sums qty per date', () => {
+    const r = parseHAEPayload({ data: { metrics: [
+      { name: 'apple_exercise_time', data: [
+        { date: '2026-05-04 09:29:00 +1000', qty: 1 },
+        { date: '2026-05-04 09:35:00 +1000', qty: 1 },
+        { date: '2026-05-04 16:01:00 +1000', qty: 1 },
+      ]},
+    ]}});
+    assert.equal(r.activeMinutesRows.length, 1);
+    assert.equal(r.activeMinutesRows[0].date, '2026-05-04');
+    assert.equal(r.activeMinutesRows[0].minutes, 3);
+  });
+
+  test('workouts[]: one row per date with trained:true', () => {
+    const r = parseHAEPayload({ data: { workouts: [
+      { name: 'Functional Strength Training', start: '2026-05-04 11:06:02 +1000', duration: 1463 },
+      { name: 'Walking', start: '2026-05-04 16:00:00 +1000', duration: 600 },
+      { name: 'Running', start: '2026-05-05 07:00:00 +1000', duration: 1800 },
+    ]}});
+    assert.equal(r.workoutsRows.length, 2);
+    const byDate = Object.fromEntries(r.workoutsRows.map(r => [r.date, r]));
+    assert.equal(byDate['2026-05-04'].trained, true);
+    assert.equal(byDate['2026-05-04'].type, 'Functional Strength Training');
+    assert.equal(byDate['2026-05-05'].trained, true);
+    assert.equal(byDate['2026-05-05'].type, 'Running');
+  });
+
+  test('ignores unrelated metric names', () => {
+    const r = parseHAEPayload({ data: { metrics: [
+      { name: 'blood_oxygen', data: [{ date: '2026-05-04', qty: 98 }] },
+      { name: 'heart_rate', data: [{ date: '2026-05-04', qty: 62 }] },
+    ]}});
+    assert.deepEqual(r.sleepRows, []);
+    assert.deepEqual(r.stepsRows, []);
+    assert.deepEqual(r.activeMinutesRows, []);
+    assert.deepEqual(r.workoutsRows, []);
+  });
+
+  test('malformed samples (missing date or qty) are skipped, not thrown', () => {
+    const r = parseHAEPayload({ data: { metrics: [
+      { name: 'step_count', data: [
+        { date: '2026-05-04', qty: 100 },
+        { qty: 200 },              // missing date
+        { date: '2026-05-05', qty: 'not-a-number' },
+        { date: '2026-05-05', qty: 300 },
+      ]},
+    ]}});
+    const byDate = Object.fromEntries(r.stepsRows.map(r => [r.date, r.count]));
+    assert.equal(byDate['2026-05-04'], 100);
+    assert.equal(byDate['2026-05-05'], 300);
+  });
+
+  test('accepts raw payload without outer data wrapper', () => {
+    // Some HAE versions send {metrics:[...]} at the top level
+    const r = parseHAEPayload({
+      metrics: [{ name: 'step_count', data: [{ date: '2026-05-04', qty: 1500 }] }],
+    });
+    assert.equal(r.stepsRows.length, 1);
+    assert.equal(r.stepsRows[0].count, 1500);
+  });
+});
+
+describe('mergeByDate', () => {
+  test('appends new dates', () => {
+    const merged = mergeByDate(
+      [{ date: '2026-05-01', hours: 7 }],
+      [{ date: '2026-05-02', hours: 8 }],
+    );
+    assert.equal(merged.length, 2);
+    assert.equal(merged[0].date, '2026-05-01');
+    assert.equal(merged[1].date, '2026-05-02');
+  });
+
+  test('overwrites row for same date', () => {
+    const merged = mergeByDate(
+      [{ date: '2026-05-01', hours: 7 }],
+      [{ date: '2026-05-01', hours: 9 }],
+    );
+    assert.equal(merged.length, 1);
+    assert.equal(merged[0].hours, 9);
+  });
+
+  test('sorted by date ascending', () => {
+    const merged = mergeByDate(
+      [{ date: '2026-05-03', hours: 7 }],
+      [{ date: '2026-05-01', hours: 8 }, { date: '2026-05-02', hours: 7.5 }],
+    );
+    assert.deepEqual(merged.map(r => r.date), ['2026-05-01', '2026-05-02', '2026-05-03']);
+  });
+
+  test('handles missing existing data', () => {
+    const merged = mergeByDate(null, [{ date: '2026-05-01', hours: 7 }]);
+    assert.equal(merged.length, 1);
+  });
+
+  test('drops new rows with no date', () => {
+    const merged = mergeByDate(
+      [{ date: '2026-05-01', hours: 7 }],
+      [{ hours: 99 }, { date: '2026-05-02', hours: 8 }],
+    );
+    assert.equal(merged.length, 2);
+    assert.ok(merged.every(r => r.date));
+  });
+});


### PR DESCRIPTION
## Summary

Adds a token-gated HTTP ingest endpoint for the iPhone Health Auto
Export app's webhook automation. Parses HAE's native payload shape
and upserts into four atomic klebb manifests.

## Why

Klebb already had a reserved `auto-export/` directory and read-only
GET endpoints left over from earlier code, but nothing wrote into
it. This ships the missing writer so klebb can be a self-contained
destination for iPhone health data — no second service, no bespoke
Shortcut, just the webhook automation that already exists in the
HAE app.

## How

**Endpoint:**

```
POST /api/health-auto-export
Authorization: Bearer <HEALTH_AUTO_EXPORT_TOKEN>
Content-Type: application/json
```

**Flow:**

1. `HEALTH_AUTO_EXPORT_TOKEN` env unset → 501 (feature off).
2. Bearer missing or wrong → 401.
3. Otherwise: archive raw payload to
   `$HEALTH_HOME/data/auto-export/raw/<ms-stamp>.json`
   (always, even on parse failure — the iPhone retry loop shouldn't
   spiral on bad data we haven't seen yet).
4. Parse HAE's `{data:{metrics:[...], workouts:[...]}}` shape.
5. Upsert by date into four manifests (creates them on first write
   if absent, merges by date if they exist):
   - `sleep_analysis` → `sleep-hours` `{date, hours}`
   - `step_count` → `steps` `{date, count}` (sum per date)
   - `apple_exercise_time` → `active-minutes` `{date, minutes}`
   - `workouts[]` → `workouts` `{date, trained: true, type}`
6. Response: `{ok: true, ingested: {...}}`. Any error after auth
   passes → `{ok: true, warning: "..."}` with raw already archived.

**Auth bypass:** the outer `isAuthenticated` gate at
`server.js:502` was carved to let exactly this one POST route
through (exact path + method match) so the handler's own bearer
check runs. No session cookie or `AGENT_API_TOKEN` is needed for
HAE — the iPhone app isn't a browser and has no session.

## Files

- `health-auto-export/ingest.js` **(new, 200 lines)** — pure
  `parseHAEPayload(payload)`, `mergeByDate`, `upsertInto(registry,
  parsed)`, plus minimal templates for auto-creation of the four
  target manifests.
- `config/env.js` — `HEALTH_AUTO_EXPORT_TOKEN` parsing, default
  `null`.
- `server.js` — route handler (~55 lines) + auth-gate carveout
  (~5 lines).
- `tests/health-auto-export.parser.test.js` **(new, 17 tests)** —
  parser unit tests covering date extraction, per-metric
  aggregation, malformed samples, unwrapped payloads.
- `tests/health-auto-export.ingest.test.js` **(new, 6 tests)** —
  integration via sandbox: 501 when env unset, 401 no/wrong bearer,
  200 with correct bearer + four manifests upserted + raw archived,
  idempotent re-POST for same date, parse failure archives raw.

## Testing checklist

- [x] `npm test` — 415/416 passing (the 1 failure
  `no-personal-refs` is pre-existing on `main`, unrelated to this
  PR).
- [x] `tests/health-auto-export.parser.test.js` — 17/17.
- [x] `tests/health-auto-export.ingest.test.js` — 6/6.
- [ ] Manual smoke: set `HEALTH_AUTO_EXPORT_TOKEN=test` in `.env`,
  POST the fixture payload with curl, confirm manifests appear in
  `$HEALTH_HOME/data/` and raw archive shows up under
  `auto-export/raw/`.
- [ ] Live: point iPhone HAE app at a dev instance, verify after
  6-hour push the four cards populate.

## Out of scope / deferred

- Per-type endpoints (e.g. `POST /api/health-auto-export/sleep`):
  HAE sends one payload with everything; a single route is simpler.
- Richer manifests (`sleep-stages`, `sleep-bed-wake`,
  `workouts-detailed`, `vitals`) — follow-up issues.
- File-drop ingest (read from a synced iCloud directory) — future
  alternative transport.

Pairs naturally with #102 (atomic cards flipped to ingest-only)
but doesn't depend on it; landing either first is fine.

Closes #94