### PR TITLE
fix(chat): teach agent schedule-card data shape + inject today's date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Chat agent no longer builds empty schedule-cards.** The agent was
+  writing items into \`meta.schedule[]\` (not a real field on the
+  \`schedule-card\` shape) and leaving \`data\` empty, so the card
+  rendered blank. The system prompt now carries a full
+  schedule-card example with items in \`data.items[]\`, spells out
+  which renderer reads which path, and forbids silently setting
+  optional embellishments (\`meta.prompt\`, \`meta.calendar\`,
+  \`meta.trends\`, \`meta.reports\`, thresholds) on initial create.
+  The server also injects today's absolute date into the system
+  prompt so the agent stops hallucinating 2025 dates; the
+  \`create_manifest\` tool description reinforces both rules.
+  (Fixes #130)
+
 ### Changed
 
 - **Onboarding is LLM-first.** Removed the Add Card modal and its

--- a/chat/tools.js
+++ b/chat/tools.js
@@ -14,7 +14,7 @@ const TOOL_DEFS = [
     function: {
       name: 'create_manifest',
       description:
-        "Create a new card on the user's dashboard. Pass a full klebb.datafile.v1 manifest object. Returns {ok, id, source} on success; validation errors come back as {error} — read the message and retry with a fixed manifest (e.g. pick a different id on 'duplicate id', sanitise bad chars on 'invalid id').",
+        "Create a new card on the user's dashboard. Pass a full klebb.datafile.v1 manifest object. Returns {ok, id, source} on success; validation errors come back as {error} — read the message and retry with a fixed manifest (e.g. pick a different id on 'duplicate id', sanitise bad chars on 'invalid id'). IMPORTANT: per-renderer data shape matters: e.g. schedule-card items live in data.items[], NOT meta.schedule. Do NOT set optional embellishments (meta.prompt, meta.calendar, meta.trends, meta.reports, meta.view.display.thresholds) unless the user explicitly asked for them; offer them afterwards and apply via patch_manifest if accepted. Use today's absolute date (provided in the system prompt) for any date field; never guess the year from training data.",
       parameters: {
         type: 'object',
         properties: {

--- a/config/env.js
+++ b/config/env.js
@@ -255,7 +255,7 @@ Everything else is optional pass-through. The endpoint is lenient: if the render
 - \`generic-card\` — single latest value + delta. Data is \`[{date, <field>...}]\`. Uses \`meta.view.display\` (object: \`{template, secondary?, emptyHeadline?, unit?, emojiMap?, thresholds?, trendArrow?}\`) to format the headline.
 - \`list-card\` — persistent chronological list of entries; data is \`[{date, ...fields}]\`.
 - \`checklist-card\` — tickable daily items; data \`{items:[{id,doses:[...]}]}\`-ish.
-- \`schedule-card\` — scheduled doses/events with recurrence; data tracks check-offs.
+- \`schedule-card\` — scheduled doses/events with recurrence; data is \`{items:[{name, dose_mg?, dose_units?, route?, schedule, doses?:[]}]}\`. Each item's \`schedule\` is a schedule-shape object (see below). **Items ALWAYS live in \`data.items[]\`; never in \`meta.schedule\`.** \`meta.schedule\` is only used by the \`schedule-timeline\` renderer for a single card-level cadence, and it's rare.
 - \`schedule-timeline\` — stacked timeline across a window; reads \`meta.schedule\`.
 - \`markdown-doc\` — renders markdown; data \`{markdown:"..."}\`.
 - \`line-chart\` — time-series chart (aliases: \`area-chart\`, \`bar-chart\`); data \`[{date,value}]\` or rows keyed via \`meta.trends.field\`/\`series\`.
@@ -346,7 +346,39 @@ Call \`create_manifest\` with this \`manifest\` argument. Note: every field name
 }
 \`\`\`
 
-### Example 3 — ad-hoc (renderer not yet implemented)
+### Example 3 — schedule-card (peptide/medication cycle)
+
+Call \`create_manifest\` with this \`manifest\` argument. **Note:** items live in \`data.items[]\`, not \`meta.schedule\`. Each item carries its own \`schedule\` object. Leave \`doses\` as \`[]\` on creation; check-offs are appended as the user taps the card.
+
+\`\`\`
+{
+  "$schema":"klebb.datafile.v1",
+  "meta":{
+    "id":"peptide-cycle","label":"Peptide Cycle","emoji":"💉","order":320,
+    "view":{"enabled":true,"component":"schedule-card","dateContext":"exact-date"},
+    "writeable":{"fromWebapp":true,"pastAllowed":true,"todayAllowed":true,"futureAllowed":false}
+  },
+  "description":"Injectable peptide cycle. Each item has name, dose_mg, dose_units, route, and a schedule. Doses are appended as check-offs.",
+  "data":{
+    "items":[
+      {
+        "name":"BPC-157",
+        "dose_mg":0.25,"dose_units":"mg","route":"subcutaneous",
+        "schedule":{"type":"daily","times_per_day":1,"start_date":"2026-05-06","cycle_weeks":6},
+        "doses":[]
+      },
+      {
+        "name":"TB-500",
+        "dose_mg":2.5,"dose_units":"mg","route":"subcutaneous",
+        "schedule":{"type":"weekly","on_days":["Mon","Thu"],"start_date":"2026-05-06","cycle_weeks":6},
+        "doses":[]
+      }
+    ]
+  }
+}
+\`\`\`
+
+### Example 4 — ad-hoc (renderer not yet implemented)
 
 Call \`create_manifest\` with this \`manifest\` argument:
 
@@ -385,6 +417,8 @@ Once \`create_manifest\` succeeds, your reply MUST end with a short offer of opt
 - **A daily target or reminder prompt:** \`meta.prompt = {enabled:true, ...}\` if the user wants to be nudged.
 
 Offer them as a single short sentence or a 2-3 item bullet list, e.g. "Done. Want me to add a trends chart, a daily target, or a calendar marker?" — not a long menu. Never auto-add beyond what was asked.
+
+**Embellishments are opt-in only.** Do NOT set \`meta.prompt\`, \`meta.calendar\`, \`meta.trends\`, \`meta.reports\`, or \`meta.view.display.thresholds\` on a \`create_manifest\` call unless the user explicitly asked for them. The initial manifest should contain only: \`$schema\`, \`meta.id\`, \`meta.label\`, \`meta.emoji\` (if obvious), \`meta.order\` (sensible default), \`meta.view\`, \`meta.writeable\` (if the card is user-writeable), \`description\`, and \`data\`. Everything else waits for the user to pick from your suggestions.
 
 If the user picks one of your suggestions, apply it with \`patch_manifest(id, metaPatch)\` — it edits the meta in place and preserves data. Use delete+recreate ONLY right after initial creation (card has no data yet), or when the user explicitly wants to discard the data and start fresh. For any existing card with data, patch_manifest is the right tool.
 

--- a/server.js
+++ b/server.js
@@ -1181,7 +1181,12 @@ const server = http.createServer(async (req, res) => {
             ? `\n\n## Currently available cards\n\n${cardList}\n`
             : '\n\n## Currently available cards\n\n(none yet)\n';
 
-          let systemPrompt = HEALTH_SYSTEM_PROMPT + cardListBlock;
+          // Inject today's absolute date (in the server's TZ) so the agent
+          // computes relative dates from ground truth rather than guessing
+          // from training data.
+          const todayBlock = `\n\n## Today's date\n\nToday is ${todayIso()}. Use this as the reference point for any relative date ("next Monday", "in two weeks", "three months from now"). Never hardcode a year from training data.\n`;
+
+          let systemPrompt = HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock;
           if (voiceMode) {
             systemPrompt = `You are ${process.env.CHAT_AGENT_NAME || 'Chat'}, a health assistant.
 Voice mode is active: the user is speaking to you and will hear your reply aloud.
@@ -1214,7 +1219,7 @@ Return STRICTLY the JSON object. No leading/trailing text. No markdown fences.
 
 Original system prompt follows:
 
-` + HEALTH_SYSTEM_PROMPT + cardListBlock;
+` + HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock;
           }
 
           // Prepend system prompt

--- a/tests/chat-prompt-cards.test.js
+++ b/tests/chat-prompt-cards.test.js
@@ -105,6 +105,40 @@ describe('chat proxy dynamic card-list injection', () => {
     assert.ok(sp.includes('weight'));
   });
 
+  test('system prompt injects today\'s absolute date', async () => {
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'hi' }], voiceMode: false },
+    });
+    assert.equal(res.status, 200);
+    const sp = gateway.getLastPrompt();
+    assert.ok(sp.includes("Today's date"), 'prompt has the date header');
+    const today = new Date().toLocaleDateString('en-CA', { timeZone: process.env.TZ || undefined });
+    assert.ok(sp.includes(today), `prompt includes today's ISO date (${today})`);
+  });
+
+  test('system prompt teaches schedule-card data.items[] shape', async () => {
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'hi' }], voiceMode: false },
+    });
+    assert.equal(res.status, 200);
+    const sp = gateway.getLastPrompt();
+    assert.ok(sp.includes('data.items[]'), 'prompt mentions data.items[] for schedule-card');
+    assert.ok(/never in .?meta\.schedule.?/i.test(sp), 'prompt warns against meta.schedule');
+  });
+
+  test('system prompt forbids silent embellishments on create', async () => {
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'hi' }], voiceMode: false },
+    });
+    assert.equal(res.status, 200);
+    const sp = gateway.getLastPrompt();
+    assert.ok(/embellishments are opt-in/i.test(sp), 'prompt states opt-in rule');
+    assert.ok(sp.includes('meta.prompt'), 'prompt names meta.prompt as opt-in');
+  });
+
   test('with zero cards, prompt says "(none yet)"', async () => {
     // Temporarily clear data/ then trigger another request
     const fs = require('fs');


### PR DESCRIPTION
## Summary

- Server now injects today's absolute date (in the configured TZ) into the \`/api/chat\` system prompt so the agent stops hallucinating years.
- System prompt carries a full schedule-card example with items in \`data.items[]\`; the renderer glossary spells out which renderer reads which path.
- New rule: embellishments (\`meta.prompt\`, \`meta.calendar\`, \`meta.trends\`, \`meta.reports\`, \`meta.view.display.thresholds\`) are opt-in only. Agent offers them after creation and applies via \`patch_manifest\`.
- \`create_manifest\` tool description reinforces the same three rules.

## Why

Reported in #130: the chat agent built a peptide-cycle card and the dashboard showed an empty card. Three separate bugs in one manifest:

1. Items were written into \`meta.schedule[]\`; \`eh-schedule-card.js\` reads \`data.items[]\`, so the card rendered nothing.
2. All dates were 2025 despite today being 2026-05-06 (cycle end dates already in the past).
3. \`meta.prompt.enabled: true\` was set without being asked, so a modal prompt would fire every day.

## How

- **\`server.js\`** — build a \`todayBlock\` with \`todayIso()\` on every chat request, prepend it alongside the existing \`cardListBlock\`. Both normal and voice-mode prompts get it.
- **\`config/env.js\`** — expand the schedule-card renderer entry with its real data shape, add a peptide-cycle worked example (Example 3), add the opt-in-only rule to the "After creating" section.
- **\`chat/tools.js\`** — append the three rules to the \`create_manifest\` tool description so the agent sees them even when skimming.
- **\`tests/chat-prompt-cards.test.js\`** — three new assertions covering the date injection, the \`data.items[]\` guidance, and the opt-in rule.

## Testing

- [x] \`node --test tests/chat-prompt-cards.test.js\` — 6/6 pass
- [x] \`node --test tests/chat-tool-use.test.js tests/chat-tools-crud.test.js tests/chat-proxy-reset.test.js tests/chat-status.test.js\` — 16/16 pass
- [x] Full \`npm test\` — 571/573 pass; the 2 failures are pre-existing (\`no-personal-refs\` scanning gitignored dotfiles, unrelated to this PR).
- [ ] Manual smoke: kick the chat agent through a peptide-cycle prompt against a live instance and confirm the card renders with items.

Fixes #130