### PR TITLE
feat(server): /api/templates and /api/prompts endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **\`GET /api/templates\` and \`GET /api/prompts\` endpoints.** Plain
+  JSON read-only endpoints that surface the contents of \`templates/\`
+  and \`prompts/\` for the Add Card modal and prompts gallery to
+  consume. Both session-gated (inherit the app-wide auth), both set
+  \`Cache-Control: no-store\`, both read the directories at request
+  time so contributor additions are picked up without a restart.
+  Malformed files are logged and skipped; the response stays 200 and
+  carries the rest. (#116)
+
 - **\`templates/\` + \`prompts/\` directories.** Ten starter card
   templates and seven conversational prompts covering the main Klebb
   use cases (weight, BP, waist, resting HR, injection protocol,

--- a/CONTRIBUTING-PROMPTS.md
+++ b/CONTRIBUTING-PROMPTS.md
@@ -74,6 +74,24 @@ briefing for the agent, not the user. Good prompts:
       renderer.
 - [ ] File name is `kebab-case.md` and matches the topic.
 
+## How the app consumes prompts
+
+The server exposes prompts at `GET /api/prompts` (session-gated). The
+response is:
+
+```json
+{ "prompts": [
+  { "id": "glp1-cycle", "title": "...", "summary": "...",
+    "tags": ["..."], "body": "..." }
+] }
+```
+
+`body` is the markdown content with frontmatter stripped. The prompts
+gallery modal loads the body into the chat input without sending; the
+user reviews, edits if they want, then sends themselves. The
+server-side endpoint reads `prompts/` at request time, so newly-added
+prompts appear without a restart.
+
 ## Examples
 
 See `prompts/new-to-klebb.md` for the conversational onboarding

--- a/CONTRIBUTING-TEMPLATES.md
+++ b/CONTRIBUTING-TEMPLATES.md
@@ -70,6 +70,24 @@ Before opening a PR:
 - [ ] The template describes a real-world tracking use case, not a
       demonstration of schema features.
 
+## How the app consumes templates
+
+The server exposes templates at `GET /api/templates` (session-gated).
+The response is:
+
+```json
+{ "templates": [
+  { "id": "weight", "title": "Weight", "summary": "...",
+    "category": "tracking", "tags": ["..."], "manifest": { ... } }
+] }
+```
+
+`manifest` is the full template JSON with placeholders intact. The
+Add Card modal substitutes placeholder tokens client-side as the user
+types, then POSTs the substituted manifest to `/api/manifests`. The
+server-side endpoint reads `templates/` at request time, so
+newly-added templates appear without a restart.
+
 ## Examples
 
 See the templates already in `templates/` for worked examples across

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ const ENV = require('./config/env');
 const registry = require('./manifests/registry');
 const { convertDateKeyedToArray } = require('./scripts/migrate-date-keyed-to-array');
 const { runFirstBoot } = require('./server/first-boot');
+const { listTemplates, listPrompts } = require('./server/content');
 const voice = require('./voice/fish');
 const voiceCache = require('./voice/cache');
 const { TOOL_DEFS, dispatchToolCall } = require('./chat/tools');
@@ -754,6 +755,23 @@ const server = http.createServer(async (req, res) => {
     }
 
     // === End settings endpoints ===
+
+    // === Content endpoints (templates + prompts) ===
+    // Served from templates/ and prompts/ at the repo root. Read at request
+    // time so a contributor's newly added content is picked up without a
+    // restart; the directories are small and traffic is infrequent.
+
+    if (parts[0] === 'templates' && parts.length === 1 && req.method === 'GET') {
+      res.setHeader('Cache-Control', 'no-store');
+      return sendJSON(res, { templates: listTemplates() });
+    }
+
+    if (parts[0] === 'prompts' && parts.length === 1 && req.method === 'GET') {
+      res.setHeader('Cache-Control', 'no-store');
+      return sendJSON(res, { prompts: listPrompts() });
+    }
+
+    // === End content endpoints ===
 
     // Simple JSON file endpoints
     const simpleFiles = {

--- a/server/content/index.js
+++ b/server/content/index.js
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// server/content/index.js
+// Reads templates/ and prompts/ from disk on each request and returns them
+// as JSON. No in-memory cache: directories are small, content changes rarely,
+// and the cost of staleness (a contributor adds a template, doesn't see it)
+// outweighs the cost of a couple of disk reads per hit.
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const TEMPLATES_DIR = path.join(REPO_ROOT, 'templates');
+const PROMPTS_DIR = path.join(REPO_ROOT, 'prompts');
+
+function listTemplates({ log = console.warn } = {}) {
+  const out = [];
+  let entries;
+  try {
+    entries = fs.readdirSync(TEMPLATES_DIR, { withFileTypes: true });
+  } catch (e) {
+    if (e.code !== 'ENOENT') log('[content] templates dir read failed:', e.message);
+    return out;
+  }
+  for (const ent of entries) {
+    if (!ent.isFile()) continue;
+    if (!ent.name.endsWith('.klebb.json')) continue;
+    const full = path.join(TEMPLATES_DIR, ent.name);
+    let raw;
+    try {
+      raw = fs.readFileSync(full, 'utf8');
+    } catch (e) {
+      log(`[content] templates/${ent.name}: read failed: ${e.message}`);
+      continue;
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (e) {
+      log(`[content] templates/${ent.name}: parse failed: ${e.message}`);
+      continue;
+    }
+    const t = parsed && parsed.meta && parsed.meta.template;
+    if (!t || !t.id || !t.title || !t.summary || !t.category || !Array.isArray(t.tags)) {
+      log(`[content] templates/${ent.name}: missing or incomplete meta.template`);
+      continue;
+    }
+    out.push({
+      id: t.id,
+      title: t.title,
+      summary: t.summary,
+      category: t.category,
+      tags: t.tags,
+      manifest: parsed,
+    });
+  }
+  out.sort((a, b) => a.title.localeCompare(b.title));
+  return out;
+}
+
+// Parse YAML frontmatter + body. Matches the tolerant parser used in tests.
+function parseFrontmatter(raw) {
+  const m = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!m) return null;
+  const body = raw.slice(m[0].length);
+  const frontmatter = {};
+  for (const line of m[1].split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    const kv = line.match(/^([a-z][a-z0-9_-]*):\s*(.+)$/i);
+    if (!kv) continue;
+    const key = kv[1];
+    let value = kv[2].trim();
+    if (value.startsWith('[') && value.endsWith(']')) {
+      value = value.slice(1, -1)
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean);
+    }
+    frontmatter[key] = value;
+  }
+  return { frontmatter, body };
+}
+
+function listPrompts({ log = console.warn } = {}) {
+  const out = [];
+  let entries;
+  try {
+    entries = fs.readdirSync(PROMPTS_DIR, { withFileTypes: true });
+  } catch (e) {
+    if (e.code !== 'ENOENT') log('[content] prompts dir read failed:', e.message);
+    return out;
+  }
+  for (const ent of entries) {
+    if (!ent.isFile()) continue;
+    if (!ent.name.endsWith('.md')) continue;
+    const full = path.join(PROMPTS_DIR, ent.name);
+    let raw;
+    try {
+      raw = fs.readFileSync(full, 'utf8');
+    } catch (e) {
+      log(`[content] prompts/${ent.name}: read failed: ${e.message}`);
+      continue;
+    }
+    const parsed = parseFrontmatter(raw);
+    if (!parsed) {
+      log(`[content] prompts/${ent.name}: missing frontmatter`);
+      continue;
+    }
+    const { frontmatter, body } = parsed;
+    if (!frontmatter.title || !frontmatter.summary || !Array.isArray(frontmatter.tags)) {
+      log(`[content] prompts/${ent.name}: frontmatter missing title/summary/tags`);
+      continue;
+    }
+    out.push({
+      id: ent.name.replace(/\.md$/, ''),
+      title: frontmatter.title,
+      summary: frontmatter.summary,
+      tags: frontmatter.tags,
+      body: body.trim(),
+    });
+  }
+  out.sort((a, b) => a.title.localeCompare(b.title));
+  return out;
+}
+
+module.exports = { listTemplates, listPrompts };

--- a/tests/content-api.test.js
+++ b/tests/content-api.test.js
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/content-api.test.js
+// Integration tests for GET /api/templates + GET /api/prompts.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const { createSandbox, cleanupSandbox, spawnServer, req } = require('./helpers/sandbox');
+
+describe('content API', () => {
+  let sandbox, server;
+
+  before(async () => {
+    sandbox = createSandbox();
+    server = await spawnServer(sandbox);
+  });
+  after(async () => {
+    if (server) await server.kill();
+    cleanupSandbox(sandbox);
+  });
+
+  test('GET /api/templates returns the shipped template list', async () => {
+    const res = await req(server.baseUrl, '/api/templates');
+    assert.equal(res.status, 200);
+    assert.equal(res.headers['cache-control'], 'no-store');
+    assert.ok(Array.isArray(res.json.templates));
+    assert.ok(res.json.templates.length >= 10, `expected >= 10 templates, got ${res.json.templates.length}`);
+  });
+
+  test('each template row has id, title, summary, category, tags, manifest', async () => {
+    const res = await req(server.baseUrl, '/api/templates');
+    for (const t of res.json.templates) {
+      assert.ok(typeof t.id === 'string' && t.id.length > 0);
+      assert.ok(typeof t.title === 'string' && t.title.length > 0);
+      assert.ok(typeof t.summary === 'string' && t.summary.length > 0);
+      assert.ok(typeof t.category === 'string' && t.category.length > 0);
+      assert.ok(Array.isArray(t.tags));
+      assert.ok(t.manifest && t.manifest.meta && t.manifest.meta.template);
+      assert.equal(t.manifest.meta.template.id, t.id);
+    }
+  });
+
+  test('GET /api/prompts returns the shipped prompt list', async () => {
+    const res = await req(server.baseUrl, '/api/prompts');
+    assert.equal(res.status, 200);
+    assert.equal(res.headers['cache-control'], 'no-store');
+    assert.ok(Array.isArray(res.json.prompts));
+    assert.ok(res.json.prompts.length >= 6, `expected >= 6 prompts, got ${res.json.prompts.length}`);
+  });
+
+  test('each prompt row has id, title, summary, tags, body', async () => {
+    const res = await req(server.baseUrl, '/api/prompts');
+    for (const p of res.json.prompts) {
+      assert.ok(typeof p.id === 'string' && p.id.length > 0);
+      assert.ok(typeof p.title === 'string' && p.title.length > 0);
+      assert.ok(typeof p.summary === 'string' && p.summary.length > 0);
+      assert.ok(Array.isArray(p.tags));
+      assert.ok(typeof p.body === 'string' && p.body.length > 20);
+    }
+  });
+
+  test('prompts include the new-to-klebb meta-prompt', async () => {
+    const res = await req(server.baseUrl, '/api/prompts');
+    const ids = res.json.prompts.map(p => p.id);
+    assert.ok(ids.includes('new-to-klebb'), 'new-to-klebb prompt must be discoverable');
+  });
+
+  test('malformed files under templates/ and prompts/ are skipped, response stays 200',
+    async (t) => {
+      const fs = require('fs');
+      const path = require('path');
+      const REPO_ROOT = path.resolve(__dirname, '..');
+      const badTemplate = path.join(REPO_ROOT, 'templates', '__test_malformed.klebb.json');
+      const badPrompt = path.join(REPO_ROOT, 'prompts', '__test_malformed.md');
+      fs.writeFileSync(badTemplate, '{ this is not json');
+      fs.writeFileSync(badPrompt, 'no frontmatter, just prose');
+      t.after(() => {
+        try { fs.unlinkSync(badTemplate); } catch {}
+        try { fs.unlinkSync(badPrompt); } catch {}
+      });
+
+      const tRes = await req(server.baseUrl, '/api/templates');
+      assert.equal(tRes.status, 200);
+      // bad file should not appear
+      const tIds = tRes.json.templates.map(x => x.id);
+      assert.ok(!tIds.includes('__test_malformed'),
+        'malformed template leaked into the response');
+
+      const pRes = await req(server.baseUrl, '/api/prompts');
+      assert.equal(pRes.status, 200);
+      const pIds = pRes.json.prompts.map(x => x.id);
+      assert.ok(!pIds.includes('__test_malformed'),
+        'malformed prompt leaked into the response');
+    });
+
+  test('/api/templates and /api/prompts require auth when credentials registered',
+    async (t) => {
+      // Spin up a second server with credentials registered so the auth gate
+      // is actually armed. No session cookie = 401.
+      const { fakeAuthState } = require('./helpers/sandbox');
+      const auth = fakeAuthState('test');
+      const box = createSandbox({
+        credentials: auth.credentials,
+        sessions: auth.sessions,
+      });
+      const srv = await spawnServer(box);
+      t.after(async () => { await srv.kill(); cleanupSandbox(box); });
+
+      const noAuth = await req(srv.baseUrl, '/api/templates');
+      assert.equal(noAuth.status, 401);
+      const noAuthP = await req(srv.baseUrl, '/api/prompts');
+      assert.equal(noAuthP.status, 401);
+
+      const authed = await req(srv.baseUrl, '/api/templates', { cookie: auth.cookie });
+      assert.equal(authed.status, 200);
+    });
+});

--- a/tests/prompts.test.js
+++ b/tests/prompts.test.js
@@ -15,11 +15,11 @@ const PROMPTS_DIR = path.join(__dirname, '..', 'prompts');
 // Minimal YAML frontmatter parser: top-level keys only, array values via
 // [a, b, c] syntax. Good enough for our controlled prompt files.
 function parseFrontmatter(raw) {
-  const m = raw.match(/^---\n([\s\S]*?)\n---\n/);
+  const m = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
   if (!m) return null;
   const body = raw.slice(m[0].length);
   const frontmatter = {};
-  for (const line of m[1].split('\n')) {
+  for (const line of m[1].split(/\r?\n/)) {
     if (!line.trim()) continue;
     const kv = line.match(/^([a-z][a-z0-9_-]*):\s*(.+)$/i);
     if (!kv) continue;


### PR DESCRIPTION
## Summary

Exposes the \`templates/\` and \`prompts/\` directories (#123) over
HTTP so the Add Card modal (#117) and prompts gallery (#118) can
consume them. Plain JSON, session-gated, no cache layer.

## Why

UI PRs need a way to fetch the content. Splitting this plumbing from
the UI work (and from the content itself) keeps each review small.

## How

- **New \`server/content/\` module.** Reads \`templates/*.klebb.json\`
  and \`prompts/*.md\` at request time. Malformed files are logged
  and skipped; the response stays 200 so a single bad file can't
  break the whole gallery.
- **Two new route handlers in \`server.js\`:**
  \`GET /api/templates\` → \`{ templates: [{ id, title, summary,
  category, tags, manifest }] }\`
  \`GET /api/prompts\` → \`{ prompts: [{ id, title, summary, tags,
  body }] }\`
  Both inherit the app-wide auth gate (anything under \`/api/\`
  that isn't public returns 401 when credentials are registered
  and no valid session cookie is present).
- **Both endpoints set \`Cache-Control: no-store\`.** Content is
  small, traffic is infrequent, and the cost of a contributor
  adding a template and not seeing it is higher than the cost of
  a few disk reads per hit. No in-memory cache, no watcher.
- **Cross-platform frontmatter parsing fix.** The prompts
  frontmatter regex now accepts \`\r?\n\` so CRLF files (what
  Git's \`core.autocrlf\` produces on Windows) parse correctly.
  The same fix lands in \`tests/prompts.test.js\`.

## Testing

- [x] New \`tests/content-api.test.js\` covers the happy path for
      both endpoints (row-shape contract, content presence,
      cache headers), the new-to-klebb meta-prompt discoverability,
      the auth gate (401 without cookie, 200 with), and malformed-
      file isolation (writes junk to both dirs mid-test, asserts
      they don't leak into the response).
- [x] \`npm test\` full suite: 566/568 pass locally; the two
      failures are the same pre-existing ones (flaky chat-proxy-
      reset; no-personal-refs scanner hitting gitignored files).
- [ ] Manual verification deferred until the UI consumers land.

Fixes #116