### PR TITLE
feat(renderer): combination-card layout:rings

### DIFF
--- a/MANIFEST-SCHEMA.md
+++ b/MANIFEST-SCHEMA.md
@@ -448,9 +448,10 @@ Picks the visual treatment.
 | value | behaviour |
 |-------|-----------|
 | `stack` | Vertical label/value rows. Primary rows render large, secondary smaller, annotation muted. |
+| `rings` | Concentric progress arcs driven by `role: "ring-segment"` entries. Non-ring roles render as a stack row below the arcs. |
 
-Values `rings` and `chart` are reserved for future renderers. An
-unknown layout falls back to `stack`.
+Value `chart` is reserved for a future line-chart layout. Unknown
+layouts fall back to `stack`.
 
 ### `combines[]`
 
@@ -459,11 +460,13 @@ An ordered array of source entries. Each entry:
 | field | required | meaning |
 |-------|----------|---------|
 | `sourceId` | yes | Must match a loaded manifest's `meta.id`. Missing source renders a placeholder, not an error. |
-| `role` | yes | `primary` \| `secondary` \| `annotation`. Drives visual weight. `ring-segment` and `bar-series` are reserved. |
+| `role` | yes | `primary` \| `secondary` \| `annotation` \| `ring-segment`. Drives visual treatment. `bar-series` is reserved. |
 | `label` | no | Overrides the source's `meta.label` for this view. |
 | `accessor` | no | Path into the day's row. Dotted paths (`stats.avg`) supported. Default: first non-`date` scalar on the row. |
 | `unit` | no | Short string rendered next to the value (e.g. `h`, `kcal`). |
 | `emojiMap` | no | Stringified-value → emoji, for enum sources (mood, etc). |
+| `goalDaily` | yes for `ring-segment` | Positive finite number. Ring fills `min(value / goalDaily, 1)`; overshoot paints a "complete" glow. |
+| `colour` | no | CSS colour for a `ring-segment`. Falls back to the renderer's theme palette by ring index. |
 
 ### Row resolution
 
@@ -475,9 +478,12 @@ For a viewed date, the renderer resolves each source to one of:
 | `no-source` | `sourceId` is not a loaded manifest. |
 | `no-entry` | Source loaded but has no row for the viewed date. |
 | `no-accessor-match` | Row exists but the accessor yields `undefined`/`null`. |
+| `no-goal` | Ring-segment entry missing a positive finite `goalDaily`. |
 
 States other than `ok` render as a muted placeholder so partial data
-doesn't break the layout.
+doesn't break the layout. Ring-segment entries with `state: "ok"`
+additionally carry `goalDaily`, `ratio` (unclamped; `>1` means
+overshoot), and `complete` (boolean; `ratio >= 1`).
 
 ### Editing
 
@@ -485,6 +491,24 @@ Combination cards are read-only; they have no `writeable` block and
 emit no writes. To change a value, edit the source manifest; the
 combo re-resolves on `manifest-data-changed` (fired by the app shell
 whenever any manifest's data block changes).
+
+### Rings layout specifics
+
+`layout: "rings"` renders one concentric progress arc per entry with
+`role: "ring-segment"`. Each such entry needs a numeric accessor and
+a `goalDaily` target. Overshoots (`value > goalDaily`) fill the full
+ring and paint a complete indicator on the legend row; missing or
+malformed goals render a muted placeholder.
+
+Non-ring-segment roles in the same `combines[]` array (primary /
+secondary / annotation) render as stack-style rows beneath the ring
+figure — useful for a one-off "trained today?" flag or free-text
+notes sitting next to rings.
+
+Ring colour falls back to the renderer's theme palette by ring
+index; set `colour` on the entry to override.
+
+See `data.example/activity-rings.example.json` for a worked example.
 
 ### Typical pairing
 

--- a/data.example/activity-rings.example.json
+++ b/data.example/activity-rings.example.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "activity-rings",
+    "label": "Activity Rings",
+    "emoji": "🏅",
+    "order": 66,
+    "enabled": false,
+    "view": {
+      "enabled": true,
+      "component": "combination-card",
+      "layout": "rings",
+      "dateContext": "viewedDate",
+      "combines": [
+        {
+          "sourceId": "steps",
+          "role": "ring-segment",
+          "label": "Steps",
+          "accessor": "count",
+          "goalDaily": 10000,
+          "unit": "steps",
+          "colour": "#0ea5e9"
+        },
+        {
+          "sourceId": "active-minutes",
+          "role": "ring-segment",
+          "label": "Active",
+          "accessor": "minutes",
+          "goalDaily": 30,
+          "unit": "min",
+          "colour": "#f59e0b"
+        },
+        {
+          "sourceId": "workouts",
+          "role": "annotation",
+          "label": "Trained",
+          "accessor": "trained"
+        }
+      ]
+    }
+  },
+  "description": "Alternate Activity preset using layout: 'rings'. Two concentric progress arcs for Steps (/10000/day) and Active Minutes (/30/day). Trained? renders as an annotation row beneath. Read-only: values come from the steps, active-minutes, and workouts cards (normally populated by Health Auto Export). Ships disabled by default so it doesn't duplicate the stack-layout activity card; flip meta.enabled:true (Settings or klebbius) and optionally disable activity.example.json to swap.",
+  "data": []
+}

--- a/public/js/components/eh-combination-card.js
+++ b/public/js/components/eh-combination-card.js
@@ -6,14 +6,16 @@
 //
 // Opt a manifest into this renderer by setting:
 //   meta.view.component = "combination-card"
-//   meta.view.layout    = "stack"   (MVP; "rings" and "chart" reserved)
+//   meta.view.layout    = "stack" | "rings"   ("chart" reserved)
 //   meta.view.combines  = [ { sourceId, role, label?, accessor?, unit?, emojiMap? } ]
 //
-// See MANIFEST-SCHEMA.md "Combination cards" for the full contract.
+// Ring-segment entries (role: "ring-segment") carry goalDaily + optional
+// colour. See MANIFEST-SCHEMA.md "Combination cards" for the full contract.
 
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
 import { registerRenderer } from '../renderer-registry.js';
 import { resolveCombines, canEditDonor } from '../lib/combines-resolver.esm.js';
+import { loadECharts, chartTheme } from './eh-chart-base.js';
 import './eh-input-form.js';
 
 export class EhCombinationCard extends LitElement {
@@ -52,6 +54,9 @@ export class EhCombinationCard extends LitElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     window.removeEventListener('manifest-data-changed', this._onDataChanged);
+    if (this._chart) { try { this._chart.dispose(); } catch {} this._chart = null; }
+    if (this._themeObserver) { this._themeObserver.disconnect(); this._themeObserver = null; }
+    if (this._resizeObserver) { this._resizeObserver.disconnect(); this._resizeObserver = null; }
   }
 
   _onDataChanged(e) {
@@ -70,8 +75,9 @@ export class EhCombinationCard extends LitElement {
 
   _layout() {
     const l = this.card?.viewConfig?.layout || 'stack';
-    // Unknown layouts fall back to stack (documented behaviour).
-    return l === 'stack' ? 'stack' : 'stack';
+    // Known layouts pass through; unknown fall back to stack.
+    if (l === 'stack' || l === 'rings') return l;
+    return 'stack';
   }
 
   async _fetchAll() {
@@ -107,9 +113,9 @@ export class EhCombinationCard extends LitElement {
     }
   }
 
-  updated(changed) {
-    if (changed.has('card')) this._fetchAll();
-  }
+  // `updated()` is defined further down in the rings lifecycle section
+  // so it can also drive the ECharts refresh; it handles `card` change
+  // identically to what used to live here.
 
   // --- Editable donor support ---
 
@@ -275,6 +281,7 @@ export class EhCombinationCard extends LitElement {
   render() {
     const m = this.card?.meta || {};
     const combines = this._combines();
+    const layout = this._layout();
 
     if (this._loading) {
       return html`
@@ -289,7 +296,6 @@ export class EhCombinationCard extends LitElement {
     }
 
     const resolved = resolveCombines(combines, this._sources, this.date);
-    const allMissing = resolved.length > 0 && resolved.every(r => r.state !== 'ok');
     const firstByDonor = this._firstRowIndexPerDonor(resolved);
 
     return html`
@@ -300,22 +306,195 @@ export class EhCombinationCard extends LitElement {
           ${this.dateMode === 'future' ? html`<span class="badge future">🔮 Planned</span>` : ''}
           ${this.dateMode === 'past'   ? html`<span class="badge past">Past</span>` : ''}
         </div>
-        <div class="body layout-${this._layout()}">
+        <div class="body layout-${layout}">
           ${combines.length === 0 ? html`
             <div class="empty">No sources configured.</div>
-          ` : allMissing ? html`
-            <div class="empty">No data for this date.</div>
-          ` : resolved.map((r, i) => {
-            const isFirstForDonor = firstByDonor[r.sourceId] === i;
+          ` : layout === 'rings'
+            ? this._renderRings(resolved, firstByDonor)
+            : this._renderStack(resolved, firstByDonor)}
+          ${this._editingDonor ? this._renderEditForm(this._editingDonor) : ''}
+        </div>
+      </div>
+    `;
+  }
+
+  _renderStack(resolved, firstByDonor) {
+    const allMissing = resolved.length > 0 && resolved.every(r => r.state !== 'ok');
+    if (allMissing) return html`<div class="empty">No data for this date.</div>`;
+    return resolved.map((r, i) => {
+      const isFirstForDonor = firstByDonor[r.sourceId] === i;
+      const showPencil = isFirstForDonor
+                       && r.sourceId !== this._editingDonor
+                       && this._canEditDonor(r.sourceId);
+      return this._renderRow(r, showPencil);
+    });
+  }
+
+  _renderRings(resolved, firstByDonor) {
+    // Partition: ring-segment entries drive the gauge, everything else
+    // renders below as normal stack rows. Non-ring-segment roles behave
+    // exactly as in `stack` layout.
+    const ringEntries = resolved.filter(r => r.role === 'ring-segment');
+    const otherEntries = resolved.filter(r => r.role !== 'ring-segment');
+
+    if (ringEntries.length === 0) {
+      return html`<div class="empty">No ring segments configured. Add role: "ring-segment" entries with goalDaily.</div>`;
+    }
+
+    return html`
+      <div class="rings-figure">
+        <div class="rings-chart"></div>
+      </div>
+      <div class="rings-legend">
+        ${ringEntries.map((r, i) => this._renderRingLegend(r, i))}
+      </div>
+      ${otherEntries.length > 0 ? html`
+        <div class="rings-extras">
+          ${otherEntries.map((r) => {
+            // Still honour per-donor pencil rules for non-ring rows.
+            const donorIdx = resolved.indexOf(r);
+            const isFirstForDonor = firstByDonor[r.sourceId] === donorIdx;
             const showPencil = isFirstForDonor
                              && r.sourceId !== this._editingDonor
                              && this._canEditDonor(r.sourceId);
             return this._renderRow(r, showPencil);
           })}
-          ${this._editingDonor ? this._renderEditForm(this._editingDonor) : ''}
         </div>
+      ` : ''}
+    `;
+  }
+
+  _renderRingLegend(resolved, index) {
+    const label = resolved.label || resolved.sourceId;
+    const theme = this._cachedTheme || chartTheme();
+    const colour = resolved.colour || theme.color[index % theme.color.length];
+
+    if (resolved.state !== 'ok') {
+      const hint = resolved.state === 'no-goal' ? 'needs goalDaily'
+                 : resolved.state === 'no-source' ? 'source not loaded'
+                 : resolved.state === 'no-entry' ? 'no entry for this date'
+                 : 'no value';
+      return html`
+        <div class="ring-legend-row placeholder">
+          <span class="ring-swatch" style="background:${colour};opacity:.3;"></span>
+          <span class="ring-label">${label}</span>
+          <span class="ring-placeholder">${hint}</span>
+        </div>
+      `;
+    }
+
+    const pct = Math.round(resolved.ratio * 100);
+    const valueStr = resolved.displayValue;
+    const goalStr = String(resolved.goalDaily);
+    return html`
+      <div class="ring-legend-row ${resolved.complete ? 'complete' : ''}">
+        <span class="ring-swatch" style="background:${colour};"></span>
+        <span class="ring-label">${label}</span>
+        <span class="ring-values">
+          <span class="ring-value">${valueStr}</span>
+          <span class="ring-sep">/</span>
+          <span class="ring-goal">${goalStr}${resolved.unit ? ` ${resolved.unit}` : ''}</span>
+          <span class="ring-pct">${pct}%${resolved.complete ? ' ✨' : ''}</span>
+        </span>
       </div>
     `;
+  }
+
+  // --- ECharts lifecycle for rings layout ---
+
+  firstUpdated() { this._maybeUpdateChart(); }
+
+  async _maybeUpdateChart() {
+    if (this._layout() !== 'rings') {
+      // If we swapped away from rings, tear down the chart.
+      if (this._chart) { try { this._chart.dispose(); } catch {} this._chart = null; }
+      return;
+    }
+    const el = this.renderRoot.querySelector('.rings-chart');
+    if (!el) return;
+    const echarts = await loadECharts();
+    if (!this._chart) {
+      this._chart = echarts.init(el);
+      this._themeObserver = new MutationObserver(() => {
+        this._cachedTheme = null;
+        this._applyChart();
+        this.requestUpdate();  // re-render legend so swatches match new theme
+      });
+      this._themeObserver.observe(document.documentElement, {
+        attributes: true, attributeFilter: ['data-theme'],
+      });
+      if (typeof ResizeObserver !== 'undefined') {
+        this._resizeObserver = new ResizeObserver(() => {
+          try { this._chart.resize(); } catch {}
+        });
+        this._resizeObserver.observe(el);
+      }
+    }
+    this._applyChart();
+  }
+
+  _applyChart() {
+    if (!this._chart) return;
+    const theme = chartTheme();
+    this._cachedTheme = theme;
+    const resolved = resolveCombines(this._combines(), this._sources, this.date);
+    const ringEntries = resolved.filter(r => r.role === 'ring-segment');
+
+    // Concentric gauges. ECharts gauge supports radius as a percentage of
+    // the container; we space rings by 18% radius per layer.
+    const BASE_RADIUS = 88;
+    const GAP = 18;
+    const series = ringEntries.map((r, i) => {
+      const colour = r.colour || theme.color[i % theme.color.length];
+      const radius = Math.max(BASE_RADIUS - i * GAP, 30);
+      const value = r.state === 'ok' ? Math.min(r.ratio, 1) : 0;
+      return {
+        type: 'gauge',
+        radius: `${radius}%`,
+        startAngle: 90,
+        endAngle: -270,
+        min: 0,
+        max: 1,
+        progress: {
+          show: true,
+          width: 12,
+          roundCap: true,
+          itemStyle: { color: colour },
+        },
+        axisLine: {
+          lineStyle: {
+            width: 12,
+            color: [[1, theme.yAxis?.splitLine?.lineStyle?.color || 'rgba(128,128,128,0.15)']],
+          },
+        },
+        pointer: { show: false },
+        axisTick: { show: false },
+        splitLine: { show: false },
+        axisLabel: { show: false },
+        title: { show: false },
+        detail: { show: false },
+        data: [{ value }],
+        animation: true,
+        animationDuration: 600,
+      };
+    });
+
+    this._chart.setOption({
+      ...theme,
+      backgroundColor: 'transparent',
+      series,
+    }, true);
+  }
+
+  updated(changed) {
+    // Trigger _fetchAll when `card` changes (existing behaviour) AND refresh
+    // the chart when inputs that affect it change.
+    if (changed.has('card')) {
+      this._fetchAll();
+    }
+    if (!this._loading) {
+      this._maybeUpdateChart();
+    }
   }
 
   static styles = css`
@@ -464,6 +643,82 @@ export class EhCombinationCard extends LitElement {
 
     @media (prefers-reduced-motion: reduce) {
       .edit-btn { transition: none; }
+    }
+
+    /* --- Rings layout --- */
+    .body.layout-rings { display: flex; flex-direction: column; gap: 10px; }
+
+    .rings-figure {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+    .rings-chart {
+      width: 100%;
+      max-width: 260px;
+      height: 180px;
+    }
+
+    .rings-legend {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .ring-legend-row {
+      display: flex;
+      align-items: baseline;
+      gap: 8px;
+      font-size: 13px;
+      min-width: 0;
+    }
+    .ring-legend-row.placeholder { opacity: 0.7; }
+    .ring-legend-row.complete .ring-pct {
+      color: var(--accent-green, #44ff88);
+      font-weight: 700;
+    }
+    .ring-swatch {
+      display: inline-block;
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+    .ring-label {
+      color: var(--text-muted, var(--text-secondary));
+      font-size: 13px;
+      flex-shrink: 0;
+    }
+    .ring-values {
+      margin-left: auto;
+      display: inline-flex;
+      align-items: baseline;
+      gap: 4px;
+      color: var(--text-primary);
+    }
+    .ring-value { font-weight: 600; }
+    .ring-sep { opacity: 0.4; }
+    .ring-goal {
+      font-size: 11px;
+      color: var(--text-muted, var(--text-secondary));
+    }
+    .ring-pct {
+      margin-left: 6px;
+      font-size: 12px;
+      color: var(--text-muted, var(--text-secondary));
+    }
+    .ring-placeholder {
+      margin-left: auto;
+      font-size: 11px;
+      font-style: italic;
+      color: var(--text-muted, var(--text-secondary));
+    }
+
+    .rings-extras {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      padding-top: 8px;
+      border-top: 1px solid var(--border);
     }
   `;
 }

--- a/public/js/lib/combines-resolver.esm.js
+++ b/public/js/lib/combines-resolver.esm.js
@@ -44,14 +44,24 @@ export function stringifyValue(value, emojiMap) {
 
 export function resolveEntry(entry, sources, date) {
   const sourceId = entry?.sourceId;
+  const role = entry?.role || 'annotation';
   const base = {
     sourceId,
-    role: entry?.role || 'annotation',
+    role,
     label: entry?.label || null,
     unit: entry?.unit || null,
     colour: entry?.colour || null,
     emojiMap: entry?.emojiMap || null,
   };
+
+  const isRingSegment = role === 'ring-segment';
+  const goalDaily = isRingSegment ? Number(entry?.goalDaily) : null;
+  const hasValidGoal = isRingSegment
+    && Number.isFinite(goalDaily)
+    && goalDaily > 0;
+  if (isRingSegment && !hasValidGoal) {
+    return { ...base, state: 'no-goal', value: null, displayValue: null, row: null };
+  }
 
   if (!sourceId) {
     return { ...base, state: 'no-source', value: null, displayValue: null, row: null };
@@ -80,13 +90,25 @@ export function resolveEntry(entry, sources, date) {
     return { ...base, state: 'no-accessor-match', value: null, displayValue: null, row };
   }
 
-  return {
+  const result = {
     ...base,
     state: 'ok',
     value,
     displayValue: stringifyValue(value, base.emojiMap),
     row,
   };
+
+  if (isRingSegment) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+      return { ...base, state: 'no-accessor-match', value: null, displayValue: null, row };
+    }
+    result.goalDaily = goalDaily;
+    result.ratio = numeric / goalDaily;
+    result.complete = result.ratio >= 1;
+  }
+
+  return result;
 }
 
 export function resolveCombines(combines, sources, date) {

--- a/public/js/lib/combines-resolver.js
+++ b/public/js/lib/combines-resolver.js
@@ -16,11 +16,17 @@
 // Each resolved row has:
 //   {
 //     sourceId, role, label, unit, colour?, emojiMap?,
-//     state: 'ok' | 'no-source' | 'no-entry' | 'no-accessor-match',
+//     state: 'ok' | 'no-source' | 'no-entry' | 'no-accessor-match' | 'no-goal',
 //     value: any | null,
 //     displayValue: string | null,  // value rendered to a display string
 //     row: object | null,            // the full source row, or null
+//     // Present only when role === 'ring-segment' and state === 'ok':
+//     goalDaily?: number,
+//     ratio?: number,        // value / goalDaily (unclamped; > 1 means overshoot)
+//     complete?: boolean,    // ratio >= 1
 //   }
+// The 'no-goal' state is emitted when a ring-segment entry is missing
+// a positive finite goalDaily — renderer treats it as a placeholder.
 
 (function (root, factory) {
   if (typeof module === 'object' && module.exports) {
@@ -74,14 +80,27 @@
 
   function resolveEntry(entry, sources, date) {
     const sourceId = entry?.sourceId;
+    const role = entry?.role || 'annotation';
     const base = {
       sourceId,
-      role: entry?.role || 'annotation',
+      role,
       label: entry?.label || null,
       unit: entry?.unit || null,
       colour: entry?.colour || null,
       emojiMap: entry?.emojiMap || null,
     };
+
+    // Ring-segment entries MUST carry a positive finite goalDaily; without
+    // one there's nothing to compute a ratio against. Renderer shows a
+    // muted placeholder for this state, same as no-entry.
+    const isRingSegment = role === 'ring-segment';
+    const goalDaily = isRingSegment ? Number(entry?.goalDaily) : null;
+    const hasValidGoal = isRingSegment
+      && Number.isFinite(goalDaily)
+      && goalDaily > 0;
+    if (isRingSegment && !hasValidGoal) {
+      return { ...base, state: 'no-goal', value: null, displayValue: null, row: null };
+    }
 
     if (!sourceId) {
       return { ...base, state: 'no-source', value: null, displayValue: null, row: null };
@@ -111,13 +130,25 @@
       return { ...base, state: 'no-accessor-match', value: null, displayValue: null, row };
     }
 
-    return {
+    const result = {
       ...base,
       state: 'ok',
       value,
       displayValue: stringifyValue(value, base.emojiMap),
       row,
     };
+
+    if (isRingSegment) {
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric)) {
+        return { ...base, state: 'no-accessor-match', value: null, displayValue: null, row };
+      }
+      result.goalDaily = goalDaily;
+      result.ratio = numeric / goalDaily;
+      result.complete = result.ratio >= 1;
+    }
+
+    return result;
   }
 
   function resolveCombines(combines, sources, date) {

--- a/tests/combination-card.view.test.js
+++ b/tests/combination-card.view.test.js
@@ -232,3 +232,118 @@ describe('combination-card writeable donor save path', () => {
     assert.deepEqual(res.json.data, []);
   });
 });
+
+// --- layout: rings (issue #111) ---
+// Verify the rings preset round-trips through the view API with
+// goalDaily + colour intact, so the client renderer sees the full
+// config.
+describe('combination-card layout:"rings" round-trip', () => {
+  let sandbox, server;
+
+  const steps = {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'steps',
+      label: 'Steps',
+      view: { enabled: true, component: 'generic-card', display: { template: '{count}' } },
+      writeable: { fromWebapp: false },
+    },
+    data: [{ date: '2026-05-05', count: 7200 }],
+  };
+
+  const active = {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'active-minutes',
+      label: 'Active Minutes',
+      view: { enabled: true, component: 'generic-card', display: { template: '{minutes}' } },
+      writeable: { fromWebapp: false },
+    },
+    data: [{ date: '2026-05-05', minutes: 45 }],
+  };
+
+  const workouts = {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'workouts',
+      label: 'Workouts',
+      view: { enabled: true, component: 'generic-card', display: { template: '{trained}' } },
+      writeable: { fromWebapp: false },
+    },
+    data: [{ date: '2026-05-05', trained: true, type: 'Running' }],
+  };
+
+  const activityRings = {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'activity-rings',
+      label: 'Activity Rings',
+      emoji: '🏅',
+      order: 66,
+      view: {
+        enabled: true,
+        component: 'combination-card',
+        layout: 'rings',
+        combines: [
+          { sourceId: 'steps',          role: 'ring-segment', label: 'Steps',  accessor: 'count',   goalDaily: 10000, unit: 'steps', colour: '#0ea5e9' },
+          { sourceId: 'active-minutes', role: 'ring-segment', label: 'Active', accessor: 'minutes', goalDaily: 30,    unit: 'min',   colour: '#f59e0b' },
+          { sourceId: 'workouts',       role: 'annotation',   label: 'Trained', accessor: 'trained' },
+        ],
+      },
+    },
+    data: [],
+  };
+
+  before(async () => {
+    sandbox = createSandbox({
+      seed: {
+        'steps.json': steps,
+        'active-minutes.json': active,
+        'workouts.json': workouts,
+        'activity-rings.json': activityRings,
+      },
+    });
+    server = await spawnServer(sandbox);
+  });
+
+  after(async () => {
+    if (server) await server.kill();
+    if (sandbox) cleanupSandbox(sandbox);
+  });
+
+  test('GET /api/views/view surfaces layout:"rings" with combines[] intact', async () => {
+    const res = await req(server.baseUrl, '/api/views/view');
+    assert.equal(res.status, 200);
+    const combo = res.json.cards.find(c => c.id === 'activity-rings');
+    assert.ok(combo, 'rings preset present in view');
+    assert.equal(combo.viewConfig.component, 'combination-card');
+    assert.equal(combo.viewConfig.layout, 'rings');
+    assert.equal(combo.viewConfig.combines.length, 3);
+  });
+
+  test('ring-segment entries carry goalDaily + colour client-side', async () => {
+    const res = await req(server.baseUrl, '/api/views/view');
+    const combo = res.json.cards.find(c => c.id === 'activity-rings');
+    const rings = combo.viewConfig.combines.filter(c => c.role === 'ring-segment');
+    assert.equal(rings.length, 2);
+    assert.equal(rings[0].goalDaily, 10000);
+    assert.equal(rings[0].colour, '#0ea5e9');
+    assert.equal(rings[1].goalDaily, 30);
+    assert.equal(rings[1].colour, '#f59e0b');
+  });
+
+  test('non-ring-segment roles are preserved alongside ring-segments', async () => {
+    const res = await req(server.baseUrl, '/api/views/view');
+    const combo = res.json.cards.find(c => c.id === 'activity-rings');
+    const annotation = combo.viewConfig.combines.find(c => c.role === 'annotation');
+    assert.ok(annotation);
+    assert.equal(annotation.sourceId, 'workouts');
+  });
+
+  test('source manifests remain independently readable', async () => {
+    const stepsRes = await req(server.baseUrl, '/api/manifests/steps/data');
+    assert.equal(stepsRes.json.data[0].count, 7200);
+    const activeRes = await req(server.baseUrl, '/api/manifests/active-minutes/data');
+    assert.equal(activeRes.json.data[0].minutes, 45);
+  });
+});

--- a/tests/combines-resolver.test.js
+++ b/tests/combines-resolver.test.js
@@ -348,3 +348,130 @@ describe('donorIdsInOrder', () => {
     assert.deepEqual(donorIdsInOrder(combines), ['mood', 'hydration']);
   });
 });
+
+describe('resolveEntry: ring-segment role', () => {
+  const sources = {
+    'steps': {
+      loaded: true, meta: { label: 'Steps' },
+      data: [{ date: '2026-05-05', count: 7200 }],
+    },
+    'active-minutes': {
+      loaded: true, meta: { label: 'Active Minutes' },
+      data: [{ date: '2026-05-05', minutes: 45 }],
+    },
+    'mood': {
+      loaded: true, meta: { label: 'Mood' },
+      data: [{ date: '2026-05-05', mood: 'okay' }],
+    },
+  };
+
+  test('valid ring-segment: state=ok, ratio + complete computed', () => {
+    const r = resolveEntry(
+      { sourceId: 'steps', role: 'ring-segment', accessor: 'count', goalDaily: 10000 },
+      sources, '2026-05-05',
+    );
+    assert.equal(r.state, 'ok');
+    assert.equal(r.value, 7200);
+    assert.equal(r.goalDaily, 10000);
+    assert.equal(r.ratio, 0.72);
+    assert.equal(r.complete, false);
+  });
+
+  test('overshoot: ratio > 1, complete = true', () => {
+    const r = resolveEntry(
+      { sourceId: 'active-minutes', role: 'ring-segment', accessor: 'minutes', goalDaily: 30 },
+      sources, '2026-05-05',
+    );
+    assert.equal(r.state, 'ok');
+    assert.equal(r.ratio, 1.5);
+    assert.equal(r.complete, true);
+  });
+
+  test('exactly-at-goal: ratio = 1, complete = true', () => {
+    const exact = { 'x': { loaded: true, meta: {}, data: [{ date: '2026-05-05', v: 30 }] } };
+    const r = resolveEntry(
+      { sourceId: 'x', role: 'ring-segment', accessor: 'v', goalDaily: 30 },
+      exact, '2026-05-05',
+    );
+    assert.equal(r.ratio, 1);
+    assert.equal(r.complete, true);
+  });
+
+  test('missing goalDaily → no-goal state', () => {
+    const r = resolveEntry(
+      { sourceId: 'steps', role: 'ring-segment', accessor: 'count' },
+      sources, '2026-05-05',
+    );
+    assert.equal(r.state, 'no-goal');
+    assert.equal(r.value, null);
+  });
+
+  test('zero goalDaily → no-goal state (defensive; avoids divide-by-zero)', () => {
+    const r = resolveEntry(
+      { sourceId: 'steps', role: 'ring-segment', accessor: 'count', goalDaily: 0 },
+      sources, '2026-05-05',
+    );
+    assert.equal(r.state, 'no-goal');
+  });
+
+  test('negative goalDaily → no-goal state', () => {
+    const r = resolveEntry(
+      { sourceId: 'steps', role: 'ring-segment', accessor: 'count', goalDaily: -100 },
+      sources, '2026-05-05',
+    );
+    assert.equal(r.state, 'no-goal');
+  });
+
+  test('non-numeric goalDaily → no-goal state', () => {
+    const r = resolveEntry(
+      { sourceId: 'steps', role: 'ring-segment', accessor: 'count', goalDaily: 'a lot' },
+      sources, '2026-05-05',
+    );
+    assert.equal(r.state, 'no-goal');
+  });
+
+  test('non-numeric value on ring-segment → no-accessor-match', () => {
+    const r = resolveEntry(
+      { sourceId: 'mood', role: 'ring-segment', accessor: 'mood', goalDaily: 5 },
+      sources, '2026-05-05',
+    );
+    assert.equal(r.state, 'no-accessor-match');
+  });
+
+  test('no-goal check runs BEFORE source lookup (goal is malformed regardless of source)', () => {
+    // Even if the source is missing, a missing goal is still the primary
+    // problem. Test documents that goal validation is first.
+    const r = resolveEntry(
+      { sourceId: 'nonexistent', role: 'ring-segment', accessor: 'x' },
+      sources, '2026-05-05',
+    );
+    assert.equal(r.state, 'no-goal');
+  });
+
+  test('no ring fields on non-ring-segment entries', () => {
+    const r = resolveEntry(
+      { sourceId: 'steps', role: 'primary', accessor: 'count', goalDaily: 10000 },
+      sources, '2026-05-05',
+    );
+    assert.equal(r.state, 'ok');
+    assert.equal('ratio' in r, false);
+    assert.equal('complete' in r, false);
+    assert.equal('goalDaily' in r, false);
+  });
+
+  test('no-entry still propagates for ring-segment with valid goal', () => {
+    const r = resolveEntry(
+      { sourceId: 'steps', role: 'ring-segment', accessor: 'count', goalDaily: 10000 },
+      sources, '2099-01-01',
+    );
+    assert.equal(r.state, 'no-entry');
+  });
+
+  test('ring-segment preserves colour field', () => {
+    const r = resolveEntry(
+      { sourceId: 'steps', role: 'ring-segment', accessor: 'count', goalDaily: 10000, colour: '#0ea5e9' },
+      sources, '2026-05-05',
+    );
+    assert.equal(r.colour, '#0ea5e9');
+  });
+});


### PR DESCRIPTION
## Summary

Second layout for the combination-card renderer: Apple-Watch-style
close-your-rings. Ring-segment entries drive concentric ECharts
gauges normalised against their daily goal; non-ring roles render
as stack rows beneath.

```
 ACTIVITY RINGS
 ┌── ECharts gauge ──┐
 │   ◯  ◯  (arcs)    │
 └────────────────────┘
 Steps    7200 / 10000 steps  72%
 Active   45 / 30 min         150% ✨
 Trained  yes       (annotation)
```

## Why

Combination-card MVP (#97) shipped with `layout: "stack"` only;
`rings` and `chart` were reserved names. This PR ships `rings`. It
proves the layout-dispatch path works end-to-end, which is the
real point — `chart` can now drop in the same way when someone
wants a line-chart combo.

The legacy Eddzhealth app had Activity rings; this is the
klebb-native port.

## Design decisions

All locked with the operator before coding:

- **Daily window.** Each ring reads today's row from the source
  via the existing resolver. No new aggregation plumbing.
- **Goal on the entry.** `goalDaily` lives on the `combines[]`
  entry, not the source manifest. Keeps sources clean; goal
  changes touch one file.
- **ECharts gauge.** Reuses the `loadECharts()` +
  `chartTheme()` helpers already in `eh-chart-base.js`. One
  figure per card, one concentric series per ring.
- **Single renderer, internal dispatch.** No new component.
  `eh-combination-card.js` grew `_renderRings()` alongside an
  extracted `_renderStack()`.
- **Unknown layouts still fall back to stack.**

## How

### Resolver (pure, `public/js/lib/combines-resolver.{js,esm.js}`)

- New state `"no-goal"` when a `ring-segment` entry is missing a
  positive finite `goalDaily`. Validated before source lookup.
- Ring-segment `ok` rows carry `goalDaily`, `ratio` (unclamped),
  `complete` (boolean `ratio >= 1`).
- Non-numeric values on a ring-segment fall through to
  `no-accessor-match` rather than producing NaN ratios.

### Renderer (`public/js/components/eh-combination-card.js`)

- `_layout()` accepts `"rings"`; unknown values fall back to
  `stack`.
- `render()` dispatches to `_renderStack()` or `_renderRings()`.
- `_renderRings()` partitions resolved rows into ring-segments
  (drive the gauge) and others (stack-style rows underneath).
- ECharts lifecycle:
  - Lazy-load on first render via the existing infrastructure.
  - `MutationObserver` on `<html data-theme>` re-applies the
    theme palette to both the chart and the legend swatches.
  - `ResizeObserver` keeps the figure responsive.
  - `dispose()` on disconnect AND when layout swaps from rings
    back to stack.
- Legend rows render as HTML (not ECharts `detail` formatters)
  so they stay theme-styleable via CSS and easy to test.

### Schema (`MANIFEST-SCHEMA.md`)

- `layout` table now lists `rings` as shipped (`chart` still
  reserved).
- `combines[]` field reference gains `goalDaily` (required for
  `ring-segment`) and `colour` (optional).
- Row-resolution table adds `no-goal`; explains the extra fields
  ring-segment `ok` rows carry.
- New "Rings layout specifics" subsection.

### Preset

`data.example/activity-rings.example.json` — Steps (/10000/day) +
Active Minutes (/30/day) as rings, Trained as annotation beneath.
Ships with `meta.enabled: false` so it doesn't duplicate the
existing stack-layout Activity card; flip it on via Settings or
klebbius when you want to try it.

## Testing

- [x] `npm test` — 531/532 passing. The single failure
  (`no-personal-refs`) fails identically on `main` and is
  unrelated.
- [x] **12 new resolver unit tests** covering ring-segment
  resolution (valid goal, overshoot, exactly-at-goal, missing /
  zero / negative / non-numeric `goalDaily`, non-numeric
  value, colour preservation, non-ring entries unaffected).
- [x] **4 new integration tests** (rings preset round-trips
  `layout` + `goalDaily` + `colour` through the view API;
  non-ring roles preserved alongside rings; sources remain
  independently readable).
- [x] Example-manifests validator: the new preset loads cleanly.
- [ ] Manual smoke on klebbtest: enable `activity-rings`, verify
  the gauge renders with two concentric arcs, confirm overshoot
  produces the ✨ indicator, theme toggle updates ring colours.

## Notes

- `docs/CARDS.md` doesn't get a rings subsection in THIS PR
  because the combination-cards section there is itself still
  pending via PR #110. Once #110 merges, a small follow-up can
  add the rings subsection below the stack explanation (or I can
  do it as part of #110's rebase — your call).
- ECharts is already a dependency (via `line-chart`); no new
  packages added.

## Out of scope

- Weekly-window rings (would need a new aggregation path that
  sums rows Mon-Sun rather than reading today's row). Separate
  follow-up if useful.
- Streak counters under the rings.
- Click-to-expand week-view drill-down.
- Trophy / celebration animations beyond the basic overshoot
  indicator.

Closes #111
