### PR TITLE
test(chat-proxy): skip RST regression test on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Chat proxy RST test no longer flakes on Windows.** The test
+  simulates an upstream gateway that RSTs its TCP socket immediately
+  after flushing a successful response. On Linux the response bytes
+  have already been buffered by Node's HTTP parser before the RST
+  arrives, so the client still gets the reply; on Windows the RST
+  purges the kernel receive buffer before any bytes surface, losing
+  the response. The production path is unaffected (Linux CI has
+  always passed); the test is now gated on non-Windows platforms so
+  local dev on Windows stops hitting a false-positive failure.
+  (Fixes #146)
+
 - **Chat agent no longer hallucinates weekdays for relative dates.**
   Asked "what's on 5 days from now?" on a Wednesday, the agent would
   compute the ISO date correctly (+5) but then confidently name the

--- a/tests/chat-proxy-reset.test.js
+++ b/tests/chat-proxy-reset.test.js
@@ -4,11 +4,19 @@
 // Regression: if the chat gateway sends a complete response and then RSTs the
 // TCP socket, the proxy must still deliver the reply to the client and must
 // not crash the server by trying to write a 502 on an already-ended response.
+//
+// Skipped on Windows: `socket.resetAndDestroy()` sends a TCP RST that purges
+// the kernel receive buffer before Node's HTTP parser can deliver any bytes
+// to user-land, so the simulation can't reliably reproduce the production
+// shape (where the response body has already been buffered by the time the
+// RST lands). Linux CI covers this path on every run.
 
 const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert');
 const net = require('net');
 const { createSandbox, cleanupSandbox, spawnServer, req } = require('./helpers/sandbox');
+
+const skipOnWindows = { skip: process.platform === 'win32' ? 'unreliable on Windows: RST drops receive buffer before Node reads it' : false };
 
 function startResetGateway() {
   const body = JSON.stringify({
@@ -61,7 +69,7 @@ function makeCard(id) {
   };
 }
 
-describe('chat proxy survives upstream RST after successful response', () => {
+describe('chat proxy survives upstream RST after successful response', skipOnWindows, () => {
   let sandbox, server, gateway;
 
   before(async () => {


### PR DESCRIPTION
## Summary

The chat-proxy RST regression test flakes on Windows (~1/3 pass rate locally). Linux CI has never flaked.

## Why

The test simulates an upstream LLM gateway that RSTs its TCP socket immediately after flushing a successful response. On Linux, Node's HTTP parser has already buffered the response body before the RST arrives, so \`proxyRes.on('end')\` fires, the client gets the reply, and the test passes deterministically.

On Windows, \`socket.resetAndDestroy()\` sends a TCP RST that purges the kernel receive buffer before any bytes surface to user-land. I confirmed this by tapping the raw socket: 0 bytes arrive in the failing case. No amount of server-side recovery can help; the data is gone at the TCP layer.

Two options:
1. Skip on Windows (this PR).
2. Rewrite the test gateway to half-close cleanly (\`socket.end()\` after write). But then it no longer reproduces the original production shape (which was specifically a RST, observed live on a self-managed TLS endpoint with \`Connection: close\`), weakening the regression into something that doesn't exercise the bug #42 fixed.

Going with option 1: the production path is still covered by Linux CI on every run.

## How

- Gate the describe block on \`process.platform !== 'win32'\` with a human-readable skip reason.

## Testing

- [x] On Windows: \`node --test tests/chat-proxy-reset.test.js\` — skipped with reason
- [x] On Windows: \`npm test\` — 611/612 (only pre-existing unrelated hygiene failure remains)
- [ ] CI (Linux): verifies the test still runs and still passes under real load

Fixes #146