### PR TITLE
fix(chat): preserve line breaks in user chat bubbles

### DIFF
--- a/public/js/components/eh-welcome-card.js
+++ b/public/js/components/eh-welcome-card.js
@@ -40,6 +40,7 @@ export class EhWelcomeCard extends EhBaseCard {
         border-radius: 12px;
         text-align: left;
         width: 100%;
+        box-sizing: border-box;
         color: inherit;
         font: inherit;
         cursor: pointer;

--- a/public/js/components/health-chat.js
+++ b/public/js/components/health-chat.js
@@ -271,6 +271,7 @@ class HealthChat extends LitElement {
       background: var(--accent);
       color: var(--text-inverse, white);
       border-bottom-right-radius: 4px;
+      white-space: pre-wrap;
     }
     .msg.assistant {
       align-self: flex-start;


### PR DESCRIPTION
Paste a multi-line prompt from the starter-prompts gallery, hit
send, and the user's chat bubble flattens all newlines into
single spaces. The assistant bubble doesn't have this problem
because its markdown renderer handles it.

\`white-space: pre-wrap\` on \`.msg.user\` aligns the two.

Trivial one-line fix.