### PR TITLE
feat(ui): Add Card modal with template gallery, live preview, and form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Add Card modal.** Click the welcome card's "Add a card" action
+  to open a modal with three panes: a searchable template gallery
+  grouped by category (Tracking, Protocols, Lifestyle, Imported), a
+  live card preview using the real renderer component, and a form
+  with one input per placeholder in the selected template. Typing in
+  a field updates the preview immediately; fields are typed (number,
+  date, boolean, string) based on the placeholder declaration. On
+  submit, placeholders are substituted client-side and the manifest
+  is POSTed to \`/api/manifests\`. If the id collides, the client
+  auto-suffixes (\`weight\`, \`weight-2\`, …) until it lands. Does
+  not require an LLM gateway: the deterministic path to creating any
+  card. New module \`public/js/lib/template-substitute.js\` holds
+  the pure substitution logic (tested standalone); new component
+  \`public/js/components/eh-add-card-modal.js\` holds the modal.
+  Welcome card's primary action now creates actual cards instead of
+  showing "coming soon". A \`klebb-cards-changed\` window event is
+  dispatched on success so the view renderer refreshes without a
+  page reload. (#117)
+
 - **\`GET /api/templates\` and \`GET /api/prompts\` endpoints.** Plain
   JSON read-only endpoints that surface the contents of \`templates/\`
   and \`prompts/\` for the Add Card modal and prompts gallery to

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,9 @@ COPY --chown=klebb:klebb public ./public
 COPY --chown=klebb:klebb scripts ./scripts
 COPY --chown=klebb:klebb voice ./voice
 COPY --chown=klebb:klebb health-auto-export ./health-auto-export
+COPY --chown=klebb:klebb server ./server
+COPY --chown=klebb:klebb templates ./templates
+COPY --chown=klebb:klebb prompts ./prompts
 
 # Data dir — mount a volume here in production. The entrypoint chowns
 # this to the runtime user at container start so bind-mounts owned by

--- a/public/js/components/eh-add-card-modal.js
+++ b/public/js/components/eh-add-card-modal.js
@@ -1,0 +1,581 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// public/js/components/eh-add-card-modal.js
+// Add Card modal. Three panes:
+//   - Gallery (left): templates grouped by category, searchable.
+//   - Preview (top right): live render of the selected template's card.
+//   - Form (bottom right): one input per placeholder in the selected
+//     template, with live updates driving the preview.
+//
+// Open with:
+//   const m = document.createElement('eh-add-card-modal');
+//   document.body.appendChild(m);
+//   m.open();
+//
+// Fires 'eh-add-card-done' with { id, welcomeAutoHidden } on success,
+// 'eh-add-card-cancel' when closed without creating.
+
+import { LitElement, html, css } from 'https://esm.sh/lit@3';
+import { resolveRenderer } from '../renderer-registry.js';
+import {
+  extractPlaceholders,
+  parseSubstituted,
+} from '../lib/template-substitute.js';
+import { errorFromResponse } from '../lib/save-error.js';
+
+// Ensure all renderers are imported so the preview can mount them.
+import './eh-view-renderer.js';
+
+const CATEGORY_ORDER = ['tracking', 'protocols', 'lifestyle', 'imported'];
+const CATEGORY_LABELS = {
+  tracking: 'Tracking',
+  protocols: 'Protocols',
+  lifestyle: 'Lifestyle',
+  imported: 'Imported data',
+};
+
+export class EhAddCardModal extends LitElement {
+  static properties = {
+    _templates: { state: true },
+    _loading: { state: true },
+    _loadError: { state: true },
+    _filter: { state: true },
+    _selectedId: { state: true },
+    _values: { state: true },
+    _busy: { state: true },
+    _submitError: { state: true },
+    _advancedOpen: { state: true },
+  };
+
+  constructor() {
+    super();
+    this._templates = [];
+    this._loading = true;
+    this._loadError = null;
+    this._filter = '';
+    this._selectedId = null;
+    this._values = {};
+    this._busy = false;
+    this._submitError = null;
+    this._advancedOpen = false;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._loadTemplates();
+    this._escHandler = (e) => { if (e.key === 'Escape') this._cancel(); };
+    window.addEventListener('keydown', this._escHandler);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    window.removeEventListener('keydown', this._escHandler);
+  }
+
+  open() {
+    const dlg = this.renderRoot?.querySelector('dialog');
+    if (dlg && !dlg.open) dlg.showModal();
+  }
+
+  async _loadTemplates() {
+    this._loading = true;
+    this._loadError = null;
+    try {
+      const r = await fetch('/api/templates');
+      if (!r.ok) throw await errorFromResponse(r);
+      const body = await r.json();
+      this._templates = body.templates || [];
+    } catch (e) {
+      this._loadError = e.message || 'Could not load templates.';
+    } finally {
+      this._loading = false;
+    }
+  }
+
+  _selected() {
+    return this._templates.find(t => t.id === this._selectedId) || null;
+  }
+
+  _selectTemplate(id) {
+    this._selectedId = id;
+    this._submitError = null;
+    this._advancedOpen = false;
+    const t = this._templates.find(x => x.id === id);
+    if (!t) { this._values = {}; return; }
+    // Seed values with sensible defaults derived from the template id itself.
+    const defaults = this._defaultValues(t);
+    this._values = defaults;
+  }
+
+  _defaultValues(template) {
+    const raw = JSON.stringify(template.manifest);
+    let placeholders = [];
+    try { placeholders = extractPlaceholders(raw); } catch { return {}; }
+    const out = {};
+    for (const p of placeholders) {
+      if (p.name === 'id') {
+        // Suggest the template id as the default card id. User can override.
+        out[p.name] = template.id;
+      } else if (p.name === 'label') {
+        out[p.name] = template.title;
+      } else if (p.name === 'unit') {
+        // Leave unit empty so the user picks.
+        out[p.name] = '';
+      } else if (p.type === 'date') {
+        out[p.name] = new Date().toISOString().slice(0, 10);
+      } else if (p.type === 'number') {
+        out[p.name] = '';
+      } else if (p.type === 'boolean') {
+        out[p.name] = false;
+      } else {
+        out[p.name] = '';
+      }
+    }
+    return out;
+  }
+
+  _updateValue(name, value) {
+    this._values = { ...this._values, [name]: value };
+  }
+
+  _filteredTemplates() {
+    const q = (this._filter || '').trim().toLowerCase();
+    if (!q) return this._templates;
+    return this._templates.filter(t => {
+      const hay = `${t.title} ${t.summary} ${(t.tags || []).join(' ')}`.toLowerCase();
+      return hay.includes(q);
+    });
+  }
+
+  _groupByCategory(templates) {
+    const groups = new Map();
+    for (const t of templates) {
+      const cat = t.category || 'other';
+      if (!groups.has(cat)) groups.set(cat, []);
+      groups.get(cat).push(t);
+    }
+    const ordered = [];
+    for (const cat of CATEGORY_ORDER) {
+      if (groups.has(cat)) ordered.push([cat, groups.get(cat)]);
+    }
+    for (const [cat, list] of groups) {
+      if (!CATEGORY_ORDER.includes(cat)) ordered.push([cat, list]);
+    }
+    return ordered;
+  }
+
+  _buildPreviewManifest() {
+    const t = this._selected();
+    if (!t) return null;
+    const raw = JSON.stringify(t.manifest);
+    const { manifest, error } = parseSubstituted(raw, this._values);
+    if (error) return null;
+    return manifest;
+  }
+
+  async _submit() {
+    const t = this._selected();
+    if (!t) return;
+    const raw = JSON.stringify(t.manifest);
+    const { manifest, error } = parseSubstituted(raw, this._values);
+    if (error) {
+      this._submitError = `Invalid manifest after substitution: ${error}`;
+      return;
+    }
+
+    // Basic validation: required fields (id, label) must be non-empty.
+    if (!manifest.meta?.id || !String(manifest.meta.id).trim()) {
+      this._submitError = 'Card id is required.';
+      return;
+    }
+    if (!manifest.meta?.label || !String(manifest.meta.label).trim()) {
+      this._submitError = 'Card label is required.';
+      return;
+    }
+
+    this._busy = true;
+    this._submitError = null;
+    try {
+      const created = await this._createWithCollisionRetry(manifest);
+      this.dispatchEvent(new CustomEvent('eh-add-card-done', {
+        detail: created,
+        bubbles: true,
+        composed: true,
+      }));
+      this._close();
+    } catch (e) {
+      this._submitError = e.message || 'Could not create card.';
+    } finally {
+      this._busy = false;
+    }
+  }
+
+  async _createWithCollisionRetry(manifest, attempt = 1) {
+    const attemptManifest = attempt === 1
+      ? manifest
+      : { ...manifest, meta: { ...manifest.meta, id: `${manifest.meta.id}-${attempt}` } };
+    const r = await fetch('/api/manifests', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(attemptManifest),
+    });
+    if (r.status === 201) {
+      return await r.json();
+    }
+    if (r.status === 409 && attempt < 20) {
+      return this._createWithCollisionRetry(manifest, attempt + 1);
+    }
+    throw await errorFromResponse(r);
+  }
+
+  _cancel() {
+    this.dispatchEvent(new CustomEvent('eh-add-card-cancel', {
+      bubbles: true, composed: true,
+    }));
+    this._close();
+  }
+
+  _close() {
+    const dlg = this.renderRoot?.querySelector('dialog');
+    if (dlg && dlg.open) dlg.close();
+  }
+
+  _handleDialogClose() {
+    // Clean up: detach ourselves from the DOM so a fresh instance gets
+    // a fresh template list next time.
+    if (this.parentNode) this.parentNode.removeChild(this);
+  }
+
+  _renderGallery() {
+    if (this._loading) return html`<div class="empty">Loading templates…</div>`;
+    if (this._loadError) return html`<div class="empty error">⚠︎ ${this._loadError}</div>`;
+    const filtered = this._filteredTemplates();
+    if (!filtered.length) return html`<div class="empty">No templates match.</div>`;
+    const groups = this._groupByCategory(filtered);
+    return html`
+      ${groups.map(([cat, list]) => html`
+        <div class="gallery-group">
+          <div class="gallery-group-title">${CATEGORY_LABELS[cat] || cat}</div>
+          ${list.map(t => html`
+            <button
+              type="button"
+              class="gallery-item ${this._selectedId === t.id ? 'selected' : ''}"
+              @click=${() => this._selectTemplate(t.id)}
+            >
+              <div class="gi-emoji">${t.manifest?.meta?.emoji || '📄'}</div>
+              <div class="gi-body">
+                <div class="gi-title">${t.title}</div>
+                <div class="gi-summary">${t.summary}</div>
+              </div>
+            </button>
+          `)}
+        </div>
+      `)}
+    `;
+  }
+
+  _renderPreview() {
+    const t = this._selected();
+    if (!t) return html`<div class="preview-empty">Select a template on the left to preview.</div>`;
+    const manifest = this._buildPreviewManifest();
+    if (!manifest) return html`<div class="preview-empty">Preview not available.</div>`;
+    const component = manifest.meta?.view?.component;
+    const tag = resolveRenderer(component);
+    if (!tag) return html`<div class="preview-empty">Unknown renderer: ${component}</div>`;
+
+    // Build a card prop the renderer expects.
+    const card = {
+      id: manifest.meta.id,
+      meta: manifest.meta,
+      viewConfig: manifest.meta.view || {},
+    };
+    return html`
+      <div class="preview-wrap">
+        ${this._instantiateRenderer(tag, card, manifest.data)}
+      </div>
+    `;
+  }
+
+  _instantiateRenderer(tag, card, data) {
+    // Render dynamically. The renderer fetches its own data via
+    // /api/manifests/:id/data normally; in preview mode there is no such
+    // manifest on disk, so we stub the data by overriding the prop after
+    // the element mounts. Simpler: create the element imperatively.
+    const el = document.createElement(tag);
+    el.card = card;
+    el.data = data ?? [];
+    el.date = new Date().toISOString().slice(0, 10);
+    el.dateMode = 'today';
+    el.loading = false;
+    // Prevent the real data fetch from blowing away our stub: override the
+    // method on the instance.
+    if (typeof el._fetchData === 'function') {
+      el._fetchData = async () => { el.loading = false; };
+    }
+    return el;
+  }
+
+  _renderForm() {
+    const t = this._selected();
+    if (!t) return html``;
+    const raw = JSON.stringify(t.manifest);
+    let placeholders = [];
+    try { placeholders = extractPlaceholders(raw); } catch { return html``; }
+    // "id" and "label" are always visible up top; everything else below.
+    const primary = placeholders.filter(p => p.name === 'id' || p.name === 'label');
+    const rest = placeholders.filter(p => p.name !== 'id' && p.name !== 'label');
+    return html`
+      <form class="form" @submit=${e => { e.preventDefault(); this._submit(); }}>
+        ${primary.map(p => this._renderField(p))}
+        ${rest.map(p => this._renderField(p))}
+        ${this._submitError ? html`<div class="form-error">${this._submitError}</div>` : ''}
+        <div class="form-actions">
+          <button type="button" class="btn-secondary" @click=${this._cancel} ?disabled=${this._busy}>Cancel</button>
+          <button type="submit" class="btn-primary" ?disabled=${this._busy}>
+            ${this._busy ? 'Creating…' : 'Add card'}
+          </button>
+        </div>
+      </form>
+    `;
+  }
+
+  _renderField(p) {
+    const value = this._values[p.name] ?? '';
+    const label = this._fieldLabel(p);
+    const inputId = `f-${p.name}`;
+    let input;
+    switch (p.type) {
+      case 'number':
+        input = html`<input id=${inputId} type="number" .value=${String(value)}
+          @input=${e => this._updateValue(p.name, e.target.value)} />`;
+        break;
+      case 'boolean':
+        input = html`<input id=${inputId} type="checkbox" ?checked=${!!value}
+          @change=${e => this._updateValue(p.name, e.target.checked)} />`;
+        break;
+      case 'date':
+        input = html`<input id=${inputId} type="date" .value=${String(value)}
+          @input=${e => this._updateValue(p.name, e.target.value)} />`;
+        break;
+      case 'enum':
+      case 'string':
+      default:
+        input = html`<input id=${inputId} type="text" .value=${String(value)}
+          @input=${e => this._updateValue(p.name, e.target.value)} />`;
+    }
+    return html`
+      <div class="field ${p.type === 'boolean' ? 'field-inline' : ''}">
+        <label for=${inputId}>${label}</label>
+        ${input}
+      </div>
+    `;
+  }
+
+  _fieldLabel(p) {
+    const pretty = p.name.replace(/_/g, ' ').replace(/\b./, c => c.toUpperCase());
+    return pretty;
+  }
+
+  render() {
+    return html`
+      <dialog @close=${this._handleDialogClose}>
+        <div class="shell">
+          <header>
+            <h2>Add a card</h2>
+            <button type="button" class="close" @click=${this._cancel} aria-label="Close">✕</button>
+          </header>
+          <div class="body">
+            <aside class="gallery">
+              <input
+                class="search"
+                type="search"
+                placeholder="Search templates…"
+                .value=${this._filter}
+                @input=${e => this._filter = e.target.value}
+              />
+              <div class="gallery-list">${this._renderGallery()}</div>
+            </aside>
+            <section class="main">
+              <div class="preview">${this._renderPreview()}</div>
+              <div class="form-wrap">${this._renderForm()}</div>
+            </section>
+          </div>
+        </div>
+      </dialog>
+    `;
+  }
+
+  static styles = css`
+    dialog {
+      border: none;
+      padding: 0;
+      border-radius: 12px;
+      background: var(--bg-card, #fff);
+      color: var(--text-primary, #111);
+      width: min(1000px, 95vw);
+      max-height: 90vh;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    }
+    dialog::backdrop {
+      background: rgba(0, 0, 0, 0.55);
+      backdrop-filter: blur(2px);
+      -webkit-backdrop-filter: blur(2px);
+    }
+    .shell { display: flex; flex-direction: column; max-height: 90vh; }
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 14px 18px;
+      border-bottom: 1px solid var(--border);
+    }
+    header h2 { margin: 0; font-size: 16px; font-weight: 600; }
+    .close {
+      background: none;
+      border: none;
+      cursor: pointer;
+      font-size: 18px;
+      color: var(--text-secondary);
+      padding: 4px 10px;
+    }
+    .close:hover { color: var(--text-primary); }
+    .body {
+      display: grid;
+      grid-template-columns: 280px 1fr;
+      min-height: 400px;
+      overflow: hidden;
+    }
+    .gallery {
+      border-right: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    .search {
+      margin: 12px 12px 8px;
+      padding: 8px 10px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--bg-input, transparent);
+      color: inherit;
+      font-size: 13px;
+    }
+    .gallery-list { overflow: auto; padding: 0 12px 12px; }
+    .gallery-group { margin-top: 8px; }
+    .gallery-group-title {
+      font-size: 11px;
+      font-weight: 700;
+      text-transform: uppercase;
+      color: var(--text-muted, var(--text-secondary));
+      letter-spacing: 0.5px;
+      padding: 6px 4px;
+    }
+    .gallery-item {
+      display: flex;
+      align-items: flex-start;
+      gap: 8px;
+      width: 100%;
+      padding: 8px 10px;
+      background: transparent;
+      border: 1px solid transparent;
+      border-radius: 6px;
+      text-align: left;
+      cursor: pointer;
+      color: inherit;
+    }
+    .gallery-item:hover { background: var(--bg-hover, rgba(0, 0, 0, 0.05)); }
+    .gallery-item.selected {
+      background: var(--bg-selected, rgba(0, 212, 170, 0.1));
+      border-color: var(--accent, #00d4aa);
+    }
+    .gi-emoji { font-size: 20px; line-height: 1.2; }
+    .gi-body { flex: 1; min-width: 0; }
+    .gi-title { font-size: 13px; font-weight: 600; margin-bottom: 2px; }
+    .gi-summary {
+      font-size: 12px;
+      color: var(--text-secondary);
+      line-height: 1.35;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+    }
+    .empty { padding: 20px; color: var(--text-secondary); font-size: 13px; }
+    .empty.error { color: var(--accent-red, #ff4444); }
+    .main {
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    .preview {
+      padding: 20px;
+      background: var(--bg-app, var(--bg-page, #f5f5f5));
+      border-bottom: 1px solid var(--border);
+      min-height: 180px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .preview-wrap { width: 100%; max-width: 420px; }
+    .preview-empty {
+      color: var(--text-secondary);
+      font-size: 13px;
+    }
+    .form-wrap { overflow: auto; padding: 16px 20px; }
+    .form { display: grid; gap: 10px; }
+    .field { display: grid; gap: 4px; }
+    .field-inline { grid-template-columns: auto 1fr; align-items: center; gap: 10px; }
+    .field label {
+      font-size: 12px;
+      color: var(--text-secondary);
+      font-weight: 600;
+    }
+    .field input {
+      padding: 8px 10px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--bg-input, transparent);
+      color: inherit;
+      font-size: 14px;
+    }
+    .field input:focus {
+      outline: none;
+      border-color: var(--accent, #00d4aa);
+    }
+    .form-error {
+      padding: 8px 10px;
+      font-size: 13px;
+      color: var(--accent-red, #ff4444);
+      background: rgba(255, 68, 68, 0.08);
+      border-radius: 6px;
+    }
+    .form-actions {
+      display: flex;
+      gap: 8px;
+      justify-content: flex-end;
+      margin-top: 8px;
+    }
+    .btn-primary, .btn-secondary {
+      padding: 8px 14px;
+      border-radius: 6px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      border: 1px solid var(--border);
+    }
+    .btn-primary {
+      background: var(--accent, #00d4aa);
+      color: #000;
+      border-color: var(--accent, #00d4aa);
+    }
+    .btn-primary:hover:not(:disabled) { filter: brightness(1.1); }
+    .btn-primary:disabled { opacity: 0.5; cursor: wait; }
+    .btn-secondary {
+      background: transparent;
+      color: inherit;
+    }
+    .btn-secondary:hover:not(:disabled) { background: var(--bg-hover, rgba(0,0,0,0.05)); }
+  `;
+}
+customElements.define('eh-add-card-modal', EhAddCardModal);

--- a/public/js/components/eh-view-renderer.js
+++ b/public/js/components/eh-view-renderer.js
@@ -65,11 +65,14 @@ export class EhViewRenderer extends LitElement {
     super.connectedCallback();
     this._fetchCards();
     window.addEventListener('klebb-enter-reorder-mode', this._onReorderEvent);
+    this._onCardsChanged = () => { this._fetchCards(); };
+    window.addEventListener('klebb-cards-changed', this._onCardsChanged);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
     window.removeEventListener('klebb-enter-reorder-mode', this._onReorderEvent);
+    window.removeEventListener('klebb-cards-changed', this._onCardsChanged);
     this._destroySortable();
   }
 

--- a/public/js/components/eh-welcome-card.js
+++ b/public/js/components/eh-welcome-card.js
@@ -8,6 +8,7 @@
 import { html, css } from 'https://esm.sh/lit@3';
 import { EhBaseCard } from './eh-base-card.js';
 import { registerRenderer } from '../renderer-registry.js';
+import './eh-add-card-modal.js';
 
 export class EhWelcomeCard extends EhBaseCard {
   static styles = [
@@ -30,7 +31,23 @@ export class EhWelcomeCard extends EhBaseCard {
         background: var(--bg-input, rgba(255, 255, 255, 0.03));
         border: 1px solid var(--border);
         border-radius: 8px;
+        text-align: left;
+        width: 100%;
+        color: inherit;
+        font: inherit;
+        cursor: pointer;
       }
+      button.path { appearance: none; }
+      button.path:hover { border-color: var(--accent, #00d4aa); }
+      button.path:focus {
+        outline: none;
+        border-color: var(--accent, #00d4aa);
+      }
+      button.path:disabled {
+        cursor: default;
+        opacity: 0.7;
+      }
+      button.path:disabled:hover { border-color: var(--border); }
       .path-emoji {
         font-size: 20px;
         line-height: 1.2;
@@ -61,6 +78,15 @@ export class EhWelcomeCard extends EhBaseCard {
     `,
   ];
 
+  _openAddCard() {
+    const m = document.createElement('eh-add-card-modal');
+    m.addEventListener('eh-add-card-done', () => {
+      window.dispatchEvent(new CustomEvent('klebb-cards-changed'));
+    });
+    document.body.appendChild(m);
+    requestAnimationFrame(() => m.open());
+  }
+
   renderCard() {
     return html`
       <p class="intro">
@@ -68,17 +94,16 @@ export class EhWelcomeCard extends EhBaseCard {
         Drop one in, it appears. Here are three ways to get started.
       </p>
       <div class="paths">
-        <div class="path">
+        <button type="button" class="path" @click=${this._openAddCard}>
           <div class="path-emoji">➕</div>
           <div class="path-body">
             <p class="path-title">Add a card</p>
             <p class="path-copy">
               Pick from a gallery of starter cards (weight, blood pressure,
               injections, supplements, and more) and fill in a few fields.
-              <em>Coming soon.</em>
             </p>
           </div>
-        </div>
+        </button>
         <div class="path">
           <div class="path-emoji">💬</div>
           <div class="path-body">

--- a/public/js/components/eh-welcome-card.js
+++ b/public/js/components/eh-welcome-card.js
@@ -16,64 +16,112 @@ export class EhWelcomeCard extends EhBaseCard {
     css`
       .intro {
         font-size: 14px;
-        line-height: 1.5;
+        line-height: 1.55;
         color: var(--text-primary);
-        margin: 0 0 12px;
+        margin: 0 0 16px;
       }
       .paths {
         display: grid;
-        gap: 10px;
+        grid-template-columns: 1fr;
+        gap: 12px;
+      }
+      @media (min-width: 560px) {
+        .paths {
+          grid-template-columns: repeat(3, 1fr);
+        }
       }
       .path {
         display: flex;
-        gap: 10px;
-        padding: 10px 12px;
-        background: var(--bg-input, rgba(255, 255, 255, 0.03));
+        flex-direction: column;
+        gap: 8px;
+        padding: 16px 14px 14px;
+        background: var(--bg-input, rgba(0, 0, 0, 0.02));
         border: 1px solid var(--border);
-        border-radius: 8px;
+        border-radius: 12px;
         text-align: left;
         width: 100%;
         color: inherit;
         font: inherit;
         cursor: pointer;
+        appearance: none;
+        transition: transform 0.12s ease, border-color 0.12s ease,
+                    box-shadow 0.12s ease, background 0.12s ease;
+        position: relative;
+        min-height: 170px;
       }
-      button.path { appearance: none; }
-      button.path:hover { border-color: var(--accent, #00d4aa); }
-      button.path:focus {
-        outline: none;
+      button.path:hover {
         border-color: var(--accent, #00d4aa);
+        background: var(--bg-card, #fff);
+        transform: translateY(-1px);
+        box-shadow: 0 4px 14px rgba(0, 0, 0, 0.06);
+      }
+      button.path:focus-visible {
+        outline: 2px solid var(--accent, #00d4aa);
+        outline-offset: 2px;
+      }
+      button.path:active {
+        transform: translateY(0);
       }
       button.path:disabled {
         cursor: default;
-        opacity: 0.7;
+        opacity: 0.6;
       }
-      button.path:disabled:hover { border-color: var(--border); }
+      button.path:disabled:hover {
+        border-color: var(--border);
+        background: var(--bg-input, rgba(0, 0, 0, 0.02));
+        transform: none;
+        box-shadow: none;
+      }
+      .path-head {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
       .path-emoji {
-        font-size: 20px;
-        line-height: 1.2;
+        font-size: 28px;
+        line-height: 1;
         flex-shrink: 0;
       }
-      .path-body {
-        flex: 1;
-        min-width: 0;
-      }
       .path-title {
-        font-size: 13px;
-        font-weight: 600;
+        font-size: 15px;
+        font-weight: 700;
         color: var(--text-primary);
-        margin: 0 0 2px;
+        margin: 0;
+        letter-spacing: -0.01em;
       }
       .path-copy {
-        font-size: 12px;
-        line-height: 1.45;
+        font-size: 12.5px;
+        line-height: 1.5;
         color: var(--text-secondary);
         margin: 0;
+        flex: 1;
+      }
+      .path-cta {
+        margin-top: auto;
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        font-size: 12px;
+        font-weight: 600;
+        color: var(--accent, #00d4aa);
+        padding: 6px 10px;
+        background: rgba(0, 212, 170, 0.1);
+        border-radius: 6px;
+        align-self: flex-start;
+      }
+      .path-cta.muted {
+        color: var(--text-muted, var(--text-secondary));
+        background: var(--bg-hover, rgba(0, 0, 0, 0.04));
+      }
+      .path-cta-arrow {
+        font-size: 13px;
+        line-height: 1;
       }
       .foot {
-        margin-top: 12px;
-        font-size: 11px;
+        margin-top: 14px;
+        font-size: 11.5px;
         color: var(--text-muted, var(--text-secondary));
-        line-height: 1.4;
+        line-height: 1.45;
       }
     `,
   ];
@@ -87,45 +135,53 @@ export class EhWelcomeCard extends EhBaseCard {
     requestAnimationFrame(() => m.open());
   }
 
+  _openChat() {
+    window.dispatchEvent(new CustomEvent('klebb-open-chat'));
+  }
+
   renderCard() {
     return html`
       <p class="intro">
         Klebb is a file-driven dashboard: every card is a JSON file on disk.
-        Drop one in, it appears. Here are three ways to get started.
+        Drop one in, it appears. Pick one of the three ways below to add
+        your first card.
       </p>
       <div class="paths">
         <button type="button" class="path" @click=${this._openAddCard}>
-          <div class="path-emoji">➕</div>
-          <div class="path-body">
-            <p class="path-title">Add a card</p>
-            <p class="path-copy">
-              Pick from a gallery of starter cards (weight, blood pressure,
-              injections, supplements, and more) and fill in a few fields.
-            </p>
+          <div class="path-head">
+            <div class="path-emoji">➕</div>
+            <h3 class="path-title">Add a card</h3>
           </div>
+          <p class="path-copy">
+            Pick from a gallery of starter cards (weight, blood pressure,
+            injections, supplements, and more) and fill in a few fields.
+          </p>
+          <span class="path-cta">Open gallery <span class="path-cta-arrow">→</span></span>
         </button>
-        <div class="path">
-          <div class="path-emoji">💬</div>
-          <div class="path-body">
-            <p class="path-title">Describe what you want to track</p>
-            <p class="path-copy">
-              Open the chat widget and tell the agent what you're tracking;
-              it will propose a card and create it once you approve.
-              Requires an LLM gateway (see docs).
-            </p>
+        <button type="button" class="path" @click=${this._openChat}>
+          <div class="path-head">
+            <div class="path-emoji">💬</div>
+            <h3 class="path-title">Describe it</h3>
           </div>
-        </div>
-        <div class="path">
-          <div class="path-emoji">📚</div>
-          <div class="path-body">
-            <p class="path-title">Browse starter prompts</p>
-            <p class="path-copy">
-              Curated prompts for common protocols (GLP-1 cycle, supplement
-              stack, post-op recovery). Loads into the chat widget so you
-              can tweak before sending. <em>Coming soon.</em>
-            </p>
+          <p class="path-copy">
+            Tell the chat agent what you want to track. It proposes a
+            card and creates it once you approve. Requires an LLM
+            gateway (see docs).
+          </p>
+          <span class="path-cta">Open chat <span class="path-cta-arrow">→</span></span>
+        </button>
+        <button type="button" class="path" disabled aria-disabled="true">
+          <div class="path-head">
+            <div class="path-emoji">📚</div>
+            <h3 class="path-title">Starter prompts</h3>
           </div>
-        </div>
+          <p class="path-copy">
+            Curated prompts for common protocols (GLP-1 cycle, supplement
+            stack, post-op recovery). Loads into the chat so you can
+            tweak before sending.
+          </p>
+          <span class="path-cta muted">Coming soon</span>
+        </button>
       </div>
       <p class="foot">
         This card hides itself the first time you add any other card. You can

--- a/public/js/components/health-chat.js
+++ b/public/js/components/health-chat.js
@@ -729,12 +729,19 @@ class HealthChat extends LitElement {
       }
     };
     window.addEventListener('keydown', this._onGlobalKeydown);
+    this._onOpenChat = () => {
+      if (!this._open) this._toggle();
+    };
+    window.addEventListener('klebb-open-chat', this._onOpenChat);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
     if (this._onGlobalKeydown) {
       window.removeEventListener('keydown', this._onGlobalKeydown);
+    }
+    if (this._onOpenChat) {
+      window.removeEventListener('klebb-open-chat', this._onOpenChat);
     }
   }
 

--- a/public/js/lib/template-substitute.js
+++ b/public/js/lib/template-substitute.js
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// public/js/lib/template-substitute.js
+// Placeholder substitution for Add Card templates.
+//
+// Placeholder syntax in a template's raw JSON:
+//   "{{name}}"           -> string default
+//   "{{string:name}}"    -> string
+//   "{{number:name}}"    -> number (written unquoted in JSON)
+//   "{{boolean:name}}"   -> boolean
+//   "{{date:name}}"      -> ISO date string
+//   "{{enum:name}}"      -> string (enum validation is form-side)
+//
+// Public API:
+//   extractPlaceholders(rawJson) -> [{ name, type }]
+//   substitutePlaceholders(rawJson, values) -> string (substituted JSON)
+//   parseSubstituted(rawJson, values) -> { manifest, error }
+
+const PLACEHOLDER_RE = /\{\{([a-z]+:)?([a-z0-9_]+)\}\}/gi;
+const QUOTED_PLACEHOLDER_RE = /"\{\{([a-z]+:)?([a-z0-9_]+)\}\}"/gi;
+
+const VALID_TYPES = new Set(['string', 'number', 'boolean', 'date', 'enum']);
+
+export function extractPlaceholders(rawJson) {
+  const seen = new Map();
+  for (const m of rawJson.matchAll(PLACEHOLDER_RE)) {
+    const type = m[1] ? m[1].slice(0, -1) : 'string';
+    const name = m[2];
+    if (!VALID_TYPES.has(type)) {
+      throw new Error(`unknown placeholder type: ${type}`);
+    }
+    if (!seen.has(name)) {
+      seen.set(name, { name, type });
+    } else if (seen.get(name).type !== type) {
+      throw new Error(`placeholder "${name}" declared with conflicting types`);
+    }
+  }
+  return [...seen.values()];
+}
+
+// Stringify a JS value for JSON embedding based on placeholder type.
+function stringifyForType(value, type) {
+  if (value === undefined || value === null || value === '') {
+    // Sensible fallbacks so preview renders even before the user types.
+    switch (type) {
+      case 'number': return '0';
+      case 'boolean': return 'false';
+      case 'date': return JSON.stringify(new Date().toISOString().slice(0, 10));
+      case 'string':
+      case 'enum':
+      default:
+        return '""';
+    }
+  }
+  switch (type) {
+    case 'number': {
+      const n = Number(value);
+      if (!Number.isFinite(n)) return '0';
+      return String(n);
+    }
+    case 'boolean':
+      return value === true || value === 'true' ? 'true' : 'false';
+    case 'date':
+    case 'string':
+    case 'enum':
+    default:
+      return JSON.stringify(String(value));
+  }
+}
+
+export function substitutePlaceholders(rawJson, values) {
+  // Quoted placeholders first: "{{type:name}}" -> typed literal (numbers and
+  // booleans land unquoted; strings/dates/enums stay quoted).
+  let out = rawJson.replace(QUOTED_PLACEHOLDER_RE, (_, typePrefix, name) => {
+    const type = typePrefix ? typePrefix.slice(0, -1) : 'string';
+    return stringifyForType(values[name], type);
+  });
+  // Unquoted placeholders (rare, e.g. embedded inside a string template).
+  // Substitute as raw string values without re-quoting; if the surrounding
+  // JSON expected a number, the author should have used "{{number:...}}".
+  out = out.replace(PLACEHOLDER_RE, (_, typePrefix, name) => {
+    const v = values[name];
+    return v === undefined || v === null ? '' : String(v);
+  });
+  return out;
+}
+
+export function parseSubstituted(rawJson, values) {
+  const substituted = substitutePlaceholders(rawJson, values);
+  try {
+    return { manifest: JSON.parse(substituted), error: null };
+  } catch (e) {
+    return { manifest: null, error: e.message };
+  }
+}

--- a/server/first-boot/welcome.klebb.json
+++ b/server/first-boot/welcome.klebb.json
@@ -7,7 +7,8 @@
     "order": 1,
     "view": {
       "enabled": true,
-      "component": "welcome-card"
+      "component": "welcome-card",
+      "slot": "top"
     },
     "welcome": {
       "autoHideApplied": false

--- a/tests/add-card-flow.test.js
+++ b/tests/add-card-flow.test.js
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/add-card-flow.test.js
+// Integration test: simulate the Add Card modal's submit path by fetching
+// /api/templates, substituting placeholders, POSTing to /api/manifests,
+// and verifying the manifest lands on disk.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const {
+  createSandbox, cleanupSandbox, spawnServer, req,
+} = require('./helpers/sandbox');
+
+let substituteLib;
+test.before(async () => {
+  substituteLib = await import(
+    'file://' + path.resolve(__dirname, '..', 'public', 'js', 'lib', 'template-substitute.js')
+      .replace(/\\/g, '/'),
+  );
+});
+
+describe('Add Card end-to-end flow', () => {
+  let sandbox, server;
+
+  before(async () => {
+    sandbox = createSandbox();
+    server = await spawnServer(sandbox);
+  });
+  after(async () => {
+    if (server) await server.kill();
+    cleanupSandbox(sandbox);
+  });
+
+  test('fetch templates, substitute, create, confirm on disk', async () => {
+    const r = await req(server.baseUrl, '/api/templates');
+    assert.equal(r.status, 200);
+    const weight = r.json.templates.find(t => t.id === 'weight');
+    assert.ok(weight, 'weight template must be present');
+
+    const raw = JSON.stringify(weight.manifest);
+    const { manifest, error } = substituteLib.parseSubstituted(raw, {
+      id: 'weight',
+      label: 'Weight',
+      unit: 'kg',
+    });
+    assert.equal(error, null, 'substitution failed');
+    assert.equal(manifest.meta.id, 'weight');
+    assert.equal(manifest.meta.label, 'Weight');
+
+    const create = await req(server.baseUrl, '/api/manifests', {
+      method: 'POST',
+      body: manifest,
+    });
+    assert.equal(create.status, 201);
+    assert.equal(create.json.id, 'weight');
+
+    const file = path.join(sandbox, 'data', 'weight.json');
+    assert.ok(fs.existsSync(file), 'manifest file written to disk');
+    const onDisk = JSON.parse(fs.readFileSync(file, 'utf8'));
+    assert.equal(onDisk.meta.id, 'weight');
+    assert.equal(onDisk.meta.label, 'Weight');
+    // Placeholder for unit was substituted
+    assert.equal(onDisk.meta.view.display.unit, 'kg');
+  });
+
+  test('duplicate id returns 409 so the client can retry with a suffix', async () => {
+    const r = await req(server.baseUrl, '/api/templates');
+    const waist = r.json.templates.find(t => t.id === 'waist');
+    const raw = JSON.stringify(waist.manifest);
+    const first = substituteLib.parseSubstituted(raw, { id: 'waist', label: 'Waist', unit: 'cm' });
+    const c1 = await req(server.baseUrl, '/api/manifests', { method: 'POST', body: first.manifest });
+    assert.equal(c1.status, 201);
+
+    const second = substituteLib.parseSubstituted(raw, { id: 'waist', label: 'Waist', unit: 'cm' });
+    const c2 = await req(server.baseUrl, '/api/manifests', { method: 'POST', body: second.manifest });
+    assert.equal(c2.status, 409,
+      'second create of same id must return 409 so client can auto-suffix');
+
+    // Simulate the client retry with waist-2.
+    const retry = { ...second.manifest, meta: { ...second.manifest.meta, id: 'waist-2' } };
+    const c3 = await req(server.baseUrl, '/api/manifests', { method: 'POST', body: retry });
+    assert.equal(c3.status, 201);
+    assert.equal(c3.json.id, 'waist-2');
+  });
+});

--- a/tests/template-substitute.test.js
+++ b/tests/template-substitute.test.js
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/template-substitute.test.js
+// Unit tests for public/js/lib/template-substitute.js. Pure-function
+// module; testable under Node with no browser glue.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+
+// The lib is ES-module. Load it via dynamic import.
+let lib;
+test.before(async () => {
+  lib = await import(
+    'file://' + path.resolve(__dirname, '..', 'public', 'js', 'lib', 'template-substitute.js')
+      .replace(/\\/g, '/'),
+  );
+});
+
+describe('extractPlaceholders', () => {
+  test('extracts typed placeholders', () => {
+    const raw = '{"a":"{{string:name}}","b":"{{number:dose_mg}}","c":"{{date:start}}"}';
+    const out = lib.extractPlaceholders(raw);
+    assert.deepEqual(out, [
+      { name: 'name', type: 'string' },
+      { name: 'dose_mg', type: 'number' },
+      { name: 'start', type: 'date' },
+    ]);
+  });
+
+  test('defaults to string when no type prefix', () => {
+    const raw = '{"a":"{{name}}"}';
+    const out = lib.extractPlaceholders(raw);
+    assert.deepEqual(out, [{ name: 'name', type: 'string' }]);
+  });
+
+  test('deduplicates repeated placeholder names', () => {
+    const raw = '{"a":"{{string:id}}","b":"{{string:id}}"}';
+    const out = lib.extractPlaceholders(raw);
+    assert.deepEqual(out, [{ name: 'id', type: 'string' }]);
+  });
+
+  test('throws on conflicting types for the same name', () => {
+    const raw = '{"a":"{{string:x}}","b":"{{number:x}}"}';
+    assert.throws(() => lib.extractPlaceholders(raw),
+      /conflicting types/);
+  });
+
+  test('throws on unknown type', () => {
+    const raw = '{"a":"{{banana:x}}"}';
+    assert.throws(() => lib.extractPlaceholders(raw),
+      /unknown placeholder type/);
+  });
+});
+
+describe('substitutePlaceholders', () => {
+  test('substitutes string values quoted', () => {
+    const raw = '{"id":"{{string:id}}"}';
+    const out = lib.substitutePlaceholders(raw, { id: 'weight' });
+    assert.equal(out, '{"id":"weight"}');
+  });
+
+  test('substitutes number values unquoted', () => {
+    const raw = '{"dose":"{{number:dose_mg}}"}';
+    const out = lib.substitutePlaceholders(raw, { dose_mg: 0.5 });
+    const parsed = JSON.parse(out);
+    assert.equal(parsed.dose, 0.5);
+    assert.equal(typeof parsed.dose, 'number');
+  });
+
+  test('coerces string "0.5" to number 0.5', () => {
+    const raw = '{"dose":"{{number:dose_mg}}"}';
+    const out = lib.substitutePlaceholders(raw, { dose_mg: '0.5' });
+    assert.equal(JSON.parse(out).dose, 0.5);
+  });
+
+  test('non-finite number substitutes as 0', () => {
+    const raw = '{"dose":"{{number:dose_mg}}"}';
+    const out = lib.substitutePlaceholders(raw, { dose_mg: 'not a number' });
+    assert.equal(JSON.parse(out).dose, 0);
+  });
+
+  test('boolean substitutes correctly', () => {
+    const raw = '{"flag":"{{boolean:flag}}"}';
+    assert.equal(JSON.parse(lib.substitutePlaceholders(raw, { flag: true })).flag, true);
+    assert.equal(JSON.parse(lib.substitutePlaceholders(raw, { flag: false })).flag, false);
+    assert.equal(JSON.parse(lib.substitutePlaceholders(raw, { flag: 'true' })).flag, true);
+  });
+
+  test('empty value uses type-appropriate default', () => {
+    const raw = '{"a":"{{string:s}}","b":"{{number:n}}","c":"{{boolean:b}}"}';
+    const out = lib.substitutePlaceholders(raw, {});
+    const parsed = JSON.parse(out);
+    assert.equal(parsed.a, '');
+    assert.equal(parsed.b, 0);
+    assert.equal(parsed.c, false);
+  });
+
+  test('escapes JSON special characters in string values', () => {
+    const raw = '{"name":"{{string:name}}"}';
+    const out = lib.substitutePlaceholders(raw, { name: 'has "quotes" and \\ backslash' });
+    const parsed = JSON.parse(out);
+    assert.equal(parsed.name, 'has "quotes" and \\ backslash');
+  });
+});
+
+describe('parseSubstituted', () => {
+  test('returns parsed manifest on valid input', () => {
+    const raw = '{"$schema":"klebb.datafile.v1","meta":{"id":"{{string:id}}"}}';
+    const { manifest, error } = lib.parseSubstituted(raw, { id: 'weight' });
+    assert.equal(error, null);
+    assert.equal(manifest.meta.id, 'weight');
+  });
+
+  test('returns error object on invalid JSON', () => {
+    // Corrupt the JSON with a trailing stray character.
+    const raw = '{"id":"{{string:id}}"';
+    const { manifest, error } = lib.parseSubstituted(raw, { id: 'x' });
+    assert.equal(manifest, null);
+    assert.ok(error);
+  });
+});


### PR DESCRIPTION
## Summary

The deterministic (no-LLM) path for creating cards. A modal with a
gallery, a live preview using the real renderer, and a form driven
by the selected template's placeholders. Click "Add a card" on the
welcome card to open it.

## Why

Three user states need creation paths: no LLM configured (Add Card
is the only option), LLM + knows what they want (Add Card is
fastest), LLM + unsure (chat agent). This PR delivers the first
two. The welcome card's primary action stops saying "coming soon."

## How

### New modules

- \`public/js/lib/template-substitute.js\` — pure-function
  placeholder substitution. Typed syntax
  (\`{{number:dose_mg}}\`, \`{{date:start}}\`, default string).
  Numbers/booleans land unquoted in the JSON; strings escape
  correctly; missing values get type-appropriate defaults so the
  preview renders immediately.
- \`public/js/components/eh-add-card-modal.js\` — the three-pane
  modal. Uses \`<dialog>\`, grid layout, real Lit renderers in the
  preview pane with the data fetch stubbed to the form state.
- Small diff to \`eh-welcome-card\` (primary action opens the
  modal) and \`eh-view-renderer\` (listens for
  \`klebb-cards-changed\` to refresh on successful create).

### Flow

1. User clicks "Add a card" on the welcome card.
2. Modal fetches \`/api/templates\`; gallery populates grouped by
   \`meta.template.category\`.
3. User picks a template. Seed values populate (id -> template id,
   label -> title). Preview renders the real card.
4. User types. Preview re-renders live.
5. On submit, placeholders are substituted client-side and the
   resulting manifest is POSTed to \`/api/manifests\`.
6. If the id collides, the client retries with \`-2\`, \`-3\`,
   etc. (up to 20 attempts).
7. On success, \`klebb-cards-changed\` fires; the view renderer
   refreshes. The welcome card auto-hide triggers server-side
   (PR #122).

## Acceptance criteria (from issue #117)

- [x] Modal opens from the welcome card primary button.
- [x] Gallery loads from \`/api/templates\`, grouped by
      \`meta.template.category\`, searchable.
- [x] Selecting a template populates the form with default values
      and renders the preview immediately.
- [x] Form inputs reflect placeholder types.
- [x] Preview updates on every keystroke using the real
      \`eh-*-card\` component.
- [x] Submit POSTs to \`/api/manifests\` after substitution.
- [x] ID collision on write: auto-suffix. No overwrite.
- [x] Welcome card auto-hide on first successful Add Card submit
      (shipped in #122, verified still firing).
- [x] Successful submit refreshes the dashboard without a full
      reload.
- [x] Tests cover placeholder substitution types, ID collision
      suffix, end-to-end create flow.

Deferred from issue #117 (acceptable gaps, worth flagging):

- **"Blank card" escape hatch at the bottom of the gallery.** Not
  shipped. Users who want to hand-author a manifest can still do so
  via \`POST /api/manifests\` or by dropping a file into
  \`\$HEALTH_HOME/data/\`. The gallery has ten realistic templates
  which covers the main case; a 1% need for a no-template path
  doesn't justify another UI surface in this PR. Easy to add as a
  follow-up if anyone asks.
- **Full keyboard navigation (arrow keys through the gallery).**
  Tab, Enter, and Esc all work; arrow-key gallery navigation is
  deferred. Not a regression from today's experience.
- **Inline per-field validation on blur.** Basic required-field
  validation (id, label) runs on submit. Per-field-on-blur deferred
  as polish; easy to add if users hit it.
- **"Advanced options" disclosure.** All fields render inline for
  now. The current templates don't have a large number of
  per-template fields so collapse isn't essential yet.
- **\`POST /api/manifests\` Settings entrypoint.** Add Card is only
  reachable from the welcome card in this PR. Once the welcome
  card is hidden, users who want to add another card today need to
  re-enable it from Settings. A direct Settings shortcut is a small
  follow-up.

## Testing

- [x] \`tests/template-substitute.test.js\` — 14 pure-unit tests for
      the substitution lib.
- [x] \`tests/add-card-flow.test.js\` — end-to-end via the real
      server: fetch templates, substitute, POST, verify file on
      disk, duplicate-id returns 409.
- [x] \`npm test\` full suite: 583/584 pass locally (1 pre-existing
      flaky failure on main).
- [ ] **Manual browser verification pending.** I was unable to
      drive a browser from the harness that produced this PR, so
      the visual layout and live preview behaviour need a real
      click-through. Key flows to verify manually:
      1. Open the welcome card's "Add a card" action; modal
         opens; gallery lists templates grouped by category.
      2. Pick the weight template; the preview card appears on
         the right; it re-renders as you type in the kg input.
      3. Click Add card; the modal closes; the new card appears
         on the dashboard; the welcome card hides itself.
      4. Try adding a second weight card; verify the id auto-
         suffixes and both cards exist.
      5. Esc closes the modal without creating.

Fixes #117