### PR TITLE
Move voice config to its own doc (docs/VOICE.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ defaults.
 - [`docs/RECIPES.md`](docs/RECIPES.md) — 10 copy-pasteable card patterns (cookbook)
 - [`MANIFEST-SCHEMA.md`](MANIFEST-SCHEMA.md) — Manifest format reference
 - [`docs/CHAT-AGENT.md`](docs/CHAT-AGENT.md) — Chat widget + server-to-server integration
+- [`docs/VOICE.md`](docs/VOICE.md) — Voice chat (Fish Audio) configuration
 - [`docs/DEPLOY.md`](docs/DEPLOY.md) — Single-user + multi-user deploy guide
 - [`docs/CI.md`](docs/CI.md) — CI workflow overview
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — Contributor conventions

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -76,7 +76,7 @@ CHAT_MODEL=<model-id>
 # Optional: server-to-server agent writes
 # AGENT_API_TOKEN=<random-strong-token>
 
-# Optional: voice chat via Fish Audio
+# Optional: voice chat via Fish Audio — see docs/VOICE.md
 # FISH_AUDIO_API_KEY=<key>
 # FISH_AUDIO_DEFAULT_VOICE=<voice-model-id>
 ```
@@ -180,29 +180,8 @@ sudo nginx -t && sudo systemctl reload nginx
 
 ### Voice chat (optional)
 
-Klebb ships with optional voice input (speech-to-text) and voice replies
-(text-to-speech) powered by Fish Audio. When configured, a microphone
-button appears in the chat input row and every voice-mode reply gets a
-native audio control for playback. When it isn't configured, the mic is
-still visible but greyed out and clicking it shows an in-chat message
-pointing back to this section.
-
-To enable it, set these in your env file:
-
-```ini
-FISH_AUDIO_API_KEY=<key>
-FISH_AUDIO_DEFAULT_VOICE=<voice-model-id>
-```
-
-Then restart the service. Sanity-check from the server:
-
-```bash
-curl -s http://127.0.0.1:8080/api/voice/config | jq
-# → { "enabled": true, ... }
-```
-
-If `enabled` is `false`, the key is missing or the Fish Audio API
-rejected it. Details surface under `/api/voice/config`.
+Voice input and voice replies are supported via Fish Audio. See
+[`docs/VOICE.md`](VOICE.md) for configuration and troubleshooting.
 
 ---
 
@@ -374,8 +353,8 @@ Mismatch between browser origin and server RP_ID is the #1 cause.
 `CHAT_ENDPOINT_URL` or `CHAT_API_KEY` is unset. Set both in the env file and restart.
 
 **Voice doesn't work.**
-`FISH_AUDIO_API_KEY` is unset or invalid. Check `/api/voice/config` in
-the browser dev tools to see the error.
+See [`docs/VOICE.md`](VOICE.md) for Fish Audio configuration and the
+full troubleshooting list.
 
 **Server starts but dashboard is blank.**
 Look at `journalctl -u klebb -n 100`. Common cause: malformed

--- a/docs/VOICE.md
+++ b/docs/VOICE.md
@@ -1,0 +1,90 @@
+# Voice chat
+
+Klebb ships with optional voice input (speech-to-text) and voice
+replies (text-to-speech), powered by Fish Audio. When configured, a
+microphone button appears in the chat input row and every voice-mode
+reply gets a native audio control for playback.
+
+Voice is strictly optional. Everything works without it; the mic just
+renders greyed out and clicking it points users back here.
+
+---
+
+## 1. How it works
+
+Three HTTP endpoints handle the round-trip:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `POST /api/voice/asr` | Client uploads recorded audio, server returns transcribed text |
+| `POST /api/chat` with `voiceMode: true` | Normal chat turn, but the model is prompted to return a `{ speak, display }` pair |
+| `POST /api/voice/tts` | Server synthesises an audio clip, returns a cache key; `GET /api/voice/tts/:key` serves the audio with `Content-Length` + `Range` support |
+
+`GET /api/voice/config` exposes the current status — whether voice is
+enabled, the backend tier, remaining credit, and the active voice ID.
+The chat widget polls this on boot and decides whether to render the
+mic as active or greyed-out.
+
+---
+
+## 2. Configuration
+
+Set these in your env file (e.g. `/etc/klebb.env`):
+
+```ini
+FISH_AUDIO_API_KEY=<key>
+FISH_AUDIO_DEFAULT_VOICE=<voice-model-id>
+```
+
+Then restart the service.
+
+### Picking a voice model ID
+
+Fish Audio exposes a library of voice models; each has a unique ID
+(a hex string). Browse models in the Fish Audio dashboard, pick one,
+and paste its ID into `FISH_AUDIO_DEFAULT_VOICE`. Users with specific
+preferences can override per-instance.
+
+### Sanity check
+
+```bash
+curl -s http://127.0.0.1:8080/api/voice/config | jq
+# → { "enabled": true, "tier": "...", "credit": ..., "voiceId": "..." }
+```
+
+If `enabled` is `false`, voice is off. Common causes are below.
+
+---
+
+## 3. Troubleshooting
+
+**Mic button is greyed and clicking shows "Voice isn't configured".**
+`FISH_AUDIO_API_KEY` is unset or the API rejected it. Check
+`/api/voice/config` in the browser dev tools for details.
+
+**Voice works but playback is silent on iOS Safari.**
+Check that the shared audio element is being primed inside the user
+gesture. See the comment block at the top of
+`public/js/components/health-chat.js` for the pattern; breaking it
+silently disables autoplay on iOS.
+
+**"Insufficient credit" or 402 errors.**
+Your Fish Audio account is out of credit. Top up or switch tiers in
+the Fish Audio dashboard.
+
+**ASR returns empty text for valid audio.**
+The server transcodes all incoming audio to 16kHz mono 16-bit WAV for
+STT. If the client-captured audio is unusable (no mic permission, wrong
+codec, etc.) the transcode succeeds but STT returns nothing. Check the
+browser console for `getUserMedia` errors.
+
+---
+
+## 4. What's NOT included
+
+- No voice selection UI. Users get whatever `FISH_AUDIO_DEFAULT_VOICE`
+  points at. Per-user voice picks would need a small settings surface
+  and a manifest to persist the choice.
+- No wake-word / always-listening. The mic is tap-to-record only.
+- No non-Fish-Audio backends. The integration lives in `voice/fish.js`;
+  swapping providers means implementing the same ASR/TTS contract.

--- a/public/js/components/health-chat.js
+++ b/public/js/components/health-chat.js
@@ -893,7 +893,7 @@ class HealthChat extends LitElement {
         this._messages = [...this._messages, {
           id,
           role: 'assistant',
-          content: "Voice isn't configured. Klebb uses Fish Audio for speech. [See docs](https://github.com/Aristocles/klebb/blob/main/docs/DEPLOY.md#voice-chat-optional) to set it up.",
+          content: "Voice isn't configured. Klebb uses Fish Audio for speech. [See docs](https://github.com/Aristocles/klebb/blob/main/docs/VOICE.md) to set it up.",
           voiceUnconfiguredNotice: true,
         }];
         this._scrollToBottom();


### PR DESCRIPTION
## Summary

Follow-up to #134. The voice-chat section I added under \`docs/DEPLOY.md\` is the wrong home: voice has its own config surface, pipeline, and gotchas, matching how the chat agent has its own \`CHAT-AGENT.md\`.

- New \`docs/VOICE.md\`: endpoints + how they compose, env vars, picking a voice model, sanity-checking \`/api/voice/config\`, troubleshooting (credit, iOS autoplay, empty ASR)
- \`docs/DEPLOY.md\`: drop the voice-chat subsection; troubleshooting entry and env-file comment now point at \`VOICE.md\`
- \`public/js/components/health-chat.js\`: unconfigured-mic in-chat message link retargeted at \`VOICE.md\`
- \`README.md\`: \`VOICE.md\` added to the docs index alongside \`CHAT-AGENT.md\`

No behaviour changes.

## Testing

- [ ] \`npm test\` passes locally (pre-existing \`no-personal-refs\` failure is unrelated and present on \`main\`)
- [ ] With \`FISH_AUDIO_API_KEY\` unset, click the greyed mic; the in-chat message's \"See docs\" link opens \`docs/VOICE.md\` on GitHub
- [ ] \`docs/DEPLOY.md\` still renders cleanly; pointer to \`VOICE.md\` resolves
- [ ] \`README.md\` docs index lists VOICE.md between CHAT-AGENT.md and DEPLOY.md