### PR TITLE
chore(ci): bump Docker workflow actions off deprecated Node 20

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,13 +19,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -33,7 +33,7 @@ jobs:
 
       - name: Compute image tags
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -50,7 +50,7 @@ jobs:
             org.opencontainers.image.url=https://github.com/${{ github.repository }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,10 +40,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build (no push)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64


### PR DESCRIPTION
## Summary

GitHub is retiring Node 20 from hosted runners on 2026-09-16. Every run was flagging the v3/v5 majors of the Docker actions we use. Newer majors run on Node 24.

Pins bumped across \`.github/workflows/test.yml\` and \`.github/workflows/publish.yml\`:

| Action | Was | Now |
|--------|-----|-----|
| \`docker/setup-qemu-action\` | v3 | v4 |
| \`docker/setup-buildx-action\` | v3 | v4 |
| \`docker/login-action\` | v3 | v4 |
| \`docker/metadata-action\` | v5 | v6 |
| \`docker/build-push-action\` | v5 | v7 |

No input changes: existing inputs (\`context\`, \`platforms\`, \`push\`, \`tags\`, \`labels\`, \`cache-from\`, \`cache-to\`) are all still valid on the new majors.

Fixes #140

## Testing

- [ ] \`test\` workflow passes on this PR, including the Docker-build-dry-run job — proves v4 buildx + v7 build-push work
- [ ] After merge, the first push to \`main\` triggers \`publish.yml\` against the full v4/v6/v7 stack (QEMU + buildx + login + metadata + multi-arch build+push to GHCR); watch for a clean run and a new \`:latest\` / \`:sha-xxxx\` image at \`ghcr.io/aristocles/klebb\`
- [ ] Deprecation warning about Node 20 no longer appears in subsequent run logs