### PR TITLE
fix(renderer): schedule-card renders items with synth cycle from schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
   spanning -14..+60 days in the server's TZ, and instructs the agent
   not to compute weekdays itself. (Fixes #143)
 
+- **`schedule-card` renders items that only declare their cycle on the
+  schedule object.** The renderer's visibility filter required every
+  item to carry an explicit `cycles[]` array; agent-authored manifests
+  carry the cycle on `schedule.start_date` + `schedule.cycle_weeks`
+  (or `cycle_days`) instead, so every item got filtered out and the
+  card appeared empty. `public/js/lib/schedule.js` now synthesises a
+  single cycle from the schedule's start date + duration when an
+  explicit `cycles[]` is absent; explicit cycles still win. Unit tests
+  cover both shapes, open-ended (no duration), and the legacy
+  `schedule.startDate` alias. (Fixes #138)
+
 - **Left/right arrow keys work inside the chat textarea again.** The
   date-view's window-level arrow handler was calling
   \`preventDefault()\` on every ArrowLeft/ArrowRight, with a guard

--- a/public/js/components/eh-schedule-card.js
+++ b/public/js/components/eh-schedule-card.js
@@ -17,7 +17,7 @@
 
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
 import { EhBaseCard } from './eh-base-card.js';
-import { isScheduledOnDate } from '../lib/schedule.js';
+import { isScheduledOnDate, effectiveCycles } from '../lib/schedule.js';
 import { registerRenderer } from '../renderer-registry.js';
 
 const DAY_LETTERS = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
@@ -53,8 +53,9 @@ function weekDatesFor(dateStr) {
 
 // Find the active cycle that contains the given date.
 function activeCycle(item, dateStr) {
-  if (!Array.isArray(item.cycles)) return null;
-  for (const c of item.cycles) {
+  const cycles = effectiveCycles(item);
+  if (!cycles) return null;
+  for (const c of cycles) {
     const start = c.start || c.start_date;
     const end = c.end || c.end_date;
     if (!start) continue;

--- a/public/js/lib/schedule.js
+++ b/public/js/lib/schedule.js
@@ -11,6 +11,33 @@ function dayName(dateStr) {
   return DAY_NAMES_SHORT[d.getDay()];
 }
 
+function iso(d) {
+  return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+}
+
+// Resolve the cycles to evaluate for a schedule-card item.
+// Explicit item.cycles[] always wins. When absent, synthesise a single
+// cycle from schedule.start_date (+ schedule.cycle_weeks or cycle_days)
+// so agent-authored manifests render without needing a separate cycles
+// array. Returns null when nothing usable is declared.
+export function effectiveCycles(item) {
+  if (Array.isArray(item.cycles) && item.cycles.length > 0) return item.cycles;
+  const s = item.schedule;
+  const start = s && (s.start_date || s.startDate);
+  if (!start) return null;
+  if (s.cycle_weeks > 0) {
+    const d = new Date(start + 'T00:00:00');
+    d.setDate(d.getDate() + s.cycle_weeks * 7 - 1);
+    return [{ type: 'on', start, end: iso(d) }];
+  }
+  if (s.cycle_days > 0) {
+    const d = new Date(start + 'T00:00:00');
+    d.setDate(d.getDate() + s.cycle_days - 1);
+    return [{ type: 'on', start, end: iso(d) }];
+  }
+  return [{ type: 'on', start }];
+}
+
 // Returns one of:
 //   'scheduled' — on an active cycle + schedule day
 //   'rest'      — on an active cycle but a rest day per the schedule
@@ -18,7 +45,7 @@ function dayName(dateStr) {
 //   false       — outside all cycles
 export function isScheduledOnDate(item, dateStr) {
   const sched = item.schedule;
-  const cycles = item.cycles;
+  const cycles = effectiveCycles(item);
 
   // If no cycles: just use schedule directly + optional item-level dates
   if (!cycles || cycles.length === 0) {

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -7,7 +7,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { isScheduledOnDate, enumerateDates } from '../public/js/lib/schedule.js';
+import { isScheduledOnDate, enumerateDates, effectiveCycles } from '../public/js/lib/schedule.js';
 
 // --- Canonical schema tests ---
 
@@ -211,4 +211,87 @@ test('enumerateDates: single-day range', () => {
 test('enumerateDates: handles month boundary', () => {
   const out = enumerateDates('2026-03-30', '2026-04-02');
   assert.deepEqual(out, ['2026-03-30', '2026-03-31', '2026-04-01', '2026-04-02']);
+});
+
+// --- effectiveCycles: synthesised cycles from schedule.start_date + duration ---
+
+test('effectiveCycles: explicit cycles[] wins over schedule-derived', () => {
+  const item = {
+    schedule: { type: 'daily', start_date: '2026-01-01', cycle_weeks: 4 },
+    cycles: [{ type: 'on', start: '2026-05-01', end: '2026-05-10' }],
+  };
+  assert.deepEqual(effectiveCycles(item), [{ type: 'on', start: '2026-05-01', end: '2026-05-10' }]);
+});
+
+test('effectiveCycles: schedule.start_date + cycle_weeks → bounded synthetic cycle', () => {
+  const item = {
+    schedule: { type: 'weekly', on_days: ['Mon', 'Wed', 'Fri'], start_date: '2026-05-06', cycle_weeks: 6 },
+  };
+  // 6 weeks = 42 days inclusive of the start date → end = 2026-06-16
+  assert.deepEqual(effectiveCycles(item), [{ type: 'on', start: '2026-05-06', end: '2026-06-16' }]);
+});
+
+test('effectiveCycles: schedule.start_date + cycle_days → bounded synthetic cycle', () => {
+  const item = {
+    schedule: { type: 'daily', start_date: '2026-05-01', cycle_days: 20 },
+  };
+  assert.deepEqual(effectiveCycles(item), [{ type: 'on', start: '2026-05-01', end: '2026-05-20' }]);
+});
+
+test('effectiveCycles: start_date only → open-ended synthetic cycle', () => {
+  const item = { schedule: { type: 'daily', start_date: '2026-05-06' } };
+  assert.deepEqual(effectiveCycles(item), [{ type: 'on', start: '2026-05-06' }]);
+});
+
+test('effectiveCycles: no cycles and no start_date → null', () => {
+  const item = { schedule: { type: 'daily' } };
+  assert.equal(effectiveCycles(item), null);
+});
+
+test('effectiveCycles: legacy schedule.startDate also feeds the synthesiser', () => {
+  const item = { schedule: { type: 'daily', startDate: '2026-05-06' } };
+  assert.deepEqual(effectiveCycles(item), [{ type: 'on', start: '2026-05-06' }]);
+});
+
+// --- isScheduledOnDate with synthesised cycles ---
+//
+// Regression for #138: agent-authored peptide cards land with only
+// schedule.start_date + cycle_weeks/cycle_days. The renderer must treat
+// them the same as cards carrying an explicit cycles[] array.
+
+test('isScheduledOnDate: synth cycle from cycle_weeks gates dates inside window', () => {
+  // BPC-157 shape from the #138 reproduction manifest.
+  const item = {
+    name: 'BPC-157',
+    schedule: { type: 'weekly', on_days: ['Mon', 'Wed', 'Fri'], start_date: '2026-05-06', cycle_weeks: 6 },
+  };
+  // 2026-05-06 is a Wed → scheduled (start of cycle)
+  assert.equal(isScheduledOnDate(item, '2026-05-06'), 'scheduled');
+  // 2026-05-08 Fri → scheduled
+  assert.equal(isScheduledOnDate(item, '2026-05-08'), 'scheduled');
+  // 2026-05-07 Thu → rest (within cycle, not a scheduled day)
+  assert.equal(isScheduledOnDate(item, '2026-05-07'), 'rest');
+  // Before the cycle start → outside all cycles
+  assert.equal(isScheduledOnDate(item, '2026-05-05'), false);
+  // After the 6-week window (2026-06-17) → outside all cycles
+  assert.equal(isScheduledOnDate(item, '2026-06-17'), false);
+});
+
+test('isScheduledOnDate: synth cycle from cycle_days honours end boundary', () => {
+  // Epitalon shape from the #138 reproduction manifest.
+  const item = {
+    name: 'Epitalon',
+    schedule: { type: 'daily', start_date: '2026-05-01', cycle_days: 20 },
+  };
+  assert.equal(isScheduledOnDate(item, '2026-05-01'), 'scheduled');
+  assert.equal(isScheduledOnDate(item, '2026-05-20'), 'scheduled'); // last day
+  assert.equal(isScheduledOnDate(item, '2026-05-21'), false);       // past end
+  assert.equal(isScheduledOnDate(item, '2026-04-30'), false);       // before start
+});
+
+test('isScheduledOnDate: open-ended synth cycle lets schedule run forever', () => {
+  const item = { schedule: { type: 'daily', start_date: '2026-05-06' } };
+  assert.equal(isScheduledOnDate(item, '2026-05-06'), 'scheduled');
+  assert.equal(isScheduledOnDate(item, '2030-01-01'), 'scheduled');
+  assert.equal(isScheduledOnDate(item, '2026-05-05'), false);
 });


### PR DESCRIPTION
## Summary

- \`eh-schedule-card\` was filtering out every item that lacked an explicit \`cycles[]\` array.
- Agent-authored schedule-card manifests carry the cycle on the schedule object (\`schedule.start_date\` + \`cycle_weeks\` | \`cycle_days\`), so all items got filtered out and the card rendered empty.
- New \`effectiveCycles(item)\` in \`public/js/lib/schedule.js\` synthesises a single \`{type:'on', start, end?}\` cycle when \`cycles[]\` is missing; explicit cycles still win.

## Why

Reported repro: user talked the chat agent through a three-peptide cycle (BPC-157, TB-500, Epitalon); \"create it\" landed a manifest with three items populated under \`data.items[]\` (so #130's fix held), but the dashboard card rendered blank.

Root cause: \`eh-schedule-card.js\`'s \`activeCycle()\` returned null unless \`item.cycles\` was an array, and \`renderCard()\` filtered on \`activeCycle()\`. The existing long-lived working peptides card on the operator's prod instance has \`cycles[]\` populated, which hid the bug from everyday use.

## How

- \`public/js/lib/schedule.js\` — new exported \`effectiveCycles(item)\`. Explicit \`item.cycles[]\` wins. Otherwise synthesise from \`schedule.start_date\` (+ \`cycle_weeks\` ×7−1 or \`cycle_days\`−1 to compute the inclusive end). Open-ended when no duration is given. \`isScheduledOnDate()\` now reads cycles through \`effectiveCycles()\` so the status chip / week-dot status stays consistent with the visibility filter.
- \`public/js/components/eh-schedule-card.js\` — \`activeCycle()\` delegates to \`effectiveCycles()\`; the local \`iso\` helper there is untouched, just no longer used inside cycle derivation.
- \`tests/schedule.test.js\` — 9 new assertions: explicit-cycles precedence, bounded cycle from \`cycle_weeks\`, bounded cycle from \`cycle_days\`, open-ended when duration absent, null when nothing declared, legacy \`schedule.startDate\` alias, and three end-to-end \`isScheduledOnDate\` checks mirroring the failing peptide shapes (BPC-157 weekly + 6-week window, Epitalon daily + 20-day window, open-ended daily).

No data migration: the \`peptide-cycle.json\` on the test instance already has the right shape, it just couldn't render. Once this ships the existing file renders correctly.

## Testing

- [x] \`node --test tests/schedule.test.js\` — 32/32 pass (9 new).
- [x] Full \`npm test\` — 588/590 pass; the two failures are pre-existing and unrelated (\`no-personal-refs\` scanning gitignored dotfiles, and a flaky chat-proxy RST test — both documented in #131's PR body).
- [ ] Manual smoke on the test instance: reload the card in the browser, confirm the three items render with cycle rings, week dots, and the Inject/Rest day chip on today.

Fixes #138