### PR TITLE
feat(chat): full read + edit parity for manifests via klebbius

### DIFF
--- a/chat/tools.js
+++ b/chat/tools.js
@@ -91,6 +91,64 @@ const TOOL_DEFS = [
       },
     },
   },
+  {
+    type: 'function',
+    function: {
+      name: 'read_manifest',
+      description:
+        "Return the full content of a single card: meta, description, schema, and the data block. Use this before any write (write_manifest_data or patch_manifest) so you can see what you're about to change and preserve everything you don't want to touch. Also the right tool for answering 'what did I log for X', 'what's my threshold', etc.",
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'Manifest id.' },
+        },
+        required: ['id'],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'write_manifest_data',
+      description:
+        "Replace a card's entire data block. This is a full rewrite, not a row-level patch — to add/edit/delete a row, first call read_manifest to get the current data, mutate the array (or object) in memory, then pass the whole new value here. Rejected if meta.writeable.fromWebapp is false (ingest-only cards). Destructive-feeling writes (removing rows) must be confirmed with the user exactly once before calling this.",
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'Manifest id.' },
+          data: {
+            description:
+              "The full new data value. Shape matches what read_manifest returned: usually an array of rows like [{date, ...}], but some cards use {items:[...]}, {markdown:'...'}, etc. Pass whatever shape the card uses.",
+          },
+        },
+        required: ['id', 'data'],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'patch_manifest',
+      description:
+        "Edit a card's meta or description in place without touching its data. Uses RFC 7396 JSON Merge Patch: nested objects deep-merge, arrays replace wholesale, null removes a key. Use this for any meta-only change — thresholds, labels, emoji maps, input types, writeable flags. The data block is preserved byte-for-byte. You CANNOT change $schema or meta.id via this tool; for those, delete_manifest + create_manifest is the path (and data will be lost). ALWAYS call read_manifest first so you're patching over the real current meta. Destructive-feeling patches (removing inputs from a writeable card, flipping writeable.fromWebapp from true to false on a card that has data) must be confirmed with the user exactly once before calling this.",
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'Manifest id.' },
+          patch: {
+            type: 'object',
+            description:
+              "Partial manifest. Only meta and description are patchable. Example: {meta: {writeable: {inputs: [{key:'mood', type:'emoji-picker', emojis:['😩','😴','😐','🙂','😄'], emitIndex:true, required:true, autoSubmit:false}, ...]}}} — note that meta.writeable.inputs is an ARRAY, so the WHOLE array replaces. You have to include every input you want to keep.",
+            additionalProperties: true,
+          },
+        },
+        required: ['id', 'patch'],
+        additionalProperties: false,
+      },
+    },
+  },
 ];
 
 // Execute a single tool_call from an assistant response. Always returns a
@@ -131,6 +189,34 @@ function dispatchToolCall(tc) {
           enabled: c.meta?.enabled !== false,
         }));
         return JSON.stringify({ cards: rows });
+      }
+      case 'read_manifest': {
+        const entry = registry.get(args.id);
+        if (!entry) {
+          return JSON.stringify({ error: `unknown manifest: ${args.id}` });
+        }
+        return JSON.stringify({
+          meta: entry.meta,
+          description: entry.description || null,
+          schema: entry.schema || null,
+          data: entry.data,
+        });
+      }
+      case 'write_manifest_data': {
+        const entry = registry.get(args.id);
+        if (!entry) {
+          return JSON.stringify({ error: `unknown manifest: ${args.id}` });
+        }
+        const w = entry.meta?.writeable;
+        if (!w || !w.fromWebapp) {
+          return JSON.stringify({ error: `${args.id} is not writeable from the webapp (meta.writeable.fromWebapp is not true). Use patch_manifest to flip the flag first if the user wants to make it writeable.` });
+        }
+        registry.writeData(args.id, args.data);
+        return JSON.stringify({ ok: true, id: args.id });
+      }
+      case 'patch_manifest': {
+        const result = registry.patchManifest(args.id, args.patch);
+        return JSON.stringify({ ok: true, ...result });
       }
       default:
         return JSON.stringify({ error: 'unknown tool: ' + name });

--- a/config/env.js
+++ b/config/env.js
@@ -149,7 +149,31 @@ You, ${CHAT_AGENT_NAME}, are embedded in the dashboard itself. You act by callin
 - \`delete_manifest(id)\` → remove a card and its file. Destructive — data goes with the file. ALWAYS confirm exactly once before calling it, even if the user's first word was "delete". The single confirmation message must warn that the card and its data are gone for good and offer \`hide_card\` as the non-destructive alternative. On any affirmative reply ("delete", "delete it", "yes", "confirm", "go ahead", "do it", "sure") call \`delete_manifest\` immediately; never ask a second time.
 - \`hide_card(id)\` → sets master \`meta.enabled:false\`. Hides the card from every view but keeps the file + data intact. This is the right tool for "stop showing me the hydration card", "hide this for now", etc. No confirmation needed — it's reversible with \`show_card\`.
 - \`show_card(id)\` → sets master \`meta.enabled:true\`. Reverses \`hide_card\`.
-- \`list_manifests()\` → current card list (each entry includes \`enabled\` so you can tell a hidden card from an active one). Useful mid-conversation after a create, or to check an id isn't already taken before proposing one.
+- \`list_manifests()\` → compact card list (id, label, description, enabled). Useful to re-check state or to look up an id.
+- \`read_manifest(id)\` → full card content: meta + description + schema + data. No confirmation. Use before any write so you can see what you're changing and preserve everything else.
+- \`write_manifest_data(id, data)\` → replace the full data block of a card. Full-array rewrite, not a row-level patch — to add/edit/delete one row you first read_manifest, mutate the array in memory, then write it back. Rejected if \`meta.writeable.fromWebapp\` is not \`true\` (ingest-only cards are untouchable; use \`patch_manifest\` to flip the flag first if the user really wants to make the card writeable). Confirm with the user EXACTLY ONCE before a write that removes rows.
+- \`patch_manifest(id, patch)\` → edit meta or description without touching data. RFC 7396 JSON Merge Patch: nested objects deep-merge, ARRAYS REPLACE, \`null\` removes a key. Use for thresholds, labels, emoji maps, input types, writeable flags. Cannot change \`$schema\` or \`meta.id\`. Confirm ONCE before destructive-feeling patches (removing inputs from a writeable card, flipping \`writeable.fromWebapp\` from \`true\` to \`false\` on a card that has data).
+
+## When to use which write tool
+
+Choose the smallest-blast-radius tool for the job:
+
+| User intent | Tool |
+|-------------|------|
+| "What's my BP threshold?" / "What did I log yesterday?" | \`read_manifest\` |
+| Add / edit / remove a row in a card's data | \`read_manifest\` → mutate in memory → \`write_manifest_data\` |
+| Change a threshold, label, emoji map, input type, writeable flag | \`read_manifest\` → \`patch_manifest\` |
+| "Stop showing this card" / "show it again" | \`hide_card\` / \`show_card\` |
+| "I want a new tracker for X" | \`create_manifest\` |
+| "Throw this card away and start over" (explicit data loss OK) | \`delete_manifest\` then \`create_manifest\` |
+
+**Read before write.** Any call to \`write_manifest_data\` or \`patch_manifest\` MUST be preceded by \`read_manifest\` in the same turn. Never blind-write — you'll clobber fields you didn't mean to touch. Arrays in JSON Merge Patch replace wholesale, so if you \`patch_manifest(id, {meta:{writeable:{inputs:[…]}}})\` you must include every input you want to keep, not just the one you're changing.
+
+**Confirmation rules.** One-shot confirmation (same pattern as \`delete_manifest\`) is mandatory before:
+- \`delete_manifest\` (always).
+- \`write_manifest_data\` when the new value removes existing rows (e.g. truncating a data array).
+- \`patch_manifest\` when the patch removes any \`inputs[]\` from a writeable card, or flips \`writeable.fromWebapp\` from \`true\` to \`false\` on a card that has data.
+Pure additions / non-destructive patches (adding a new threshold band, renaming a label, changing an emoji map) don't need confirmation.
 
 ## HTTP API (reference for external agents)
 
@@ -159,6 +183,7 @@ External agents running outside this app (with \`AGENT_API_TOKEN\`) hit these en
 - \`GET /api/manifests/:id\` → full manifest (meta + data)
 - \`GET /api/manifests/:id/data\` → just the data block
 - \`POST /api/manifests/:id/data\` with \`{ data: [...] }\` → replace data
+- \`PATCH /api/manifests/:id\` with \`{ meta?: {...}, description?: "..." }\` → RFC 7396 JSON Merge Patch over meta + description; data and \`$schema\` untouched
 - \`POST /api/manifests\` with a full manifest body → create a brand new card (201; 409 if id exists)
 - \`DELETE /api/manifests/:id\` → remove a card and its file (200; 404 if missing)
 - \`GET /api/views/today\` / \`/trends\` / \`/reports\` / \`/calendar\` → cards enabled for that view
@@ -355,7 +380,7 @@ Once \`create_manifest\` succeeds, your reply MUST end with a short offer of opt
 
 Offer them as a single short sentence or a 2-3 item bullet list, e.g. "Done. Want me to add a trends chart, a daily target, or a calendar marker?" — not a long menu. Never auto-add beyond what was asked.
 
-If the user picks one of your suggestions, apply it by calling \`delete_manifest(id)\` followed immediately by \`create_manifest\` with the augmented manifest. This is safe ONLY right after initial creation because the card has no user data yet. Do NOT use delete+recreate to modify an existing card that has data — tell the user that editing an existing card in place isn't supported yet and they'll need to add data-preserving tooling or accept the loss.
+If the user picks one of your suggestions, apply it with \`patch_manifest(id, metaPatch)\` — it edits the meta in place and preserves data. Use delete+recreate ONLY right after initial creation (card has no data yet), or when the user explicitly wants to discard the data and start fresh. For any existing card with data, patch_manifest is the right tool.
 
 ### Deletion
 

--- a/manifests/merge-patch.js
+++ b/manifests/merge-patch.js
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// manifests/merge-patch.js
+// RFC 7396 JSON Merge Patch — apply a partial document over a target.
+//
+// Rules:
+//   - If patch is not a plain object, replace target with patch.
+//   - Otherwise for each key in patch:
+//       - if value is null, remove the key from target.
+//       - if value is a plain object, recurse into target[key] (creating
+//         an empty object first if target[key] isn't a plain object).
+//       - otherwise (primitive, array), replace target[key] with value.
+//
+// Arrays are always REPLACED, never merged. That's the spec; it also
+// matches the user-visible semantics we want for e.g. rewriting
+// meta.writeable.inputs to drop a single flag on one input.
+
+function isPlainObject(v) {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function mergePatch(target, patch) {
+  if (!isPlainObject(patch)) return patch;
+  const base = isPlainObject(target) ? { ...target } : {};
+  for (const key of Object.keys(patch)) {
+    const pv = patch[key];
+    if (pv === null) {
+      delete base[key];
+    } else if (isPlainObject(pv)) {
+      base[key] = mergePatch(base[key], pv);
+    } else {
+      base[key] = pv;
+    }
+  }
+  return base;
+}
+
+module.exports = { mergePatch, isPlainObject };

--- a/manifests/registry.js
+++ b/manifests/registry.js
@@ -15,6 +15,7 @@
 const fs = require('fs');
 const path = require('path');
 const PATHS = require('../config/paths');
+const { mergePatch, isPlainObject } = require('./merge-patch');
 
 const SUPPORTED_SCHEMAS = ['klebb.datafile.v1'];
 const RESERVED_DIR_PREFIX = '_';
@@ -392,6 +393,69 @@ function createManifest(manifestObj) {
   return { id, source: targetPath };
 }
 
+// Apply a JSON Merge Patch (RFC 7396) to an existing manifest's meta and/or
+// description. `data` and `$schema` are preserved verbatim; `meta.id` cannot
+// change. The full merged manifest is re-validated before writing.
+//
+// Patch shape: { meta?: {...}, description?: "..." }
+//   - Nested objects under meta deep-merge per RFC 7396.
+//   - Arrays replace wholesale (e.g. meta.writeable.inputs replaces).
+//   - `null` in patch removes the key from the target.
+//
+// Throws:
+//   "unknown manifest: <id>"              -> handler maps to 404
+//   "patch touches protected field: ..."  -> 400
+//   "missing meta.id" / "invalid id: *"   -> 400/422 (from validation)
+function patchManifest(id, patch) {
+  const entry = _entries.get(id);
+  if (!entry) throw new Error(`unknown manifest: ${id}`);
+  if (!patch || typeof patch !== 'object' || Array.isArray(patch)) {
+    throw new Error('patch must be an object');
+  }
+  // Protected fields: reject patches that try to rename or re-version.
+  if ('$schema' in patch) {
+    throw new Error('patch touches protected field: $schema');
+  }
+  if (isPlainObject(patch.meta) && 'id' in patch.meta) {
+    throw new Error('patch touches protected field: meta.id');
+  }
+  if ('data' in patch) {
+    throw new Error('patch touches protected field: data (use writeData)');
+  }
+
+  const merged = {
+    $schema: entry.version,
+    meta: isPlainObject(patch.meta)
+      ? mergePatch(entry.meta, patch.meta)
+      : entry.meta,
+  };
+  // description: patch can set (string) or remove (null). Undefined = keep.
+  if ('description' in patch) {
+    if (patch.description === null) {
+      // removed
+    } else if (typeof patch.description === 'string') {
+      merged.description = patch.description;
+    } else {
+      throw new Error('description must be a string or null');
+    }
+  } else if (entry.description) {
+    merged.description = entry.description;
+  }
+  if (entry.schema) merged.schema = entry.schema;
+  if (entry.data !== null) merged.data = entry.data;
+
+  // Re-validate. strictId:false so we don't reject legacy ids that already
+  // loaded; we already blocked id changes above.
+  validateManifestShape(merged, { strictId: false });
+
+  const tmp = entry.source + '.tmp';
+  fs.writeFileSync(tmp, JSON.stringify(merged, null, 2));
+  fs.renameSync(tmp, entry.source);
+  entry.meta = merged.meta;
+  entry.description = merged.description || null;
+  return { id };
+}
+
 // Remove a manifest's file and drop its entry from the cache. Throws if the
 // id is unknown (map to 404 in the handler).
 function deleteManifest(id) {
@@ -423,6 +487,7 @@ module.exports = {
   setMasterEnabled,
   reorderByIds,
   createManifest,
+  patchManifest,
   deleteManifest,
   validateManifestShape,
 };

--- a/server.js
+++ b/server.js
@@ -574,6 +574,37 @@ const server = http.createServer(async (req, res) => {
       }
     }
 
+    // PATCH /api/manifests/:id — RFC 7396 JSON Merge Patch over meta + description.
+    // Body: { meta?: {...}, description?: "..." }
+    //   - Nested objects deep-merge; arrays replace; null removes.
+    //   - data + $schema + meta.id are protected.
+    if (parts[0] === 'manifests' && parts.length === 2 && req.method === 'PATCH') {
+      const id = parts[1];
+      if (!registry.get(id)) return send404(res, 'manifest not found');
+      let body = '';
+      req.on('data', c => body += c);
+      req.on('end', () => {
+        let patch;
+        try {
+          patch = JSON.parse(body || '{}');
+        } catch (e) {
+          return sendJSON(res, { error: 'invalid JSON body' }, 400);
+        }
+        try {
+          const result = registry.patchManifest(id, patch);
+          return sendJSON(res, { ok: true, id: result.id });
+        } catch (e) {
+          const msg = e.message || 'patch failed';
+          const status = /unknown manifest/.test(msg) ? 404
+            : /protected field|patch must be|missing|description must/.test(msg) ? 400
+            : /invalid id/.test(msg) ? 422
+            : 500;
+          return sendJSON(res, { error: msg }, status);
+        }
+      });
+      return;
+    }
+
     // GET /api/views/:viewName — cards that opt into a named view
     if (parts[0] === 'views' && parts.length === 2 && req.method === 'GET') {
       const viewName = parts[1];

--- a/tests/chat-tools-crud.test.js
+++ b/tests/chat-tools-crud.test.js
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/chat-tools-crud.test.js
+// Direct-dispatch tests for the new read/write/patch tools. Bypasses the
+// chat agent loop (covered by chat-tool-use.test.js); verifies the dispatch
+// contract the loop relies on.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const { createSandbox, cleanupSandbox } = require('./helpers/sandbox');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const MANIFESTS_DIR = path.resolve(REPO_ROOT, 'manifests') + path.sep;
+const CONFIG_DIR = path.resolve(REPO_ROOT, 'config') + path.sep;
+const CHAT_DIR = path.resolve(REPO_ROOT, 'chat') + path.sep;
+
+function freshTools(sandboxRoot) {
+  for (const key of Object.keys(require.cache)) {
+    if (key.startsWith(MANIFESTS_DIR) ||
+        key.startsWith(CONFIG_DIR) ||
+        key.startsWith(CHAT_DIR)) {
+      delete require.cache[key];
+    }
+  }
+  process.env.HEALTH_HOME = sandboxRoot;
+  const registry = require(path.join(REPO_ROOT, 'manifests', 'registry.js'));
+  registry.init();
+  const { TOOL_DEFS, dispatchToolCall } = require(path.join(REPO_ROOT, 'chat', 'tools.js'));
+  return { registry, TOOL_DEFS, dispatchToolCall };
+}
+
+function makeToolCall(name, args) {
+  return {
+    function: { name, arguments: JSON.stringify(args) },
+  };
+}
+
+const MOOD = {
+  $schema: 'klebb.datafile.v1',
+  meta: {
+    id: 'mood',
+    label: 'Mood',
+    writeable: {
+      fromWebapp: true,
+      inputs: [
+        { key: 'mood', type: 'emoji-picker', autoSubmit: true, emitIndex: true },
+        { key: 'notes', type: 'textarea' },
+      ],
+    },
+  },
+  description: 'Daily mood.',
+  data: [
+    { date: '2026-05-04', mood: 4 },
+    { date: '2026-05-05', mood: 5, notes: 'great' },
+  ],
+};
+
+const INGEST_ONLY = {
+  $schema: 'klebb.datafile.v1',
+  meta: {
+    id: 'steps',
+    label: 'Steps',
+    view: { enabled: true, component: 'generic-card' },
+    writeable: { fromWebapp: false },
+  },
+  description: 'Ingest-only.',
+  data: [{ date: '2026-05-05', count: 7200 }],
+};
+
+describe('chat tools: read/write/patch', () => {
+  test('TOOL_DEFS includes the three new tools', () => {
+    const sandbox = createSandbox();
+    try {
+      const { TOOL_DEFS } = freshTools(sandbox);
+      const names = TOOL_DEFS.map(t => t.function.name);
+      assert.ok(names.includes('read_manifest'));
+      assert.ok(names.includes('write_manifest_data'));
+      assert.ok(names.includes('patch_manifest'));
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('read_manifest returns full content', () => {
+    const sandbox = createSandbox({ seed: { 'mood.json': MOOD } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = JSON.parse(dispatchToolCall(makeToolCall('read_manifest', { id: 'mood' })));
+      assert.ok(res.meta);
+      assert.equal(res.meta.id, 'mood');
+      assert.equal(res.description, 'Daily mood.');
+      assert.deepEqual(res.data, MOOD.data);
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('read_manifest unknown id returns {error}', () => {
+    const sandbox = createSandbox();
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = JSON.parse(dispatchToolCall(makeToolCall('read_manifest', { id: 'ghost' })));
+      assert.match(res.error, /unknown manifest/);
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('write_manifest_data round-trip: read → modify → write → re-read matches', () => {
+    const sandbox = createSandbox({ seed: { 'mood.json': MOOD } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const current = JSON.parse(dispatchToolCall(makeToolCall('read_manifest', { id: 'mood' })));
+      // Remove the 2026-05-04 entry, add a new one for 2026-05-06
+      const newData = current.data
+        .filter(r => r.date !== '2026-05-04')
+        .concat([{ date: '2026-05-06', mood: 3, notes: 'meh' }]);
+      const write = JSON.parse(dispatchToolCall(makeToolCall('write_manifest_data', { id: 'mood', data: newData })));
+      assert.equal(write.ok, true);
+      const verify = JSON.parse(dispatchToolCall(makeToolCall('read_manifest', { id: 'mood' })));
+      assert.equal(verify.data.length, 2);
+      assert.ok(verify.data.find(r => r.date === '2026-05-05'));
+      assert.ok(verify.data.find(r => r.date === '2026-05-06'));
+      assert.ok(!verify.data.find(r => r.date === '2026-05-04'));
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('write_manifest_data rejects ingest-only card', () => {
+    const sandbox = createSandbox({ seed: { 'steps.json': INGEST_ONLY } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = JSON.parse(dispatchToolCall(makeToolCall('write_manifest_data', { id: 'steps', data: [] })));
+      assert.match(res.error, /not writeable/);
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('patch_manifest updates meta; data preserved', () => {
+    const sandbox = createSandbox({ seed: { 'mood.json': MOOD } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const dataBefore = JSON.parse(dispatchToolCall(makeToolCall('read_manifest', { id: 'mood' }))).data;
+      const res = JSON.parse(dispatchToolCall(makeToolCall('patch_manifest', {
+        id: 'mood',
+        patch: {
+          meta: {
+            writeable: {
+              inputs: [
+                { key: 'mood', type: 'emoji-picker', autoSubmit: false, emitIndex: true },
+                { key: 'notes', type: 'textarea' },
+              ],
+            },
+          },
+        },
+      })));
+      assert.equal(res.ok, true);
+      const after = JSON.parse(dispatchToolCall(makeToolCall('read_manifest', { id: 'mood' })));
+      assert.equal(after.meta.writeable.inputs[0].autoSubmit, false);
+      assert.deepEqual(after.data, dataBefore);
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('patch_manifest rejects protected fields (returns {error})', () => {
+    const sandbox = createSandbox({ seed: { 'mood.json': MOOD } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = JSON.parse(dispatchToolCall(makeToolCall('patch_manifest', {
+        id: 'mood',
+        patch: { meta: { id: 'renamed' } },
+      })));
+      assert.match(res.error, /meta\.id/);
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('patch_manifest on unknown id returns {error}', () => {
+    const sandbox = createSandbox();
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = JSON.parse(dispatchToolCall(makeToolCall('patch_manifest', {
+        id: 'ghost',
+        patch: { meta: { label: 'x' } },
+      })));
+      assert.match(res.error, /unknown manifest/);
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+});

--- a/tests/merge-patch.test.js
+++ b/tests/merge-patch.test.js
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/merge-patch.test.js
+// Unit tests for the RFC 7396 JSON Merge Patch helper.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { mergePatch, isPlainObject } = require('../manifests/merge-patch');
+
+describe('isPlainObject', () => {
+  test('objects', () => { assert.equal(isPlainObject({}), true); assert.equal(isPlainObject({a:1}), true); });
+  test('not arrays', () => { assert.equal(isPlainObject([]), false); });
+  test('not null', () => { assert.equal(isPlainObject(null), false); });
+  test('not primitives', () => {
+    assert.equal(isPlainObject(1), false);
+    assert.equal(isPlainObject('x'), false);
+    assert.equal(isPlainObject(true), false);
+    assert.equal(isPlainObject(undefined), false);
+  });
+});
+
+describe('mergePatch', () => {
+  test('shallow key set', () => {
+    assert.deepEqual(mergePatch({a:1}, {b:2}), {a:1, b:2});
+  });
+
+  test('shallow key replace', () => {
+    assert.deepEqual(mergePatch({a:1}, {a:2}), {a:2});
+  });
+
+  test('null removes key', () => {
+    assert.deepEqual(mergePatch({a:1, b:2}, {a:null}), {b:2});
+  });
+
+  test('null removes deep key', () => {
+    assert.deepEqual(
+      mergePatch({a: {b:1, c:2}}, {a: {b: null}}),
+      {a: {c:2}},
+    );
+  });
+
+  test('deep merge nested object', () => {
+    assert.deepEqual(
+      mergePatch({a: {b:1, c:2}}, {a: {c: 99, d: 100}}),
+      {a: {b:1, c:99, d:100}},
+    );
+  });
+
+  test('arrays replace wholesale (RFC 7396)', () => {
+    assert.deepEqual(
+      mergePatch({a: [1,2,3]}, {a: [9]}),
+      {a: [9]},
+    );
+  });
+
+  test('array inside nested object still replaces', () => {
+    assert.deepEqual(
+      mergePatch({meta: {inputs: [{k:'a'},{k:'b'}]}}, {meta: {inputs: [{k:'a'}]}}),
+      {meta: {inputs: [{k:'a'}]}},
+    );
+  });
+
+  test('non-object patch replaces target entirely', () => {
+    assert.equal(mergePatch({a:1}, 42), 42);
+    assert.equal(mergePatch({a:1}, 'hello'), 'hello');
+    assert.deepEqual(mergePatch({a:1}, [1,2]), [1,2]);
+    assert.equal(mergePatch({a:1}, null), null);
+  });
+
+  test('target missing key gets nested structure created', () => {
+    assert.deepEqual(
+      mergePatch({}, {a: {b: {c: 1}}}),
+      {a: {b: {c: 1}}},
+    );
+  });
+
+  test('target key that is not an object gets replaced by nested patch', () => {
+    // Target a=5 (number); patch a={b:1} — target isn't mergeable so it's replaced.
+    assert.deepEqual(mergePatch({a:5}, {a:{b:1}}), {a:{b:1}});
+  });
+
+  test('original target not mutated', () => {
+    const target = {a: {b: 1}};
+    const patched = mergePatch(target, {a: {c: 2}});
+    assert.deepEqual(target, {a: {b: 1}});
+    assert.deepEqual(patched, {a: {b:1, c:2}});
+  });
+
+  test('empty patch returns equal copy', () => {
+    assert.deepEqual(mergePatch({a:1}, {}), {a:1});
+  });
+
+  test('klebb-flavoured: flipping a single input flag', () => {
+    const before = {
+      meta: {
+        writeable: {
+          fromWebapp: true,
+          inputs: [
+            { key: 'mood', type: 'emoji-picker', autoSubmit: true },
+            { key: 'notes', type: 'textarea' },
+          ],
+        },
+      },
+    };
+    // The patch must include the full inputs array (arrays replace).
+    const patch = {
+      meta: {
+        writeable: {
+          inputs: [
+            { key: 'mood', type: 'emoji-picker', autoSubmit: false },
+            { key: 'notes', type: 'textarea' },
+          ],
+        },
+      },
+    };
+    const after = mergePatch(before, patch);
+    assert.equal(after.meta.writeable.fromWebapp, true, 'fromWebapp preserved');
+    assert.equal(after.meta.writeable.inputs[0].autoSubmit, false);
+    assert.equal(after.meta.writeable.inputs[1].type, 'textarea');
+  });
+});

--- a/tests/patch-api.test.js
+++ b/tests/patch-api.test.js
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/patch-api.test.js
+// End-to-end tests for PATCH /api/manifests/:id.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const { createSandbox, cleanupSandbox, spawnServer, req } = require('./helpers/sandbox');
+
+const MOOD = {
+  $schema: 'klebb.datafile.v1',
+  meta: {
+    id: 'mood',
+    label: 'Mood',
+    emoji: '🙂',
+    writeable: {
+      fromWebapp: true,
+      inputs: [
+        { key: 'mood', type: 'emoji-picker', autoSubmit: true, emitIndex: true },
+        { key: 'notes', type: 'textarea' },
+      ],
+    },
+  },
+  description: 'Daily mood.',
+  data: [{ date: '2026-05-05', mood: 4, notes: 'ok' }],
+};
+
+describe('PATCH /api/manifests/:id', () => {
+  let sandbox, server;
+
+  before(async () => {
+    sandbox = createSandbox({ seed: { 'mood.json': MOOD } });
+    server = await spawnServer(sandbox);
+  });
+
+  after(async () => {
+    if (server) await server.kill();
+    if (sandbox) cleanupSandbox(sandbox);
+  });
+
+  test('200 on valid patch; meta updated, data byte-for-byte identical', async () => {
+    const dataBefore = JSON.parse(fs.readFileSync(path.join(sandbox, 'data', 'mood.json'), 'utf8')).data;
+
+    const res = await req(server.baseUrl, '/api/manifests/mood', {
+      method: 'PATCH',
+      body: {
+        meta: {
+          writeable: {
+            inputs: [
+              { key: 'mood', type: 'emoji-picker', autoSubmit: false, emitIndex: true },
+              { key: 'notes', type: 'textarea' },
+            ],
+          },
+        },
+      },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.json.ok, true);
+
+    // fs.watch reload settles
+    await new Promise(r => setTimeout(r, 200));
+
+    const after = JSON.parse(fs.readFileSync(path.join(sandbox, 'data', 'mood.json'), 'utf8'));
+    assert.equal(after.meta.writeable.inputs[0].autoSubmit, false);
+    assert.deepEqual(after.data, dataBefore);
+  });
+
+  test('400 on patch touching $schema', async () => {
+    const res = await req(server.baseUrl, '/api/manifests/mood', {
+      method: 'PATCH',
+      body: { $schema: 'bad' },
+    });
+    assert.equal(res.status, 400);
+    assert.match(res.json.error, /\$schema/);
+  });
+
+  test('400 on patch touching meta.id', async () => {
+    const res = await req(server.baseUrl, '/api/manifests/mood', {
+      method: 'PATCH',
+      body: { meta: { id: 'renamed' } },
+    });
+    assert.equal(res.status, 400);
+    assert.match(res.json.error, /meta\.id/);
+  });
+
+  test('400 on patch touching data', async () => {
+    const res = await req(server.baseUrl, '/api/manifests/mood', {
+      method: 'PATCH',
+      body: { data: [] },
+    });
+    assert.equal(res.status, 400);
+    assert.match(res.json.error, /data/);
+  });
+
+  test('400 on validation failure (null meta.label) — file unchanged', async () => {
+    const filePath = path.join(sandbox, 'data', 'mood.json');
+    const before = fs.readFileSync(filePath, 'utf8');
+    const res = await req(server.baseUrl, '/api/manifests/mood', {
+      method: 'PATCH',
+      body: { meta: { label: null } },
+    });
+    assert.equal(res.status, 400);
+    const after = fs.readFileSync(filePath, 'utf8');
+    assert.equal(after, before);
+  });
+
+  test('400 on malformed JSON body', async () => {
+    // raw string body bypasses the helper's default JSON.stringify path
+    const url = new URL('/api/manifests/mood', server.baseUrl);
+    const http = require('http');
+    const r = await new Promise((resolve, reject) => {
+      const rq = http.request({
+        method: 'PATCH',
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname,
+        headers: { 'Content-Type': 'application/json' },
+      }, res => {
+        let buf = '';
+        res.on('data', c => buf += c);
+        res.on('end', () => resolve({ status: res.statusCode, body: buf }));
+      });
+      rq.on('error', reject);
+      rq.end('not json{');
+    });
+    assert.equal(r.status, 400);
+  });
+
+  test('404 on unknown id', async () => {
+    const res = await req(server.baseUrl, '/api/manifests/ghost', {
+      method: 'PATCH',
+      body: { meta: { label: 'x' } },
+    });
+    assert.equal(res.status, 404);
+  });
+});

--- a/tests/registry-patch.test.js
+++ b/tests/registry-patch.test.js
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/registry-patch.test.js
+// Unit tests for registry.patchManifest — data preserved, meta merged,
+// protected fields rejected.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const { createSandbox, cleanupSandbox } = require('./helpers/sandbox');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const MANIFESTS_DIR = path.resolve(REPO_ROOT, 'manifests') + path.sep;
+const CONFIG_DIR = path.resolve(REPO_ROOT, 'config') + path.sep;
+
+function freshRegistry(sandboxRoot) {
+  for (const key of Object.keys(require.cache)) {
+    if (key.startsWith(MANIFESTS_DIR) || key.startsWith(CONFIG_DIR)) {
+      delete require.cache[key];
+    }
+  }
+  process.env.HEALTH_HOME = sandboxRoot;
+  return require(path.join(REPO_ROOT, 'manifests', 'registry.js'));
+}
+
+const MOOD_MANIFEST = {
+  $schema: 'klebb.datafile.v1',
+  meta: {
+    id: 'mood',
+    label: 'Mood',
+    emoji: '🙂',
+    writeable: {
+      fromWebapp: true,
+      inputs: [
+        { key: 'mood', type: 'emoji-picker', autoSubmit: true, emitIndex: true },
+        { key: 'notes', type: 'textarea' },
+      ],
+    },
+  },
+  description: 'Daily mood tracker.',
+  data: [
+    { date: '2026-05-04', mood: 4, notes: 'good day' },
+    { date: '2026-05-05', mood: 5 },
+  ],
+};
+
+describe('registry.patchManifest', () => {
+  test('patches meta; data preserved byte-for-byte', () => {
+    const sandbox = createSandbox({ seed: { 'mood.json': MOOD_MANIFEST } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      const before = JSON.parse(fs.readFileSync(path.join(sandbox, 'data', 'mood.json'), 'utf8'));
+      assert.equal(before.meta.writeable.inputs[0].autoSubmit, true);
+
+      registry.patchManifest('mood', {
+        meta: {
+          writeable: {
+            inputs: [
+              { key: 'mood', type: 'emoji-picker', autoSubmit: false, emitIndex: true },
+              { key: 'notes', type: 'textarea' },
+            ],
+          },
+        },
+      });
+
+      const after = JSON.parse(fs.readFileSync(path.join(sandbox, 'data', 'mood.json'), 'utf8'));
+      assert.equal(after.meta.writeable.inputs[0].autoSubmit, false);
+      assert.equal(after.meta.writeable.fromWebapp, true, 'unrelated meta kept');
+      assert.deepEqual(after.data, before.data, 'data unchanged');
+      assert.equal(after.description, before.description);
+      assert.equal(after.$schema, 'klebb.datafile.v1');
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('null in patch removes a meta key', () => {
+    const sandbox = createSandbox({ seed: { 'mood.json': MOOD_MANIFEST } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      registry.patchManifest('mood', { meta: { emoji: null } });
+      const after = JSON.parse(fs.readFileSync(path.join(sandbox, 'data', 'mood.json'), 'utf8'));
+      assert.equal('emoji' in after.meta, false, 'emoji key removed');
+      assert.equal(after.meta.label, 'Mood', 'other meta preserved');
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('description patch: string replaces, null removes', () => {
+    const sandbox = createSandbox({ seed: { 'mood.json': MOOD_MANIFEST } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      registry.patchManifest('mood', { description: 'New description.' });
+      let after = JSON.parse(fs.readFileSync(path.join(sandbox, 'data', 'mood.json'), 'utf8'));
+      assert.equal(after.description, 'New description.');
+      registry.patchManifest('mood', { description: null });
+      after = JSON.parse(fs.readFileSync(path.join(sandbox, 'data', 'mood.json'), 'utf8'));
+      assert.equal('description' in after, false);
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('rejects patch to $schema', () => {
+    const sandbox = createSandbox({ seed: { 'mood.json': MOOD_MANIFEST } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      assert.throws(
+        () => registry.patchManifest('mood', { $schema: 'other.v2' }),
+        /protected field: \$schema/,
+      );
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('rejects patch to meta.id', () => {
+    const sandbox = createSandbox({ seed: { 'mood.json': MOOD_MANIFEST } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      assert.throws(
+        () => registry.patchManifest('mood', { meta: { id: 'renamed' } }),
+        /protected field: meta\.id/,
+      );
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('rejects patch touching data', () => {
+    const sandbox = createSandbox({ seed: { 'mood.json': MOOD_MANIFEST } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      assert.throws(
+        () => registry.patchManifest('mood', { data: [] }),
+        /protected field: data/,
+      );
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('rejects unknown id', () => {
+    const sandbox = createSandbox();
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      assert.throws(
+        () => registry.patchManifest('ghost', { meta: { label: 'x' } }),
+        /unknown manifest: ghost/,
+      );
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('rejects non-object patch', () => {
+    const sandbox = createSandbox({ seed: { 'mood.json': MOOD_MANIFEST } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      assert.throws(() => registry.patchManifest('mood', null), /must be an object/);
+      assert.throws(() => registry.patchManifest('mood', 'string'), /must be an object/);
+      assert.throws(() => registry.patchManifest('mood', [1,2]), /must be an object/);
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('validation failure leaves file on disk unchanged', () => {
+    const sandbox = createSandbox({ seed: { 'mood.json': MOOD_MANIFEST } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      const filePath = path.join(sandbox, 'data', 'mood.json');
+      const before = fs.readFileSync(filePath, 'utf8');
+      // meta.label required; a null removes it -> validation fails.
+      assert.throws(
+        () => registry.patchManifest('mood', { meta: { label: null } }),
+        /missing meta\.label/,
+      );
+      const after = fs.readFileSync(filePath, 'utf8');
+      assert.equal(after, before, 'file untouched on validation failure');
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('in-memory cache updated after successful patch', () => {
+    const sandbox = createSandbox({ seed: { 'mood.json': MOOD_MANIFEST } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      registry.patchManifest('mood', { meta: { label: 'Feelings' } });
+      const entry = registry.get('mood');
+      assert.equal(entry.meta.label, 'Feelings');
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Gives klebbius (the chat agent) full read + edit parity with whats on
disk: read manifests including data, rewrite the data block, patch
meta in place. Closes the capability gap where the only path to
modify a card was delete+recreate (which wiped history) and the
agent had nothing better to offer.

Three new tools, one new HTTP endpoint, a system-prompt rewrite,
and 42 new tests.

## Why

Observed while deploying combination cards. User asked klebbius to
flip `autoSubmit: true → false` on the mood cards emoji-picker
input. Klebbius correctly refused delete+create (mood data worth
preserving) but had no other path — the system prompt at line 358
literally told it to give up. Thats a real gap: the agent should
be able to do anything the user can do on disk, including
modify-in-place.

## New capabilities

### Tools

- **`read_manifest(id)`** — full card content (meta, description,
  schema, data). Wraps the existing `GET /api/manifests/:id`; no
  server change. Agent calls this before any write so it can
  preserve the fields it doesnt want to touch.
- **`write_manifest_data(id, data)`** — replace the entire data
  block. Wraps the existing `POST /api/manifests/:id/data`.
  **Shape-agnostic**: works for `[{date,...}]` rows, `{items:[...]}`
  schedules, `{markdown:"..."}` blobs, etc. Rejected with
  `{error}` if the card is ingest-only
  (`writeable.fromWebapp:false`).
- **`patch_manifest(id, patch)`** — RFC 7396 JSON Merge Patch over
  `meta` and `description`. `data`, `$schema` and `meta.id` are
  protected. Nested objects deep-merge; arrays replace; `null`
  removes a key.

### Server endpoint

**`PATCH /api/manifests/:id`** — new route. Merges the body over
the stored manifest, re-validates, writes atomically via the
existing tmp+rename pattern. Returns `400` on protected-field
touch, validation failure, or malformed JSON (file on disk stays
untouched in every failure case). `404` on unknown id. Same auth
as the rest of `/api/manifests/*`.

### System-prompt rewrite

Substantial update to `DEFAULT_HEALTH_SYSTEM_PROMPT` in
`config/env.js`:

- Three new tools added to the tool list with behavioural rules.
- **When-to-use-which decision guide** — a compact table mapping
  user intent → tool.
- **Read-before-modify rule**: any `write_manifest_data` /
  `patch_manifest` must be preceded by `read_manifest` in the
  same turn so the agent never clobbers fields it hasnt seen.
- **One-shot confirmation** (same pattern as `delete_manifest`)
  required before:
  - `write_manifest_data` that removes rows.
  - `patch_manifest` that removes inputs from a writeable card.
  - `patch_manifest` that flips `writeable.fromWebapp` from
    `true → false` on a card with data.
- Stale "editing in place isnt supported yet" line removed.

## How the mood `autoSubmit` example works now

User: "turn off autoSubmit on the mood emoji picker"

1. Klebbius: `read_manifest("mood")` → sees full
   `writeable.inputs` array.
2. Klebbius: `patch_manifest("mood", { meta: { writeable: {
   inputs: [... full array with autoSubmit:false on the picker
   entry ...] } } })`.
3. Registry: merges, re-validates, writes atomically. `data`
   preserved byte-for-byte.
4. Done.

No confirmation needed (pure non-destructive patch). Mood history
untouched.

## Files

- `manifests/merge-patch.js` **(new, ~40 lines)** — pure RFC 7396
  helper.
- `manifests/registry.js` — `patchManifest(id, patch)` (~60
  lines). Re-uses `validateManifestShape` + the existing atomic
  write.
- `server.js` — `PATCH /api/manifests/:id` route.
- `chat/tools.js` — three new tool defs + dispatch cases.
- `config/env.js` — system-prompt rewrite.
- `tests/merge-patch.test.js` **(17 unit tests)** — merge
  semantics.
- `tests/registry-patch.test.js` **(10 unit tests)** —
  patchManifest round-trip, protected-field rejection,
  validation-failure rollback.
- `tests/patch-api.test.js` **(7 HTTP tests)** — status-code
  matrix, malformed body, file-unchanged on failure.
- `tests/chat-tools-crud.test.js` **(8 dispatch tests)** — tool
  registration, round-trip write, ingest-only rejection,
  protected-field rejection.

## Testing checklist

- [x] `npm test` — 439/440 passing (pre-existing
  `no-personal-refs` failure, identical on `main`).
- [x] RFC 7396 semantics: 17/17.
- [x] Registry: 10/10.
- [x] HTTP API: 7/7.
- [x] Chat dispatch: 8/8.
- [ ] Manual smoke on klebbtest: ask klebbius to toggle
  `autoSubmit` on the mood card; verify mood history preserved
  and form behaviour changes.

## Out of scope

- UI "edit card meta" form for humans. This issue is about the
  agents capability; a manual UI can follow later.
- Row-level data tools (`add_row`, `update_row`, `delete_row`).
  Shape-agnostic read-modify-write handles every data shape today
  and tomorrow; if token round-trip cost becomes an issue we can
  add row-level helpers later.
- Patching `$schema` or `meta.id`. Identity-bearing; changing them
  is effectively delete+create.

Closes #108
