### PR TITLE
fix(chat): stop agent hallucinating weekdays for relative dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,29 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Added
+
+- **Embellishment chips after chat creates/edits a card.** When the chat
+  agent successfully creates or patches a manifest, the chat response now
+  carries a small follow-up row of one-click suggestions tailored to the
+  card's renderer (add an emoji, show on the calendar, add a target
+  range, include in Trends, track adherence in Reports, and so on). The
+  picker in `chat/embellish.js` is pure, renderer-aware, and only
+  surfaces embellishments whose target field is currently absent.
+  Clicking a chip sends a canned prompt back through the agent and
+  disables the chip row so the same offer can't be applied twice.
+  (Fixes #142)
+
 ### Fixed
+
+- **Chat agent no longer hallucinates weekdays for relative dates.**
+  Asked "what's on 5 days from now?" on a Wednesday, the agent would
+  compute the ISO date correctly (+5) but then confidently name the
+  wrong weekday ("Friday" for a Monday). Language models are
+  unreliable at weekday arithmetic from an ISO date, so the system
+  prompt now carries a pre-computed offset/weekday/ISO lookup table
+  spanning -14..+60 days in the server's TZ, and instructs the agent
+  not to compute weekdays itself. (Fixes #143)
 
 - **Left/right arrow keys work inside the chat textarea again.** The
   date-view's window-level arrow handler was calling

--- a/chat/date-context.js
+++ b/chat/date-context.js
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// chat/date-context.js
+//
+// Builds the "## Today's date" system-prompt block. Language models are
+// unreliable at weekday arithmetic from an ISO date (they confidently name
+// the wrong weekday), so we inject a pre-computed lookup table and tell
+// the model not to compute weekdays itself.
+
+const WEEKDAY_LONG = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+const WEEKDAY_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+// Today's YYYY-MM-DD in the given IANA timezone.
+function todayIsoInTz(now, tz) {
+  return now.toLocaleDateString('en-CA', { timeZone: tz });
+}
+
+// Weekday (0=Sun..6=Sat) for a YYYY-MM-DD calendar date. A bare YYYY-MM-DD
+// has an unambiguous weekday regardless of timezone, so we resolve it via
+// UTC midnight.
+function weekdayFor(isoDate) {
+  const [y, m, d] = isoDate.split('-').map(Number);
+  return new Date(Date.UTC(y, m - 1, d)).getUTCDay();
+}
+
+function addDays(isoDate, n) {
+  const [y, m, d] = isoDate.split('-').map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  dt.setUTCDate(dt.getUTCDate() + n);
+  return dt.toISOString().slice(0, 10);
+}
+
+function offsetLabel(n) {
+  if (n === 0) return ' 00';
+  const mag = String(Math.abs(n)).padStart(2, '0');
+  return (n > 0 ? '+' : '-') + mag;
+}
+
+// Build the full system-prompt block. Exposed for testing; server.js
+// calls buildTodayBlock() which uses defaults.
+function buildDateContextBlock({ now = new Date(), tz = 'UTC', pastDays = 14, futureDays = 60 } = {}) {
+  const today = todayIsoInTz(now, tz);
+  const todayWeekday = WEEKDAY_LONG[weekdayFor(today)];
+
+  const lines = [];
+  for (let n = -pastDays; n <= futureDays; n++) {
+    const iso = addDays(today, n);
+    const wk = WEEKDAY_SHORT[weekdayFor(iso)];
+    let suffix = '';
+    if (n === 0) suffix = '  (today)';
+    else if (n === 1) suffix = '  (tomorrow)';
+    else if (n === -1) suffix = '  (yesterday)';
+    lines.push(`  ${offsetLabel(n)}  ${wk}  ${iso}${suffix}`);
+  }
+
+  return `\n\n## Today's date
+
+Today is ${todayWeekday}, ${today}.
+
+Use the table below to resolve any relative date ("next Monday", "in two weeks", "tomorrow", "5 days from now"). Do NOT compute weekdays yourself; if the date you need is in the table, copy its weekday from the table; if it isn't, give the ISO date only and do not state a weekday you have not been told.
+
+Known dates (offset, weekday, ISO):
+
+${lines.join('\n')}
+
+Never hardcode a year from training data.
+`;
+}
+
+module.exports = { buildDateContextBlock };

--- a/server.js
+++ b/server.js
@@ -16,6 +16,7 @@ const { listTemplates, listPrompts } = require('./server/content');
 const voice = require('./voice/fish');
 const voiceCache = require('./voice/cache');
 const { TOOL_DEFS, dispatchToolCall } = require('./chat/tools');
+const { buildDateContextBlock } = require('./chat/date-context');
 const hae = require('./health-auto-export/ingest');
 
 // chat endpoint config (env-driven; see config/env.js)
@@ -1181,10 +1182,11 @@ const server = http.createServer(async (req, res) => {
             ? `\n\n## Currently available cards\n\n${cardList}\n`
             : '\n\n## Currently available cards\n\n(none yet)\n';
 
-          // Inject today's absolute date (in the server's TZ) so the agent
-          // computes relative dates from ground truth rather than guessing
-          // from training data.
-          const todayBlock = `\n\n## Today's date\n\nToday is ${todayIso()}. Use this as the reference point for any relative date ("next Monday", "in two weeks", "three months from now"). Never hardcode a year from training data.\n`;
+          // Inject today's absolute date + a pre-computed weekday lookup
+          // table in the server's TZ. Language models are unreliable at
+          // weekday arithmetic from an ISO date, so we hand them the
+          // answer rather than asking them to compute it.
+          const todayBlock = buildDateContextBlock({ tz: ENV.TZ });
 
           let systemPrompt = HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock;
           if (voiceMode) {

--- a/tests/date-context.test.js
+++ b/tests/date-context.test.js
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/date-context.test.js
+//
+// Unit tests for chat/date-context.js. The bug these lock in: the chat
+// agent used to compute weekdays from an ISO date itself and got them
+// confidently wrong (said Friday for 2026-05-11, which is a Monday).
+// We now pre-compute a weekday lookup table and inject it into the
+// system prompt.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { buildDateContextBlock } = require('../chat/date-context');
+
+test('today line names the correct weekday', () => {
+  // 2026-05-06 is a Wednesday.
+  const now = new Date('2026-05-06T06:00:00Z');
+  const block = buildDateContextBlock({ now, tz: 'UTC', pastDays: 1, futureDays: 1 });
+  assert.match(block, /Today is Wednesday, 2026-05-06\./);
+});
+
+test('lookup table names the correct weekday for +5 days (the regression case)', () => {
+  // Regression: agent said "Friday, 2026-05-11" when asked "5 days from
+  // now" on Wed 2026-05-06. 2026-05-11 is a Monday.
+  const now = new Date('2026-05-06T06:00:00Z');
+  const block = buildDateContextBlock({ now, tz: 'UTC', pastDays: 0, futureDays: 7 });
+  assert.match(block, /\+05 {2}Mon {2}2026-05-11/);
+  assert.doesNotMatch(block, /Fri {2}2026-05-11/);
+});
+
+test('tomorrow and yesterday are labelled', () => {
+  const now = new Date('2026-05-06T06:00:00Z');
+  const block = buildDateContextBlock({ now, tz: 'UTC', pastDays: 1, futureDays: 1 });
+  assert.match(block, /\+01 {2}Thu {2}2026-05-07 {2}\(tomorrow\)/);
+  assert.match(block, /-01 {2}Tue {2}2026-05-05 {2}\(yesterday\)/);
+  assert.match(block, /0 {2}Wed {2}2026-05-06 {2}\(today\)/);
+});
+
+test('spans month and year boundaries correctly', () => {
+  // Dec 31 2026 is a Thursday. +1 is Jan 1 2027 (Friday).
+  const now = new Date('2026-12-31T12:00:00Z');
+  const block = buildDateContextBlock({ now, tz: 'UTC', pastDays: 0, futureDays: 2 });
+  assert.match(block, /Today is Thursday, 2026-12-31\./);
+  assert.match(block, /\+01 {2}Fri {2}2027-01-01/);
+  assert.match(block, /\+02 {2}Sat {2}2027-01-02/);
+});
+
+test('respects TZ when computing "today"', () => {
+  // 2026-05-06T14:00:00Z is Thursday 07 May 2026 at 00:00 in Sydney
+  // (UTC+10), but still Wednesday 06 May in UTC.
+  const now = new Date('2026-05-06T14:00:00Z');
+  const utc = buildDateContextBlock({ now, tz: 'UTC', pastDays: 0, futureDays: 0 });
+  const syd = buildDateContextBlock({ now, tz: 'Australia/Sydney', pastDays: 0, futureDays: 0 });
+  assert.match(utc, /Today is Wednesday, 2026-05-06\./);
+  assert.match(syd, /Today is Thursday, 2026-05-07\./);
+});
+
+test('tells the model not to compute weekdays itself', () => {
+  const now = new Date('2026-05-06T06:00:00Z');
+  const block = buildDateContextBlock({ now, tz: 'UTC' });
+  assert.match(block, /Do NOT compute weekdays yourself/);
+  assert.match(block, /do not state a weekday you have not been told/);
+});
+
+test('default window is -14..+60 days', () => {
+  const now = new Date('2026-05-06T06:00:00Z');
+  const block = buildDateContextBlock({ now, tz: 'UTC' });
+  // 75 total offset lines: -14..+60 inclusive.
+  const lines = block.split('\n').filter(l => /^ {2}[-+ ]\d/.test(l));
+  assert.equal(lines.length, 75);
+  assert.match(block, /-14 {2}[A-Z][a-z]{2} {2}\d{4}-\d{2}-\d{2}/);
+  assert.match(block, /\+60 {2}[A-Z][a-z]{2} {2}\d{4}-\d{2}-\d{2}/);
+});
+
+test('every listed weekday matches the ISO date it is paired with', () => {
+  const now = new Date('2026-05-06T06:00:00Z');
+  const block = buildDateContextBlock({ now, tz: 'UTC', pastDays: 30, futureDays: 90 });
+  const shortNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  const re = /^ {2}[-+ ]\d\d {2}([A-Z][a-z]{2}) {2}(\d{4})-(\d{2})-(\d{2})/gm;
+  let m;
+  let checked = 0;
+  while ((m = re.exec(block)) !== null) {
+    const [, name, y, mo, d] = m;
+    const expected = shortNames[new Date(Date.UTC(+y, +mo - 1, +d)).getUTCDay()];
+    assert.equal(name, expected, `weekday mismatch for ${y}-${mo}-${d}`);
+    checked++;
+  }
+  assert.ok(checked > 100, `expected to check many rows, got ${checked}`);
+});


### PR DESCRIPTION
## Summary

Chat agent was confidently naming the wrong weekday for any relative date. The ISO arithmetic was correct (+5 days from 2026-05-06 is 2026-05-11); the weekday was not (called it Friday; it's a Monday).

Root cause: language models are unreliable at weekday arithmetic from an ISO date. Prompting "be careful" doesn't fix a capability gap.

## Why

The model hallucinating weekdays in scheduling answers is a critical correctness bug for a health dashboard that drives peptide cycles, medication timing, and "what's on today/tomorrow/Friday" questions.

## How

- New helper `chat/date-context.js` builds a `## Today's date` block with a pre-computed offset/weekday/ISO table spanning -14..+60 days in the server's TZ.
- `server.js` swaps the inline one-liner for `buildDateContextBlock({ tz: ENV.TZ })`.
- The block tells the agent not to compute weekdays itself: if the date is in the table, copy the weekday; if it isn't, give the ISO date only and don't state a weekday.
- Window default -14..+60 covers schedule-card cycles without bloating the prompt (~75 rows, trivial tokens).

## Testing

- [x] `node --test tests/date-context.test.js` — 8 tests, including the exact +5 regression case (2026-05-11 must say Mon not Fri), month/year boundaries, and an exhaustive check that every row's weekday matches its ISO date
- [x] `npm test` — 600/601 pass (the one failure is pre-existing and unrelated: `no-personal-refs.test.js` matching `.claude/` skill content and `data/sessions/` on disk)

Fixes #143