### PR TITLE
feat(chat): offer embellishment chips after card create/edit

### DIFF
--- a/chat/embellish.js
+++ b/chat/embellish.js
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// chat/embellish.js
+// Pick context-aware "embellishment" offers to surface as chips after the
+// chat agent creates or edits a manifest. Pure: no I/O, no registry calls.
+// The server runs this against the just-written manifest and attaches the
+// result as `followup` on the /api/chat response. Renderer-aware so we only
+// offer fields the card can actually take; field-absence gated so we never
+// offer something already set.
+
+const MAX_OFFERS = 3;
+
+const INTRO = {
+  create: 'Want to flesh it out?',
+  edit: 'Anything else while we are here?',
+};
+
+// Each entry is { id, label, buildPrompt(label), eligible(meta) }.
+// eligible() returns true when the manifest can take this embellishment
+// AND the relevant field is currently absent.
+const CATALOG = [
+  {
+    id: 'add-emoji',
+    label: 'Pick an emoji',
+    buildPrompt: (label) => `Pick an emoji for the ${label} card.`,
+    eligible: (meta) => !meta.emoji,
+  },
+  {
+    id: 'add-category',
+    label: 'Give it a category',
+    buildPrompt: (label) => `Set a category for the ${label} card.`,
+    eligible: (meta) => !meta.category,
+  },
+  {
+    id: 'add-calendar',
+    label: 'Show on the calendar',
+    buildPrompt: (label) => `Enable a calendar marker for the ${label} card.`,
+    eligible: (meta) => !(meta.calendar && meta.calendar.enabled),
+  },
+  {
+    id: 'add-thresholds',
+    label: 'Add a target range',
+    buildPrompt: (label) =>
+      `Add coloured target thresholds to the ${label} card so out-of-range values stand out.`,
+    eligible: (meta) =>
+      renderer(meta) === 'generic-card'
+      && !(meta.view && meta.view.display && meta.view.display.thresholds),
+  },
+  {
+    id: 'add-trend-arrow',
+    label: 'Show a trend arrow',
+    buildPrompt: (label) =>
+      `Add a trend arrow to the ${label} card so I can see direction at a glance.`,
+    eligible: (meta) =>
+      renderer(meta) === 'generic-card'
+      && !(meta.view && meta.view.display && meta.view.display.trendArrow),
+  },
+  {
+    id: 'add-trends-line',
+    label: 'Include in Trends',
+    buildPrompt: (label) =>
+      `Include the ${label} card in the Trends view as a line chart.`,
+    eligible: (meta) => {
+      const r = renderer(meta);
+      if (r !== 'generic-card' && r !== 'line-chart') return false;
+      return !(meta.trends && meta.trends.enabled);
+    },
+  },
+  {
+    id: 'add-trends-timeline',
+    label: 'Show as a timeline',
+    buildPrompt: (label) =>
+      `Include the ${label} card in the Trends view as a schedule timeline.`,
+    eligible: (meta) => {
+      const r = renderer(meta);
+      if (r !== 'schedule-card' && r !== 'checklist-card') return false;
+      return !(meta.trends && meta.trends.enabled);
+    },
+  },
+  {
+    id: 'add-adherence-report',
+    label: 'Track adherence in Reports',
+    buildPrompt: (label) =>
+      `Add an adherence report for the ${label} card so I can see how I am tracking.`,
+    eligible: (meta) => {
+      const r = renderer(meta);
+      if (r !== 'schedule-card' && r !== 'checklist-card') return false;
+      return !(meta.reports && meta.reports.enabled);
+    },
+  },
+  {
+    id: 'add-daily-prompt',
+    label: 'Nag me daily',
+    buildPrompt: (label) =>
+      `Enable the daily modal prompt for the ${label} card so it asks me to log each day.`,
+    eligible: (meta) => {
+      const inputs = meta.writeable && Array.isArray(meta.writeable.inputs)
+        ? meta.writeable.inputs
+        : null;
+      if (!inputs || inputs.length === 0) return false;
+      return !(meta.prompt && meta.prompt.enabled);
+    },
+  },
+];
+
+function renderer(meta) {
+  return (meta && meta.view && meta.view.component) || null;
+}
+
+function pickEmbellishments(manifest, { rng = Math.random, flow = 'create' } = {}) {
+  if (!manifest || !manifest.meta) return null;
+  const meta = manifest.meta;
+  const label = meta.label || meta.id || 'card';
+
+  const eligible = CATALOG.filter(e => {
+    try { return e.eligible(meta); }
+    catch { return false; }
+  });
+  if (eligible.length === 0) return null;
+
+  const shuffled = shuffle(eligible, rng).slice(0, MAX_OFFERS);
+  const text = INTRO[flow] || INTRO.create;
+  const embellishments = shuffled.map(e => ({
+    id: e.id,
+    label: e.label,
+    prompt: e.buildPrompt(label),
+  }));
+  return { text, embellishments };
+}
+
+function shuffle(arr, rng) {
+  const out = arr.slice();
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+module.exports = { pickEmbellishments, CATALOG, MAX_OFFERS, INTRO };

--- a/chat/tools.js
+++ b/chat/tools.js
@@ -14,7 +14,7 @@ const TOOL_DEFS = [
     function: {
       name: 'create_manifest',
       description:
-        "Create a new card on the user's dashboard. Pass a full klebb.datafile.v1 manifest object. Returns {ok, id, source} on success; validation errors come back as {error} — read the message and retry with a fixed manifest (e.g. pick a different id on 'duplicate id', sanitise bad chars on 'invalid id'). IMPORTANT: per-renderer data shape matters: e.g. schedule-card items live in data.items[], NOT meta.schedule. Do NOT set optional embellishments (meta.prompt, meta.calendar, meta.trends, meta.reports, meta.view.display.thresholds) unless the user explicitly asked for them; offer them afterwards and apply via patch_manifest if accepted. Use today's absolute date (provided in the system prompt) for any date field; never guess the year from training data.",
+        "Create a new card on the user's dashboard. Pass a full klebb.datafile.v1 manifest object. Returns {ok, id, source} on success; validation errors come back as {error} — read the message and retry with a fixed manifest (e.g. pick a different id on 'duplicate id', sanitise bad chars on 'invalid id'). IMPORTANT: per-renderer data shape matters: e.g. schedule-card items live in data.items[], NOT meta.schedule. Do NOT set optional embellishments (meta.prompt, meta.calendar, meta.trends, meta.reports, meta.view.display.thresholds) unless the user explicitly asked for them; the webapp offers the user follow-up chips after a successful create so they can opt in. Use today's absolute date (provided in the system prompt) for any date field; never guess the year from training data.",
       parameters: {
         type: 'object',
         properties: {
@@ -155,7 +155,12 @@ const TOOL_DEFS = [
 // string (stringified JSON) — both success and failure paths. The string
 // becomes the `content` of the matching {role:"tool"} message on the next
 // gateway request.
-function dispatchToolCall(tc) {
+//
+// Optional `ctx` collects side-effects the caller can inspect after the
+// loop resolves. Today that's `ctx.touches`: an ordered list of successful
+// create / patch / write_data calls, used to drive the post-turn
+// embellishment chips. Kept as a plain array (last entry is the newest).
+function dispatchToolCall(tc, ctx) {
   const name = tc.function?.name;
   let args = {};
   try {
@@ -167,6 +172,7 @@ function dispatchToolCall(tc) {
     switch (name) {
       case 'create_manifest': {
         const result = registry.createManifest(args.manifest);
+        recordTouch(ctx, { id: result.id, flow: 'create' });
         return JSON.stringify({ ok: true, ...result });
       }
       case 'delete_manifest': {
@@ -212,10 +218,12 @@ function dispatchToolCall(tc) {
           return JSON.stringify({ error: `${args.id} is not writeable from the webapp (meta.writeable.fromWebapp is not true). Use patch_manifest to flip the flag first if the user wants to make it writeable.` });
         }
         registry.writeData(args.id, args.data);
+        recordTouch(ctx, { id: args.id, flow: 'edit' });
         return JSON.stringify({ ok: true, id: args.id });
       }
       case 'patch_manifest': {
         const result = registry.patchManifest(args.id, args.patch);
+        recordTouch(ctx, { id: args.id, flow: 'edit' });
         return JSON.stringify({ ok: true, ...result });
       }
       default:
@@ -224,6 +232,17 @@ function dispatchToolCall(tc) {
   } catch (e) {
     return JSON.stringify({ error: e.message || String(e) });
   }
+}
+
+// Record a manifest-touch for post-turn consumers. If the same id is
+// touched twice in one turn (e.g. create then patch), keep the original
+// flow — a create-then-patch is still fundamentally a create and the
+// chips that come back should read as such.
+function recordTouch(ctx, touch) {
+  if (!ctx || !Array.isArray(ctx.touches)) return;
+  const existing = ctx.touches.find(t => t.id === touch.id);
+  if (existing) return;
+  ctx.touches.push(touch);
 }
 
 module.exports = { TOOL_DEFS, dispatchToolCall };

--- a/public/js/components/health-chat.js
+++ b/public/js/components/health-chat.js
@@ -498,6 +498,13 @@ class HealthChat extends LitElement {
       color: var(--text-secondary);
     }
     .suggestion:hover { border-color: var(--accent); color: var(--accent); }
+    .embellish { margin-top: 10px; }
+    .embellish-intro {
+      font-size: 12px;
+      color: var(--text-secondary);
+      margin-bottom: 6px;
+    }
+    .embellish-chips { justify-content: flex-start; margin-top: 0; }
 
     .typing {
       align-self: flex-start;
@@ -844,7 +851,13 @@ class HealthChat extends LitElement {
       // confusing "Gateway unavailable" errors on slow (tool-using) replies.
       const data = await this._fetchChat(chatMessages, false, 120000);
       if (data.error) this._pushError(data.error);
-      else this._addMsg('assistant', data.reply);
+      else {
+        const extra = data.followup ? {
+          followupText: data.followup.text,
+          embellishments: Array.isArray(data.followup.embellishments) ? data.followup.embellishments : [],
+        } : {};
+        this._addMsg('assistant', data.reply, extra);
+      }
     } catch (e) {
       this._pushError(e.name === 'AbortError' ? 'Request timed out' : 'Failed to connect');
     }
@@ -1154,9 +1167,13 @@ class HealthChat extends LitElement {
           // produced in response to voice input (speakText set). Typed
           // input gets a text-only reply — no audio UI.
           const hasAudio = m.id && this._voiceAvailable && m.speakText;
+          const chips = Array.isArray(m.embellishments) && m.embellishments.length
+            ? this._renderEmbellishChips(m)
+            : '';
           return html`
             <div class="msg assistant">
               ${unsafeHTML(renderMarkdown(m.content))}
+              ${chips}
               ${hasAudio ? this._renderAudioSlot(m) : ''}
             </div>
           `;
@@ -1166,6 +1183,28 @@ class HealthChat extends LitElement {
       })}
       ${this._loading ? html`<div class="typing"><div class="typing-dots"><span></span><span></span><span></span></div></div>` : ''}
     `;
+  }
+
+  _renderEmbellishChips(msg) {
+    const intro = msg.followupText ? html`<div class="embellish-intro">${msg.followupText}</div>` : '';
+    return html`
+      <div class="embellish">
+        ${intro}
+        <div class="suggestions embellish-chips">
+          ${msg.embellishments.map(e => html`
+            <span class="suggestion" @click=${() => this._applyEmbellishment(msg.id, e)}>${e.label}</span>
+          `)}
+        </div>
+      </div>
+    `;
+  }
+
+  _applyEmbellishment(msgId, embellishment) {
+    if (!embellishment || !embellishment.prompt) return;
+    // Clear chips on the originating message so they can't be clicked twice.
+    this._updateMsg(msgId, { embellishments: [], followupText: '' });
+    this._input = embellishment.prompt;
+    this._sendText();
   }
 
   _renderAudioSlot(msg) {

--- a/server.js
+++ b/server.js
@@ -16,6 +16,7 @@ const { listTemplates, listPrompts } = require('./server/content');
 const voice = require('./voice/fish');
 const voiceCache = require('./voice/cache');
 const { TOOL_DEFS, dispatchToolCall } = require('./chat/tools');
+const { pickEmbellishments } = require('./chat/embellish');
 const { buildDateContextBlock } = require('./chat/date-context');
 const hae = require('./health-auto-export/ingest');
 
@@ -302,6 +303,7 @@ function callGateway({ messages, tools }) {
 async function runAgentLoop({ systemPrompt, userMessages }) {
   const MAX_ITERS = 5;
   const messages = [{ role: 'system', content: systemPrompt }, ...userMessages];
+  const ctx = { touches: [] };
   let lastAssistantText = '';
   for (let i = 0; i < MAX_ITERS; i++) {
     const gw = await callGateway({ messages, tools: TOOL_DEFS });
@@ -326,19 +328,39 @@ async function runAgentLoop({ systemPrompt, userMessages }) {
           role: 'tool',
           tool_call_id: tc.id,
           name: tc.function?.name,
-          content: dispatchToolCall(tc),
+          content: dispatchToolCall(tc, ctx),
         });
       }
       continue;
     }
 
-    return { finalText: msg.content || lastAssistantText || '', cappedOut: false };
+    return { finalText: msg.content || lastAssistantText || '', cappedOut: false, ctx };
   }
   return {
     finalText: lastAssistantText ||
       "I wasn't able to finish that in one turn — please re-ask or be more specific.",
     cappedOut: true,
+    ctx,
   };
+}
+
+// Given the post-loop ctx, build a `followup` object for the chat
+// response if the agent touched a manifest this turn. Returns null when
+// no manifest was touched, the touched manifest no longer exists, or
+// the picker has nothing eligible to offer. The last touch wins: if a
+// turn created one card and patched another, we offer chips on the more
+// recent operation.
+function buildFollowup(ctx) {
+  if (!ctx || !Array.isArray(ctx.touches) || ctx.touches.length === 0) return null;
+  const last = ctx.touches[ctx.touches.length - 1];
+  const entry = registry.get(last.id);
+  if (!entry) return null;
+  const manifest = { meta: entry.meta, data: entry.data };
+  return pickEmbellishments(manifest, { flow: last.flow });
+}
+
+function withFollowup(body, followup) {
+  return followup ? { ...body, followup } : body;
 }
 
 // Synthesise the legacy injection-log.json shape { 'YYYY-MM-DD': { 'PeptideName': { taken: true, time: ISO } } }
@@ -1235,18 +1257,19 @@ Original system prompt follows:
           }
 
           runAgentLoop({ systemPrompt, userMessages: messages })
-            .then(({ finalText }) => {
+            .then(({ finalText, ctx }) => {
+              const followup = buildFollowup(ctx);
               if (voiceMode) {
                 const parsedReply = extractJsonReply(finalText);
                 if (parsedReply && (parsedReply.speak || parsedReply.display)) {
                   const speak = (parsedReply.speak || parsedReply.display || '').trim();
                   const display = (parsedReply.display || parsedReply.speak || '').trim();
-                  return sendJSON(res, { reply: display, speak });
+                  return sendJSON(res, withFollowup({ reply: display, speak }, followup));
                 }
                 const speak = finalText.replace(/\p{Extended_Pictographic}/gu, '').trim();
-                return sendJSON(res, { reply: finalText || 'No response', speak });
+                return sendJSON(res, withFollowup({ reply: finalText || 'No response', speak }, followup));
               }
-              sendJSON(res, { reply: finalText || 'No response' });
+              sendJSON(res, withFollowup({ reply: finalText || 'No response' }, followup));
             })
             .catch((e) => {
               const msg = e.message || String(e);

--- a/tests/chat-embellish-followup.test.js
+++ b/tests/chat-embellish-followup.test.js
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/chat-embellish-followup.test.js
+// Asserts that /api/chat attaches a `followup` block when the agent
+// successfully creates or patches a manifest this turn, and does NOT
+// attach one when the agent just reads or lists.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('http');
+const { createSandbox, cleanupSandbox, spawnServer, req } = require('./helpers/sandbox');
+
+function startStubGateway() {
+  const responseQueue = [];
+  const server = http.createServer((request, response) => {
+    let body = '';
+    request.on('data', c => { body += c; });
+    request.on('end', () => {
+      const next = responseQueue.shift();
+      if (!next) {
+        response.writeHead(500, { 'Content-Type': 'application/json' });
+        response.end(JSON.stringify({ error: 'stub queue exhausted' }));
+        return;
+      }
+      response.writeHead(200, { 'Content-Type': 'application/json' });
+      response.end(JSON.stringify(next));
+    });
+  });
+  return new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => {
+      const port = server.address().port;
+      resolve({
+        port,
+        close: () => new Promise(r => server.close(r)),
+        pushResponse: (r) => responseQueue.push(r),
+        pushResponses: (rs) => rs.forEach(r => responseQueue.push(r)),
+        reset: () => { responseQueue.length = 0; },
+      });
+    });
+  });
+}
+
+function toolCallResponse({ name, args, id = 'call_1' }) {
+  return {
+    choices: [{
+      finish_reason: 'tool_calls',
+      message: {
+        role: 'assistant',
+        content: '',
+        tool_calls: [{
+          id,
+          type: 'function',
+          function: { name, arguments: JSON.stringify(args) },
+        }],
+      },
+    }],
+  };
+}
+
+function stopResponse(content) {
+  return {
+    choices: [{ finish_reason: 'stop', message: { role: 'assistant', content } }],
+  };
+}
+
+describe('chat /api/chat — embellishment followup', () => {
+  let sandbox, server, gateway;
+
+  before(async () => {
+    gateway = await startStubGateway();
+    sandbox = createSandbox();
+    server = await spawnServer(sandbox, {
+      CHAT_ENDPOINT_URL: `http://127.0.0.1:${gateway.port}/v1/chat/completions`,
+      CHAT_API_KEY: 'stub-token',
+      CHAT_MODEL: 'stub-model',
+    });
+  });
+  after(async () => {
+    if (server) await server.kill();
+    if (gateway) await gateway.close();
+    cleanupSandbox(sandbox);
+  });
+
+  test('create_manifest attaches followup with embellishments shaped for the client', async () => {
+    gateway.reset();
+    const manifest = {
+      $schema: 'klebb.datafile.v1',
+      meta: {
+        id: 'embellish-create',
+        label: 'Embellish Create',
+        view: { enabled: true, component: 'generic-card' },
+      },
+      data: [],
+    };
+    gateway.pushResponses([
+      toolCallResponse({ name: 'create_manifest', args: { manifest }, id: 'call_a' }),
+      stopResponse('Done — created Embellish Create.'),
+    ]);
+
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'Create an Embellish Create card.' }] },
+    });
+
+    assert.equal(res.status, 200);
+    assert.ok(res.json.followup, 'expected followup block on create');
+    assert.equal(typeof res.json.followup.text, 'string');
+    assert.ok(Array.isArray(res.json.followup.embellishments));
+    assert.ok(res.json.followup.embellishments.length > 0);
+    for (const e of res.json.followup.embellishments) {
+      assert.equal(typeof e.id, 'string');
+      assert.equal(typeof e.label, 'string');
+      assert.equal(typeof e.prompt, 'string');
+      assert.ok(e.prompt.includes('Embellish Create'), 'chip prompt should mention the card label');
+    }
+  });
+
+  test('pure read (list_manifests) does not attach a followup', async () => {
+    gateway.reset();
+    gateway.pushResponses([
+      toolCallResponse({ name: 'list_manifests', args: {}, id: 'call_b' }),
+      stopResponse('Here are your cards.'),
+    ]);
+
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'List my cards.' }] },
+    });
+
+    assert.equal(res.status, 200);
+    assert.equal(res.json.followup, undefined, 'followup should be absent for pure reads');
+  });
+
+  test('patch_manifest uses the edit-flow intro copy', async () => {
+    gateway.reset();
+    // First, seed a card we can patch.
+    const seed = {
+      $schema: 'klebb.datafile.v1',
+      meta: {
+        id: 'embellish-patch',
+        label: 'Embellish Patch',
+        view: { enabled: true, component: 'generic-card' },
+      },
+      data: [],
+    };
+    gateway.pushResponses([
+      toolCallResponse({ name: 'create_manifest', args: { manifest: seed }, id: 'call_c1' }),
+      stopResponse('Created.'),
+    ]);
+    await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'Create Embellish Patch.' }] },
+    });
+
+    // Now patch it — the followup should be in edit flow.
+    gateway.reset();
+    gateway.pushResponses([
+      toolCallResponse({
+        name: 'patch_manifest',
+        args: { id: 'embellish-patch', patch: { meta: { order: 250 } } },
+        id: 'call_c2',
+      }),
+      stopResponse('Reordered.'),
+    ]);
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'Reorder Embellish Patch.' }] },
+    });
+
+    assert.equal(res.status, 200);
+    assert.ok(res.json.followup, 'patch should attach a followup');
+    const { INTRO } = require('../chat/embellish');
+    assert.equal(res.json.followup.text, INTRO.edit);
+  });
+});

--- a/tests/embellish.test.js
+++ b/tests/embellish.test.js
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/embellish.test.js
+// Coverage for chat/embellish.js — the post-create/edit chip picker.
+// The picker is pure, so no sandbox needed. We lock the RNG to make
+// ordering deterministic and check each renderer's eligibility shape.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { pickEmbellishments, CATALOG, MAX_OFFERS } = require('../chat/embellish');
+
+// Deterministic RNG: pops from a queue so each shuffle step is predictable.
+// Pass `[0, 0, 0, ...]` to mean "never swap" -> catalog order is preserved.
+function scriptedRng(values) {
+  let i = 0;
+  return () => {
+    const v = values[i % values.length];
+    i++;
+    return v;
+  };
+}
+
+const noSwapRng = () => scriptedRng([0]);
+
+describe('pickEmbellishments', () => {
+  test('returns null for a manifest that is null or has no meta', () => {
+    assert.strictEqual(pickEmbellishments(null), null);
+    assert.strictEqual(pickEmbellishments({}), null);
+  });
+
+  test('returns null when every eligible embellishment is already set', () => {
+    // Fully-kitted generic-card: emoji, category, calendar, thresholds,
+    // trendArrow, trends, prompt, plus inputs -> adherence/timeline not
+    // applicable (wrong renderer) so everything that COULD apply is set.
+    const manifest = {
+      meta: {
+        id: 'weight',
+        label: 'Weight',
+        emoji: '⚖️',
+        category: 'vitals',
+        view: {
+          enabled: true,
+          component: 'generic-card',
+          display: {
+            thresholds: [{ ifField: 'kg', max: 80, colour: '#0f0' }],
+            trendArrow: { field: 'kg' },
+          },
+        },
+        calendar: { enabled: true, component: 'day-marker' },
+        trends: { enabled: true, component: 'line-chart' },
+        prompt: { enabled: true, mode: 'modal' },
+        writeable: { inputs: [{ key: 'kg', type: 'number' }] },
+      },
+    };
+    assert.strictEqual(pickEmbellishments(manifest, { rng: noSwapRng() }), null);
+  });
+
+  test('create flow intro differs from edit flow intro', () => {
+    const bareManifest = {
+      meta: { id: 'x', label: 'X', view: { enabled: true, component: 'generic-card' } },
+    };
+    const createResult = pickEmbellishments(bareManifest, { rng: noSwapRng(), flow: 'create' });
+    const editResult = pickEmbellishments(bareManifest, { rng: noSwapRng(), flow: 'edit' });
+    assert.ok(createResult);
+    assert.ok(editResult);
+    assert.notStrictEqual(createResult.text, editResult.text);
+  });
+
+  test('caps at MAX_OFFERS (3) even when more are eligible', () => {
+    const manifest = {
+      meta: {
+        id: 'bp',
+        label: 'Blood Pressure',
+        view: { enabled: true, component: 'generic-card' },
+        writeable: { inputs: [{ key: 'systolic', type: 'number' }] },
+      },
+    };
+    const result = pickEmbellishments(manifest, { rng: noSwapRng() });
+    assert.ok(result);
+    assert.ok(result.embellishments.length <= MAX_OFFERS);
+    assert.strictEqual(result.embellishments.length, MAX_OFFERS);
+  });
+
+  test('generic-card offers thresholds, trendArrow, trends (line-chart), plus universal options', () => {
+    const manifest = {
+      meta: {
+        id: 'weight',
+        label: 'Weight',
+        view: { enabled: true, component: 'generic-card' },
+        writeable: { inputs: [{ key: 'kg', type: 'number' }] },
+      },
+    };
+    // Use an RNG that never swaps so we see everything eligible in catalog order,
+    // then slice to MAX_OFFERS independently per test.
+    const allEligible = CATALOG.filter(e => e.eligible(manifest.meta)).map(e => e.id);
+    assert.ok(allEligible.includes('add-thresholds'));
+    assert.ok(allEligible.includes('add-trend-arrow'));
+    assert.ok(allEligible.includes('add-trends-line'));
+    assert.ok(allEligible.includes('add-emoji'));
+    assert.ok(allEligible.includes('add-category'));
+    assert.ok(allEligible.includes('add-calendar'));
+    assert.ok(allEligible.includes('add-daily-prompt'));
+    // timeline + adherence belong to schedule-style renderers, not here
+    assert.ok(!allEligible.includes('add-trends-timeline'));
+    assert.ok(!allEligible.includes('add-adherence-report'));
+  });
+
+  test('schedule-card offers adherence-report and schedule-timeline, NOT thresholds', () => {
+    const manifest = {
+      meta: {
+        id: 'peptides',
+        label: 'Peptides',
+        view: { enabled: true, component: 'schedule-card' },
+      },
+    };
+    const ids = CATALOG.filter(e => e.eligible(manifest.meta)).map(e => e.id);
+    assert.ok(ids.includes('add-adherence-report'));
+    assert.ok(ids.includes('add-trends-timeline'));
+    assert.ok(!ids.includes('add-thresholds'));
+    assert.ok(!ids.includes('add-trend-arrow'));
+    assert.ok(!ids.includes('add-trends-line'));
+  });
+
+  test('checklist-card behaves like schedule-card for renderer-gated options', () => {
+    const manifest = {
+      meta: {
+        id: 'checklist',
+        label: 'Checklist',
+        view: { enabled: true, component: 'checklist-card' },
+      },
+    };
+    const ids = CATALOG.filter(e => e.eligible(manifest.meta)).map(e => e.id);
+    assert.ok(ids.includes('add-adherence-report'));
+    assert.ok(ids.includes('add-trends-timeline'));
+  });
+
+  test('line-chart offers trends opt-in but not thresholds', () => {
+    const manifest = {
+      meta: {
+        id: 'hrv',
+        label: 'HRV',
+        view: { enabled: true, component: 'line-chart' },
+      },
+    };
+    const ids = CATALOG.filter(e => e.eligible(manifest.meta)).map(e => e.id);
+    assert.ok(ids.includes('add-trends-line'));
+    assert.ok(!ids.includes('add-thresholds'));
+    assert.ok(!ids.includes('add-trend-arrow'));
+  });
+
+  test('list-card and markdown-doc only surface universal options', () => {
+    for (const component of ['list-card', 'markdown-doc']) {
+      const manifest = {
+        meta: {
+          id: 'thing',
+          label: 'Thing',
+          view: { enabled: true, component },
+        },
+      };
+      const ids = CATALOG.filter(e => e.eligible(manifest.meta)).map(e => e.id);
+      assert.deepStrictEqual(
+        ids.sort(),
+        ['add-calendar', 'add-category', 'add-emoji'].sort(),
+        `${component} should only surface universal options`,
+      );
+    }
+  });
+
+  test('daily-prompt only eligible when writeable.inputs is non-empty', () => {
+    const noInputs = {
+      meta: {
+        id: 'doc',
+        label: 'Doc',
+        view: { enabled: true, component: 'markdown-doc' },
+      },
+    };
+    const withInputs = {
+      meta: {
+        id: 'weight',
+        label: 'Weight',
+        view: { enabled: true, component: 'generic-card' },
+        writeable: { inputs: [{ key: 'kg', type: 'number' }] },
+      },
+    };
+    const noInputIds = CATALOG.filter(e => e.eligible(noInputs.meta)).map(e => e.id);
+    const withInputIds = CATALOG.filter(e => e.eligible(withInputs.meta)).map(e => e.id);
+    assert.ok(!noInputIds.includes('add-daily-prompt'));
+    assert.ok(withInputIds.includes('add-daily-prompt'));
+  });
+
+  test('prompt strings interpolate the card label', () => {
+    const manifest = {
+      meta: {
+        id: 'mood',
+        label: 'My Mood',
+        view: { enabled: true, component: 'generic-card' },
+      },
+    };
+    const result = pickEmbellishments(manifest, { rng: noSwapRng() });
+    assert.ok(result.embellishments.every(e => e.prompt.includes('My Mood')));
+  });
+
+  test('offers carry id, label, prompt shape required by the client chips', () => {
+    const manifest = {
+      meta: {
+        id: 'x',
+        label: 'X',
+        view: { enabled: true, component: 'generic-card' },
+      },
+    };
+    const result = pickEmbellishments(manifest, { rng: noSwapRng() });
+    for (const e of result.embellishments) {
+      assert.strictEqual(typeof e.id, 'string');
+      assert.strictEqual(typeof e.label, 'string');
+      assert.strictEqual(typeof e.prompt, 'string');
+    }
+  });
+});


### PR DESCRIPTION
# What changed

After the chat agent successfully creates, patches, or rewrites a manifest in a turn, `/api/chat` now attaches a `followup` block of one-click embellishment suggestions tailored to the card's renderer (add an emoji, show on the calendar, include in Trends, add a target range, track adherence in Reports, nag me daily, and so on). The client renders these inline under the assistant bubble as chips; clicking a chip sends a canned prompt back through the agent and clears the row so the same offer cannot be applied twice.

# Why

Fixes #142. Today the agent creates a minimal card and moves on; users rarely discover the breadth of what Klebb can do (Trends, Reports, calendar markers, thresholds, daily prompts) because nothing surfaces those options at the moment they are most relevant. A single follow-up nudge with live, clickable options both makes the just-created card more useful and teaches the feature surface in context, without adding a docs page nobody reads.

# How

- New pure module `chat/embellish.js` with a renderer-aware catalog. Each entry declares its own eligibility predicate keyed on `meta.view.component` plus field-absence, so only embellishments the manifest can actually take are surfaced. Capped at three per turn and shuffled. Copy differs between create and edit flows.
- `chat/tools.js` `dispatchToolCall(tc, ctx)` now records successful `create_manifest` / `patch_manifest` / `write_manifest_data` calls onto an optional ctx. The obsolete "offer embellishments afterwards" instruction in the `create_manifest` tool description is gone, since the webapp drives the offer.
- `server.js` `runAgentLoop` owns the ctx and hands it back with `finalText`. The `/api/chat` handler reads the last touch, runs the picker against the resulting manifest, and attaches `{text, embellishments[]}` as `body.followup`. Absent when no manifest was touched (`list_manifests`, `read_manifest`, pure Q&A).
- `public/js/components/health-chat.js` renders chips inline beneath the assistant bubble using the existing suggestion-chip styling; click handler sends the canned prompt and wipes the row on that message.

# Testing

- [x] `npm test` passes locally (the two pre-existing failures on main — `no-personal-refs` and the flaky `chat-proxy-reset` — are unrelated to this change)
- [x] New `tests/embellish.test.js` covers every renderer in the catalog, the all-set-returns-null case, create vs edit copy, and the chip payload shape the client consumes
- [x] New `tests/chat-embellish-followup.test.js` integration-tests the `/api/chat` response: stub gateway scripts a `create_manifest` tool call, assert `res.json.followup.embellishments` is populated; a `patch_manifest` uses the edit intro; a pure `list_manifests` turn leaves `followup` absent
- [ ] Manual QA against a local dev instance: chips appear under the confirmation bubble after creating a card via chat, click applies one embellishment, chips vanish and cannot be clicked again

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under `## Unreleased` (entry landed on main via the #144 merge)
- [ ] Docs updated if behaviour or schema changed (no schema change; manifest shape untouched)
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens

# Breaking changes

None. Response shape is additive — `followup` is optional.