### PR TITLE
feat(renderer): writeable donor rows on combination-card

### DIFF
--- a/public/js/components/eh-combination-card.js
+++ b/public/js/components/eh-combination-card.js
@@ -13,7 +13,8 @@
 
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
 import { registerRenderer } from '../renderer-registry.js';
-import { resolveCombines } from '../lib/combines-resolver.esm.js';
+import { resolveCombines, canEditDonor } from '../lib/combines-resolver.esm.js';
+import './eh-input-form.js';
 
 export class EhCombinationCard extends LitElement {
   static properties = {
@@ -23,6 +24,9 @@ export class EhCombinationCard extends LitElement {
     _sources: { state: true },   // { [sourceId]: { loaded, data, meta } }
     _loading: { state: true },
     _error: { state: true },
+    _editingDonor: { state: true },   // sourceId currently being edited, or null
+    _saving: { state: true },
+    _saveError: { state: true },
   };
 
   constructor() {
@@ -33,6 +37,9 @@ export class EhCombinationCard extends LitElement {
     this._sources = {};
     this._loading = true;
     this._error = null;
+    this._editingDonor = null;
+    this._saving = false;
+    this._saveError = null;
     this._onDataChanged = this._onDataChanged.bind(this);
   }
 
@@ -48,7 +55,9 @@ export class EhCombinationCard extends LitElement {
   }
 
   _onDataChanged(e) {
-    const changedId = e?.detail?.id;
+    // app.js fires this with detail.cardId; the combo-card's own save
+    // fires it with detail.id. Accept either so both paths work.
+    const changedId = e?.detail?.cardId || e?.detail?.id;
     if (!changedId) return;
     const combines = this._combines();
     if (combines.some(c => c.sourceId === changedId)) this._fetchAll();
@@ -102,7 +111,96 @@ export class EhCombinationCard extends LitElement {
     if (changed.has('card')) this._fetchAll();
   }
 
-  _renderRow(resolved) {
+  // --- Editable donor support ---
+
+  _canEditDonor(sourceId) {
+    const src = this._sources?.[sourceId];
+    if (!src || !src.loaded) return false;
+    return canEditDonor(src.meta, this.dateMode);
+  }
+
+  _openEdit(sourceId) {
+    this._editingDonor = sourceId;
+    this._saveError = null;
+  }
+
+  _closeEdit() {
+    this._editingDonor = null;
+    this._saveError = null;
+  }
+
+  // Compute the first-row index per donor in the resolved list. The
+  // pencil attaches only to that row so multi-row donor groups (e.g.
+  // Mood's mood + wakeUps + notes) show one affordance, not three.
+  _firstRowIndexPerDonor(resolved) {
+    const byDonor = {};
+    resolved.forEach((r, i) => {
+      if (r.sourceId && !(r.sourceId in byDonor)) byDonor[r.sourceId] = i;
+    });
+    return byDonor;
+  }
+
+  // Upsert behaviour mirrors eh-generic-card._onSubmit: by default
+  // maxReadingsPerDay=1 means the new row replaces any existing row for
+  // the same date; >1 appends and caps to the N most recent.
+  async _onDonorSubmit(sourceId, e) {
+    const payload = e.detail;
+    const src = this._sources?.[sourceId];
+    const donorMeta = src?.meta;
+    if (!donorMeta) return;
+
+    this._saving = true;
+    this._saveError = null;
+    try {
+      const entry = { ...payload };
+      if (!entry.date) entry.date = this.date;
+
+      const existing = Array.isArray(src.data) ? src.data : [];
+      const max = donorMeta.writeable?.maxReadingsPerDay ?? 1;
+      const sameDay = existing.filter(d => d.date === entry.date);
+      const others  = existing.filter(d => d.date !== entry.date);
+
+      let updated;
+      if (max === 1) {
+        updated = [...others, entry];
+      } else {
+        const capped = [...sameDay, entry].slice(-max);
+        updated = [...others, ...capped];
+      }
+      updated.sort((a, b) => (a.date || '').localeCompare(b.date || ''));
+
+      const r = await fetch(`/api/manifests/${encodeURIComponent(sourceId)}/data`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ data: updated }),
+      });
+      if (!r.ok) {
+        let msg = `HTTP ${r.status}`;
+        try { const j = await r.json(); if (j?.error) msg = j.error; } catch {}
+        throw new Error(msg);
+      }
+
+      // Reflect locally + tell other listeners (atomic card renderer
+      // instances, etc.) that this donor's data changed.
+      this._sources = {
+        ...this._sources,
+        [sourceId]: { ...src, data: updated },
+      };
+      window.dispatchEvent(new CustomEvent('manifest-data-changed', {
+        detail: { cardId: sourceId, id: sourceId },
+      }));
+
+      this._editingDonor = null;
+    } catch (err) {
+      this._saveError = err.message || 'save failed';
+    } finally {
+      this._saving = false;
+    }
+  }
+
+  // --- Render helpers ---
+
+  _renderRow(resolved, showPencil) {
     const label = resolved.label || resolved.sourceId;
     const roleClass = `role-${resolved.role || 'annotation'}`;
 
@@ -113,7 +211,10 @@ export class EhCombinationCard extends LitElement {
       return html`
         <div class="row ${roleClass} placeholder">
           <span class="row-label">${label}</span>
-          <span class="row-placeholder">${hint}</span>
+          <span class="row-trailing">
+            <span class="row-placeholder">${hint}</span>
+            ${showPencil ? this._renderPencil(resolved.sourceId, true) : ''}
+          </span>
         </div>
       `;
     }
@@ -121,10 +222,52 @@ export class EhCombinationCard extends LitElement {
     return html`
       <div class="row ${roleClass}">
         <span class="row-label">${label}</span>
-        <span class="row-value">
-          ${resolved.displayValue}
-          ${resolved.unit ? html`<span class="row-unit">${resolved.unit}</span>` : ''}
+        <span class="row-trailing">
+          <span class="row-value">
+            ${resolved.displayValue}
+            ${resolved.unit ? html`<span class="row-unit">${resolved.unit}</span>` : ''}
+          </span>
+          ${showPencil ? this._renderPencil(resolved.sourceId, false) : ''}
         </span>
+      </div>
+    `;
+  }
+
+  _renderPencil(sourceId, isAdd) {
+    return html`
+      <button
+        class="edit-btn"
+        @click=${() => this._openEdit(sourceId)}
+        aria-label="${isAdd ? 'Add' : 'Edit'} entry"
+        title="${isAdd ? 'Add' : 'Edit'} entry"
+      >${isAdd ? '➕' : '✏️'}</button>
+    `;
+  }
+
+  _renderEditForm(sourceId) {
+    const src = this._sources?.[sourceId];
+    if (!src?.meta?.writeable?.inputs) return '';
+    const inputs = src.meta.writeable.inputs;
+    // Prefill with the donor's current row for this date, if any.
+    const rows = Array.isArray(src.data) ? src.data : [];
+    const current = rows.find(r => r && r.date === this.date) || {};
+    const donorLabel = src.meta.label || sourceId;
+    const hasEntry = Object.keys(current).length > 0;
+    return html`
+      <div class="edit-form-wrap">
+        <div class="edit-form-header">
+          <span class="edit-form-title">${hasEntry ? 'Edit' : 'Add'} ${donorLabel}</span>
+        </div>
+        <eh-input-form
+          .inputs=${inputs}
+          .values=${current}
+          .date=${this.date}
+          submit-label=${hasEntry ? 'Update' : 'Add'}
+          ?busy=${this._saving}
+          @eh-submit=${(e) => this._onDonorSubmit(sourceId, e)}
+          @eh-cancel=${() => this._closeEdit()}
+        ></eh-input-form>
+        ${this._saveError ? html`<div class="err">${this._saveError}</div>` : ''}
       </div>
     `;
   }
@@ -147,6 +290,7 @@ export class EhCombinationCard extends LitElement {
 
     const resolved = resolveCombines(combines, this._sources, this.date);
     const allMissing = resolved.length > 0 && resolved.every(r => r.state !== 'ok');
+    const firstByDonor = this._firstRowIndexPerDonor(resolved);
 
     return html`
       <div class="shell">
@@ -161,7 +305,14 @@ export class EhCombinationCard extends LitElement {
             <div class="empty">No sources configured.</div>
           ` : allMissing ? html`
             <div class="empty">No data for this date.</div>
-          ` : resolved.map(r => this._renderRow(r))}
+          ` : resolved.map((r, i) => {
+            const isFirstForDonor = firstByDonor[r.sourceId] === i;
+            const showPencil = isFirstForDonor
+                             && r.sourceId !== this._editingDonor
+                             && this._canEditDonor(r.sourceId);
+            return this._renderRow(r, showPencil);
+          })}
+          ${this._editingDonor ? this._renderEditForm(this._editingDonor) : ''}
         </div>
       </div>
     `;
@@ -256,6 +407,63 @@ export class EhCombinationCard extends LitElement {
       font-size: 12px;
       color: var(--text-muted, var(--text-secondary));
       text-align: center;
+    }
+
+    .row-trailing {
+      display: inline-flex;
+      align-items: baseline;
+      gap: 6px;
+      flex-shrink: 0;
+    }
+    .edit-btn {
+      background: transparent;
+      border: 1px solid transparent;
+      border-radius: 6px;
+      padding: 2px 6px;
+      cursor: pointer;
+      font-size: 13px;
+      line-height: 1;
+      color: var(--text-muted, var(--text-secondary));
+      font-family: inherit;
+      transition: border-color 0.12s, background 0.12s;
+    }
+    .edit-btn:hover {
+      border-color: var(--border);
+      background: var(--bg-hover, rgba(255,255,255,0.05));
+    }
+    .edit-btn:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
+
+    .edit-form-wrap {
+      margin-top: 10px;
+      padding: 10px 12px;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--bg-input, transparent);
+    }
+    .edit-form-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 8px;
+    }
+    .edit-form-title {
+      font-size: 11px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.6px;
+      color: var(--text-muted, var(--text-secondary));
+    }
+    .err {
+      margin-top: 6px;
+      color: #ff4466;
+      font-size: 12px;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .edit-btn { transition: none; }
     }
   `;
 }

--- a/public/js/lib/combines-resolver.esm.js
+++ b/public/js/lib/combines-resolver.esm.js
@@ -93,3 +93,27 @@ export function resolveCombines(combines, sources, date) {
   if (!Array.isArray(combines)) return [];
   return combines.map(entry => resolveEntry(entry, sources, date));
 }
+
+export function canEditDonor(donorMeta, dateMode) {
+  if (!donorMeta || typeof donorMeta !== 'object') return false;
+  const w = donorMeta.writeable;
+  if (!w || !w.fromWebapp) return false;
+  if (!Array.isArray(w.inputs) || w.inputs.length === 0) return false;
+  if (dateMode === 'today')  return w.todayAllowed !== false;
+  if (dateMode === 'past')   return w.pastAllowed === true;
+  if (dateMode === 'future') return w.futureAllowed === true;
+  return false;
+}
+
+export function donorIdsInOrder(combines) {
+  if (!Array.isArray(combines)) return [];
+  const seen = new Set();
+  const out = [];
+  for (const c of combines) {
+    const id = c?.sourceId;
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+}

--- a/public/js/lib/combines-resolver.js
+++ b/public/js/lib/combines-resolver.js
@@ -125,11 +125,45 @@
     return combines.map(entry => resolveEntry(entry, sources, date));
   }
 
+  // Given a donor manifest's meta and the viewed dateMode
+  // ("today" | "past" | "future"), decide whether the combo card should
+  // render an edit affordance for that donor. Mirrors the _canWrite
+  // getter in EhBaseCard so donors behave identically whether edited
+  // via the atomic card or via the combo.
+  function canEditDonor(donorMeta, dateMode) {
+    if (!donorMeta || typeof donorMeta !== 'object') return false;
+    const w = donorMeta.writeable;
+    if (!w || !w.fromWebapp) return false;
+    if (!Array.isArray(w.inputs) || w.inputs.length === 0) return false;
+    if (dateMode === 'today')  return w.todayAllowed !== false;
+    if (dateMode === 'past')   return w.pastAllowed === true;
+    if (dateMode === 'future') return w.futureAllowed === true;
+    return false;
+  }
+
+  // Unique sourceIds in the order they first appear in combines[]. The
+  // combo renderer attaches the edit pencil to the first row of each
+  // donor group.
+  function donorIdsInOrder(combines) {
+    if (!Array.isArray(combines)) return [];
+    const seen = new Set();
+    const out = [];
+    for (const c of combines) {
+      const id = c?.sourceId;
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      out.push(id);
+    }
+    return out;
+  }
+
   return {
     resolveCombines,
     resolveEntry,
     getByPath,
     firstScalarKey,
     stringifyValue,
+    canEditDonor,
+    donorIdsInOrder,
   };
 }));

--- a/tests/combination-card.view.test.js
+++ b/tests/combination-card.view.test.js
@@ -107,3 +107,128 @@ describe('combination-card view integration', () => {
     assert.equal(ids[0], 'sleep');
   });
 });
+
+// --- Writeable donor rows (issue #104) ---
+// The renderer uses POST /api/manifests/:donorId/data to save edits made
+// via the combo's inline form. This suite checks the server contract
+// that save relies on, end-to-end.
+describe('combination-card writeable donor save path', () => {
+  let sandbox, server;
+
+  const writeableMood = {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'mood',
+      label: 'Mood',
+      view: { enabled: true, component: 'generic-card', display: { template: '{mood}' } },
+      writeable: {
+        fromWebapp: true,
+        todayAllowed: true,
+        pastAllowed: true,
+        futureAllowed: false,
+        maxReadingsPerDay: 1,
+        inputs: [
+          { key: 'mood', type: 'rating', required: true },
+          { key: 'wakeUps', type: 'number', default: 0 },
+          { key: 'notes', type: 'textarea' },
+        ],
+      },
+    },
+    data: [{ date: '2026-05-04', mood: 3 }],
+  };
+
+  const ingestOnlySleep = {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'sleep-hours',
+      label: 'Sleep',
+      view: { enabled: true, component: 'generic-card', display: { template: '{hours}' } },
+      writeable: { fromWebapp: false },
+    },
+    data: [{ date: '2026-05-04', hours: 7.5 }],
+  };
+
+  const combo = {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'sleep',
+      label: 'Sleep',
+      view: {
+        enabled: true,
+        component: 'combination-card',
+        layout: 'stack',
+        combines: [
+          { sourceId: 'sleep-hours', role: 'primary', accessor: 'hours' },
+          { sourceId: 'mood', role: 'secondary', accessor: 'mood' },
+          { sourceId: 'mood', role: 'annotation', accessor: 'wakeUps', label: 'Wake-ups' },
+        ],
+      },
+    },
+    data: [],
+  };
+
+  before(async () => {
+    sandbox = createSandbox({
+      seed: {
+        'mood.json': writeableMood,
+        'sleep-hours.json': ingestOnlySleep,
+        'sleep.json': combo,
+      },
+    });
+    server = await spawnServer(sandbox);
+  });
+
+  after(async () => {
+    if (server) await server.kill();
+    if (sandbox) cleanupSandbox(sandbox);
+  });
+
+  test('donor meta.writeable is reachable via /api/manifests/:id', async () => {
+    // Renderer reads this endpoint to decide whether to show the pencil
+    // and what inputs to render in the inline form.
+    const res = await req(server.baseUrl, '/api/manifests/mood');
+    assert.equal(res.status, 200);
+    assert.equal(res.json.meta.writeable.fromWebapp, true);
+    assert.equal(res.json.meta.writeable.inputs.length, 3);
+    assert.equal(res.json.meta.writeable.inputs[0].key, 'mood');
+  });
+
+  test('ingest-only donor: writeable.fromWebapp is false (no pencil)', async () => {
+    const res = await req(server.baseUrl, '/api/manifests/sleep-hours');
+    assert.equal(res.status, 200);
+    assert.equal(res.json.meta.writeable.fromWebapp, false);
+  });
+
+  test('POST /api/manifests/mood/data with upserted entry: replaces same-date row', async () => {
+    // Simulate what the combo's _onDonorSubmit does: read current data,
+    // replace today's row, POST the full array.
+    const cur = await req(server.baseUrl, '/api/manifests/mood/data');
+    assert.equal(cur.status, 200);
+    const existing = cur.json.data;
+
+    const entry = { date: '2026-05-04', mood: 5, wakeUps: 1, notes: 'combo-edit' };
+    const others = existing.filter(d => d.date !== entry.date);
+    const updated = [...others, entry]
+      .sort((a, b) => (a.date || '').localeCompare(b.date || ''));
+
+    const post = await req(server.baseUrl, '/api/manifests/mood/data', {
+      method: 'POST',
+      body: { data: updated },
+    });
+    assert.equal(post.status, 200);
+    assert.equal(post.json.ok, true);
+
+    // Read back
+    const verify = await req(server.baseUrl, '/api/manifests/mood/data');
+    const today = verify.json.data.find(r => r.date === '2026-05-04');
+    assert.equal(today.mood, 5);
+    assert.equal(today.wakeUps, 1);
+    assert.equal(today.notes, 'combo-edit');
+  });
+
+  test('combo manifest is unchanged by donor writes', async () => {
+    // Writes go to the donor, never to the combo's own data block.
+    const res = await req(server.baseUrl, '/api/manifests/sleep/data');
+    assert.deepEqual(res.json.data, []);
+  });
+});

--- a/tests/combines-resolver.test.js
+++ b/tests/combines-resolver.test.js
@@ -12,6 +12,8 @@ const {
   getByPath,
   firstScalarKey,
   stringifyValue,
+  canEditDonor,
+  donorIdsInOrder,
 } = require('../public/js/lib/combines-resolver.js');
 
 describe('getByPath', () => {
@@ -255,5 +257,94 @@ describe('resolveCombines', () => {
     assert.equal(out[0].state, 'ok');
     assert.equal(out[1].state, 'no-source');
     assert.equal(out[2].state, 'no-accessor-match');
+  });
+});
+
+describe('canEditDonor', () => {
+  const writeable = {
+    fromWebapp: true,
+    todayAllowed: true,
+    pastAllowed: true,
+    futureAllowed: false,
+    inputs: [{ key: 'mood', type: 'rating' }],
+  };
+
+  test('returns false for null/undefined meta', () => {
+    assert.equal(canEditDonor(null, 'today'), false);
+    assert.equal(canEditDonor(undefined, 'today'), false);
+  });
+
+  test('returns false when writeable block missing', () => {
+    assert.equal(canEditDonor({}, 'today'), false);
+    assert.equal(canEditDonor({ label: 'x' }, 'today'), false);
+  });
+
+  test('returns false when fromWebapp is false (ingest-only donor)', () => {
+    assert.equal(canEditDonor({ writeable: { fromWebapp: false, inputs: [{ key: 'x', type: 'number' }] } }, 'today'), false);
+  });
+
+  test('returns false when inputs array is empty or missing', () => {
+    assert.equal(canEditDonor({ writeable: { fromWebapp: true } }, 'today'), false);
+    assert.equal(canEditDonor({ writeable: { fromWebapp: true, inputs: [] } }, 'today'), false);
+  });
+
+  test('today allowed by default when todayAllowed absent', () => {
+    const m = { writeable: { fromWebapp: true, inputs: [{ key: 'x', type: 'number' }] } };
+    assert.equal(canEditDonor(m, 'today'), true);
+  });
+
+  test('today disallowed when todayAllowed: false', () => {
+    const m = { writeable: { fromWebapp: true, todayAllowed: false, inputs: [{ key: 'x', type: 'number' }] } };
+    assert.equal(canEditDonor(m, 'today'), false);
+  });
+
+  test('past allowed only when explicitly true', () => {
+    const yes = { writeable: { ...writeable, pastAllowed: true } };
+    const no  = { writeable: { ...writeable, pastAllowed: false } };
+    const absent = { writeable: { fromWebapp: true, inputs: [{ key: 'x', type: 'number' }] } };
+    assert.equal(canEditDonor(yes, 'past'), true);
+    assert.equal(canEditDonor(no, 'past'), false);
+    assert.equal(canEditDonor(absent, 'past'), false);
+  });
+
+  test('future allowed only when explicitly true', () => {
+    const yes = { writeable: { fromWebapp: true, futureAllowed: true, inputs: [{ key: 'x', type: 'number' }] } };
+    const no  = { writeable: { fromWebapp: true, futureAllowed: false, inputs: [{ key: 'x', type: 'number' }] } };
+    assert.equal(canEditDonor(yes, 'future'), true);
+    assert.equal(canEditDonor(no, 'future'), false);
+  });
+
+  test('unknown dateMode returns false', () => {
+    assert.equal(canEditDonor({ writeable }, 'weird'), false);
+    assert.equal(canEditDonor({ writeable }, undefined), false);
+  });
+});
+
+describe('donorIdsInOrder', () => {
+  test('preserves first-appearance order', () => {
+    const combines = [
+      { sourceId: 'sleep-hours' },
+      { sourceId: 'mood', accessor: 'mood' },
+      { sourceId: 'mood', accessor: 'wakeUps' },
+      { sourceId: 'sleep-hours', accessor: 'note' },
+      { sourceId: 'hydration' },
+    ];
+    assert.deepEqual(donorIdsInOrder(combines), ['sleep-hours', 'mood', 'hydration']);
+  });
+
+  test('empty/missing input returns []', () => {
+    assert.deepEqual(donorIdsInOrder(null), []);
+    assert.deepEqual(donorIdsInOrder(undefined), []);
+    assert.deepEqual(donorIdsInOrder([]), []);
+  });
+
+  test('skips entries with no sourceId', () => {
+    const combines = [
+      { sourceId: 'mood' },
+      { role: 'annotation' },
+      { sourceId: null },
+      { sourceId: 'hydration' },
+    ];
+    assert.deepEqual(donorIdsInOrder(combines), ['mood', 'hydration']);
   });
 });


### PR DESCRIPTION
## Summary

Combination cards can now edit data from their donor cards. When a
donor declares `writeable.fromWebapp: true` with `inputs[]`, the
combo renders an edit pencil next to the first row for that donor;
clicking opens an inline form with the donor's full input set;
saving writes to the donor's manifest.

Builds on #97 (read-only renderer). Can land after #97 merges.

## Why

Observed on klebbtest: the Sleep combo absorbs the Mood card (with
mood set to `meta.enabled: false` to avoid double-display). Mood is
a user-edited card — you need to log it every day. With no edit
affordance on the combo, the only path to log mood was to un-hide
the donor, which defeats the purpose of having a combo.

The fix is the donor's `writeable` block **carries over** to the
combo. A read-only donor (e.g. the ingest-only atomic cards from
#102) still shows no edit affordance in the combo. Consistent,
no surprises.

## How

**Design decisions (all locked with the operator):**

- **One pencil per donor**, not per combo row. Clicking the pencil
  on the mood row opens a modal with mood + wakeUps + notes
  together — the donor's full `inputs[]` set. Less clutter, matches
  "a day's mood is one thing".
- **Full donor form**, not a subset. The combo might reference
  only `mood`, but the edit modal shows all inputs. You don't lose
  capability by viewing a card via a combo.
- **Donor's date rules inherited verbatim**
  (`todayAllowed`/`pastAllowed`/`futureAllowed`). No combo-level
  override — a combo shouldn't silently expose edits the donor was
  configured to restrict.
- **Writes go to the donor's manifest** via the existing
  `POST /api/manifests/:id/data` endpoint; combo fires
  `manifest-data-changed` so other renderer instances refresh.
- **Inline form**, not a separate modal. Replaces the combo body
  while editing so the user sees which card they're editing.

## Files

- `public/js/lib/combines-resolver.{js,esm.js}` — two new exports:
  - `canEditDonor(donorMeta, dateMode)` — mirrors
    `EhBaseCard._canWrite` so edit rules behave identically
    whether via atomic card or via combo.
  - `donorIdsInOrder(combines)` — first-appearance order of
    distinct `sourceIds`.
- `public/js/components/eh-combination-card.js` — adds
  `_editingDonor` state, pencil render, `_openEdit`/`_closeEdit`,
  `_onDonorSubmit` (upsert-by-date, POST, re-fetch, dispatch event),
  inline form render. Also fixes a latent bug where the combo's
  `manifest-data-changed` listener read `detail.id` but `app.js`
  fires the event with `detail.cardId` — accept both forms now.
- `tests/combines-resolver.test.js` — 12 new unit tests covering
  `canEditDonor` (all dateMode branches, missing/empty writeable,
  `fromWebapp: false`, etc.) and `donorIdsInOrder`.
- `tests/combination-card.view.test.js` — 4 new integration tests
  in a dedicated describe block: donor meta reachable via
  `/api/manifests/:id`, ingest-only donors expose
  `fromWebapp: false`, POST upsert replaces same-date row, combo's
  own data block stays empty.

## Testing checklist

- [x] `npm test` — 444/445 passing (pre-existing `no-personal-refs`
  failure identical on `main`).
- [x] Resolver unit tests: 12 new cases.
- [x] Integration tests: 4 new cases covering the server contract
  the combo's save path relies on.
- [ ] Manual on klebbtest: Sleep combo absorbs Mood; edit pencil
  appears next to the Mood row; clicking opens a form with mood +
  wakeUps + notes; saving writes to `mood.json` and the combo
  refreshes.

## Out of scope

- Per-row edit pencil (one per combines entry). This ships one per
  donor — simpler and matches operator preference.
- Field-subset forms (only show the combo's referenced fields).
  Opens the donor's full form; shouldn't lose capability through
  the combo.
- `editable: true|false` override on combines[] entries. The donor
  is the source of truth for write rules; no override path.

Closes #104  ·  depends on #97