### PR TITLE
fix(ui): chat textarea arrow keys work across shadow-DOM boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Left/right arrow keys work inside the chat textarea again.** The
+  date-view's window-level arrow handler was calling
+  \`preventDefault()\` on every ArrowLeft/ArrowRight, with a guard
+  that only skipped if \`e.target.tagName\` was an input. For events
+  fired inside a shadow root (like the chat widget's textarea),
+  \`e.target\` retargets to the shadow host, so the guard missed and
+  the caret never moved. Guard now walks \`e.composedPath()\` via
+  a shared \`isEditableTarget\` helper in
+  \`public/js/lib/event-target.js\`. (Fixes #136)
+
 - **Chat agent no longer builds empty schedule-cards.** The agent was
   writing items into \`meta.schedule[]\` (not a real field on the
   \`schedule-card\` shape) and leaving \`data\` empty, so the card

--- a/public/js/components/eh-date-view.js
+++ b/public/js/components/eh-date-view.js
@@ -7,6 +7,7 @@
 
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
 import './eh-view-renderer.js';
+import { isEditableTarget } from '../lib/event-target.js';
 
 function todayStr() {
   const d = new Date();
@@ -146,9 +147,7 @@ export class EhDateView extends LitElement {
   }
 
   _onKeydown(e) {
-    // Ignore if focus is on an input/textarea/select etc.
-    const t = e.target;
-    if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.tagName === 'SELECT' || t.isContentEditable)) return;
+    if (isEditableTarget(e)) return;
     if (e.key === 'ArrowLeft') { this._shift(-1); e.preventDefault(); }
     else if (e.key === 'ArrowRight') { this._shift(+1); e.preventDefault(); }
   }

--- a/public/js/lib/event-target.js
+++ b/public/js/lib/event-target.js
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// public/js/lib/event-target.js
+// Helpers for inspecting event targets across shadow-DOM boundaries.
+
+// Returns true if the event originated from (or bubbled through) an
+// editable element anywhere in the composed path. Window-level keydown
+// listeners need this because e.target retargets to the shadow host for
+// events fired inside a shadow root, so a plain e.target.tagName check
+// misses inputs inside web components (e.g. the chat widget's textarea).
+export function isEditableTarget(e) {
+  const path = e.composedPath ? e.composedPath() : [e.target];
+  for (const t of path) {
+    if (!t || !t.tagName) continue;
+    const tag = t.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || t.isContentEditable) return true;
+  }
+  return false;
+}

--- a/tests/event-target.test.js
+++ b/tests/event-target.test.js
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/event-target.test.js
+// Unit tests for public/js/lib/event-target.js — the guard that keeps the
+// date-view's window-level arrow-key handler from eating caret moves in
+// inputs, including inputs inside a web component's shadow root.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isEditableTarget } from '../public/js/lib/event-target.js';
+
+function fakeEvent(path) {
+  return { target: path[0], composedPath: () => path };
+}
+
+test('isEditableTarget: false for a bare div target', () => {
+  const div = { tagName: 'DIV' };
+  assert.equal(isEditableTarget(fakeEvent([div, { tagName: 'BODY' }])), false);
+});
+
+test('isEditableTarget: true for a direct INPUT target', () => {
+  const input = { tagName: 'INPUT' };
+  assert.equal(isEditableTarget(fakeEvent([input, { tagName: 'BODY' }])), true);
+});
+
+test('isEditableTarget: true for a direct TEXTAREA target', () => {
+  const textarea = { tagName: 'TEXTAREA' };
+  assert.equal(isEditableTarget(fakeEvent([textarea])), true);
+});
+
+test('isEditableTarget: true for a direct SELECT target', () => {
+  const select = { tagName: 'SELECT' };
+  assert.equal(isEditableTarget(fakeEvent([select])), true);
+});
+
+test('isEditableTarget: true for an isContentEditable element', () => {
+  const div = { tagName: 'DIV', isContentEditable: true };
+  assert.equal(isEditableTarget(fakeEvent([div])), true);
+});
+
+// The bug this helper fixes: a keydown fires in a textarea inside a
+// shadow root (like the chat widget's .chat-input). By the time a
+// window-level listener sees it, e.target has been retargeted to the
+// shadow host — so the old `e.target.tagName === 'TEXTAREA'` check
+// missed. composedPath() still holds the real textarea, so the walk
+// catches it.
+test('isEditableTarget: true for a shadow-DOM TEXTAREA (host as e.target)', () => {
+  const textarea = { tagName: 'TEXTAREA' };
+  const shadowHost = { tagName: 'HEALTH-CHAT' };
+  // composedPath order: deepest → outermost. target is the retargeted host.
+  const e = {
+    target: shadowHost,
+    composedPath: () => [textarea, shadowHost, { tagName: 'BODY' }],
+  };
+  assert.equal(isEditableTarget(e), true);
+});
+
+test('isEditableTarget: falls back to [e.target] when composedPath is missing', () => {
+  const input = { tagName: 'INPUT' };
+  const e = { target: input };
+  assert.equal(isEditableTarget(e), true);
+});
+
+test('isEditableTarget: ignores path entries without tagName (window, document)', () => {
+  const div = { tagName: 'DIV' };
+  const e = fakeEvent([div, {}, null, undefined]);
+  assert.equal(isEditableTarget(e), false);
+});


### PR DESCRIPTION
## Summary

- \`eh-date-view\`'s window-level \`keydown\` handler was eating ArrowLeft/ArrowRight in the chat widget's textarea (and any other shadow-DOM input) because its guard only checked \`e.target.tagName\`.
- \`e.target\` retargets to the shadow host when an event fires inside a shadow root, so the guard missed and \`preventDefault()\` ran — blocking the caret move.
- Replaced with a shared \`isEditableTarget(e)\` helper that walks \`e.composedPath()\`, which still holds the real deepest target. Handler now bails correctly.

## Why

Reported in #136. Typing in the chat box, left/right arrows did nothing; up/down worked — the exact fingerprint of a handler that only intercepts those two keys.

## How

- New \`public/js/lib/event-target.js\` exports \`isEditableTarget(e)\`. Walks \`composedPath()\`, checks tag name and \`isContentEditable\`, falls back to \`[e.target]\` when \`composedPath\` is absent (SSR / old browsers).
- \`eh-date-view.js\` imports it and uses it in \`_onKeydown\`. Net lines of code: same size.
- New \`tests/event-target.test.js\` covers the bare-div, INPUT/TEXTAREA/SELECT, content-editable, shadow-DOM-retargeted, and composedPath-absent cases. 8 tests, all pass.

## Testing

- [x] \`node --test tests/event-target.test.js\` → 8/8 pass
- [x] Full \`npm test\` → 580/581 pass (same pre-existing \`no-personal-refs\` failure, unrelated to this PR)
- [ ] Manual smoke on klebbtest: focus the chat textarea, type \"the quick brown fox\", use arrow keys to move the caret mid-word — works. Arrow keys on the dashboard still navigate days.

Fixes #136