### PR TITLE
Surface server error reason in save failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Changed
+
+- **Save-failure banners now show the server's reason string.** When a
+  writeable renderer (generic-card, list-card, settings toggles, prompt
+  modal) hit a non-2xx response from \`/api/manifests/:id/data\`, the UI
+  rendered either \`HTTP 403\` or a fixed "Could not save. Try again or
+  dismiss." — hiding the server's actual \`{error: "..."}\` payload. A
+  container running in UTC while the browser is in Australia/Sydney
+  would reject today's writes as "future-dated (2026-05-05) not allowed
+  for this card", but the operator saw only the generic message. New
+  \`public/js/lib/save-error.js\` helper (\`errorFromResponse\`) reads
+  the server's JSON \`error\` field and surfaces it as
+  \`"403: future-dated entry ... not allowed"\`, pointing straight at
+  the \`TZ\` config. Covered by a small unit test. (#106)
+
 ### Added
 
 - **Expand/collapse toggle for the chat panel.** A new header button

--- a/public/js/components/eh-generic-card.js
+++ b/public/js/components/eh-generic-card.js
@@ -30,6 +30,7 @@ import { LitElement, html, css } from 'https://esm.sh/lit@3';
 import { renderTemplate, evaluateThresholds, computeTrend } from '../lib/display-template.esm.js';
 import { registerRenderer } from '../renderer-registry.js';
 import { EhBaseCard, invalidateManifestCache } from './eh-base-card.js';
+import { errorFromResponse } from '../lib/save-error.js';
 import './eh-input-form.js';
 
 export class EhGenericCard extends EhBaseCard {
@@ -111,7 +112,7 @@ export class EhGenericCard extends EhBaseCard {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ data: updated }),
       });
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      if (!r.ok) throw await errorFromResponse(r);
 
       invalidateManifestCache(this.card.id);
       this.data = updated;

--- a/public/js/components/eh-list-card.js
+++ b/public/js/components/eh-list-card.js
@@ -32,6 +32,7 @@ import { LitElement, html, css } from 'https://esm.sh/lit@3';
 import { renderTemplate } from '../lib/display-template.esm.js';
 import { registerRenderer } from '../renderer-registry.js';
 import { EhBaseCard, invalidateManifestCache } from './eh-base-card.js';
+import { errorFromResponse } from '../lib/save-error.js';
 import './eh-input-form.js';
 
 export class EhListCard extends EhBaseCard {
@@ -147,7 +148,7 @@ export class EhListCard extends EhBaseCard {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ data: surviving }),
       });
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      if (!r.ok) throw await errorFromResponse(r);
 
       invalidateManifestCache(this.card.id);
       this.data = surviving;

--- a/public/js/components/eh-prompt-modal.js
+++ b/public/js/components/eh-prompt-modal.js
@@ -29,6 +29,7 @@
 
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
 import { localToday } from '../lib/date-util.js';
+import { errorFromResponse } from '../lib/save-error.js';
 import './eh-input-form.js';
 
 export class EhPromptModal extends LitElement {
@@ -235,14 +236,11 @@ export class EhPromptModal extends LitElement {
         credentials: 'same-origin',
         body: JSON.stringify({ data: updated }),
       });
-      if (!r.ok) {
-        const txt = await r.text().catch(() => '');
-        throw new Error(txt || `HTTP ${r.status}`);
-      }
+      if (!r.ok) throw await errorFromResponse(r);
       this._finish('saved', entry);
     } catch (err) {
       console.warn('[prompt-modal] save failed', err);
-      this._error = 'Could not save. Try again or dismiss.';
+      this._error = err.message || 'Could not save. Try again or dismiss.';
     } finally {
       this._busy = false;
     }

--- a/public/js/components/eh-settings-view.js
+++ b/public/js/components/eh-settings-view.js
@@ -9,6 +9,7 @@
 // To add a card, drop a valid manifest file into $HEALTH_HOME/data/ — see CARDS.md.
 
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
+import { errorFromResponse } from '../lib/save-error.js';
 
 export class EhSettingsView extends LitElement {
   static properties = {
@@ -38,7 +39,7 @@ export class EhSettingsView extends LitElement {
     this._error = null;
     try {
       const r = await fetch('/api/settings/cards');
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      if (!r.ok) throw await errorFromResponse(r);
       const { cards } = await r.json();
       this._cards = Array.isArray(cards) ? cards : [];
     } catch (e) {
@@ -54,7 +55,7 @@ export class EhSettingsView extends LitElement {
     try {
       const action = card.enabled ? 'disable' : 'enable';
       const r = await fetch(`/api/settings/cards/${encodeURIComponent(card.id)}/${action}`, { method: 'POST' });
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      if (!r.ok) throw await errorFromResponse(r);
       await this._load();
     } catch (e) {
       this._error = e.message;

--- a/public/js/lib/save-error.js
+++ b/public/js/lib/save-error.js
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// public/js/lib/save-error.js
+//
+// Build a human-readable Error from a failed fetch Response. Prefers the
+// server's `{ error: "..." }` JSON payload (the shape every Klebb API
+// endpoint returns on non-2xx); falls back to plain text, then status.
+//
+// Use from renderers:
+//   if (!r.ok) throw await errorFromResponse(r);
+// then render err.message directly. The operator then sees the real reason
+// (e.g. "403: future-dated entry (2026-05-05) not allowed for this card")
+// instead of a generic "HTTP 403".
+
+export async function errorFromResponse(r) {
+  let detail = '';
+  try {
+    const body = await r.clone().json();
+    if (body && typeof body.error === 'string') detail = body.error;
+  } catch {
+    try {
+      const txt = await r.text();
+      if (txt) detail = txt.slice(0, 200);
+    } catch {
+      // ignore; fall through to status-only message
+    }
+  }
+  return new Error(detail ? `${r.status}: ${detail}` : `HTTP ${r.status}`);
+}

--- a/tests/save-error.test.js
+++ b/tests/save-error.test.js
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/save-error.test.js
+// Unit tests for public/js/lib/save-error.js.
+//
+// The bug behind this helper: writeable renderers were throwing
+// `HTTP 403` on any non-2xx from /api/manifests/:id/data, hiding the
+// server's actual `{ error: "..." }` payload. A klebbtest instance
+// running in UTC rejected today's writes as "future-dated" and the
+// operator couldn't see why without DevTools. This helper exposes the
+// server's reason string in the thrown Error.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { errorFromResponse } from '../public/js/lib/save-error.js';
+
+// Minimal Response stand-in matching the bits the helper uses.
+// (node:test runs in Node, which has a real Response, but constructing
+// one with a specific status + JSON body cleanly is easier this way.)
+function makeResponse({ status, body, contentType = 'application/json' }) {
+  return {
+    status,
+    clone() { return makeResponse({ status, body, contentType }); },
+    async json() {
+      if (contentType !== 'application/json') throw new Error('not json');
+      if (typeof body === 'string') return JSON.parse(body);
+      return body;
+    },
+    async text() {
+      if (typeof body === 'string') return body;
+      return JSON.stringify(body);
+    },
+  };
+}
+
+test('errorFromResponse: prefers server-sent error string', async () => {
+  const r = makeResponse({
+    status: 403,
+    body: { error: 'future-dated entry (2026-05-05) not allowed for this card' },
+  });
+  const err = await errorFromResponse(r);
+  assert.ok(err instanceof Error);
+  assert.equal(err.message, '403: future-dated entry (2026-05-05) not allowed for this card');
+});
+
+test('errorFromResponse: falls back to HTTP status when body lacks error', async () => {
+  const r = makeResponse({ status: 500, body: {} });
+  const err = await errorFromResponse(r);
+  assert.equal(err.message, 'HTTP 500');
+});
+
+test('errorFromResponse: uses text body when JSON parse fails', async () => {
+  const r = makeResponse({
+    status: 502,
+    body: 'upstream gateway timeout',
+    contentType: 'text/plain',
+  });
+  const err = await errorFromResponse(r);
+  assert.equal(err.message, '502: upstream gateway timeout');
+});
+
+test('errorFromResponse: truncates very long text bodies', async () => {
+  const long = 'x'.repeat(500);
+  const r = makeResponse({ status: 500, body: long, contentType: 'text/plain' });
+  const err = await errorFromResponse(r);
+  assert.equal(err.message.length <= '500: '.length + 200, true);
+});
+
+test('errorFromResponse: non-string error field falls back to status', async () => {
+  const r = makeResponse({ status: 400, body: { error: { nested: 'obj' } } });
+  const err = await errorFromResponse(r);
+  assert.equal(err.message, 'HTTP 400');
+});


### PR DESCRIPTION
## Summary

Writeable renderers now show the server's actual error string on save
failures, instead of a generic "Could not save" or bare HTTP status.

## Why

If a container runs in a different timezone from the browser, the
server's `findDateAllowanceViolation` rejects today's writes as
"future-dated" — returning a useful JSON error:

```
{"error":"future-dated entry (2026-05-05) not allowed for this card"}
```

…but the UI swallowed that payload and rendered either `HTTP 403` or
"Could not save. Try again or dismiss." The operator had to open
DevTools Network > Response to see the real reason.

With this change the banner reads:

> 403: future-dated entry (2026-05-05) not allowed for this card

…which points straight at the `TZ` config without any debugging dance.

## How

New `public/js/lib/save-error.js` exports `errorFromResponse(r)`:
prefers `{error: "..."}` JSON, falls back to text body (capped at
200 chars), falls back to `HTTP N`. Every `if (!r.ok) throw new
Error(\`HTTP \${r.status}\`)` site in writeable renderers now routes
through it:

- `public/js/components/eh-prompt-modal.js` (also swaps the fixed
  banner string for `err.message`)
- `public/js/components/eh-generic-card.js`
- `public/js/components/eh-list-card.js`
- `public/js/components/eh-settings-view.js` (both load + toggle paths)

No server change. The server already emits useful `{error}` payloads
at `server.js:607, 614, 632, 638` — this just surfaces them.

## Testing

- [x] New `tests/save-error.test.js` covers: JSON with string error,
      JSON without error field, plain-text body, non-string error,
      body truncation.
- [x] `npm test` on this branch: 398 tests, 396 pass; the 2 failing
      tests (`no-personal-refs`) are pre-existing on `main` and flag
      only gitignored files.
- [ ] Manual: trigger a 403 from any writeable card modal (e.g. by
      setting the server TZ wrong) and confirm the banner shows the
      server error rather than the generic string.

Fixes #106