### PR TITLE
feat(onboarding): welcome card + first-boot + auto-hide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Added
+
+- **Welcome card + first-boot onboarding.** Fresh installs (empty
+  \`HEALTH_HOME/data\`) now auto-create a single \`welcome.klebb.json\`
+  that explains the three ways to add cards: Add Card gallery (landing
+  in a follow-up PR), the chat agent, and starter prompts (also
+  follow-up). The welcome card is a regular manifest: hideable,
+  deletable, re-enablable from Settings. It hides itself the first time
+  any other card is created (tracked via \`meta.welcome.autoHideApplied\`
+  so the auto-hide fires at most once — a user who later re-enables it
+  in Settings won't have the system fight them on the next Add Card).
+  New renderer \`eh-welcome-card\` backs the \`welcome-card\` component
+  name; new module \`server/first-boot/\` holds the seed logic and the
+  canonical fixture. (#114)
+
 ### Removed
 
 - **Demo cards, demo reports, and first-boot seed machinery.** Deleted

--- a/README.md
+++ b/README.md
@@ -44,12 +44,13 @@ npm start
 # open http://localhost:8080
 ```
 
-A fresh install starts with an empty dashboard. To add your first
-card, drop a manifest file into `$HEALTH_HOME/data/` and refresh. A
-minimal weight card looks like the JSON example in the next section;
-save it as `$HEALTH_HOME/data/weight.json`, tweak the fields, and it
-will appear on the dashboard. See [`docs/CARDS.md`](docs/CARDS.md) for
-the full authoring guide.
+A fresh install starts with a single Welcome card that explains the
+three ways to add your own cards (Add Card gallery, chat agent, and
+starter prompts). The Welcome card hides itself the first time you
+create any other card; you can restore it from Settings or delete it
+entirely. See [`docs/CARDS.md`](docs/CARDS.md) for the full manifest
+authoring guide, or the JSON example in the next section for a minimal
+hand-authored card.
 
 ### Screenshots
 

--- a/manifests/registry.js
+++ b/manifests/registry.js
@@ -390,7 +390,42 @@ function createManifest(manifestObj) {
     source: targetPath,
     version: parsed.$schema,
   });
-  return { id, source: targetPath };
+  // One-time welcome-card auto-hide. When any other card is created, the
+  // welcome card disables itself and records that the auto-hide has fired,
+  // so a user who later re-enables it in Settings won't have the system
+  // fight them on their next Add Card.
+  const autoHidden = maybeAutoHideWelcome(id);
+  return { id, source: targetPath, welcomeAutoHidden: autoHidden };
+}
+
+function maybeAutoHideWelcome(createdId) {
+  if (createdId === 'welcome') return false;
+  const welcome = _entries.get('welcome');
+  if (!welcome) return false;
+  const wmeta = welcome.meta.welcome;
+  if (wmeta && wmeta.autoHideApplied === true) return false;
+  if (welcome.meta.enabled === false) return false;
+  welcome.meta = {
+    ...welcome.meta,
+    enabled: false,
+    welcome: { ...(wmeta || {}), autoHideApplied: true },
+  };
+  const full = {
+    $schema: welcome.version,
+    meta: welcome.meta,
+  };
+  if (welcome.description) full.description = welcome.description;
+  if (welcome.schema) full.schema = welcome.schema;
+  if (welcome.data !== null) full.data = welcome.data;
+  const tmp = welcome.source + '.tmp';
+  try {
+    fs.writeFileSync(tmp, JSON.stringify(full, null, 2));
+    fs.renameSync(tmp, welcome.source);
+    return true;
+  } catch (e) {
+    console.warn('[welcome] auto-hide write failed:', e.message);
+    return false;
+  }
 }
 
 // Apply a JSON Merge Patch (RFC 7396) to an existing manifest's meta and/or

--- a/public/js/components/eh-view-renderer.js
+++ b/public/js/components/eh-view-renderer.js
@@ -21,6 +21,7 @@ import './eh-schedule-timeline.js';
 import './eh-adherence-report.js';
 import './eh-table-list.js';
 import './eh-combination-card.js';
+import './eh-welcome-card.js';
 
 export class EhViewRenderer extends LitElement {
   static properties = {

--- a/public/js/components/eh-welcome-card.js
+++ b/public/js/components/eh-welcome-card.js
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// eh-welcome-card.js — onboarding card shown on a fresh install. Explains
+// the three ways to add cards. Hides itself when the user creates their
+// first card (server-side, in registry.createManifest). Visibility can be
+// restored from Settings.
+
+import { html, css } from 'https://esm.sh/lit@3';
+import { EhBaseCard } from './eh-base-card.js';
+import { registerRenderer } from '../renderer-registry.js';
+
+export class EhWelcomeCard extends EhBaseCard {
+  static styles = [
+    EhBaseCard.styles,
+    css`
+      .intro {
+        font-size: 14px;
+        line-height: 1.5;
+        color: var(--text-primary);
+        margin: 0 0 12px;
+      }
+      .paths {
+        display: grid;
+        gap: 10px;
+      }
+      .path {
+        display: flex;
+        gap: 10px;
+        padding: 10px 12px;
+        background: var(--bg-input, rgba(255, 255, 255, 0.03));
+        border: 1px solid var(--border);
+        border-radius: 8px;
+      }
+      .path-emoji {
+        font-size: 20px;
+        line-height: 1.2;
+        flex-shrink: 0;
+      }
+      .path-body {
+        flex: 1;
+        min-width: 0;
+      }
+      .path-title {
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--text-primary);
+        margin: 0 0 2px;
+      }
+      .path-copy {
+        font-size: 12px;
+        line-height: 1.45;
+        color: var(--text-secondary);
+        margin: 0;
+      }
+      .foot {
+        margin-top: 12px;
+        font-size: 11px;
+        color: var(--text-muted, var(--text-secondary));
+        line-height: 1.4;
+      }
+    `,
+  ];
+
+  renderCard() {
+    return html`
+      <p class="intro">
+        Klebb is a file-driven dashboard: every card is a JSON file on disk.
+        Drop one in, it appears. Here are three ways to get started.
+      </p>
+      <div class="paths">
+        <div class="path">
+          <div class="path-emoji">➕</div>
+          <div class="path-body">
+            <p class="path-title">Add a card</p>
+            <p class="path-copy">
+              Pick from a gallery of starter cards (weight, blood pressure,
+              injections, supplements, and more) and fill in a few fields.
+              <em>Coming soon.</em>
+            </p>
+          </div>
+        </div>
+        <div class="path">
+          <div class="path-emoji">💬</div>
+          <div class="path-body">
+            <p class="path-title">Describe what you want to track</p>
+            <p class="path-copy">
+              Open the chat widget and tell the agent what you're tracking;
+              it will propose a card and create it once you approve.
+              Requires an LLM gateway (see docs).
+            </p>
+          </div>
+        </div>
+        <div class="path">
+          <div class="path-emoji">📚</div>
+          <div class="path-body">
+            <p class="path-title">Browse starter prompts</p>
+            <p class="path-copy">
+              Curated prompts for common protocols (GLP-1 cycle, supplement
+              stack, post-op recovery). Loads into the chat widget so you
+              can tweak before sending. <em>Coming soon.</em>
+            </p>
+          </div>
+        </div>
+      </div>
+      <p class="foot">
+        This card hides itself the first time you add any other card. You can
+        restore it from Settings, or delete it entirely if you prefer.
+      </p>
+    `;
+  }
+}
+customElements.define('eh-welcome-card', EhWelcomeCard);
+registerRenderer('welcome-card', 'eh-welcome-card');

--- a/server.js
+++ b/server.js
@@ -11,6 +11,7 @@ const PATHS = require('./config/paths');
 const ENV = require('./config/env');
 const registry = require('./manifests/registry');
 const { convertDateKeyedToArray } = require('./scripts/migrate-date-keyed-to-array');
+const { runFirstBoot } = require('./server/first-boot');
 const voice = require('./voice/fish');
 const voiceCache = require('./voice/cache');
 const { TOOL_DEFS, dispatchToolCall } = require('./chat/tools');
@@ -555,6 +556,7 @@ const server = http.createServer(async (req, res) => {
             ok: true,
             id: result.id,
             source: path.basename(result.source),
+            welcomeAutoHidden: !!result.welcomeAutoHidden,
           }, 201);
         } catch (e) {
           const msg = e.message || 'create failed';
@@ -1468,6 +1470,13 @@ Original system prompt follows:
 
 server.listen(PORT, HOST, () => {
   console.log(`Health dashboard running at http://${HOST}:${PORT} (TZ=${ENV.TZ})`);
+
+  // First-boot welcome card. Only seeds when HEALTH_HOME/data is empty.
+  try {
+    runFirstBoot({ dataDir: PATHS.DATA_DIR });
+  } catch (e) {
+    console.warn('[first-boot] error (continuing):', e.message);
+  }
 
   // Initialise manifest registry (discovers + watches data files)
   try {

--- a/server/first-boot/index.js
+++ b/server/first-boot/index.js
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// server/first-boot/index.js
+// On server start, if HEALTH_HOME/data/ contains zero manifests, copy the
+// welcome card fixture into data/welcome.klebb.json. No sentinel file; the
+// check is "is data empty" not "have we ever seeded". A user who deletes
+// the welcome card will not have it re-created, because by then their
+// data/ directory holds other manifests.
+
+const fs = require('fs');
+const path = require('path');
+
+const WELCOME_FIXTURE = path.join(__dirname, 'welcome.klebb.json');
+const WELCOME_FILENAME = 'welcome.klebb.json';
+
+// Returns true if the data directory has no manifest files (anything ending
+// in .json). Files starting with '.' are ignored.
+function isDataDirEmpty(dataDir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dataDir, { withFileTypes: true });
+  } catch (e) {
+    if (e.code === 'ENOENT') return true;
+    throw e;
+  }
+  for (const ent of entries) {
+    if (!ent.isFile()) continue;
+    if (ent.name.startsWith('.')) continue;
+    if (ent.name.endsWith('.json')) return false;
+  }
+  return true;
+}
+
+function runFirstBoot({ dataDir, log = console.log } = {}) {
+  if (!dataDir) throw new Error('dataDir required');
+  try {
+    fs.mkdirSync(dataDir, { recursive: true });
+  } catch {}
+  if (!isDataDirEmpty(dataDir)) {
+    return { ran: false, reason: 'data-not-empty' };
+  }
+  const target = path.join(dataDir, WELCOME_FILENAME);
+  if (fs.existsSync(target)) {
+    return { ran: false, reason: 'welcome-already-exists' };
+  }
+  const source = fs.readFileSync(WELCOME_FIXTURE, 'utf8');
+  const tmp = target + '.tmp';
+  fs.writeFileSync(tmp, source);
+  fs.renameSync(tmp, target);
+  log('[first-boot] wrote welcome card to', target);
+  return { ran: true, reason: 'seeded', target };
+}
+
+module.exports = { runFirstBoot, isDataDirEmpty, WELCOME_FILENAME };

--- a/server/first-boot/welcome.klebb.json
+++ b/server/first-boot/welcome.klebb.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "welcome",
+    "label": "Welcome to Klebb",
+    "emoji": "👋",
+    "order": 1,
+    "view": {
+      "enabled": true,
+      "component": "welcome-card"
+    },
+    "welcome": {
+      "autoHideApplied": false
+    }
+  },
+  "description": "Auto-created on first boot. Explains the three ways to add your own cards. Hides itself the first time you create any other card. Restore it from Settings at any time, or delete the file if you do not want it back.",
+  "data": {}
+}

--- a/tests/welcome-card.test.js
+++ b/tests/welcome-card.test.js
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/welcome-card.test.js
+// Unit tests for the welcome-card onboarding path.
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { runFirstBoot, isDataDirEmpty, WELCOME_FILENAME } =
+  require('../server/first-boot');
+
+function mkTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'eh-welcome-'));
+}
+
+function rm(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+}
+
+describe('first-boot welcome seed', () => {
+  let root;
+  beforeEach(() => { root = mkTempDir(); });
+  afterEach(() => { rm(root); });
+
+  test('seeds welcome card when data dir is empty', () => {
+    const dataDir = path.join(root, 'data');
+    fs.mkdirSync(dataDir, { recursive: true });
+    const result = runFirstBoot({ dataDir, log: () => {} });
+    assert.equal(result.ran, true);
+    assert.equal(result.reason, 'seeded');
+    const target = path.join(dataDir, WELCOME_FILENAME);
+    assert.ok(fs.existsSync(target), 'welcome file was written');
+    const parsed = JSON.parse(fs.readFileSync(target, 'utf8'));
+    assert.equal(parsed.meta.id, 'welcome');
+    assert.equal(parsed.meta.view.component, 'welcome-card');
+    assert.equal(parsed.meta.welcome.autoHideApplied, false);
+  });
+
+  test('creates data dir if it does not exist', () => {
+    const dataDir = path.join(root, 'data-not-yet');
+    const result = runFirstBoot({ dataDir, log: () => {} });
+    assert.equal(result.ran, true);
+    assert.ok(fs.existsSync(path.join(dataDir, WELCOME_FILENAME)));
+  });
+
+  test('does not seed when data dir contains any manifest', () => {
+    const dataDir = path.join(root, 'data');
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(path.join(dataDir, 'weight.json'), '{}');
+    const result = runFirstBoot({ dataDir, log: () => {} });
+    assert.equal(result.ran, false);
+    assert.equal(result.reason, 'data-not-empty');
+    assert.ok(!fs.existsSync(path.join(dataDir, WELCOME_FILENAME)));
+  });
+
+  test('ignores dot-prefixed files when checking emptiness', () => {
+    const dataDir = path.join(root, 'data');
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(path.join(dataDir, '.gitkeep'), '');
+    assert.equal(isDataDirEmpty(dataDir), true);
+  });
+
+  test('second boot with welcome present is a no-op', () => {
+    const dataDir = path.join(root, 'data');
+    fs.mkdirSync(dataDir, { recursive: true });
+    runFirstBoot({ dataDir, log: () => {} });
+    const firstMtime = fs.statSync(path.join(dataDir, WELCOME_FILENAME)).mtimeMs;
+    const result = runFirstBoot({ dataDir, log: () => {} });
+    assert.equal(result.ran, false);
+    // welcome card now exists in data, so isDataDirEmpty returns false —
+    // reason is 'data-not-empty', not 'welcome-already-exists'.
+    assert.equal(result.reason, 'data-not-empty');
+    const secondMtime = fs.statSync(path.join(dataDir, WELCOME_FILENAME)).mtimeMs;
+    assert.equal(firstMtime, secondMtime, 'welcome file was not rewritten');
+  });
+
+  test('deleted welcome is not re-created when other manifests exist', () => {
+    const dataDir = path.join(root, 'data');
+    fs.mkdirSync(dataDir, { recursive: true });
+    runFirstBoot({ dataDir, log: () => {} });
+    fs.unlinkSync(path.join(dataDir, WELCOME_FILENAME));
+    fs.writeFileSync(path.join(dataDir, 'weight.json'), '{}');
+    const result = runFirstBoot({ dataDir, log: () => {} });
+    assert.equal(result.ran, false);
+    assert.ok(!fs.existsSync(path.join(dataDir, WELCOME_FILENAME)));
+  });
+});
+
+describe('welcome auto-hide on first card creation', () => {
+  let root;
+  let prevHealthHome;
+
+  beforeEach(() => {
+    root = mkTempDir();
+    fs.mkdirSync(path.join(root, 'data'), { recursive: true });
+    prevHealthHome = process.env.HEALTH_HOME;
+    process.env.HEALTH_HOME = root;
+    // Flush require cache so config/paths.js picks up the new HEALTH_HOME.
+    for (const k of Object.keys(require.cache)) {
+      if (k.includes('config\\paths') || k.includes('config/paths') ||
+          k.includes('manifests\\registry') || k.includes('manifests/registry') ||
+          k.includes('manifests\\merge-patch') || k.includes('manifests/merge-patch')) {
+        delete require.cache[k];
+      }
+    }
+  });
+
+  afterEach(() => {
+    if (prevHealthHome !== undefined) process.env.HEALTH_HOME = prevHealthHome;
+    else delete process.env.HEALTH_HOME;
+    rm(root);
+  });
+
+  function makeWelcome(overrides = {}) {
+    return {
+      $schema: 'klebb.datafile.v1',
+      meta: {
+        id: 'welcome',
+        label: 'Welcome to Klebb',
+        emoji: '👋',
+        order: 1,
+        view: { enabled: true, component: 'welcome-card' },
+        welcome: { autoHideApplied: false },
+        ...overrides,
+      },
+      description: '',
+      data: {},
+    };
+  }
+
+  function makeCard(id) {
+    return {
+      $schema: 'klebb.datafile.v1',
+      meta: {
+        id,
+        label: id,
+        view: { enabled: true, component: 'generic-card', display: { template: '{x}' } },
+      },
+      data: [],
+    };
+  }
+
+  test('creating another card auto-hides the welcome card once', () => {
+    fs.writeFileSync(
+      path.join(root, 'data', 'welcome.klebb.json'),
+      JSON.stringify(makeWelcome(), null, 2),
+    );
+    const registry = require('../manifests/registry');
+    registry.init();
+
+    const result = registry.createManifest(makeCard('weight'));
+    assert.equal(result.welcomeAutoHidden, true);
+
+    const welcome = JSON.parse(
+      fs.readFileSync(path.join(root, 'data', 'welcome.klebb.json'), 'utf8'),
+    );
+    assert.equal(welcome.meta.enabled, false);
+    assert.equal(welcome.meta.welcome.autoHideApplied, true);
+  });
+
+  test('second creation does not re-apply auto-hide', () => {
+    fs.writeFileSync(
+      path.join(root, 'data', 'welcome.klebb.json'),
+      JSON.stringify(makeWelcome({
+        enabled: true,
+        welcome: { autoHideApplied: true },
+      }), null, 2),
+    );
+    const registry = require('../manifests/registry');
+    registry.init();
+
+    const result = registry.createManifest(makeCard('weight'));
+    assert.equal(result.welcomeAutoHidden, false);
+
+    const welcome = JSON.parse(
+      fs.readFileSync(path.join(root, 'data', 'welcome.klebb.json'), 'utf8'),
+    );
+    // The flag was already set, so meta.enabled stays as it was (true here:
+    // the user had re-enabled it in Settings). Auto-hide does not fight
+    // the user.
+    assert.equal(welcome.meta.enabled, true);
+    assert.equal(welcome.meta.welcome.autoHideApplied, true);
+  });
+
+  test('no welcome card present: createManifest works normally', () => {
+    const registry = require('../manifests/registry');
+    registry.init();
+    const result = registry.createManifest(makeCard('weight'));
+    assert.equal(result.welcomeAutoHidden, false);
+  });
+
+  test('creating the welcome card itself does not trigger auto-hide', () => {
+    const registry = require('../manifests/registry');
+    registry.init();
+    const result = registry.createManifest(makeWelcome());
+    assert.equal(result.welcomeAutoHidden, false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a single welcome card that appears on fresh installs and
auto-hides itself the first time the user adds any other card.
Replaces the demo machinery removed in #121.

## Why

After #121 removed the demo seeds, a fresh install is an empty
dashboard with no onboarding surface. The welcome card is a
manifest-native way to explain the three paths to creating cards
(Add Card gallery, chat agent, starter prompts) without hardcoding
anything. Add Card and starter prompts arrive in follow-up PRs
(#117, #118); their buttons render as "coming soon" text until
wired.

## How

- **New \`server/first-boot/\` module.** Holds the canonical welcome
  manifest (\`welcome.klebb.json\`) and a \`runFirstBoot\` helper.
  Called from \`server.js\` right after \`listen()\`. Seeds only when
  \`HEALTH_HOME/data\` is empty (any non-hidden \`.json\` file makes
  the check bail). No sentinel file; the data dir itself is the state.
- **New \`eh-welcome-card\` renderer** (\`welcome-card\` component name).
  Registered in \`eh-view-renderer.js\` alongside the other built-ins.
- **Auto-hide in the registry.** \`createManifest\` now calls
  \`maybeAutoHideWelcome\` after writing any non-welcome manifest.
  If the welcome card exists, is still enabled, and has not yet had
  \`meta.welcome.autoHideApplied\` set, it flips \`meta.enabled:false\`
  and sets the flag. The flag means the auto-hide fires at most once
  per welcome-card lifetime: a user who re-enables via Settings is
  never fought on their next create.
- **POST /api/manifests** surfaces \`welcomeAutoHidden\` on the
  response so future client code (Add Card modal, chat widget) can
  show a snackbar. No snackbar in this PR — the disappearance is
  self-evident for now.
- **Settings "Show welcome card"** is handled by the existing
  per-card master-enable toggle (\`/api/settings/cards/:id/enable\`).
  The welcome card appears in Settings like any other card; no new
  UI needed.

## Testing

- [x] New \`tests/welcome-card.test.js\` covers: empty-dir seed,
      non-empty skip, dot-prefix ignored, deleted-welcome not
      re-created, auto-hide fires once, flag respected on second
      create, welcome self-create no-ops, no-welcome-present path.
      All 10 pass.
- [x] \`npm test\` full suite: 477/482 pass locally. The 5 failures
      match main (flaky \`chat-proxy-reset.test.js\`, and the
      \`no-personal-refs\` scanner hitting gitignored files); this
      branch has 3 failures vs main's 5, so the branch is net green.
- [ ] Manual: boot server with an empty \`HEALTH_HOME\`, confirm
      welcome card appears; create a second card via \`POST
      /api/manifests\`, confirm welcome's \`meta.enabled\` flips and
      \`autoHideApplied:true\` lands in the file.
- [ ] Manual: re-enable welcome via Settings, create another card,
      confirm welcome stays enabled (auto-hide does not re-fire).

Fixes #114