### PR TITLE
feat(ui): starter prompts gallery + load-into-chat wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Starter prompts gallery.** The welcome card's third action now
+  opens a modal listing prompts from \`/api/prompts\`, with the
+  \`new-to-klebb\` meta-prompt featured at the top. Clicking "Load
+  into chat" pastes the prompt body into the chat input (without
+  sending) and opens the chat widget; the user reviews, edits, then
+  sends themselves. If the chat gateway isn't configured, the
+  primary action becomes "Copy to clipboard" and a banner explains
+  how to enable the gateway. Each row has a Preview toggle to show
+  the full prompt body inline before sending. New \`GET
+  /api/chat/status\` endpoint exposes a boolean \`configured\` flag
+  the gallery uses to pick its action mode; the chat widget gains a
+  \`klebb-paste-into-chat\` window-event listener so the gallery can
+  drive it. (#118)
+
 - **Add Card modal.** Click the welcome card's "Add a card" action
   to open a modal with three panes: a searchable template gallery
   grouped by category (Tracking, Protocols, Lifestyle, Imported), a

--- a/public/js/components/eh-prompts-gallery.js
+++ b/public/js/components/eh-prompts-gallery.js
@@ -1,0 +1,409 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// eh-prompts-gallery.js — starter-prompts gallery modal.
+//
+// Opens from the welcome card's "Starter prompts" action. Lists prompts
+// fetched from /api/prompts. Clicking "Load into chat" pastes the prompt
+// body into the chat input (without sending) and opens the chat panel.
+// If the chat gateway isn't configured, the action becomes "Copy to
+// clipboard" with an inline note.
+//
+//   const m = document.createElement('eh-prompts-gallery');
+//   document.body.appendChild(m);
+//   m.open();
+
+import { LitElement, html, css } from 'https://esm.sh/lit@3';
+import { errorFromResponse } from '../lib/save-error.js';
+
+const FEATURED_ID = 'new-to-klebb';
+
+export class EhPromptsGallery extends LitElement {
+  static properties = {
+    _prompts: { state: true },
+    _loading: { state: true },
+    _loadError: { state: true },
+    _filter: { state: true },
+    _chatConfigured: { state: true },
+    _copiedId: { state: true },
+    _expandedId: { state: true },
+  };
+
+  constructor() {
+    super();
+    this._prompts = [];
+    this._loading = true;
+    this._loadError = null;
+    this._filter = '';
+    this._chatConfigured = null;
+    this._copiedId = null;
+    this._expandedId = null;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._loadPrompts();
+    this._loadChatStatus();
+    this._escHandler = (e) => { if (e.key === 'Escape') this._close(); };
+    window.addEventListener('keydown', this._escHandler);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    window.removeEventListener('keydown', this._escHandler);
+  }
+
+  open() {
+    const dlg = this.renderRoot?.querySelector('dialog');
+    if (dlg && !dlg.open) dlg.showModal();
+  }
+
+  _close() {
+    const dlg = this.renderRoot?.querySelector('dialog');
+    if (dlg && dlg.open) dlg.close();
+  }
+
+  _handleDialogClose() {
+    if (this.parentNode) this.parentNode.removeChild(this);
+  }
+
+  async _loadPrompts() {
+    this._loading = true;
+    this._loadError = null;
+    try {
+      const r = await fetch('/api/prompts');
+      if (!r.ok) throw await errorFromResponse(r);
+      const body = await r.json();
+      this._prompts = body.prompts || [];
+    } catch (e) {
+      this._loadError = e.message || 'Could not load prompts.';
+    } finally {
+      this._loading = false;
+    }
+  }
+
+  async _loadChatStatus() {
+    try {
+      const r = await fetch('/api/chat/status');
+      if (!r.ok) { this._chatConfigured = false; return; }
+      const body = await r.json();
+      this._chatConfigured = !!body.configured;
+    } catch {
+      this._chatConfigured = false;
+    }
+  }
+
+  _filteredPrompts() {
+    const q = (this._filter || '').trim().toLowerCase();
+    if (!q) return this._prompts;
+    return this._prompts.filter(p => {
+      const hay = `${p.title} ${p.summary} ${(p.tags || []).join(' ')}`.toLowerCase();
+      return hay.includes(q);
+    });
+  }
+
+  _orderPrompts(list) {
+    const featured = list.find(p => p.id === FEATURED_ID);
+    const rest = list.filter(p => p.id !== FEATURED_ID);
+    return featured ? [featured, ...rest] : list;
+  }
+
+  _action(prompt) {
+    if (this._chatConfigured) {
+      window.dispatchEvent(new CustomEvent('klebb-paste-into-chat', {
+        detail: { text: prompt.body },
+      }));
+      this._close();
+    } else {
+      this._copy(prompt);
+    }
+  }
+
+  async _copy(prompt) {
+    try {
+      await navigator.clipboard.writeText(prompt.body);
+      this._copiedId = prompt.id;
+      setTimeout(() => { if (this._copiedId === prompt.id) this._copiedId = null; }, 1800);
+    } catch {
+      // Fallback: select into a hidden textarea
+      const ta = document.createElement('textarea');
+      ta.value = prompt.body;
+      document.body.appendChild(ta);
+      ta.select();
+      try { document.execCommand('copy'); } catch {}
+      ta.remove();
+      this._copiedId = prompt.id;
+      setTimeout(() => { if (this._copiedId === prompt.id) this._copiedId = null; }, 1800);
+    }
+  }
+
+  _toggleExpand(id) {
+    this._expandedId = this._expandedId === id ? null : id;
+  }
+
+  _renderList() {
+    if (this._loading) return html`<div class="empty">Loading prompts…</div>`;
+    if (this._loadError) return html`<div class="empty error">⚠︎ ${this._loadError}</div>`;
+
+    const filtered = this._filteredPrompts();
+    if (!filtered.length) {
+      return html`<div class="empty">
+        No prompts match.
+        ${this._prompts.length === 0 ? html`
+          <div class="sub">See <code>CONTRIBUTING-PROMPTS.md</code> to add one.</div>
+        ` : ''}
+      </div>`;
+    }
+
+    const ordered = this._orderPrompts(filtered);
+    return html`
+      <ul class="prompt-list">
+        ${ordered.map(p => this._renderRow(p))}
+      </ul>
+    `;
+  }
+
+  _renderRow(p) {
+    const isFeatured = p.id === FEATURED_ID;
+    const isExpanded = this._expandedId === p.id;
+    const copied = this._copiedId === p.id;
+    const actionLabel = this._chatConfigured === false
+      ? (copied ? 'Copied ✓' : 'Copy to clipboard')
+      : 'Load into chat →';
+    return html`
+      <li class="row ${isFeatured ? 'featured' : ''} ${isExpanded ? 'expanded' : ''}">
+        ${isFeatured ? html`<div class="featured-chip">★ Start here</div>` : ''}
+        <div class="row-head">
+          <div class="row-body">
+            <div class="row-title">${p.title}</div>
+            <div class="row-summary">${p.summary}</div>
+            ${p.tags && p.tags.length ? html`
+              <div class="row-tags">
+                ${p.tags.map(t => html`<span class="tag">${t}</span>`)}
+              </div>
+            ` : ''}
+          </div>
+          <div class="row-actions">
+            <button type="button" class="btn-ghost"
+              @click=${() => this._toggleExpand(p.id)}
+              aria-expanded=${isExpanded}>
+              ${isExpanded ? 'Hide' : 'Preview'}
+            </button>
+            <button type="button" class="btn-primary"
+              @click=${() => this._action(p)}
+              ?disabled=${this._chatConfigured === null}>
+              ${actionLabel}
+            </button>
+          </div>
+        </div>
+        ${isExpanded ? html`
+          <div class="row-preview"><pre>${p.body}</pre></div>
+        ` : ''}
+      </li>
+    `;
+  }
+
+  render() {
+    const notConfigured = this._chatConfigured === false;
+    return html`
+      <dialog @close=${this._handleDialogClose}>
+        <div class="shell">
+          <header>
+            <h2>Starter prompts</h2>
+            <button type="button" class="close" @click=${this._close} aria-label="Close">✕</button>
+          </header>
+          <div class="toolbar">
+            <input
+              class="search"
+              type="search"
+              placeholder="Search prompts…"
+              .value=${this._filter}
+              @input=${e => this._filter = e.target.value}
+            />
+          </div>
+          ${notConfigured ? html`
+            <div class="banner">
+              <strong>Chat agent not configured.</strong>
+              You can still copy any prompt to paste into another tool, or
+              set up a chat gateway (see docs) to use them with Klebb's chat.
+            </div>
+          ` : ''}
+          <div class="body">${this._renderList()}</div>
+        </div>
+      </dialog>
+    `;
+  }
+
+  static styles = css`
+    dialog {
+      border: none;
+      padding: 0;
+      border-radius: 12px;
+      background: var(--bg-card, #fff);
+      color: var(--text-primary, #111);
+      width: min(760px, 95vw);
+      max-height: 90vh;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    }
+    dialog::backdrop {
+      background: rgba(0, 0, 0, 0.55);
+      backdrop-filter: blur(2px);
+      -webkit-backdrop-filter: blur(2px);
+    }
+    .shell { display: flex; flex-direction: column; max-height: 90vh; }
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 14px 18px;
+      border-bottom: 1px solid var(--border);
+    }
+    header h2 { margin: 0; font-size: 16px; font-weight: 600; }
+    .close {
+      background: none;
+      border: none;
+      cursor: pointer;
+      font-size: 18px;
+      color: var(--text-secondary);
+      padding: 4px 10px;
+    }
+    .close:hover { color: var(--text-primary); }
+    .toolbar { padding: 12px 18px 8px; }
+    .search {
+      width: 100%;
+      padding: 8px 10px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--bg-input, transparent);
+      color: inherit;
+      font-size: 13px;
+    }
+    .banner {
+      margin: 0 18px 8px;
+      padding: 10px 12px;
+      background: rgba(255, 170, 0, 0.08);
+      border: 1px solid rgba(255, 170, 0, 0.3);
+      color: var(--text-primary);
+      border-radius: 8px;
+      font-size: 12.5px;
+      line-height: 1.5;
+    }
+    .body { overflow: auto; padding: 6px 18px 18px; }
+    .empty {
+      padding: 24px 10px;
+      color: var(--text-secondary);
+      font-size: 13px;
+      text-align: center;
+    }
+    .empty.error { color: var(--accent-red, #ff4444); }
+    .empty .sub {
+      margin-top: 6px;
+      font-size: 12px;
+      color: var(--text-muted, var(--text-secondary));
+    }
+    .prompt-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 10px; }
+    .row {
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 14px 16px;
+      background: var(--bg-input, rgba(0, 0, 0, 0.02));
+      position: relative;
+    }
+    .row.featured {
+      border-color: var(--accent, #00d4aa);
+      background: rgba(0, 212, 170, 0.06);
+    }
+    .featured-chip {
+      position: absolute;
+      top: -9px;
+      left: 14px;
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+      padding: 3px 8px;
+      background: var(--accent, #00d4aa);
+      color: #000;
+      border-radius: 10px;
+    }
+    .row-head {
+      display: flex;
+      align-items: flex-start;
+      gap: 14px;
+    }
+    .row-body { flex: 1; min-width: 0; }
+    .row-title {
+      font-size: 14px;
+      font-weight: 700;
+      color: var(--text-primary);
+      margin-bottom: 4px;
+    }
+    .row-summary {
+      font-size: 12.5px;
+      line-height: 1.5;
+      color: var(--text-secondary);
+      margin-bottom: 6px;
+    }
+    .row-tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+    }
+    .tag {
+      font-size: 10.5px;
+      padding: 2px 7px;
+      background: var(--bg-hover, rgba(0, 0, 0, 0.05));
+      border-radius: 10px;
+      color: var(--text-muted, var(--text-secondary));
+    }
+    .row-actions {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      flex-shrink: 0;
+    }
+    @media (max-width: 520px) {
+      .row-head { flex-direction: column; }
+      .row-actions { flex-direction: row; }
+    }
+    .btn-primary, .btn-ghost {
+      padding: 7px 12px;
+      border-radius: 6px;
+      font-size: 12px;
+      font-weight: 600;
+      cursor: pointer;
+      border: 1px solid var(--border);
+      white-space: nowrap;
+    }
+    .btn-primary {
+      background: var(--accent, #00d4aa);
+      color: #000;
+      border-color: var(--accent, #00d4aa);
+    }
+    .btn-primary:hover:not(:disabled) { filter: brightness(1.1); }
+    .btn-primary:disabled { opacity: 0.5; cursor: wait; }
+    .btn-ghost {
+      background: transparent;
+      color: inherit;
+    }
+    .btn-ghost:hover { background: var(--bg-hover, rgba(0, 0, 0, 0.05)); }
+    .row-preview {
+      margin-top: 10px;
+      padding: 10px 12px;
+      background: var(--bg-card, #fff);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      max-height: 300px;
+      overflow: auto;
+    }
+    .row-preview pre {
+      margin: 0;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+      font-size: 12px;
+      line-height: 1.5;
+      font-family: inherit;
+      color: var(--text-primary);
+    }
+  `;
+}
+customElements.define('eh-prompts-gallery', EhPromptsGallery);

--- a/public/js/components/eh-welcome-card.js
+++ b/public/js/components/eh-welcome-card.js
@@ -9,6 +9,7 @@ import { html, css } from 'https://esm.sh/lit@3';
 import { EhBaseCard } from './eh-base-card.js';
 import { registerRenderer } from '../renderer-registry.js';
 import './eh-add-card-modal.js';
+import './eh-prompts-gallery.js';
 
 export class EhWelcomeCard extends EhBaseCard {
   static styles = [
@@ -139,6 +140,12 @@ export class EhWelcomeCard extends EhBaseCard {
     window.dispatchEvent(new CustomEvent('klebb-open-chat'));
   }
 
+  _openPrompts() {
+    const m = document.createElement('eh-prompts-gallery');
+    document.body.appendChild(m);
+    requestAnimationFrame(() => m.open());
+  }
+
   renderCard() {
     return html`
       <p class="intro">
@@ -170,7 +177,7 @@ export class EhWelcomeCard extends EhBaseCard {
           </p>
           <span class="path-cta">Open chat <span class="path-cta-arrow">→</span></span>
         </button>
-        <button type="button" class="path" disabled aria-disabled="true">
+        <button type="button" class="path" @click=${this._openPrompts}>
           <div class="path-head">
             <div class="path-emoji">📚</div>
             <h3 class="path-title">Starter prompts</h3>
@@ -180,7 +187,7 @@ export class EhWelcomeCard extends EhBaseCard {
             stack, post-op recovery). Loads into the chat so you can
             tweak before sending.
           </p>
-          <span class="path-cta muted">Coming soon</span>
+          <span class="path-cta">Browse prompts <span class="path-cta-arrow">→</span></span>
         </button>
       </div>
       <p class="foot">

--- a/public/js/components/health-chat.js
+++ b/public/js/components/health-chat.js
@@ -435,6 +435,11 @@ class HealthChat extends LitElement {
       font-size: 16px;
       font-family: inherit;
       outline: none;
+      resize: none;
+      line-height: 1.4;
+      min-height: 36px;
+      max-height: 240px;
+      overflow-y: auto;
     }
     .chat-input:focus { border-color: var(--accent); }
     .chat-input:disabled { opacity: 0.5; }
@@ -741,6 +746,7 @@ class HealthChat extends LitElement {
         const input = this.shadowRoot?.querySelector('.chat-input');
         if (input) {
           input.focus();
+          this._autoSize(input);
           // Move caret to end so the user can continue typing after the paste.
           const n = input.value.length;
           input.setSelectionRange(n, n);
@@ -797,6 +803,10 @@ class HealthChat extends LitElement {
     if (!text || this._loading) return;
     this._addMsg('user', text);
     this._input = '';
+    this.updateComplete.then(() => {
+      const input = this.shadowRoot?.querySelector('.chat-input');
+      if (input) this._autoSize(input);
+    });
     this._loading = true;
     this._scrollToBottom();
     const chatMessages = this._messages.filter(m => m.role !== 'error');
@@ -829,6 +839,12 @@ class HealthChat extends LitElement {
       e.preventDefault();
       this._sendText();
     }
+  }
+
+  _autoSize(el) {
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = Math.min(el.scrollHeight, 240) + 'px';
   }
 
   _useSuggestion(text) {
@@ -1166,14 +1182,15 @@ class HealthChat extends LitElement {
                 aria-label=${this._recording ? 'stop recording' : 'start recording'}
               >${this._recording ? '\u23F9' : '\u{1F3A4}'}</button>
             ` : ''}
-            <input
+            <textarea
               class="chat-input"
+              rows="1"
               placeholder=${this._recording ? 'Recording…' : 'Ask about your health...'}
               .value=${this._input}
-              @input=${(e) => this._input = e.target.value}
+              @input=${(e) => { this._input = e.target.value; this._autoSize(e.target); }}
               @keydown=${this._handleKeydown}
               ?disabled=${this._loading || this._recording}
-            />
+            ></textarea>
             <button class="send-btn" @click=${this._sendText} ?disabled=${this._loading || this._recording || !this._input.trim()}>\u2191</button>
           </div>
         </div>

--- a/public/js/components/health-chat.js
+++ b/public/js/components/health-chat.js
@@ -733,6 +733,21 @@ class HealthChat extends LitElement {
       if (!this._open) this._toggle();
     };
     window.addEventListener('klebb-open-chat', this._onOpenChat);
+    this._onPasteIntoChat = (e) => {
+      const text = e.detail?.text || '';
+      this._input = text;
+      if (!this._open) this._toggle();
+      this.updateComplete.then(() => {
+        const input = this.shadowRoot?.querySelector('.chat-input');
+        if (input) {
+          input.focus();
+          // Move caret to end so the user can continue typing after the paste.
+          const n = input.value.length;
+          input.setSelectionRange(n, n);
+        }
+      });
+    };
+    window.addEventListener('klebb-paste-into-chat', this._onPasteIntoChat);
   }
 
   disconnectedCallback() {
@@ -742,6 +757,9 @@ class HealthChat extends LitElement {
     }
     if (this._onOpenChat) {
       window.removeEventListener('klebb-open-chat', this._onOpenChat);
+    }
+    if (this._onPasteIntoChat) {
+      window.removeEventListener('klebb-paste-into-chat', this._onPasteIntoChat);
     }
   }
 

--- a/server.js
+++ b/server.js
@@ -771,6 +771,14 @@ const server = http.createServer(async (req, res) => {
       return sendJSON(res, { prompts: listPrompts() });
     }
 
+    // GET /api/chat/status — is a chat endpoint configured? UI affordances
+    // that depend on the agent use this to render an enabled/disabled state
+    // without making an actual chat request.
+    if (parts[0] === 'chat' && parts[1] === 'status' && parts.length === 2 && req.method === 'GET') {
+      res.setHeader('Cache-Control', 'no-store');
+      return sendJSON(res, { configured: !!CHAT_ENDPOINT });
+    }
+
     // === End content endpoints ===
 
     // Simple JSON file endpoints

--- a/tests/chat-status.test.js
+++ b/tests/chat-status.test.js
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/chat-status.test.js
+// Verifies GET /api/chat/status returns the configured flag the
+// prompts-gallery modal uses to decide whether "Load into chat" or
+// "Copy to clipboard" is the primary action.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const { createSandbox, cleanupSandbox, spawnServer, req } = require('./helpers/sandbox');
+
+describe('chat status', () => {
+  test('reports configured:false when CHAT_ENDPOINT_URL is unset', async () => {
+    const box = createSandbox();
+    const srv = await spawnServer(box, {
+      CHAT_ENDPOINT_URL: '',
+      CHAT_API_KEY: '',
+    });
+    try {
+      const r = await req(srv.baseUrl, '/api/chat/status');
+      assert.equal(r.status, 200);
+      assert.equal(r.json.configured, false);
+    } finally {
+      await srv.kill();
+      cleanupSandbox(box);
+    }
+  });
+
+  test('reports configured:true when CHAT_ENDPOINT_URL is set', async () => {
+    const box = createSandbox();
+    const srv = await spawnServer(box, {
+      CHAT_ENDPOINT_URL: 'http://127.0.0.1:1/v1/chat/completions',
+      CHAT_API_KEY: 'dummy',
+    });
+    try {
+      const r = await req(srv.baseUrl, '/api/chat/status');
+      assert.equal(r.status, 200);
+      assert.equal(r.json.configured, true);
+    } finally {
+      await srv.kill();
+      cleanupSandbox(box);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Welcome card's third button stops being disabled and opens a modal
listing the prompts from \`/api/prompts\`. Load-into-chat pastes the
prompt body into the chat input without sending, so the user can
tweak before committing.

## Why

Prompts turn the chat agent into a guided multi-card builder without
any new code on the agent side. Users with an LLM gateway get one-
click paths to full protocol setups (GLP-1 cycle, supplement stack,
post-op recovery); users without get a library of copy-paste
starting points.

## How

- **New \`eh-prompts-gallery\` component.** Fetches \`/api/prompts\`,
  lists rows with title / summary / tags / preview / action button.
  The \`new-to-klebb\` meta-prompt is featured at the top with a
  "Start here" chip.
- **Load action depends on chat gateway state:**
  - Configured: "Load into chat →". Dispatches
    \`klebb-paste-into-chat\`; chat widget sets \`_input\` from the
    event detail, opens its panel, focuses the input, moves caret
    to end. No auto-send.
  - Not configured: "Copy to clipboard" fallback, plus a banner at
    the top of the modal pointing at the docs.
- **New \`GET /api/chat/status\`** exposes \`{ configured: boolean }\`
  so the gallery picks its action mode without making a real chat
  request.
- **Chat widget gains a \`klebb-paste-into-chat\` window event
  listener** alongside the \`klebb-open-chat\` listener from
  PR #125.
- **Welcome card's third action now opens the modal** instead of
  being disabled.

## Acceptance criteria (from #118)

- [x] Modal opens from the welcome card's 'Browse starter prompts'
      action.
- [x] Prompt list loads from \`/api/prompts\`.
- [x] 'Load into chat' pastes without sending; chat widget opens.
- [x] No gateway: action becomes 'Copy to clipboard'.
- [x] \`new-to-klebb.md\` renders as a featured row.
- [x] Empty \`prompts/\` directory: friendly empty state pointing at
      \`CONTRIBUTING-PROMPTS.md\`.
- [x] Esc closes the modal.
- [x] Tests cover: \`/api/chat/status\` both states (configured +
      not).
- [x] \`npm test\` full suite: 585/586 pass (1 pre-existing
      flaky failure).
- [x] Live on klebbtest for manual click-through.

## Deferred

- **Arrow-key navigation through the prompt list.** Tab, Enter,
  Esc all work.
- **Per-row tag filter.** Search box handles the common case; tag
  chips are visual only in this PR.

Fixes #118