### PR TITLE
feat(chat): starter prompt clears chat history before loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
   disables the chip row so the same offer can't be applied twice.
   (Fixes #142)
 
+### Changed
+
+- **Starter prompts now clear chat history before loading.** Picking a
+  starter prompt from the welcome card or prompts gallery is an
+  explicit "new workflow" entry point, so the paste-into-chat handler
+  now calls `_clearHistory()` before pasting. Prior turns no longer
+  bleed context into what was meant to be a fresh conversation.
+  (Fixes #148)
+
 ### Fixed
 
 - **Chat proxy RST test no longer flakes on Windows.** The test

--- a/public/js/components/health-chat.js
+++ b/public/js/components/health-chat.js
@@ -775,6 +775,9 @@ class HealthChat extends LitElement {
     window.addEventListener('klebb-open-chat', this._onOpenChat);
     this._onPasteIntoChat = (e) => {
       const text = e.detail?.text || '';
+      // Starter prompts are explicit "new workflow" entry points; carrying
+      // prior conversation into them bleeds stale context into the reply.
+      this._clearHistory();
       this._input = text;
       if (!this._open) this._toggle();
       this.updateComplete.then(() => {


### PR DESCRIPTION
## Summary

When a starter prompt is loaded (welcome card or prompts gallery), the chat widget now clears any existing conversation before pasting the prompt body into the input. Starter prompts are explicit "new workflow" entry points, so stale context no longer bleeds into a fresh workflow.

## Why

The gallery dispatches \`klebb-paste-into-chat\` and the handler in \`health-chat.js\` only set \`_input\`. Any prior turns stayed in \`_messages\`, so the next send shipped them back to the gateway alongside the starter prompt.

## How

- \`public/js/components/health-chat.js\`: call the existing \`_clearHistory()\` in \`_onPasteIntoChat\` before assigning \`_input\`. That reuses the audio-cleanup, server \`DELETE /api/chat/history\`, and save-timer reset paths.
- \`CHANGELOG.md\`: \`## Unreleased\` entry under \`### Changed\`.

## Testing

- [x] \`npm test\` — 611/612 (same single pre-existing failure as main; \`no-personal-refs\` flags gitignored operator files, unrelated to this diff).
- [ ] Manual: open chat, send a few messages, open welcome card → Starter prompts → Load into chat. Verify the history clears and only the pasted body remains.
- [ ] Manual: confirm the copy-to-clipboard fallback (chat not configured) is unaffected.

Fixes #148