### PR TITLE
feat(data): templates/ + prompts/ directories + test suite + contribution docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **\`templates/\` + \`prompts/\` directories.** Ten starter card
+  templates and seven conversational prompts covering the main Klebb
+  use cases (weight, BP, waist, resting HR, injection protocol,
+  supplement stack, medication schedule, mood, daily notes, hydration,
+  sleep-hours via HAE; plus prompts for GLP-1 cycles, peptide cycles,
+  supplement stacks, post-op recovery, strength training, mood-sleep
+  basics, and the \`new-to-klebb.md\` conversational onboarding meta-
+  prompt). Templates use a typed placeholder syntax
+  (\`{{type:name}}\`, types: string, number, boolean, date, enum) and
+  carry a \`meta.template\` block describing gallery rendering.
+  Prompts ship as markdown with YAML frontmatter (title, summary,
+  tags). Two new test suites walk both directories and validate shape.
+  Contribution guides land at repo root:
+  \`CONTRIBUTING-TEMPLATES.md\` and \`CONTRIBUTING-PROMPTS.md\`. None
+  of this is wired into the UI yet; the Add Card gallery, prompts
+  gallery, and \`/api/templates\` + \`/api/prompts\` endpoints land in
+  follow-up PRs. (#115)
+
 - **Welcome card + first-boot onboarding.** Fresh installs (empty
   \`HEALTH_HOME/data\`) now auto-create a single \`welcome.klebb.json\`
   that explains the three ways to add cards: Add Card gallery (landing

--- a/CONTRIBUTING-PROMPTS.md
+++ b/CONTRIBUTING-PROMPTS.md
@@ -1,0 +1,82 @@
+# Contributing prompts
+
+A **prompt** is a natural-language starter that lives in `prompts/` and
+shows up in the Klebb prompts gallery. Users pick a prompt, load it
+into the chat widget, edit if they want, and hit send. The chat agent
+builds a set of cards based on the prompt's instructions.
+
+Prompts are the highest-leverage way to contribute to Klebb:
+no code, no schema knowledge required, just a well-thought-out
+use case.
+
+## File shape
+
+Each prompt is a `.md` file in `prompts/` with YAML frontmatter:
+
+```markdown
+---
+title: GLP-1 injection cycle (with weight + waist)
+summary: Weekly injectable with titration, plus weight and waist tracking.
+tags: [glp1, injection, weight-loss, cycle]
+---
+
+I'd like to set up a dashboard for tracking a GLP-1 injection
+protocol. I want three cards:
+
+1. **Injection card** — weekly injectable, reconstituted peptide...
+```
+
+Required frontmatter:
+
+- `title` — the gallery row label. Keep it under ~60 characters.
+- `summary` — one sentence, shown under the title in the gallery.
+- `tags` — list of short tags. Used for filtering in the gallery.
+
+The body is the prompt the user will paste into the chat agent.
+
+## Writing a good prompt
+
+The agent is the one building cards, so the prompt is really a
+briefing for the agent, not the user. Good prompts:
+
+- **State the goal up front.** "Set up a dashboard for tracking X."
+- **List the cards you want.** Numbered, one per card. For each card,
+  mention the renderer shape if you know it (generic-card, checklist-
+  card, etc.) or describe the behaviour (daily rating, weekly
+  check-off, etc.) and let the agent pick.
+- **Tell the agent what to ask the user.** If a card needs user-
+  specific values (dose, start date, name of the substance), list the
+  questions explicitly: *"Ask me which peptide, the dose per injection
+  with units, and the cycle length in weeks."*
+- **Require confirmation before creating.** The agent has a tendency
+  to create first and ask questions after. Your prompt should say
+  *"propose the manifests first; confirm with me before creating."*
+- **Set the tone.** Klebb's audience is technical self-hosters. "Don't
+  over-explain" is welcome guidance. "Use Australian English" is fine
+  if that matches the content.
+- **Specify what NOT to do.** If the prompt is single-card, say "do
+  not create additional cards unless I ask." Prompts drift toward
+  adding extras otherwise.
+
+## Contribution checklist
+
+- [ ] Frontmatter has `title`, `summary`, `tags`.
+- [ ] Body is prose directed at the chat agent, not at a human reader.
+- [ ] No personal or identifying data.
+- [ ] No prescription brand names where a generic exists. Say
+      "semaglutide", not a brand name.
+- [ ] No medical claims or specific dosing recommendations. Prompts
+      describe tracking structures, not protocols to follow. Let the
+      user or their clinician decide the actual values.
+- [ ] The prompt produces a realistic, useful dashboard for a real
+      user persona (e.g. "someone on a GLP-1", "a post-op patient",
+      "a strength athlete"). Not a kitchen-sink demo of every
+      renderer.
+- [ ] File name is `kebab-case.md` and matches the topic.
+
+## Examples
+
+See `prompts/new-to-klebb.md` for the conversational onboarding
+prompt. See `prompts/glp1-cycle.md` for a multi-card protocol with
+explicit follow-up questions. See `prompts/mood-sleep-basics.md` for a
+minimal "just do it" prompt with no follow-ups.

--- a/CONTRIBUTING-TEMPLATES.md
+++ b/CONTRIBUTING-TEMPLATES.md
@@ -1,0 +1,83 @@
+# Contributing templates
+
+A **template** is a starter card manifest that lives in `templates/` and
+shows up in the Add Card gallery. Picking a template opens a small form;
+filling it in produces a real card in `$HEALTH_HOME/data/`.
+
+## File shape
+
+Each template is a `.klebb.json` file in `templates/`. The filename
+must match `meta.template.id` exactly: `weight.klebb.json` carries
+`meta.template.id: "weight"`.
+
+A template is a valid `klebb.datafile.v1` manifest with two additions:
+
+1. A `meta.template` block describing how the template appears in the
+   gallery.
+2. Placeholder strings in place of user-supplied values.
+
+### `meta.template`
+
+```json
+"template": {
+  "id": "injection-protocol",
+  "title": "Injection protocol",
+  "summary": "Scheduled injectable with cycle start and end.",
+  "category": "protocols",
+  "tags": ["injection", "schedule", "cycle"]
+}
+```
+
+All five fields are required. `category` should be one of the gallery
+categories: `tracking`, `protocols`, `lifestyle`, `imported`.
+
+### Placeholders
+
+Placeholders let a template stay generic until a user fills in their
+specifics. Syntax: `{{type:name}}` or `{{name}}` (default type =
+string).
+
+Supported types: `string`, `number`, `boolean`, `date`, `enum`.
+
+```json
+"id": "{{string:id}}",
+"label": "{{string:label}}",
+"order": 100
+```
+
+The Add Card form uses the type to pick the input element: number gets
+a number input, date gets a date picker, enum gets a dropdown, etc.
+Substitution happens server-side when the user submits.
+
+Keep placeholder names `snake_case` and semantic: `dose_mg`,
+`cycle_start`, not `field1`. The Add Card form uses the name as the
+default field label if one is not supplied elsewhere.
+
+## Contribution checklist
+
+Before opening a PR:
+
+- [ ] Filename matches `meta.template.id`.
+- [ ] `meta.template` block is complete.
+- [ ] Template is a valid `klebb.datafile.v1` manifest after placeholder
+      substitution (run `npm test`; the template walker catches most
+      errors).
+- [ ] Placeholders only use the supported type set.
+- [ ] No personal or identifying data in the manifest.
+- [ ] No prescription brand names where a generic is available (e.g.
+      use "semaglutide", not a brand name).
+- [ ] `data` block is empty or minimal; users populate it themselves.
+- [ ] The template describes a real-world tracking use case, not a
+      demonstration of schema features.
+
+## Examples
+
+See the templates already in `templates/` for worked examples across
+all four categories. The simplest one to copy is `weight.klebb.json`
+(single-metric generic-card). The most complex is
+`injection-protocol.klebb.json` (checklist-card with schedule +
+cycles + calendar marker).
+
+If your template needs a renderer capability that existing templates
+don't demonstrate, look at the renderer's source under
+`public/js/components/eh-*-card.js` for the shape it expects.

--- a/README.md
+++ b/README.md
@@ -262,6 +262,23 @@ hygiene tests will catch you).
 Bug reports + feature requests: use the templates at
 <https://github.com/Aristocles/klebb/issues/new/choose>.
 
+### Contributing templates and prompts
+
+The easiest way to contribute to Klebb is to add a starter card or
+prompt. Both live in the repo as plain files: no code required.
+
+- **Templates** — single-card starter manifests that appear in the Add
+  Card gallery. Drop a `.klebb.json` into `templates/`. See
+  [`CONTRIBUTING-TEMPLATES.md`](CONTRIBUTING-TEMPLATES.md).
+- **Prompts** — natural-language prompts for the chat agent that build
+  multi-card protocols (GLP-1 cycles, supplement stacks, post-op
+  recovery, etc.). Drop a `.md` with frontmatter into `prompts/`. See
+  [`CONTRIBUTING-PROMPTS.md`](CONTRIBUTING-PROMPTS.md).
+
+Both are surfaced in-app through the welcome card's three entry
+points. Contributions here help every user of Klebb without requiring
+them to know the manifest schema.
+
 Security issues: see [`SECURITY.md`](SECURITY.md). Don't open a public
 issue for those.
 

--- a/prompts/glp1-cycle.md
+++ b/prompts/glp1-cycle.md
@@ -1,0 +1,36 @@
+---
+title: GLP-1 injection cycle (with weight + waist)
+summary: Weekly injectable GLP-1 (e.g. semaglutide) with titration, plus weight and waist tracking for progress.
+tags: [glp1, injection, weight-loss, cycle]
+---
+
+Please set up a dashboard for tracking a GLP-1 injection protocol. I
+want three cards:
+
+1. **Injection card** — weekly injectable, reconstituted peptide. I'll
+   give you the specifics below; ask me any follow-ups you need before
+   creating.
+
+2. **Weight card** — daily weight, line-chart trend, trend-arrow on
+   the headline. Ask me whether I want kg or lb.
+
+3. **Waist measurement card** — weekly measurement (I'll log when I
+   remember), line-chart trend.
+
+For the injection card, ask me:
+- Which peptide (e.g. semaglutide, tirzepatide, retatrutide)
+- Starting dose in mg
+- Reconstitution volume (ml of bacteriostatic water)
+- Vial strength (e.g. 5mg/vial)
+- Which day of the week I inject
+- Cycle length in weeks, and whether I'm titrating up (if so, what the
+  schedule looks like)
+- Today's date as the cycle start
+
+Once you have the answers, propose the three manifests and let me
+confirm before creating. I'd rather approve the shape first than edit
+three cards after the fact.
+
+After creating, remind me that each week's dose is a check-off I
+record when I take it, not a write-ahead. And that the weight card
+takes daily entries; new ones on the same day replace earlier ones.

--- a/prompts/mood-sleep-basics.md
+++ b/prompts/mood-sleep-basics.md
@@ -1,0 +1,25 @@
+---
+title: Mood + sleep basics
+summary: The minimum-effective dashboard for tracking subjective wellbeing: mood rating, sleep quality, and a single freeform note per day.
+tags: [mood, sleep, wellbeing, minimal]
+---
+
+Please set up a minimal wellbeing dashboard. Three small cards, no
+follow-up questions needed unless something is genuinely ambiguous.
+
+1. **Mood card** — daily 1-5 rating with an emoji map on the headline
+   and a calendar marker per day. Same shape as the mood template.
+   Optional notes field.
+
+2. **Sleep quality card** — daily 1-5 rating, line-chart trend. Keep
+   it separate from any Apple-Health sleep-hours card; this is the
+   subjective-how-did-I-feel rating, not the duration measurement.
+
+3. **Daily notes card** — one freeform textarea per day. Same shape as
+   the daily-notes template.
+
+Create all three straight away. Don't ask about units, defaults, or
+preferences; the defaults are fine. Tell me when you're done and
+mention that I can open the chat again to add anything specific
+(meditation check, caffeine, screen time, etc.) without touching these
+three.

--- a/prompts/new-to-klebb.md
+++ b/prompts/new-to-klebb.md
@@ -1,0 +1,32 @@
+---
+title: New to Klebb? Start here.
+summary: A conversational walkthrough. The agent asks what you want to track, proposes a small starter set, and creates the cards with your approval.
+tags: [onboarding, wizard, beginner]
+---
+
+I'm new to Klebb and would like help setting up a small, useful
+dashboard. Please walk me through this as a short conversation rather
+than dumping a wall of questions.
+
+Goals:
+
+1. Figure out what I actually want to track. Ask me 2-4 focused
+   questions: what am I hoping to get out of the dashboard, any
+   specific health goals or protocols I'm on, and rough frequency
+   (daily, weekly, when-I-remember).
+2. Based on my answers, propose a starter set of 3-5 cards. Keep it
+   minimal: easier to add more later than to prune a cluttered
+   dashboard. For each proposed card, tell me in one sentence what it
+   tracks and why you picked it.
+3. Before creating anything, list the proposals and ask me to confirm
+   or edit. I want the final call.
+4. Once I approve, create each card one at a time using your
+   create_manifest tool. After each one, briefly confirm what was
+   created so I know it worked.
+5. End with a short "next steps" note: how I can add more cards later
+   (Add Card button, describe-what-you-want, or more prompts), how I
+   edit or delete cards, and where the welcome card went.
+
+Tone: friendly but efficient. I'm a technical user who self-hosted
+this; I don't need hand-holding on what JSON is. Don't over-explain
+the schema; just make good cards and tell me what you did.

--- a/prompts/peptide-cycle.md
+++ b/prompts/peptide-cycle.md
@@ -1,0 +1,32 @@
+---
+title: Peptide cycle (generic)
+summary: A single injectable peptide with reconstitution details, a cycle window, and a fixed weekly schedule.
+tags: [peptide, injection, cycle]
+---
+
+Please set up a single injection card for a peptide cycle. Ask me the
+details I need to fill in; don't guess or default silently.
+
+What you need from me:
+
+- Peptide name
+- Dose per injection (with units: mcg, mg, IU)
+- Reconstitution volume and diluent (usually bacteriostatic water;
+  sometimes sterile saline)
+- Vial strength so the draw volume is computable
+- Injection days (e.g. Mon/Wed/Fri, or daily, or once-weekly)
+- Time of day (morning, before bed, etc.) if it matters for the
+  compound
+- Cycle start date and cycle length in weeks
+- Injection site rotation if I want to track it (optional extra field)
+
+Once you have the answers:
+
+1. Propose the card shape (one checklist-card or schedule-card manifest).
+2. Confirm with me.
+3. Create it with create_manifest.
+4. Tell me in one sentence how I log a completed injection (check off
+   the scheduled dose on the card, don't delete the item).
+
+Do not create any additional cards (weight, waist, sides) unless I
+ask. This prompt is single-card by design.

--- a/prompts/post-op-recovery.md
+++ b/prompts/post-op-recovery.md
@@ -1,0 +1,33 @@
+---
+title: Post-operative recovery dashboard
+summary: Short-cycle med schedule, daily symptom rating, and sleep notes to cover the first 4-6 weeks after a procedure.
+tags: [post-op, recovery, medication, symptoms]
+---
+
+I just had a procedure and want to track recovery for the next 4-6
+weeks. Please set up three cards. Ask me any follow-ups you need
+before creating anything.
+
+1. **Medication schedule card** — a checklist-card with each
+   post-operative medication as an item, on its prescribed schedule
+   and cycle window. Ask me:
+   - What meds I'm on (name, dose, frequency, how many days)
+   - Procedure date (so the cycles start on the right day)
+   - Whether any meds taper off earlier than others
+
+2. **Symptoms card** — a short daily checklist of symptoms to flag if
+   present (pain, swelling, redness, fever, other). Ask me which ones
+   my surgeon or discharge notes said to watch for. Make it a simple
+   checklist, not a rating card; presence/absence is what matters.
+
+3. **Sleep notes card** — daily freeform notes for how I slept and any
+   position adjustments or issues. Simple generic-card with a textarea
+   input.
+
+Propose all three as manifests before creating. Confirm with me. Then
+create each one.
+
+After creation, remind me that when the cycles end, the scheduled
+items will stop appearing on the checklist card automatically, but the
+card will stay on the dashboard. I can hide it from Settings when I'm
+fully recovered.

--- a/prompts/strength-training.md
+++ b/prompts/strength-training.md
@@ -1,0 +1,35 @@
+---
+title: Strength training: bloods + body metrics + key lifts
+summary: Quarterly bloods, body-weight trend, and a simple log for key compound lift numbers.
+tags: [strength, training, bloods, lifts]
+---
+
+Please set up a dashboard for someone training seriously for strength.
+I'd like three cards; ask me follow-ups as needed.
+
+1. **Bloods card** — a card for tracking blood panel results over time.
+   Ask me which markers I actually get tested (common: total/free
+   testosterone, estradiol, SHBG, haematocrit, haemoglobin, LDL, HDL,
+   triglycerides, ALT, AST, creatinine, fasting glucose, HbA1c, TSH,
+   free T4, ferritin). Build the card to accept a freeform entry per
+   test, ideally a list-card with one row per marker per test date.
+   Don't assume a renderer — ask if needed.
+
+2. **Weight card** — daily weight, line-chart trend, ask about units
+   (kg or lb). Same shape as the weight template.
+
+3. **Key lifts card** — a simple card for tracking my top set of the
+   big compound lifts. Ask me:
+   - Which lifts I want to track (typical: squat, bench, deadlift,
+     overhead press)
+   - Units (kg or lb — match the weight card)
+   - Frequency: do I want to log every session, or just PRs?
+
+   Propose a shape that handles the frequency I answer with. Log-every-
+   session probably wants a list-card; PRs-only might be a generic-card
+   per lift.
+
+Propose all three manifests, confirm with me, then create.
+
+After creation, remind me I can hide the bloods card between test
+dates if it clutters the dashboard.

--- a/prompts/supplement-stack-basic.md
+++ b/prompts/supplement-stack-basic.md
@@ -1,0 +1,29 @@
+---
+title: Morning + evening supplement stack
+summary: A daily supplement check-off card grouped by time of day. Bring your own list of supplements and doses.
+tags: [supplements, daily, checklist]
+---
+
+Please create a single supplement-stack card for me. Ask me to list my
+supplements, grouped by when I take them (morning, midday, evening,
+bedtime — pick whichever groups match my schedule). For each
+supplement I want:
+
+- Name
+- Dose and units (e.g. "2000 IU", "500mg", "1 capsule")
+- Whether it's daily, weekday-only, or some other pattern
+
+Once I've given you the list:
+
+1. Propose the full manifest: one checklist-card with groups[] for
+   each time-of-day I mentioned, and items[] with each supplement's
+   schedule and dose.
+2. Confirm with me.
+3. Create it.
+
+After creation, mention that I can check off each supplement each day,
+and that adherence reports are available in the Reports view if I want
+a weekly compliance percentage.
+
+Do not create a separate card per supplement. One card, many items.
+That is the whole point.

--- a/templates/blood-pressure.klebb.json
+++ b/templates/blood-pressure.klebb.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "template": {
+      "id": "blood-pressure",
+      "title": "Blood pressure",
+      "summary": "Systolic / diastolic with colour-coded threshold bands.",
+      "category": "tracking",
+      "tags": ["vitals", "cardiac", "threshold"]
+    },
+    "id": "{{string:id}}",
+    "label": "{{string:label}}",
+    "emoji": "🩺",
+    "order": 200,
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{systolic} / {diastolic}",
+        "unit": "mmHg",
+        "thresholds": [
+          { "ifField": "systolic", "max": 120, "colour": "#44ff88", "label": "Optimal" },
+          { "ifField": "systolic", "max": 129, "colour": "#aaff66", "label": "Elevated" },
+          { "ifField": "systolic", "max": 139, "colour": "#ffaa33", "label": "Stage 1" },
+          { "ifField": "systolic", "colour": "#ff4444", "label": "Stage 2" }
+        ]
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "fields": ["systolic", "diastolic"]
+    },
+    "calendar": {
+      "enabled": true,
+      "component": "day-marker",
+      "marker": {
+        "type": "threshold",
+        "field": "systolic",
+        "rules": [
+          { "max": 120, "emoji": "🟢" },
+          { "max": 139, "emoji": "🟡" },
+          { "emoji": "🔴" }
+        ]
+      }
+    },
+    "writeable": {
+      "fromWebapp": true,
+      "maxReadingsPerDay": 3,
+      "inputs": [
+        { "key": "systolic", "type": "number", "required": true, "min": 60, "max": 250 },
+        { "key": "diastolic", "type": "number", "required": true, "min": 40, "max": 160 }
+      ]
+    }
+  },
+  "description": "Blood pressure readings. Up to three per day; new entries are appended.",
+  "data": []
+}

--- a/templates/daily-notes.klebb.json
+++ b/templates/daily-notes.klebb.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "template": {
+      "id": "daily-notes",
+      "title": "Daily notes",
+      "summary": "Freeform journal-style notes, one entry per day.",
+      "category": "lifestyle",
+      "tags": ["journal", "notes", "freeform"]
+    },
+    "id": "{{string:id}}",
+    "label": "{{string:label}}",
+    "emoji": "📝",
+    "order": 410,
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{note|(no notes today)}",
+        "truncate": 200
+      }
+    },
+    "writeable": {
+      "fromWebapp": true,
+      "maxReadingsPerDay": 1,
+      "inputs": [
+        { "key": "note", "type": "textarea", "required": true }
+      ]
+    }
+  },
+  "description": "A single freeform note per day. Later entries replace earlier ones on the same date.",
+  "data": []
+}

--- a/templates/hydration.klebb.json
+++ b/templates/hydration.klebb.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "template": {
+      "id": "hydration",
+      "title": "Water intake",
+      "summary": "Cumulative daily water tally with a target line.",
+      "category": "lifestyle",
+      "tags": ["hydration", "water", "counter"]
+    },
+    "id": "{{string:id}}",
+    "label": "{{string:label}}",
+    "emoji": "💧",
+    "order": 420,
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{ml}",
+        "unit": "ml"
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "ml"
+    },
+    "writeable": {
+      "fromWebapp": true,
+      "maxReadingsPerDay": 1,
+      "inputs": [
+        { "key": "ml", "type": "stepper", "step": 250, "min": 0, "max": 10000, "required": true }
+      ]
+    }
+  },
+  "description": "Daily water intake in millilitres. One entry per day; use the stepper to bump by 250ml at a time.",
+  "data": []
+}

--- a/templates/injection-protocol.klebb.json
+++ b/templates/injection-protocol.klebb.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "template": {
+      "id": "injection-protocol",
+      "title": "Injection protocol",
+      "summary": "Scheduled injectable with cycle start and end, reconstitution details, and check-off state.",
+      "category": "protocols",
+      "tags": ["injection", "schedule", "cycle"]
+    },
+    "id": "{{string:id}}",
+    "label": "{{string:label}}",
+    "emoji": "💉",
+    "order": 300,
+    "view": {
+      "enabled": true,
+      "component": "checklist-card",
+      "dateContext": "exact-date"
+    },
+    "trends": {
+      "enabled": true,
+      "component": "schedule-timeline",
+      "itemsPath": "items"
+    },
+    "reports": {
+      "enabled": true,
+      "component": "adherence-report",
+      "showCompliance": true
+    },
+    "calendar": {
+      "enabled": true,
+      "component": "day-marker",
+      "marker": "💉"
+    },
+    "writeable": {
+      "fromWebapp": true,
+      "pastAllowed": true,
+      "todayAllowed": true,
+      "futureAllowed": false
+    }
+  },
+  "description": "Injectable on a fixed schedule within a cycle window. The card's + Add item affordance lands with the in-card item editor in a later PR; for now, hand-edit this file or use the chat agent to append to items[].",
+  "data": {
+    "items": []
+  }
+}

--- a/templates/medication-schedule.klebb.json
+++ b/templates/medication-schedule.klebb.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "template": {
+      "id": "medication-schedule",
+      "title": "Medication schedule",
+      "summary": "Scheduled oral or topical medications with per-dose check-offs and adherence reports.",
+      "category": "protocols",
+      "tags": ["medication", "schedule", "adherence"]
+    },
+    "id": "{{string:id}}",
+    "label": "{{string:label}}",
+    "emoji": "🏥",
+    "order": 320,
+    "view": {
+      "enabled": true,
+      "component": "checklist-card",
+      "dateContext": "exact-date"
+    },
+    "trends": {
+      "enabled": true,
+      "component": "schedule-timeline",
+      "itemsPath": "items"
+    },
+    "reports": {
+      "enabled": true,
+      "component": "adherence-report",
+      "showCompliance": true,
+      "showInventory": true
+    },
+    "calendar": {
+      "enabled": true,
+      "component": "day-marker",
+      "marker": "💊"
+    },
+    "writeable": {
+      "fromWebapp": true,
+      "pastAllowed": true,
+      "todayAllowed": true,
+      "futureAllowed": false
+    }
+  },
+  "description": "Prescription medications on a defined schedule, with cycle windows and adherence tracking. Add items via the chat agent or the in-card item editor.",
+  "data": {
+    "items": []
+  }
+}

--- a/templates/mood.klebb.json
+++ b/templates/mood.klebb.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "template": {
+      "id": "mood",
+      "title": "Mood",
+      "summary": "Daily mood check-in on a 1-5 scale with an emoji marker on the calendar.",
+      "category": "lifestyle",
+      "tags": ["mood", "daily", "emoji"]
+    },
+    "id": "{{string:id}}",
+    "label": "{{string:label}}",
+    "emoji": "🙂",
+    "order": 400,
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{mood:emoji}",
+        "secondary": "{notes|(no notes)}",
+        "emojiMap": {
+          "mood": { "1": "😩", "2": "😴", "3": "😐", "4": "🙂", "5": "😄" }
+        }
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "mood"
+    },
+    "calendar": {
+      "enabled": true,
+      "component": "day-marker",
+      "marker": {
+        "type": "field-emoji",
+        "field": "mood",
+        "emojiMap": { "1": "😩", "2": "😴", "3": "😐", "4": "🙂", "5": "😄" },
+        "fallback": "🙂"
+      }
+    },
+    "writeable": {
+      "fromWebapp": true,
+      "maxReadingsPerDay": 1,
+      "inputs": [
+        { "key": "mood", "type": "rating", "min": 1, "max": 5, "required": true },
+        { "key": "notes", "type": "textarea", "required": false }
+      ]
+    }
+  },
+  "description": "Daily mood rating (1-5) with optional notes. One entry per day; new entries replace earlier ones on the same date.",
+  "data": []
+}

--- a/templates/resting-heart-rate.klebb.json
+++ b/templates/resting-heart-rate.klebb.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "template": {
+      "id": "resting-heart-rate",
+      "title": "Resting heart rate",
+      "summary": "Beats per minute, typically logged shortly after waking.",
+      "category": "tracking",
+      "tags": ["vitals", "cardiac", "trend"]
+    },
+    "id": "{{string:id}}",
+    "label": "{{string:label}}",
+    "emoji": "❤️",
+    "order": 220,
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{bpm}",
+        "unit": "bpm",
+        "trendArrow": { "field": "bpm" }
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "bpm"
+    },
+    "writeable": {
+      "fromWebapp": true,
+      "maxReadingsPerDay": 1,
+      "inputs": [
+        { "key": "bpm", "type": "number", "required": true, "min": 30, "max": 200 }
+      ]
+    }
+  },
+  "description": "Resting heart rate in beats per minute. One entry per day.",
+  "data": []
+}

--- a/templates/sleep-hours.klebb.json
+++ b/templates/sleep-hours.klebb.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "template": {
+      "id": "sleep-hours",
+      "title": "Sleep hours (Apple Health)",
+      "summary": "Total sleep per night, populated by the iPhone Health Auto Export webhook.",
+      "category": "imported",
+      "tags": ["sleep", "apple-health", "hae", "ingest-only"]
+    },
+    "id": "{{string:id}}",
+    "label": "{{string:label}}",
+    "emoji": "😴",
+    "order": 500,
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{hours:round(1)}",
+        "unit": "hrs",
+        "trendArrow": { "field": "hours" }
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "hours"
+    }
+  },
+  "description": "Total sleep duration for the night. Populated by the iPhone Health Auto Export webhook; see docs/HEALTH-AUTO-EXPORT.md for setup. Ingest-only: no webapp writes.",
+  "data": []
+}

--- a/templates/supplement-stack.klebb.json
+++ b/templates/supplement-stack.klebb.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "template": {
+      "id": "supplement-stack",
+      "title": "Supplement stack",
+      "summary": "Daily supplement checklist, grouped by time of day.",
+      "category": "protocols",
+      "tags": ["supplements", "daily", "checklist"]
+    },
+    "id": "{{string:id}}",
+    "label": "{{string:label}}",
+    "emoji": "💊",
+    "order": 310,
+    "view": {
+      "enabled": true,
+      "component": "checklist-card",
+      "dateContext": "exact-date"
+    },
+    "reports": {
+      "enabled": true,
+      "component": "adherence-report",
+      "showCompliance": true
+    },
+    "calendar": {
+      "enabled": true,
+      "component": "day-marker",
+      "marker": "💊"
+    },
+    "writeable": {
+      "fromWebapp": true,
+      "pastAllowed": true,
+      "todayAllowed": true,
+      "futureAllowed": false
+    }
+  },
+  "description": "Daily supplement check-off. Group items by time-of-day (morning, evening) using the groups[] block. Add items via the chat agent or the in-card item editor (landing in a later PR).",
+  "data": {
+    "groups": [
+      { "id": "morning", "label": "Morning", "items": [] },
+      { "id": "evening", "label": "Evening", "items": [] }
+    ],
+    "items": []
+  }
+}

--- a/templates/waist.klebb.json
+++ b/templates/waist.klebb.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "template": {
+      "id": "waist",
+      "title": "Waist measurement",
+      "summary": "Single-number circumference measurement with a trend line.",
+      "category": "tracking",
+      "tags": ["measurement", "trend"]
+    },
+    "id": "{{string:id}}",
+    "label": "{{string:label}}",
+    "emoji": "📏",
+    "order": 110,
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{cm:round(1)}",
+        "unit": "{{string:unit}}",
+        "trendArrow": { "field": "cm" }
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "cm"
+    },
+    "writeable": {
+      "fromWebapp": true,
+      "maxReadingsPerDay": 1,
+      "inputs": [
+        { "key": "cm", "type": "number", "required": true, "min": 30, "max": 250, "step": 0.5 }
+      ]
+    }
+  },
+  "description": "Waist circumference, typically at the navel. One entry per day.",
+  "data": []
+}

--- a/templates/weight.klebb.json
+++ b/templates/weight.klebb.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "template": {
+      "id": "weight",
+      "title": "Weight",
+      "summary": "Daily body weight with a line-chart trend.",
+      "category": "tracking",
+      "tags": ["weight", "metric", "trend"]
+    },
+    "id": "{{string:id}}",
+    "label": "{{string:label}}",
+    "emoji": "⚖️",
+    "order": 100,
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{kg:round(1)}",
+        "unit": "{{string:unit}}",
+        "trendArrow": { "field": "kg" }
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "kg"
+    },
+    "writeable": {
+      "fromWebapp": true,
+      "maxReadingsPerDay": 1,
+      "inputs": [
+        { "key": "kg", "type": "number", "required": true, "min": 20, "max": 500, "step": 0.1 }
+      ]
+    }
+  },
+  "description": "Body weight logged once per day. New entries replace earlier ones on the same date.",
+  "data": []
+}

--- a/tests/prompts.test.js
+++ b/tests/prompts.test.js
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/prompts.test.js
+// Validates every prompts/*.md carries complete frontmatter. Prompts are
+// user-facing content that will be pasted into the chat agent's input; a
+// missing title or summary would leave the gallery with blank rows.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+const PROMPTS_DIR = path.join(__dirname, '..', 'prompts');
+
+// Minimal YAML frontmatter parser: top-level keys only, array values via
+// [a, b, c] syntax. Good enough for our controlled prompt files.
+function parseFrontmatter(raw) {
+  const m = raw.match(/^---\n([\s\S]*?)\n---\n/);
+  if (!m) return null;
+  const body = raw.slice(m[0].length);
+  const frontmatter = {};
+  for (const line of m[1].split('\n')) {
+    if (!line.trim()) continue;
+    const kv = line.match(/^([a-z][a-z0-9_-]*):\s*(.+)$/i);
+    if (!kv) continue;
+    const key = kv[1];
+    let value = kv[2].trim();
+    if (value.startsWith('[') && value.endsWith(']')) {
+      value = value.slice(1, -1)
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean);
+    }
+    frontmatter[key] = value;
+  }
+  return { frontmatter, body };
+}
+
+function listPrompts() {
+  if (!fs.existsSync(PROMPTS_DIR)) return [];
+  return fs.readdirSync(PROMPTS_DIR)
+    .filter(f => f.endsWith('.md'))
+    .map(f => path.join(PROMPTS_DIR, f));
+}
+
+describe('prompts/ directory', () => {
+  test('exists and contains at least 6 prompts', () => {
+    const files = listPrompts();
+    assert.ok(files.length >= 6, `expected >= 6 prompts, found ${files.length}`);
+  });
+
+  test('includes the onboarding meta-prompt', () => {
+    const files = listPrompts().map(f => path.basename(f));
+    assert.ok(
+      files.includes('new-to-klebb.md'),
+      'new-to-klebb.md is required as the conversational onboarding prompt',
+    );
+  });
+});
+
+const files = listPrompts();
+for (const file of files) {
+  const name = path.basename(file);
+  describe(`prompt: ${name}`, () => {
+    const raw = fs.readFileSync(file, 'utf8');
+
+    test('has valid YAML frontmatter', () => {
+      const parsed = parseFrontmatter(raw);
+      assert.ok(parsed, `missing frontmatter block in ${name}`);
+    });
+
+    test('frontmatter has required fields', () => {
+      const { frontmatter } = parseFrontmatter(raw);
+      assert.ok(typeof frontmatter.title === 'string' && frontmatter.title.length > 0,
+        'title required');
+      assert.ok(typeof frontmatter.summary === 'string' && frontmatter.summary.length > 0,
+        'summary required');
+      assert.ok(Array.isArray(frontmatter.tags),
+        'tags required (even if empty list)');
+    });
+
+    test('body is non-empty prose', () => {
+      const { body } = parseFrontmatter(raw);
+      assert.ok(body.trim().length > 50,
+        `${name} body is suspiciously short (<50 chars)`);
+    });
+  });
+}

--- a/tests/template-manifests.test.js
+++ b/tests/template-manifests.test.js
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/template-manifests.test.js
+// Successor to the removed tests/example-manifests.test.js. Walks every
+// templates/*.klebb.json, strips placeholder tokens, and verifies the
+// stripped result is a valid klebb.datafile.v1 manifest referencing a known
+// renderer. Also validates the meta.template block and the placeholder
+// syntax itself.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+const TEMPLATES_DIR = path.join(__dirname, '..', 'templates');
+
+// Renderer names the client knows about. Kept in sync with
+// public/js/components/eh-view-renderer.js.
+const KNOWN_COMPONENTS = new Set([
+  'generic-card',
+  'schedule-card',
+  'checklist-card',
+  'markdown-doc',
+  'line-chart',
+  'schedule-timeline',
+  'table-list',
+  'adherence-report',
+  'greeting-banner',
+  'list-card',
+  'day-marker',
+  'combination-card',
+  'welcome-card',
+]);
+
+const PLACEHOLDER_TYPES = new Set([
+  'string', 'number', 'boolean', 'date', 'enum',
+]);
+
+// Matches {{type:name}} or {{name}} (default type = string).
+const PLACEHOLDER_RE = /\{\{([a-z]+:)?([a-z0-9_]+)\}\}/gi;
+
+// Placeholder default values, keyed by declared type. Used only to produce a
+// syntactically valid manifest for schema validation; no semantic meaning.
+const PLACEHOLDER_DEFAULTS = {
+  string: 'test',
+  number: 1,
+  boolean: true,
+  date: '2026-01-01',
+  enum: 'option-a',
+};
+
+function stripPlaceholders(rawJson) {
+  // Replace every placeholder with a JSON-safe default. For non-string types,
+  // the default needs to be inserted without quotes, so we swap the whole
+  // quoted-placeholder token.
+  let out = rawJson;
+
+  // First pass: quoted placeholders like "{{number:dose_mg}}" become the raw
+  // default (unquoted for numbers/booleans).
+  out = out.replace(/"\{\{([a-z]+:)?([a-z0-9_]+)\}\}"/gi, (_, typePrefix, name) => {
+    const type = typePrefix ? typePrefix.slice(0, -1) : 'string';
+    const def = PLACEHOLDER_DEFAULTS[type];
+    if (def === undefined) throw new Error(`unknown placeholder type: ${type}`);
+    if (type === 'string' || type === 'date' || type === 'enum') return JSON.stringify(def);
+    return JSON.stringify(def); // numbers + booleans: JSON.stringify handles unquoting
+  });
+
+  // Second pass: unquoted placeholders (shouldn't happen in valid templates,
+  // but catch anything we missed).
+  out = out.replace(PLACEHOLDER_RE, (_, typePrefix, name) => {
+    const type = typePrefix ? typePrefix.slice(0, -1) : 'string';
+    const def = PLACEHOLDER_DEFAULTS[type];
+    if (def === undefined) throw new Error(`unknown placeholder type: ${type}`);
+    return JSON.stringify(def);
+  });
+
+  return out;
+}
+
+function listTemplates() {
+  if (!fs.existsSync(TEMPLATES_DIR)) return [];
+  return fs.readdirSync(TEMPLATES_DIR)
+    .filter(f => f.endsWith('.klebb.json'))
+    .map(f => path.join(TEMPLATES_DIR, f));
+}
+
+describe('templates/ directory', () => {
+  test('exists and contains at least 10 templates', () => {
+    const files = listTemplates();
+    assert.ok(files.length >= 10, `expected >= 10 templates, found ${files.length}`);
+  });
+});
+
+const files = listTemplates();
+for (const file of files) {
+  const name = path.basename(file);
+  describe(`template: ${name}`, () => {
+    const raw = fs.readFileSync(file, 'utf8');
+
+    test('placeholder syntax is valid', () => {
+      const matches = [...raw.matchAll(PLACEHOLDER_RE)];
+      for (const m of matches) {
+        const typePrefix = m[1];
+        if (typePrefix) {
+          const type = typePrefix.slice(0, -1);
+          assert.ok(
+            PLACEHOLDER_TYPES.has(type),
+            `unknown placeholder type "${type}" in ${name}`,
+          );
+        }
+      }
+    });
+
+    test('parses to valid JSON after placeholder substitution', () => {
+      const stripped = stripPlaceholders(raw);
+      let parsed;
+      assert.doesNotThrow(() => { parsed = JSON.parse(stripped); },
+        `JSON parse failed after placeholder substitution in ${name}`);
+
+      assert.equal(parsed.$schema, 'klebb.datafile.v1', '$schema mismatch');
+      assert.ok(parsed.meta, 'missing meta');
+      assert.ok(typeof parsed.meta.id === 'string', 'missing meta.id');
+      assert.ok(typeof parsed.meta.label === 'string', 'missing meta.label');
+    });
+
+    test('meta.template block is complete', () => {
+      const parsed = JSON.parse(stripPlaceholders(raw));
+      const t = parsed.meta.template;
+      assert.ok(t, 'missing meta.template block');
+      assert.ok(typeof t.id === 'string' && t.id.length > 0, 'meta.template.id required');
+      assert.ok(typeof t.title === 'string' && t.title.length > 0, 'meta.template.title required');
+      assert.ok(typeof t.summary === 'string' && t.summary.length > 0, 'meta.template.summary required');
+      assert.ok(typeof t.category === 'string' && t.category.length > 0, 'meta.template.category required');
+      assert.ok(Array.isArray(t.tags), 'meta.template.tags must be array');
+    });
+
+    test('references only known renderer components', () => {
+      const parsed = JSON.parse(stripPlaceholders(raw));
+      const views = ['view', 'trends', 'calendar', 'reports'];
+      for (const v of views) {
+        const block = parsed.meta[v];
+        if (!block || !block.component) continue;
+        assert.ok(
+          KNOWN_COMPONENTS.has(block.component),
+          `unknown component "${block.component}" in meta.${v} of ${name}`,
+        );
+      }
+    });
+
+    test('template filename matches meta.template.id', () => {
+      const parsed = JSON.parse(stripPlaceholders(raw));
+      const expected = parsed.meta.template.id + '.klebb.json';
+      assert.equal(name, expected,
+        `filename ${name} does not match meta.template.id ${parsed.meta.template.id}`);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Ten starter card templates and seven conversational prompts. Content
only; the UI that surfaces this content (Add Card modal, prompts
gallery, and the \`/api/templates\` + \`/api/prompts\` endpoints)
lands in follow-up PRs.

## Why

Templates are the content source for the Add Card gallery (#117).
Prompts are the content source for the prompts gallery modal (#118).
Shipping the content + schema + tests before any UI lets the UI PRs
focus on rendering and gives contributors a stable target to PR
against.

The \`prompts/new-to-klebb.md\` meta-prompt turns the onboarding
"wizard" idea into a content feature rather than a code feature:
one markdown file instructs the chat agent to run a short
conversational setup.

## How

### Templates (\`templates/*.klebb.json\`)

Each is a valid \`klebb.datafile.v1\` manifest with:

- A \`meta.template\` block (\`id\`, \`title\`, \`summary\`,
  \`category\`, \`tags\`) for gallery rendering.
- Typed placeholder strings for user-supplied values:
  \`{{string:name}}\`, \`{{number:dose_mg}}\`, \`{{date:start}}\`,
  \`{{boolean:foo}}\`, \`{{enum:bar}}\`. Type defaults to string when
  the prefix is omitted.
- Categories: \`tracking\`, \`protocols\`, \`lifestyle\`,
  \`imported\`.

Templates shipped: weight, blood-pressure, waist, resting-heart-rate,
injection-protocol, supplement-stack, medication-schedule, mood,
daily-notes, hydration, sleep-hours.

### Prompts (\`prompts/*.md\`)

Markdown with YAML frontmatter (\`title\`, \`summary\`, \`tags\`).
Body is prose directed at the chat agent, not the user.

Prompts shipped: new-to-klebb (the meta-prompt wizard), glp1-cycle,
peptide-cycle, supplement-stack-basic, post-op-recovery,
strength-training, mood-sleep-basics.

### Tests

- \`tests/template-manifests.test.js\` — successor to the removed
  \`tests/example-manifests.test.js\`. Walks \`templates/\`, strips
  placeholders with typed substitution, validates schema, renderer
  names, \`meta.template\` completeness, and filename ↔
  \`template.id\` match.
- \`tests/prompts.test.js\` — parses frontmatter, validates required
  fields, checks body length, confirms \`new-to-klebb.md\` is
  present.

79 new test assertions; all pass.

### Docs

- \`CONTRIBUTING-TEMPLATES.md\` + \`CONTRIBUTING-PROMPTS.md\` at repo
  root. Both cover file shape, writing guidance, and a PR checklist.
- README gains a "Contributing templates and prompts" section
  pointing at both guides.

## Testing

- [x] \`npm test\` full suite: 560/561 pass. The one new failure
      continues to be the flaky \`chat-proxy-reset.test.js\` from
      main; the \`no-personal-refs\` scanner's gitignored-file hits
      also match main. Branch is net green.
- [x] Template walker enforces every rule documented in
      \`CONTRIBUTING-TEMPLATES.md\`.
- [x] Prompt walker enforces frontmatter contract.
- [ ] Manual (deferred until #116 ships): hit hypothetical
      \`/api/templates\` + \`/api/prompts\` endpoints.

Fixes #115