### PR TITLE
docs: combination-card + HAE user docs

### DIFF
--- a/docs/CARDS.md
+++ b/docs/CARDS.md
@@ -632,6 +632,175 @@ is set automatically per row on create and isn't shown in the form.
 
 ---
 
+## The `combination-card` renderer — one card, many sources
+
+A **combination card** is a read-only window over other cards' data. It
+owns no data of its own — its `data` block stays `[]` — and instead
+projects the current day's row from each of several source manifests
+into one tile.
+
+When it's useful:
+
+- Apple-Health-style summaries ("Sleep" composed of sleep-hours + mood,
+  "Activity" composed of steps + active-minutes + workouts).
+- Morning dashboards pulling the three metrics you actually check each
+  day into one tile.
+- Any time two or three cards carry fragments of the same concept and
+  you want them shown together.
+
+### Minimum shape
+
+```json
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "sleep",
+    "label": "Sleep",
+    "emoji": "😴",
+    "view": {
+      "enabled": true,
+      "component": "combination-card",
+      "layout": "stack",
+      "combines": [
+        { "sourceId": "sleep-hours", "role": "primary", "accessor": "hours", "unit": "h" },
+        { "sourceId": "mood", "role": "secondary", "accessor": "mood" }
+      ]
+    }
+  },
+  "description": "Read-only composite of sleep-hours + mood.",
+  "data": []
+}
+```
+
+Edits happen on the source cards, not here. The combo re-fetches when
+`manifest-data-changed` fires, so changes show up immediately.
+
+### `layout`
+
+Picks the visual treatment.
+
+| value | what it renders | MVP | Notes |
+|-------|-----------------|-----|-------|
+| `stack` | Vertical label / value rows. Primary rows render large, secondary smaller, annotation muted. | ✓ | Default. |
+| `rings` | Concentric progress rings (planned). | planned | Reserved name; renders as `stack` until the ring layout ships. |
+| `chart` | Reuses `line-chart` inside the combo shell (planned). | planned | Reserved name; renders as `stack` until the chart layout ships. |
+
+Unknown layout values fall back to `stack` so typos don't break the
+card.
+
+### `combines[]`
+
+An ordered array — the order is the render order. Each entry:
+
+| field | required | meaning |
+|-------|----------|---------|
+| `sourceId` | yes | Must match a loaded manifest's `meta.id`. If absent, renderer shows a placeholder — not an error. |
+| `role` | yes | `primary` \| `secondary` \| `annotation`. Drives visual weight in `stack`. `ring-segment` and `bar-series` are reserved for future layouts. |
+| `label` | no | Overrides the source's `meta.label` for this view. |
+| `accessor` | no | Path into the day's row. Dotted paths supported (`stats.avg`). Default: first non-`date` scalar on the row. |
+| `unit` | no | Short string rendered next to the value (e.g. `h`, `kcal`). |
+| `emojiMap` | no | Stringified-value → emoji, for enum sources (`{ "1": "😩", "4": "🙂" }`). |
+
+Multiple entries can point at the same source — e.g. Sleep combo pulls
+both `mood` and `wakeUps` from the mood card via two separate
+`combines[]` entries.
+
+### Row resolution
+
+For each `combines[]` entry, the renderer resolves the viewed date to
+one of:
+
+| state | meaning | how it renders |
+|-------|---------|----------------|
+| `ok` | Source exists, row for that date exists, accessor yields a value. | Normal row. |
+| `no-source` | `sourceId` is not a loaded manifest. | Muted placeholder. |
+| `no-entry` | Source loaded but has no row for the viewed date. | Muted placeholder. |
+| `no-accessor-match` | Row exists but the accessor path yields `undefined`/`null`. | Muted placeholder. |
+
+Non-`ok` states never throw — partial data just renders muted.
+
+### Editing donor data from the combo
+
+If a source declares `writeable.fromWebapp: true` with `inputs[]`, the
+combo shows an edit pencil next to the **first row for that source**.
+Clicking opens an inline form with the donor's **full** `inputs[]`
+array (not just the fields the combo references) and writes back to
+the donor's manifest. The combo refreshes on save.
+
+Rules:
+
+- One pencil per source, not per combines row. The Mood source might
+  drive three rows in the Sleep combo (mood, wakeUps, notes) — you
+  still see one pencil.
+- Donor's `writeable.todayAllowed` / `pastAllowed` / `futureAllowed`
+  are respected verbatim. If the donor denies past-dated edits, the
+  pencil hides on past dates.
+- Ingest-only donors (`writeable.fromWebapp: false`) never show a
+  pencil. Good for atomic cards populated by Health Auto Export.
+
+### Pairing with absorbed cards
+
+A combo usually absorbs one or more atomic cards. To avoid seeing the
+same value twice on Today (once in the combo, once in the atomic
+card), set the absorbed card's `meta.enabled: false`. The card stays
+in Settings (reactive-enable later if you want) and is still editable
+via the combo.
+
+### Worked example
+
+`data.example/sleep.example.json` — the shipped Sleep preset:
+
+```json
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "sleep",
+    "label": "Sleep",
+    "emoji": "😴",
+    "order": 25,
+    "view": {
+      "enabled": true,
+      "component": "combination-card",
+      "layout": "stack",
+      "dateContext": "viewedDate",
+      "combines": [
+        {
+          "sourceId": "sleep-hours",
+          "role": "primary",
+          "label": "Asleep",
+          "accessor": "hours",
+          "unit": "h"
+        },
+        {
+          "sourceId": "mood",
+          "role": "secondary",
+          "label": "Mood",
+          "accessor": "mood",
+          "emojiMap": { "1":"😩","2":"😴","3":"😐","4":"🙂","5":"😄" }
+        },
+        {
+          "sourceId": "mood",
+          "role": "annotation",
+          "label": "Wake-ups",
+          "accessor": "wakeUps"
+        }
+      ]
+    }
+  },
+  "description": "Composite Sleep card. Read-only view over sleep-hours + mood.",
+  "data": []
+}
+```
+
+Drop that alongside working `sleep-hours.json` + `mood.json` files and
+you'll see one Sleep tile showing hours + mood + wake-ups, with a
+pencil next to the Mood row (if mood is writeable).
+
+See also `data.example/activity.example.json` for an Activity combo
+over `steps` + `active-minutes` + `workouts`.
+
+---
+
 ## The `data` block
 
 Card-specific. The convention for most cards is an array of dated entries:

--- a/docs/HEALTH-AUTO-EXPORT.md
+++ b/docs/HEALTH-AUTO-EXPORT.md
@@ -1,0 +1,158 @@
+# Health Auto Export — iPhone health data into klebb
+
+Klebb can receive a webhook push from the iPhone
+[Health Auto Export](https://apps.apple.com/app/health-auto-export-json-csv/id1115567069)
+app. Each push writes the raw payload to disk for audit, then upserts
+daily rows into four atomic manifests that the Sleep and Activity
+combination cards consume.
+
+This page tells you how to set it up.
+
+---
+
+## What gets populated
+
+With the webhook enabled, each HAE push updates these four manifests:
+
+| Source metric (HAE) | Klebb manifest | Row shape |
+|---------------------|----------------|-----------|
+| `sleep_analysis` | `sleep-hours` | `{ date, hours, source? }` |
+| `step_count` (summed per date) | `steps` | `{ date, count }` |
+| `apple_exercise_time` (summed per date) | `active-minutes` | `{ date, minutes }` |
+| `workouts[]` | `workouts` | `{ date, trained: true, type }` |
+
+A manifest is created automatically on the first push if it doesn't
+already exist. Re-posting the same date overwrites only that date's
+row; other dates are untouched.
+
+The raw payload is archived unchanged at
+`$HEALTH_HOME/data/auto-export/raw/<ms-stamp>.json` regardless of
+whether parsing succeeds. Safe to delete at any time if disk space
+is tight.
+
+---
+
+## Setup
+
+### 1. Enable the endpoint
+
+Set `HEALTH_AUTO_EXPORT_TOKEN` in your klebb `.env` to any long random
+string. `openssl rand -hex 32` is a fine source.
+
+```
+HEALTH_AUTO_EXPORT_TOKEN=<your-random-hex>
+```
+
+Restart klebb (or `docker compose restart` if you run in Docker).
+
+Without this env var the endpoint returns **501** — the feature is
+off by default.
+
+### 2. Configure the iPhone app
+
+In Health Auto Export:
+
+1. **Automations** → **Add Automation** → **REST API**.
+2. **URL**: `https://<your-klebb-host>/api/health-auto-export`
+3. **Method**: `POST`
+4. **Headers**:
+   ```
+   Content-Type: application/json
+   Authorization: Bearer <your-HEALTH_AUTO_EXPORT_TOKEN>
+   ```
+5. **Metrics**: select at minimum Sleep Analysis, Step Count, Apple
+   Exercise Time, Workouts. Add any others you want archived — the
+   server ignores metrics it doesn't recognise but still keeps them
+   in the raw archive.
+6. **Export format**: JSON.
+7. **Frequency**: every 6 hours is a reasonable default. Hourly also
+   works; klebb is cheap to hit.
+
+### 3. Verify
+
+Manually trigger the first push from the HAE app, or wait for the
+schedule.
+
+```
+$ curl -s https://<your-klebb>/api/manifests/sleep-hours/data | jq '.data[-1]'
+{
+  "date": "2026-05-04",
+  "hours": 7.8,
+  "source": "Apple Watch"
+}
+
+$ ls $HEALTH_HOME/data/auto-export/raw/
+2026-05-04T115853012Z.json
+```
+
+If nothing shows up:
+
+- Check klebb's logs for `[hae]` lines.
+- Hit the endpoint manually with `curl -X POST -H "Authorization:
+  Bearer <token>" -H "Content-Type: application/json" -d
+  '{"data":{}}'` — expect `200 {"ok":true,"ingested":{...}}`.
+- Wrong token → `401`.
+- Missing env var → `501`.
+
+---
+
+## Atomic manifests are ingest-only by default
+
+The four atomic manifests listed above (`sleep-hours`, `steps`,
+`active-minutes`, `workouts`) ship with `writeable.fromWebapp: false`.
+That means klebb's webapp shows them read-only: no `+` button, no
+edit form. HAE is their only writer.
+
+The rationale: manual entry plus ingest would double-display the same
+metric on Today (combo card + atomic card + input form) and every
+HAE push would silently overwrite whatever you typed. Ingest-only
+avoids both problems.
+
+If you're not using HAE and want to log these metrics by hand,
+either:
+
+- Flip `writeable.fromWebapp: true` in the manifest file (and add an
+  `inputs[]` block), or
+- Ask klebbius: "make the steps card writeable from the webapp with
+  a single number input for count". It'll patch the manifest in
+  place.
+
+---
+
+## Endpoint reference
+
+```
+POST /api/health-auto-export
+Authorization: Bearer <HEALTH_AUTO_EXPORT_TOKEN>
+Content-Type: application/json
+```
+
+| Response | Meaning |
+|----------|---------|
+| `200 {ok:true, ingested:{...}}` | Parsed and upserted. Counts per source. |
+| `200 {ok:true, warning:"..."}` | Parse or upsert failed but raw was archived. HAE will retry. |
+| `401` | Token missing or wrong. |
+| `501 {error:"ingest disabled"}` | `HEALTH_AUTO_EXPORT_TOKEN` env var not set. |
+
+Errors after auth passes are swallowed into `200 + warning` on
+purpose: the iPhone app retries aggressively on non-2xx, and we'd
+rather have a raw archive to debug than a spiral.
+
+---
+
+## What's not in MVP
+
+- **Richer sleep manifests** (stages, bed/wake times, HRV, respiration).
+  Coming in a follow-up that adds `sleep-stages` and `sleep-bed-wake`
+  manifests alongside the current `sleep-hours`.
+- **Per-workout detail** (type, duration, avg/max HR, distance). The
+  current `workouts` card is a one-bit `trained: true` summary;
+  richer data lands with a `workouts-detailed` manifest later.
+- **Vitals ingestion** (heart rate, HRV, SpO₂, blood oxygen). Raw is
+  archived; the parser doesn't yet fan out to manifests.
+- **File-drop mode** (iCloud sync). HTTP webhook is the only
+  supported transport today.
+
+See the ingest parser at `health-auto-export/ingest.js` if you want to
+add metrics — the parser is pure, ~100 lines, and straightforward to
+extend.

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -681,6 +681,70 @@ See `data.example/mood.example.json` (field-emoji),
 
 ---
 
+## Recipe 12 — Morning dashboard combination card
+
+**Goal.** One tile on Today that surfaces three metrics you actually
+check each morning — last night's sleep, today's mood, and steps so
+far. Read-only; edits happen on the underlying cards.
+
+**Prerequisites.** You already have `sleep-hours`, `mood`, and
+`steps` cards. If not, build them first with Recipes 1, 3, 1.
+
+**File.** `$HEALTH_HOME/data/morning.json`:
+
+```json
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "morning",
+    "label": "Morning",
+    "emoji": "☀️",
+    "order": 10,
+    "view": {
+      "enabled": true,
+      "component": "combination-card",
+      "layout": "stack",
+      "dateContext": "viewedDate",
+      "combines": [
+        { "sourceId": "sleep-hours", "role": "primary",   "label": "Asleep", "accessor": "hours", "unit": "h" },
+        { "sourceId": "mood",        "role": "secondary", "label": "Mood",   "accessor": "mood",
+          "emojiMap": { "1":"😩","2":"😴","3":"😐","4":"🙂","5":"😄" } },
+        { "sourceId": "steps",       "role": "annotation","label": "Steps",  "accessor": "count" }
+      ]
+    }
+  },
+  "description": "Read-only morning summary over sleep-hours, mood, steps.",
+  "data": []
+}
+```
+
+**What you get.**
+
+- A single "Morning" tile on Today with three rows: a large sleep
+  headline, a medium mood emoji, a muted step count.
+- If `mood.meta.writeable.fromWebapp` is `true`, an edit pencil next
+  to the Mood row opens a form over `mood.json`. `sleep-hours` and
+  `steps` stay read-only (typical when they're populated by Health
+  Auto Export, see `docs/HEALTH-AUTO-EXPORT.md`).
+- Empty states: if any source has no row for the viewed date, its
+  row renders muted with a "no entry" hint instead of breaking the
+  layout.
+
+**Tips.**
+
+- Set the absorbed source's `meta.enabled: false` (via Settings or
+  klebbius) to avoid the mood card showing twice on Today.
+- Multiple `combines[]` entries can point at the same source — e.g.
+  pull both `mood` and `wakeUps` off the mood card as two rows.
+- Accessor is dotted-path aware: `accessor: "stats.avg"` reads
+  nested scalars.
+
+See `docs/CARDS.md` → "The `combination-card` renderer" for the full
+field reference, including how the pencil inherits donor date rules
+and why only one pencil per donor renders.
+
+---
+
 ## Next steps
 
 - For the full manifest spec (every field, every input type, every


### PR DESCRIPTION
## Summary

Capstone docs for the MVP feature stack.

- **`docs/CARDS.md`** — new "combination-card renderer" section
  alongside the existing generic-card and list-card sections.
  Covers:
  - `layout` (`stack` ships; `rings` and `chart` are reserved
    names that fall back to stack until their renderers land).
  - `combines[]` field reference with a table per field.
  - Row-resolution states (`ok` / `no-source` / `no-entry` /
    `no-accessor-match`).
  - Writeable donor rows — when the pencil shows, one-per-donor
    rule, donor date-window rules inherited verbatim.
  - Pair-with-hidden-absorbed-card pattern.
  - Worked example matching `data.example/sleep.example.json`.

- **`docs/HEALTH-AUTO-EXPORT.md`** — new one-pager for the iPhone
  webhook. What gets populated, `.env` + iPhone app setup steps,
  verification `curl`s, endpoint response table, what's explicitly
  deferred (richer sleep/workout manifests, vitals, file-drop).

- **`docs/RECIPES.md`** — Recipe 12 "Morning dashboard" combo over
  `sleep-hours` + `mood` + `steps`. Walks a user through authoring
  their first combo end-to-end.

## Why

Combination cards, HAE ingest, and the ingest-only atomic cards all
merged (#101 / #97 / #102 / #103 / #105) but had no user-facing
docs. A reader new to klebb couldn't author a working combo
manifest or set up HAE without reading source.

## Testing checklist

- [x] `npm test` — no regressions (the only failing test,
  `no-personal-refs`, fails identically on `main`; none of my diff
  introduces a new hit).
- [x] Markdown renders fine on GitHub (preview).
- [x] Hygiene scan: zero hits in the added content.

Closes #95