### PR TITLE
feat(templates): HAE-backed examples for 9 new catalogue metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Health Auto Export ingest now runs off a catalogue and per-manifest
+  subscription.** Manifests opt into receiving HAE data by declaring
+  `meta.ingest: { source: "hae", metric: "<name>" }`. The dispatcher
+  walks the registry on every push and routes payload slices to
+  whichever manifests subscribe, using row shapes + aggregation rules
+  defined in `health-auto-export/catalogue.js`. Day-one catalogue
+  covers 13 metrics (sleep, steps, exercise minutes, workouts, HRV,
+  resting HR, walking HR avg, SpO₂, mindful minutes, body mass, body
+  fat, systolic BP, diastolic BP). Users can now author any number of
+  HAE-backed cards without a code change; the response body also
+  reports `availableUnsubscribed` metrics so the UI can surface
+  "discovered" data in a future change. (Fixes #150)
+
+### Changed
+
+- **HAE webhook no longer auto-seeds manifests.** Previously, a first
+  push would materialise `sleep-hours`, `steps`, `active-minutes`, and
+  `workouts` manifests from hardcoded templates if they did not already
+  exist. Now the dispatcher is strictly subscribe-by-manifest: a push
+  with no subscribers writes nothing (the raw payload is still
+  archived). The four previously-autoseeded manifests ship as
+  `templates/*.klebb.json` and can be created from the Templates
+  gallery as normal. Existing installs are patched in place by
+  `scripts/migrate-hae-ingest.js`, which adds `meta.ingest` to the
+  four manifests and takes a timestamped backup. (Refs #150)
+
 - **Embellishment chips after chat creates/edits a card.** When the chat
   agent successfully creates or patches a manifest, the chat response now
   carries a small follow-up row of one-click suggestions tailored to the

--- a/MANIFEST-SCHEMA.md
+++ b/MANIFEST-SCHEMA.md
@@ -49,7 +49,8 @@ Klebb dashboard. For the human-friendly tour, see
   "trends":   { ... },                // optional trends config
   "calendar": { ... },                // optional calendar config
   "reports":  { ... },                // optional reports config
-  "writeable": { ... }                // optional input config
+  "writeable": { ... },               // optional input config
+  "ingest":   { ... }                 // optional ingest subscription
 }
 ```
 
@@ -80,6 +81,43 @@ in `meta.order` ascending. Shown-today state is tracked in
 `localStorage` under the key `klebb-prompt-shown-{cardId}-{YYYY-MM-DD}`.
 Dismissing still marks as shown. See `docs/CARDS.md` for the full
 behaviour notes.
+
+### Ingest subscription (`meta.ingest`)
+
+Opts a manifest into receiving data from an external ingest source. Today
+the only supported source is the iPhone Health Auto Export webhook.
+
+```json
+"meta": {
+  "ingest": {
+    "source": "hae",           // required; only "hae" today
+    "metric": "sleep_analysis" // required; must match a catalogue key
+  },
+  "writeable": { "fromWebapp": false }  // recommended for HAE-fed cards
+}
+```
+
+Behaviour:
+
+- On every HAE push, the dispatcher walks all manifests with
+  `meta.ingest.source === "hae"`, reshapes the payload slice for each
+  via `health-auto-export/catalogue.js`, and upserts daily rows into
+  `data[]` by date.
+- Any number of manifests can subscribe to the same metric.
+- Multiple subscribers to the same metric each receive their own copy
+  of the rows; they do not share storage.
+- If `metric` is not in the catalogue, the manifest still loads; it
+  simply never receives ingest data. Server logs a warning per push.
+- Setting `writeable.fromWebapp: false` is the recommended default for
+  ingest-fed cards — otherwise the webapp input form can overwrite
+  rows that the next push will then re-overwrite.
+- The four historically-autoseeded manifests (`sleep-hours`, `steps`,
+  `active-minutes`, `workouts`) are no longer created on first push.
+  Author them via `templates/*.klebb.json` or drop them directly into
+  `$HEALTH_HOME/data/`.
+
+See `docs/HEALTH-AUTO-EXPORT.md` for the supported-metrics table and
+catalogue row shapes.
 
 ### View config (`meta.view`, `meta.trends`, etc.)
 

--- a/docs/HEALTH-AUTO-EXPORT.md
+++ b/docs/HEALTH-AUTO-EXPORT.md
@@ -2,33 +2,75 @@
 
 Klebb can receive a webhook push from the iPhone
 [Health Auto Export](https://apps.apple.com/app/health-auto-export-json-csv/id1115567069)
-app. Each push writes the raw payload to disk for audit, then upserts
-daily rows into four atomic manifests that the Sleep and Activity
-combination cards consume.
+app. Each push archives the raw payload, then dispatches the parsed
+metric data to whichever manifests subscribe to it via `meta.ingest`.
 
-This page tells you how to set it up.
+This page tells you how to set it up, what metrics are supported, and
+how to author your own HAE-backed cards.
 
 ---
 
-## What gets populated
+## How it works
 
-With the webhook enabled, each HAE push updates these four manifests:
+Klebb ships a **catalogue** of supported Apple Health metrics in
+`health-auto-export/catalogue.js`. Each catalogue entry knows how to
+turn an HAE payload entry into a normalised row and how to aggregate
+multiple rows for the same date.
 
-| Source metric (HAE) | Klebb manifest | Row shape |
-|---------------------|----------------|-----------|
-| `sleep_analysis` | `sleep-hours` | `{ date, hours, source? }` |
-| `step_count` (summed per date) | `steps` | `{ date, count }` |
-| `apple_exercise_time` (summed per date) | `active-minutes` | `{ date, minutes }` |
-| `workouts[]` | `workouts` | `{ date, trained: true, type }` |
+A card receives HAE data by subscribing to a catalogue metric from its
+manifest:
 
-A manifest is created automatically on the first push if it doesn't
-already exist. Re-posting the same date overwrites only that date's
-row; other dates are untouched.
+```json
+"meta": {
+  "id": "sleep",
+  "label": "Sleep",
+  "emoji": "😴",
+  "ingest": { "source": "hae", "metric": "sleep_analysis" },
+  "view": {
+    "enabled": true,
+    "component": "generic-card",
+    "display": { "template": "{hours:round(1)}", "unit": "hrs" }
+  },
+  "writeable": { "fromWebapp": false }
+}
+```
+
+On every push, the dispatcher finds every manifest whose
+`meta.ingest.source === "hae"`, shapes the corresponding payload slice
+using the catalogue, and upserts the rows by date into that manifest's
+`data[]`. Any number of manifests can subscribe to the same metric.
 
 The raw payload is archived unchanged at
 `$HEALTH_HOME/data/auto-export/raw/<ms-stamp>.json` regardless of
-whether parsing succeeds. Safe to delete at any time if disk space
-is tight.
+whether parsing succeeds. Safe to delete if disk space is tight.
+
+---
+
+## Supported metrics (day-one catalogue)
+
+| Metric key (use in `meta.ingest.metric`) | Row shape | Aggregation |
+|---|---|---|
+| `sleep_analysis` | `{ date, hours, source? }` | last per date |
+| `step_count` | `{ date, count }` | sum per date |
+| `apple_exercise_time` | `{ date, minutes }` | sum per date |
+| `workouts` (pseudo-metric, reads from `data.workouts[]`) | `{ date, trained, type? }` | any-true per date |
+| `heart_rate_variability` | `{ date, ms }` | mean per date |
+| `resting_heart_rate` | `{ date, bpm }` | last per date |
+| `walking_heart_rate_average` | `{ date, bpm }` | last per date |
+| `blood_oxygen_saturation` | `{ date, pct }` | mean per date |
+| `mindful_minutes` | `{ date, minutes }` | sum per date |
+| `body_mass` | `{ date, kg }` | last per date |
+| `body_fat_percentage` | `{ date, pct }` | last per date |
+| `blood_pressure_systolic` | `{ date, systolic }` | last per date |
+| `blood_pressure_diastolic` | `{ date, diastolic }` | last per date |
+
+Metrics not in the catalogue are archived in the raw payload but not
+ingested. Adding a new metric is a one-line entry in
+`health-auto-export/catalogue.js`; open a feature request if you need
+something that's not here.
+
+Blood pressure is two separate entries; combine them with a
+combination card if you want them shown together.
 
 ---
 
@@ -60,15 +102,52 @@ In Health Auto Export:
    Content-Type: application/json
    Authorization: Bearer <your-HEALTH_AUTO_EXPORT_TOKEN>
    ```
-5. **Metrics**: select at minimum Sleep Analysis, Step Count, Apple
-   Exercise Time, Workouts. Add any others you want archived — the
-   server ignores metrics it doesn't recognise but still keeps them
-   in the raw archive.
+5. **Metrics**: pick from the table above. Enabling more than you
+   subscribe to is harmless — unsubscribed metrics are archived only.
 6. **Export format**: JSON.
 7. **Frequency**: every 6 hours is a reasonable default. Hourly also
    works; klebb is cheap to hit.
 
-### 3. Verify
+### 3. Create subscriber manifests
+
+Klebb no longer auto-seeds cards on first push. Pick the cards you
+want and create them explicitly. The fastest path is the Templates
+gallery in Settings — four templates ship for the canonical HAE-backed
+cards (`sleep-hours`, `steps`, `active-minutes`, `workouts`).
+
+To hand-author one, drop a file like this into
+`$HEALTH_HOME/data/my-hrv.json`:
+
+```json
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "my-hrv",
+    "label": "HRV",
+    "emoji": "💓",
+    "order": 540,
+    "ingest": { "source": "hae", "metric": "heart_rate_variability" },
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": { "template": "{ms}", "unit": "ms" }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "ms"
+    },
+    "writeable": { "fromWebapp": false }
+  },
+  "description": "Heart rate variability (SDNN) from Apple Watch via HAE.",
+  "data": []
+}
+```
+
+You can also ask klebbius in chat: *"Create a new HAE-backed card for
+heart rate variability"* and it will write the file for you.
+
+### 4. Verify
 
 Manually trigger the first push from the HAE app, or wait for the
 schedule.
@@ -90,32 +169,82 @@ If nothing shows up:
 - Check klebb's logs for `[hae]` lines.
 - Hit the endpoint manually with `curl -X POST -H "Authorization:
   Bearer <token>" -H "Content-Type: application/json" -d
-  '{"data":{}}'` — expect `200 {"ok":true,"ingested":{...}}`.
+  '{"data":{}}'` — expect `200 {"ok":true,"ingested":{}}`.
 - Wrong token → `401`.
 - Missing env var → `501`.
 
 ---
 
-## Atomic manifests are ingest-only by default
+## Response shape
 
-The four atomic manifests listed above (`sleep-hours`, `steps`,
-`active-minutes`, `workouts`) ship with `writeable.fromWebapp: false`.
-That means klebb's webapp shows them read-only: no `+` button, no
-edit form. HAE is their only writer.
+A successful push returns:
 
-The rationale: manual entry plus ingest would double-display the same
-metric on Today (combo card + atomic card + input form) and every
-HAE push would silently overwrite whatever you typed. Ingest-only
-avoids both problems.
+```json
+{
+  "ok": true,
+  "ingested": { "sleep-hours": 1, "steps": 1 },
+  "availableUnsubscribed": ["heart_rate_variability", "resting_heart_rate"]
+}
+```
 
-If you're not using HAE and want to log these metrics by hand,
-either:
+- `ingested` maps manifest id → rows written.
+- `availableUnsubscribed` lists metric keys present in the payload that
+  no manifest subscribes to. This is how you discover "I could build a
+  card for this".
 
-- Flip `writeable.fromWebapp: true` in the manifest file (and add an
-  `inputs[]` block), or
-- Ask klebbius: "make the steps card writeable from the webapp with
-  a single number input for count". It'll patch the manifest in
-  place.
+---
+
+## Migrating an existing install
+
+If you have existing manifests from a klebb version that auto-seeded
+the four canonical HAE cards, run the migration script once to add
+`meta.ingest` to them:
+
+```bash
+node scripts/migrate-hae-ingest.js
+# or with an explicit data dir:
+node scripts/migrate-hae-ingest.js /path/to/data
+# --dry-run shows what would change without writing anything.
+```
+
+Takes a timestamped backup (`<file>.pre-hae-<stamp>.json`) before
+writing. Idempotent: re-running is a no-op.
+
+---
+
+## Ingest-only writes, manual-entry cards, combination cards
+
+Subscriber manifests typically set `writeable.fromWebapp: false` so the
+webapp shows them read-only — input forms and write APIs would fight
+the next push.
+
+If you want a card that holds *both* ingested data and manual entries
+(e.g. HAE sleep hours alongside a manual sleep-quality rating), don't
+try to make one manifest do both. Build it as a combination card:
+
+1. A read-only HAE-backed manifest for the objective metric.
+2. A manual-input manifest for the subjective one.
+3. A combination card that lists both as donors. The pencil icon only
+   appears on the writeable donor.
+
+See `MANIFEST-SCHEMA.md` ("Combination cards") for the CC contract.
+
+---
+
+## Failure modes
+
+| Scenario | Behaviour |
+|---|---|
+| Manifest subscribes to a metric the payload omits | Logged; manifest untouched |
+| Payload contains a metric no manifest subscribes to | Archived; reported in `availableUnsubscribed` |
+| All entries for a metric are malformed (no date, non-numeric qty) | Logged; manifest untouched |
+| Mixed: some entries valid, some malformed | Valid rows upserted, invalid ones dropped silently |
+| `meta.ingest.metric` is not in the catalogue | Manifest loads; warning logged per push |
+| Webhook body is not valid JSON | `200 + {warning}`, raw archived for inspection |
+
+The no-op-on-empty invariant means manifest files are only rewritten
+when the dispatcher produced at least one row for them. A push that
+does nothing does not churn any file.
 
 ---
 
@@ -128,31 +257,12 @@ Content-Type: application/json
 ```
 
 | Response | Meaning |
-|----------|---------|
-| `200 {ok:true, ingested:{...}}` | Parsed and upserted. Counts per source. |
-| `200 {ok:true, warning:"..."}` | Parse or upsert failed but raw was archived. HAE will retry. |
-| `401` | Token missing or wrong. |
-| `501 {error:"ingest disabled"}` | `HEALTH_AUTO_EXPORT_TOKEN` env var not set. |
+|---|---|
+| `200 {ok:true, ingested:{...}, availableUnsubscribed:[...]}` | Parsed and dispatched |
+| `200 {ok:true, warning:"..."}` | Parse or dispatch failed but raw was archived; HAE will retry |
+| `401` | Token missing or wrong |
+| `501 {error:"ingest disabled"}` | `HEALTH_AUTO_EXPORT_TOKEN` env var not set |
 
 Errors after auth passes are swallowed into `200 + warning` on
 purpose: the iPhone app retries aggressively on non-2xx, and we'd
 rather have a raw archive to debug than a spiral.
-
----
-
-## What's not in MVP
-
-- **Richer sleep manifests** (stages, bed/wake times, HRV, respiration).
-  Coming in a follow-up that adds `sleep-stages` and `sleep-bed-wake`
-  manifests alongside the current `sleep-hours`.
-- **Per-workout detail** (type, duration, avg/max HR, distance). The
-  current `workouts` card is a one-bit `trained: true` summary;
-  richer data lands with a `workouts-detailed` manifest later.
-- **Vitals ingestion** (heart rate, HRV, SpO₂, blood oxygen). Raw is
-  archived; the parser doesn't yet fan out to manifests.
-- **File-drop mode** (iCloud sync). HTTP webhook is the only
-  supported transport today.
-
-See the ingest parser at `health-auto-export/ingest.js` if you want to
-add metrics — the parser is pure, ~100 lines, and straightforward to
-extend.

--- a/health-auto-export/catalogue.js
+++ b/health-auto-export/catalogue.js
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// health-auto-export/catalogue.js
+//
+// The server-owned catalogue of supported iPhone Health Auto Export metrics.
+// Each entry is a pure recipe: how to turn one HAE payload entry into one
+// normalised row, and how rows for the same date should be combined when
+// several samples arrive.
+//
+// Shape:
+//   <metricKey>: {
+//     from?:      'metrics' | 'workouts'          // default 'metrics'
+//     aggregate:  'last-per-date' | 'sum-per-date' | 'mean-per-date'
+//               | 'max-per-date'  | 'boolean-any-per-date'
+//     row(entry): object | null   // null = drop this entry
+//   }
+//
+// `metricKey` matches the value users put in `meta.ingest.metric` inside
+// their manifest. For metrics sourced from `data.metrics[]`, it also
+// matches the HAE `name` field. For workouts (sourced from `data.workouts`),
+// the key is the pseudo-name `"workouts"`.
+//
+// Rules:
+//   - row() is pure: no side effects, no I/O.
+//   - row() returns null to drop malformed entries (missing date, NaN qty).
+//   - Every successful row MUST include `date` as 'YYYY-MM-DD'.
+//   - Aggregation is applied by the dispatcher after mapping. Catalogue
+//     entries do not pre-aggregate.
+
+const { toDate, numeric } = require('./helpers');
+
+module.exports = {
+  // --- Sleep / recovery ---------------------------------------------------
+
+  sleep_analysis: {
+    aggregate: 'last-per-date',
+    row(entry) {
+      const date = toDate(entry.date || entry.sleepStart);
+      const hours = numeric(entry.totalSleep ?? entry.asleep ?? entry.inBed ?? entry.qty);
+      if (!date || hours === null) return null;
+      const row = { date, hours };
+      if (entry.source) row.source = entry.source;
+      return row;
+    },
+  },
+
+  heart_rate_variability: {
+    aggregate: 'mean-per-date',
+    row(entry) {
+      const date = toDate(entry.date);
+      const ms = numeric(entry.qty);
+      if (!date || ms === null) return null;
+      return { date, ms };
+    },
+  },
+
+  resting_heart_rate: {
+    aggregate: 'last-per-date',
+    row(entry) {
+      const date = toDate(entry.date);
+      const bpm = numeric(entry.qty);
+      if (!date || bpm === null) return null;
+      return { date, bpm };
+    },
+  },
+
+  walking_heart_rate_average: {
+    aggregate: 'last-per-date',
+    row(entry) {
+      const date = toDate(entry.date);
+      const bpm = numeric(entry.qty);
+      if (!date || bpm === null) return null;
+      return { date, bpm };
+    },
+  },
+
+  blood_oxygen_saturation: {
+    aggregate: 'mean-per-date',
+    row(entry) {
+      const date = toDate(entry.date);
+      // HAE sends SpO2 as a fraction (0.97) or percent (97) depending on
+      // version. Normalise to percent.
+      let pct = numeric(entry.qty);
+      if (pct === null || !date) return null;
+      if (pct <= 1) pct = pct * 100;
+      return { date, pct };
+    },
+  },
+
+  // --- Activity / movement ------------------------------------------------
+
+  step_count: {
+    aggregate: 'sum-per-date',
+    row(entry) {
+      const date = toDate(entry.date);
+      const count = numeric(entry.qty);
+      if (!date || count === null) return null;
+      return { date, count };
+    },
+  },
+
+  apple_exercise_time: {
+    aggregate: 'sum-per-date',
+    row(entry) {
+      const date = toDate(entry.date);
+      const minutes = numeric(entry.qty);
+      if (!date || minutes === null) return null;
+      return { date, minutes };
+    },
+  },
+
+  // --- Mindfulness --------------------------------------------------------
+
+  mindful_minutes: {
+    aggregate: 'sum-per-date',
+    row(entry) {
+      const date = toDate(entry.date);
+      const minutes = numeric(entry.qty);
+      if (!date || minutes === null) return null;
+      return { date, minutes };
+    },
+  },
+
+  // --- Body composition ---------------------------------------------------
+
+  body_mass: {
+    aggregate: 'last-per-date',
+    row(entry) {
+      const date = toDate(entry.date);
+      const kg = numeric(entry.qty);
+      if (!date || kg === null) return null;
+      return { date, kg };
+    },
+  },
+
+  body_fat_percentage: {
+    aggregate: 'last-per-date',
+    row(entry) {
+      const date = toDate(entry.date);
+      // HAE sends body fat as a fraction (0.18) in some versions, percent
+      // (18) in others. Normalise to percent.
+      let pct = numeric(entry.qty);
+      if (pct === null || !date) return null;
+      if (pct <= 1) pct = pct * 100;
+      return { date, pct };
+    },
+  },
+
+  // --- Blood pressure (two separate entries; compose via a CC if wanted) --
+
+  blood_pressure_systolic: {
+    aggregate: 'last-per-date',
+    row(entry) {
+      const date = toDate(entry.date);
+      const systolic = numeric(entry.qty);
+      if (!date || systolic === null) return null;
+      return { date, systolic };
+    },
+  },
+
+  blood_pressure_diastolic: {
+    aggregate: 'last-per-date',
+    row(entry) {
+      const date = toDate(entry.date);
+      const diastolic = numeric(entry.qty);
+      if (!date || diastolic === null) return null;
+      return { date, diastolic };
+    },
+  },
+
+  // --- Workouts (from data.workouts[], not data.metrics[]) ----------------
+
+  workouts: {
+    from: 'workouts',
+    aggregate: 'boolean-any-per-date',
+    row(entry) {
+      const date = toDate(entry.start || entry.date);
+      if (!date) return null;
+      const row = { date, trained: true };
+      if (entry.name) row.type = entry.name;
+      return row;
+    },
+  },
+};

--- a/health-auto-export/helpers.js
+++ b/health-auto-export/helpers.js
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// health-auto-export/helpers.js
+// Shared primitives used by the catalogue + dispatcher + tests.
+
+// HAE stamps dates like "2026-05-04 14:23:00 +1000". We only need the
+// calendar date for row keying; the timezone suffix is advisory.
+function toDate(stamp) {
+  if (!stamp || typeof stamp !== 'string') return null;
+  const m = stamp.match(/^(\d{4}-\d{2}-\d{2})/);
+  return m ? m[1] : null;
+}
+
+// Parse a numeric value; returns null on NaN / undefined / non-numeric.
+// Catalogue entries use this to decide whether an incoming sample is
+// usable, rather than threading Number.isFinite checks through every row().
+function numeric(v) {
+  if (v === undefined || v === null || v === '') return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+module.exports = { toDate, numeric };

--- a/health-auto-export/ingest.js
+++ b/health-auto-export/ingest.js
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
 // health-auto-export/ingest.js
-// Parses iPhone Health Auto Export webhook payloads and upserts into
-// atomic klebb manifests.
+//
+// Dispatches iPhone Health Auto Export webhook payloads to whichever
+// manifests declare `meta.ingest: { source: "hae", metric: "<name>" }`.
 //
 // Payload shape (from the HAE app's "REST API" automation):
 //
@@ -13,109 +14,37 @@
 //     }
 //   }
 //
-// Metrics the MVP cares about:
-//   sleep_analysis        -> sleep-hours  { date, hours }
-//   step_count            -> steps        { date, count }
-//   apple_exercise_time   -> active-minutes { date, minutes }
+// Row shapes, aggregation rules, and parsing for each supported metric
+// live in catalogue.js. This file is the dispatcher + aggregators; it
+// does not know what a "sleep hour" is.
 //
-// Workouts array -> workouts { date, trained: true, type }
-//
-// Everything else in the payload is ignored but archived verbatim by the
-// caller; future follow-ups can add richer manifests without re-writing
-// the webhook plumbing.
+// Failure policy: a missing metric is not an error; an unknown metric
+// subscription is not an error. Malformed entries are dropped silently
+// per catalogue.row() returning null. The only thing that can fail loudly
+// is a filesystem write.
 
-// --- Date helpers ---
+const { toDate, numeric } = require('./helpers');
+const catalogue = require('./catalogue');
 
-// HAE stamps dates like "2026-05-04 14:23:00 +1000". We only need the
-// calendar date for row keying; the timezone suffix is advisory.
-function toDate(stamp) {
-  if (!stamp || typeof stamp !== 'string') return null;
-  const m = stamp.match(/^(\d{4}-\d{2}-\d{2})/);
-  return m ? m[1] : null;
-}
+// --- Subscriber discovery -----------------------------------------------
 
-// --- Pure parser: payload -> { sleepRows, stepsRows, activeMinutesRows, workoutsRows } ---
-
-function parseHAEPayload(payload) {
-  const out = {
-    sleepRows: [],          // [{ date, hours, source? }]
-    stepsRows: [],          // [{ date, count }]
-    activeMinutesRows: [],  // [{ date, minutes }]
-    workoutsRows: [],       // [{ date, trained, type? }]
-  };
-
-  const data = payload?.data || payload || {};
-  const metrics = Array.isArray(data.metrics) ? data.metrics : [];
-
-  // Group metrics by name for targeted extraction.
-  const byName = {};
-  for (const m of metrics) {
-    if (m && typeof m.name === 'string' && Array.isArray(m.data)) {
-      byName[m.name] = m.data;
-    }
+// Walk the registry and return entries that declare HAE ingest. Shape:
+//   [{ id, metric, entry }]
+function findSubscribers(registry) {
+  const out = [];
+  const all = typeof registry.list === 'function' ? registry.list() : [];
+  for (const item of all) {
+    const ing = item?.meta?.ingest;
+    if (!ing || ing.source !== 'hae' || !ing.metric) continue;
+    out.push({ id: item.id, metric: ing.metric });
   }
-
-  // Sleep: HAE's sleep_analysis rows carry an explicit per-night `asleep`
-  // or `totalSleep` field. We pick whichever is present, preferring the
-  // more inclusive value. One row per calendar date (last wins).
-  const sleepByDate = {};
-  for (const entry of byName.sleep_analysis || []) {
-    const date = toDate(entry.date || entry.sleepStart);
-    if (!date) continue;
-    const hours = Number(
-      entry.totalSleep ?? entry.asleep ?? entry.inBed ?? entry.qty
-    );
-    if (!Number.isFinite(hours)) continue;
-    sleepByDate[date] = { date, hours };
-    if (entry.source) sleepByDate[date].source = entry.source;
-  }
-  out.sleepRows = Object.values(sleepByDate);
-
-  // Steps: HAE sends per-sample entries with `qty`. Sum per calendar date.
-  const stepsByDate = {};
-  for (const entry of byName.step_count || []) {
-    const date = toDate(entry.date);
-    if (!date) continue;
-    const qty = Number(entry.qty);
-    if (!Number.isFinite(qty)) continue;
-    stepsByDate[date] = (stepsByDate[date] || 0) + qty;
-  }
-  out.stepsRows = Object.entries(stepsByDate)
-    .map(([date, count]) => ({ date, count: Math.round(count) }));
-
-  // Active minutes: each apple_exercise_time sample is one minute (qty=1).
-  // Sum per date.
-  const activeByDate = {};
-  for (const entry of byName.apple_exercise_time || []) {
-    const date = toDate(entry.date);
-    if (!date) continue;
-    const qty = Number(entry.qty);
-    if (!Number.isFinite(qty)) continue;
-    activeByDate[date] = (activeByDate[date] || 0) + qty;
-  }
-  out.activeMinutesRows = Object.entries(activeByDate)
-    .map(([date, minutes]) => ({ date, minutes: Math.round(minutes) }));
-
-  // Workouts: boolean "did the user train that day?" derived from the
-  // workouts[] array. Type = first workout's name.
-  const workoutsByDate = {};
-  for (const w of Array.isArray(data.workouts) ? data.workouts : []) {
-    const date = toDate(w.start || w.date);
-    if (!date) continue;
-    if (!workoutsByDate[date]) {
-      workoutsByDate[date] = { date, trained: true };
-      if (w.name) workoutsByDate[date].type = w.name;
-    }
-  }
-  out.workoutsRows = Object.values(workoutsByDate);
-
   return out;
 }
 
-// --- Upsert: merge each new row into the target manifest by date ---
+// --- Merge + aggregation ------------------------------------------------
 
-// Merge newRows into existing (array of {date, ...}), replacing rows whose
-// `date` matches. Rows in newRows with no `date` are dropped.
+// Upsert by-date: rows in `newRows` replace matching dates in `existing`;
+// other existing dates are preserved. Rows with no `date` are dropped.
 function mergeByDate(existing, newRows) {
   const base = Array.isArray(existing) ? existing.slice() : [];
   const byDate = new Map(base.filter(r => r && r.date).map(r => [r.date, r]));
@@ -123,89 +52,256 @@ function mergeByDate(existing, newRows) {
     if (!row || !row.date) continue;
     byDate.set(row.date, row);
   }
-  return [...byDate.values()].sort((a, b) => String(a.date).localeCompare(String(b.date)));
+  return [...byDate.values()].sort((a, b) =>
+    String(a.date).localeCompare(String(b.date)));
 }
 
-// Upsert a single target manifest. If the manifest doesn't exist yet, create
-// it from the minimal template so the first push doesn't require the user
-// to pre-create files.
-function upsertOne(registry, id, rows, templateFn) {
-  if (!rows || rows.length === 0) return 0;
-  const existing = registry.get(id);
-  if (!existing) {
-    registry.createManifest(templateFn(rows));
-    return rows.length;
+// Reduce a list of per-entry rows (all with `date`) down to one row per date
+// according to the aggregation strategy. Input rows can be arbitrary shapes
+// so long as they carry `date`; non-date fields are combined according to
+// the strategy.
+function aggregate(rows, strategy) {
+  if (!Array.isArray(rows) || rows.length === 0) return [];
+  const groups = new Map();
+  for (const r of rows) {
+    if (!r || !r.date) continue;
+    const list = groups.get(r.date) || [];
+    list.push(r);
+    groups.set(r.date, list);
   }
-  const existingRows = Array.isArray(existing.data) ? existing.data : [];
-  const merged = mergeByDate(existingRows, rows);
-  registry.writeData(id, merged);
-  return rows.length;
+
+  const out = [];
+  for (const [date, list] of groups) {
+    switch (strategy) {
+      case 'last-per-date':
+        out.push({ ...list[list.length - 1] });
+        break;
+
+      case 'sum-per-date': {
+        const acc = { date };
+        for (const r of list) {
+          for (const k of Object.keys(r)) {
+            if (k === 'date') continue;
+            const n = numeric(r[k]);
+            if (n === null) continue;
+            acc[k] = (acc[k] ?? 0) + n;
+          }
+        }
+        // Counts are whole numbers; tidy tiny FP residue.
+        for (const k of Object.keys(acc)) {
+          if (k === 'date') continue;
+          acc[k] = Math.round(acc[k]);
+        }
+        out.push(acc);
+        break;
+      }
+
+      case 'mean-per-date': {
+        const sum = { date };
+        const counts = {};
+        for (const r of list) {
+          for (const k of Object.keys(r)) {
+            if (k === 'date') continue;
+            const n = numeric(r[k]);
+            if (n === null) continue;
+            sum[k] = (sum[k] ?? 0) + n;
+            counts[k] = (counts[k] ?? 0) + 1;
+          }
+        }
+        const mean = { date };
+        for (const k of Object.keys(sum)) {
+          if (k === 'date') continue;
+          const v = sum[k] / counts[k];
+          // Keep one decimal of precision; catalogue entries can re-round
+          // at display time via {value:round(N)} if they want.
+          mean[k] = Math.round(v * 10) / 10;
+        }
+        out.push(mean);
+        break;
+      }
+
+      case 'max-per-date': {
+        const acc = { date };
+        for (const r of list) {
+          for (const k of Object.keys(r)) {
+            if (k === 'date') continue;
+            const n = numeric(r[k]);
+            if (n === null) continue;
+            acc[k] = acc[k] === undefined ? n : Math.max(acc[k], n);
+          }
+        }
+        out.push(acc);
+        break;
+      }
+
+      case 'boolean-any-per-date': {
+        // First row wins for scalar fields (e.g. `type`); any row with a
+        // truthy `trained` flips the aggregate to `trained: true`.
+        const head = list[0];
+        const acc = { ...head };
+        for (const r of list) {
+          for (const k of Object.keys(r)) {
+            if (typeof r[k] === 'boolean' && r[k]) acc[k] = true;
+          }
+        }
+        out.push(acc);
+        break;
+      }
+
+      default:
+        // Unknown strategy: behave like last-per-date so catalogue authors
+        // get something vaguely sensible while debugging.
+        out.push({ ...list[list.length - 1] });
+    }
+  }
+  return out.sort((a, b) => String(a.date).localeCompare(String(b.date)));
 }
 
-// Minimal templates used only when a target manifest is absent. Users can
-// edit freely after first creation.
-const TEMPLATES = {
-  'sleep-hours': rows => ({
-    $schema: 'klebb.datafile.v1',
-    meta: {
-      id: 'sleep-hours', label: 'Sleep', emoji: '😴', order: 30,
-      view: { enabled: true, component: 'generic-card',
-              display: { template: '{hours:round(1)}', unit: 'hrs' } },
-      writeable: { fromWebapp: false },
-    },
-    description: 'Total sleep duration for the night. Populated by Health Auto Export.',
-    data: rows,
-  }),
-  'steps': rows => ({
-    $schema: 'klebb.datafile.v1',
-    meta: {
-      id: 'steps', label: 'Steps', emoji: '👣', order: 70,
-      view: { enabled: true, component: 'generic-card',
-              display: { template: '{count}', unit: 'steps' } },
-      writeable: { fromWebapp: false },
-    },
-    description: 'Daily step count. Populated by Health Auto Export.',
-    data: rows,
-  }),
-  'active-minutes': rows => ({
-    $schema: 'klebb.datafile.v1',
-    meta: {
-      id: 'active-minutes', label: 'Active Minutes', emoji: '⏱️', order: 74,
-      view: { enabled: true, component: 'generic-card',
-              display: { template: '{minutes}', unit: 'min' } },
-      writeable: { fromWebapp: false },
-    },
-    description: 'Daily active minutes (Apple Exercise Time). Populated by Health Auto Export.',
-    data: rows,
-  }),
-  'workouts': rows => ({
-    $schema: 'klebb.datafile.v1',
-    meta: {
-      id: 'workouts', label: 'Workout Today', emoji: '🏋️', order: 72,
-      view: { enabled: true, component: 'generic-card',
-              display: { template: '{trained?✅ Trained:❌ Rest}', secondary: '{type|}' } },
-      writeable: { fromWebapp: false },
-    },
-    description: 'Simple yes/no training tracker. Populated by Health Auto Export.',
-    data: rows,
-  }),
-};
+// --- Payload slicing ----------------------------------------------------
 
-// Apply a parsed payload to the registry. Returns per-target counts.
-function upsertInto(registry, parsed) {
+// Return the array of raw entries from the payload for a given metric,
+// consulting the catalogue entry's `from` flag. Returns null if the metric
+// is absent from the payload (distinct from "empty array").
+function extractEntries(payload, catalogueEntry) {
+  const data = payload?.data || payload || {};
+  const from = catalogueEntry.from || 'metrics';
+
+  if (from === 'workouts') {
+    return Array.isArray(data.workouts) ? data.workouts : null;
+  }
+
+  // Default: look inside data.metrics[] for the named stream.
+  if (!Array.isArray(data.metrics)) return null;
+  for (const m of data.metrics) {
+    if (m && typeof m.name === 'string' && m.name === catalogueEntry._metricName) {
+      return Array.isArray(m.data) ? m.data : null;
+    }
+  }
+  return null;
+}
+
+// Enumerate every metric name actually present in the payload. Used for the
+// "available but unsubscribed" diagnostic. For `workouts[]` we report the
+// pseudo-name `workouts` so the output space matches catalogue keys.
+function metricsPresent(payload) {
+  const data = payload?.data || payload || {};
+  const names = new Set();
+  if (Array.isArray(data.metrics)) {
+    for (const m of data.metrics) {
+      if (m && typeof m.name === 'string') names.add(m.name);
+    }
+  }
+  if (Array.isArray(data.workouts) && data.workouts.length > 0) {
+    names.add('workouts');
+  }
+  return names;
+}
+
+// --- Dispatch -----------------------------------------------------------
+
+// Main entry point. Walks subscribers, routes each to the matching catalogue
+// entry, aggregates per date, and upserts into the manifest's data[].
+//
+// Returns a summary object the caller can echo to the client and/or write
+// to disk as a diagnostic:
+//   {
+//     subscribers: [{ id, metric, rowsWritten, note? }],
+//     availableUnsubscribed: [<metric>, ...],
+//     warnings: [<string>, ...]
+//   }
+function dispatch(registry, payload) {
   const summary = {
-    'sleep-hours': upsertOne(registry, 'sleep-hours', parsed.sleepRows, TEMPLATES['sleep-hours']),
-    'steps': upsertOne(registry, 'steps', parsed.stepsRows, TEMPLATES['steps']),
-    'active-minutes': upsertOne(registry, 'active-minutes', parsed.activeMinutesRows, TEMPLATES['active-minutes']),
-    'workouts': upsertOne(registry, 'workouts', parsed.workoutsRows, TEMPLATES['workouts']),
+    subscribers: [],
+    availableUnsubscribed: [],
+    warnings: [],
   };
+
+  const subs = findSubscribers(registry);
+  const presentMetrics = metricsPresent(payload);
+  const subscribedMetrics = new Set(subs.map(s => s.metric));
+
+  for (const sub of subs) {
+    const metricKey = sub.metric;
+    const cat = catalogue[metricKey];
+
+    if (!cat) {
+      const note = `unknown metric "${metricKey}" (not in catalogue)`;
+      summary.subscribers.push({ id: sub.id, metric: metricKey, rowsWritten: 0, note });
+      summary.warnings.push(`[hae] manifest "${sub.id}" subscribes to ${note}`);
+      continue;
+    }
+
+    // Attach metricKey to the catalogue entry for extractEntries() without
+    // mutating the exported catalogue object (shallow copy is fine).
+    const entries = extractEntries(payload, { ...cat, _metricName: metricKey });
+
+    if (entries === null) {
+      summary.subscribers.push({
+        id: sub.id, metric: metricKey, rowsWritten: 0,
+        note: 'no entries in payload',
+      });
+      continue;
+    }
+
+    if (entries.length === 0) {
+      summary.subscribers.push({
+        id: sub.id, metric: metricKey, rowsWritten: 0,
+        note: 'metric present but empty',
+      });
+      continue;
+    }
+
+    const mapped = [];
+    for (const raw of entries) {
+      const row = cat.row(raw);
+      if (row && row.date) mapped.push(row);
+    }
+
+    if (mapped.length === 0) {
+      summary.subscribers.push({
+        id: sub.id, metric: metricKey, rowsWritten: 0,
+        note: 'all entries malformed',
+      });
+      continue;
+    }
+
+    const aggregated = aggregate(mapped, cat.aggregate);
+
+    const existing = registry.data(sub.id);
+    const merged = mergeByDate(existing, aggregated);
+    try {
+      registry.writeData(sub.id, merged);
+      summary.subscribers.push({
+        id: sub.id, metric: metricKey, rowsWritten: aggregated.length,
+      });
+    } catch (e) {
+      summary.subscribers.push({
+        id: sub.id, metric: metricKey, rowsWritten: 0,
+        note: `write failed: ${e.message}`,
+      });
+      summary.warnings.push(`[hae] write failed for ${sub.id}: ${e.message}`);
+    }
+  }
+
+  // "Available but unsubscribed" powers the discovery card surface.
+  for (const name of presentMetrics) {
+    if (!subscribedMetrics.has(name)) summary.availableUnsubscribed.push(name);
+  }
+  summary.availableUnsubscribed.sort();
+
   return summary;
 }
 
 module.exports = {
+  // Core
+  dispatch,
+  findSubscribers,
+
+  // Helpers (exported for testing + potential future callers)
   toDate,
-  parseHAEPayload,
   mergeByDate,
-  upsertInto,
-  TEMPLATES,
+  aggregate,
+  extractEntries,
+  metricsPresent,
+  catalogue,
 };

--- a/scripts/migrate-hae-ingest.js
+++ b/scripts/migrate-hae-ingest.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// scripts/migrate-hae-ingest.js
+// ---------------------------------------------------------------
+// Adds `meta.ingest: { source: "hae", metric: <name> }` to the four
+// manifests that were previously ingested into by the hardcoded HAE
+// path. After this migration, the dispatcher finds them by walking
+// subscribers instead of by hardcoded ID.
+//
+// Mapping (manifest id -> HAE metric):
+//   sleep-hours     -> sleep_analysis
+//   steps           -> step_count
+//   active-minutes  -> apple_exercise_time
+//   workouts        -> workouts         (pseudo-metric, sources from data.workouts[])
+//
+// Usage:
+//   node scripts/migrate-hae-ingest.js [<path/to/data/>] [--dry-run]
+//
+// Default target: $HEALTH_HOME/data (or ~/.klebb/data if unset).
+// Backs up each touched file to <file>.pre-hae-<timestamp>.json.
+// Idempotent: re-running is a no-op on already-migrated files.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const MAPPING = {
+  'sleep-hours':    'sleep_analysis',
+  'steps':          'step_count',
+  'active-minutes': 'apple_exercise_time',
+  'workouts':       'workouts',
+};
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const args = process.argv.slice(2).filter(a => !a.startsWith('--'));
+const TARGET = args[0] || path.join(
+  process.env.HEALTH_HOME || path.join(os.homedir(), '.klebb'),
+  'data',
+);
+
+function log(msg) { process.stdout.write(msg + '\n'); }
+
+if (!fs.existsSync(TARGET)) {
+  log(`no data dir at ${TARGET}; nothing to migrate`);
+  process.exit(0);
+}
+
+const stamp = new Date().toISOString().replace(/[:.]/g, '');
+let touched = 0;
+let skipped = 0;
+
+for (const [id, metric] of Object.entries(MAPPING)) {
+  const file = path.join(TARGET, `${id}.json`);
+  if (!fs.existsSync(file)) {
+    skipped += 1;
+    log(`skip ${id}: file not present`);
+    continue;
+  }
+
+  let raw, parsed;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    log(`skip ${id}: could not parse (${e.message})`);
+    skipped += 1;
+    continue;
+  }
+
+  if (!parsed || !parsed.meta) {
+    log(`skip ${id}: missing meta block`);
+    skipped += 1;
+    continue;
+  }
+
+  const current = parsed.meta.ingest;
+  if (current
+      && current.source === 'hae'
+      && current.metric === metric) {
+    log(`skip ${id}: already migrated`);
+    skipped += 1;
+    continue;
+  }
+
+  // Write ingest at a stable position: after `order` if present, else
+  // wherever JSON.stringify puts it. Pass through all existing meta.
+  const nextMeta = { ...parsed.meta, ingest: { source: 'hae', metric } };
+  const next = { ...parsed, meta: nextMeta };
+  const serialised = JSON.stringify(next, null, 2);
+
+  if (DRY_RUN) {
+    log(`would migrate ${id}: add meta.ingest = { source: "hae", metric: "${metric}" }`);
+    touched += 1;
+    continue;
+  }
+
+  const backup = `${file}.pre-hae-${stamp}.json`;
+  fs.writeFileSync(backup, raw);
+  const tmp = `${file}.tmp`;
+  fs.writeFileSync(tmp, serialised);
+  fs.renameSync(tmp, file);
+  log(`migrated ${id} -> metric=${metric} (backup: ${path.basename(backup)})`);
+  touched += 1;
+}
+
+log('');
+log(`done. ${touched} ${DRY_RUN ? 'would be migrated' : 'migrated'}, ${skipped} skipped.`);

--- a/server.js
+++ b/server.js
@@ -903,12 +903,19 @@ const server = http.createServer(async (req, res) => {
         }
 
         try {
-          const parsed = hae.parseHAEPayload(payload);
-          const summary = hae.upsertInto(registry, parsed);
-          return sendJSON(res, { ok: true, ingested: summary });
+          const summary = hae.dispatch(registry, payload);
+          // Echo a compact ingested-per-subscriber map for back-compat with
+          // the original response shape; full detail lives in `summary`.
+          const ingested = {};
+          for (const s of summary.subscribers) ingested[s.id] = s.rowsWritten;
+          return sendJSON(res, {
+            ok: true,
+            ingested,
+            availableUnsubscribed: summary.availableUnsubscribed,
+          });
         } catch (e) {
-          console.error('[hae] upsert failed:', e.message);
-          return sendJSON(res, { ok: true, warning: 'upsert failed, raw saved' });
+          console.error('[hae] dispatch failed:', e.message);
+          return sendJSON(res, { ok: true, warning: 'dispatch failed, raw saved' });
         }
       });
       return;

--- a/templates/active-minutes.klebb.json
+++ b/templates/active-minutes.klebb.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "template": {
+      "id": "active-minutes",
+      "title": "Active minutes (Apple Health)",
+      "summary": "Daily Apple Exercise Time, populated by the iPhone Health Auto Export webhook.",
+      "category": "imported",
+      "tags": ["activity", "apple-health", "hae", "ingest-only"]
+    },
+    "id": "{{string:id}}",
+    "label": "{{string:label}}",
+    "emoji": "⏱️",
+    "order": 525,
+    "ingest": {
+      "source": "hae",
+      "metric": "apple_exercise_time"
+    },
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{minutes}",
+        "unit": "min",
+        "trendArrow": { "field": "minutes" }
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "minutes"
+    },
+    "writeable": { "fromWebapp": false }
+  },
+  "description": "Daily active minutes (Apple Exercise Time). Populated by the iPhone Health Auto Export webhook; see docs/HEALTH-AUTO-EXPORT.md for setup. Ingest-only: no webapp writes.",
+  "data": []
+}

--- a/templates/blood-oxygen-saturation.klebb.json
+++ b/templates/blood-oxygen-saturation.klebb.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "template": {
+      "id": "blood-oxygen-saturation",
+      "title": "Blood oxygen (SpO₂) (Apple Health)",
+      "summary": "Daily SpO₂ percentage, populated by the iPhone Health Auto Export webhook.",
+      "category": "imported",
+      "tags": ["vitals", "respiratory", "apple-health", "hae", "ingest-only"]
+    },
+    "id": "{{string:id}}",
+    "label": "{{string:label}}",
+    "emoji": "🫁",
+    "order": 555,
+    "ingest": {
+      "source": "hae",
+      "metric": "blood_oxygen_saturation"
+    },
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{pct:round(0)}",
+        "unit": "%",
+        "trendArrow": { "field": "pct" }
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "pct"
+    },
+    "writeable": { "fromWebapp": false }
+  },
+  "description": "Blood oxygen saturation from Apple Watch. Populated by the iPhone Health Auto Export webhook; see docs/HEALTH-AUTO-EXPORT.md for setup. Ingest-only: no webapp writes.",
+  "data": []
+}

--- a/templates/blood-pressure-diastolic.klebb.json
+++ b/templates/blood-pressure-diastolic.klebb.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "template": {
+      "id": "blood-pressure-diastolic",
+      "title": "Diastolic BP (Apple Health)",
+      "summary": "Daily diastolic blood pressure in mmHg, populated by the iPhone Health Auto Export webhook.",
+      "category": "imported",
+      "tags": ["vitals", "cardiac", "apple-health", "hae", "ingest-only"]
+    },
+    "id": "{{string:id}}",
+    "label": "{{string:label}}",
+    "emoji": "🩺",
+    "order": 580,
+    "ingest": {
+      "source": "hae",
+      "metric": "blood_pressure_diastolic"
+    },
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{diastolic}",
+        "unit": "mmHg",
+        "trendArrow": { "field": "diastolic" }
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "diastolic"
+    },
+    "writeable": { "fromWebapp": false }
+  },
+  "description": "Diastolic blood pressure from Apple Health (pushed by a connected BP cuff or manually entered in the Health app). Populated by the iPhone Health Auto Export webhook. Pair with a systolic card via a combination card to show a full reading.",
+  "data": []
+}

--- a/templates/blood-pressure-systolic.klebb.json
+++ b/templates/blood-pressure-systolic.klebb.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "template": {
+      "id": "blood-pressure-systolic",
+      "title": "Systolic BP (Apple Health)",
+      "summary": "Daily systolic blood pressure in mmHg, populated by the iPhone Health Auto Export webhook.",
+      "category": "imported",
+      "tags": ["vitals", "cardiac", "apple-health", "hae", "ingest-only"]
+    },
+    "id": "{{string:id}}",
+    "label": "{{string:label}}",
+    "emoji": "🩺",
+    "order": 575,
+    "ingest": {
+      "source": "hae",
+      "metric": "blood_pressure_systolic"
+    },
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{systolic}",
+        "unit": "mmHg",
+        "trendArrow": { "field": "systolic" }
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "systolic"
+    },
+    "writeable": { "fromWebapp": false }
+  },
+  "description": "Systolic blood pressure from Apple Health (pushed by a connected BP cuff or manually entered in the Health app). Populated by the iPhone Health Auto Export webhook. Pair with a diastolic card via a combination card to show a full reading. If you'd rather log BP directly in klebb with colour-coded threshold bands, use the 'Blood pressure' manual-entry template instead.",
+  "data": []
+}

--- a/templates/body-fat-percentage.klebb.json
+++ b/templates/body-fat-percentage.klebb.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "template": {
+      "id": "body-fat-percentage",
+      "title": "Body fat (Apple Health)",
+      "summary": "Daily body fat percentage, populated by the iPhone Health Auto Export webhook.",
+      "category": "imported",
+      "tags": ["body-composition", "apple-health", "hae", "ingest-only"]
+    },
+    "id": "{{string:id}}",
+    "label": "{{string:label}}",
+    "emoji": "📉",
+    "order": 570,
+    "ingest": {
+      "source": "hae",
+      "metric": "body_fat_percentage"
+    },
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{pct:round(1)}",
+        "unit": "%",
+        "trendArrow": { "field": "pct" }
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "pct"
+    },
+    "writeable": { "fromWebapp": false }
+  },
+  "description": "Body fat percentage from Apple Health (typically pushed by a connected smart scale with impedance measurement). Populated by the iPhone Health Auto Export webhook; see docs/HEALTH-AUTO-EXPORT.md for setup. Ingest-only: no webapp writes.",
+  "data": []
+}

--- a/templates/body-mass-hae.klebb.json
+++ b/templates/body-mass-hae.klebb.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "template": {
+      "id": "body-mass-hae",
+      "title": "Weight (Apple Health)",
+      "summary": "Daily body weight in kg, populated by the iPhone Health Auto Export webhook.",
+      "category": "imported",
+      "tags": ["weight", "body-composition", "apple-health", "hae", "ingest-only"]
+    },
+    "id": "{{string:id}}",
+    "label": "{{string:label}}",
+    "emoji": "⚖️",
+    "order": 565,
+    "ingest": {
+      "source": "hae",
+      "metric": "body_mass"
+    },
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{kg:round(1)}",
+        "unit": "kg",
+        "trendArrow": { "field": "kg" }
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "kg"
+    },
+    "writeable": { "fromWebapp": false }
+  },
+  "description": "Body weight from Apple Health (typically pushed by a connected smart scale or manual entries in the Health app). Populated by the iPhone Health Auto Export webhook; see docs/HEALTH-AUTO-EXPORT.md for setup. Ingest-only: no webapp writes. If you'd rather log weight directly in klebb, use the 'Weight' manual-entry template.",
+  "data": []
+}

--- a/templates/hrv.klebb.json
+++ b/templates/hrv.klebb.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "template": {
+      "id": "hrv",
+      "title": "Heart rate variability (Apple Health)",
+      "summary": "SDNN in milliseconds, populated by the iPhone Health Auto Export webhook.",
+      "category": "imported",
+      "tags": ["recovery", "apple-health", "hae", "ingest-only"]
+    },
+    "id": "{{string:id}}",
+    "label": "{{string:label}}",
+    "emoji": "💓",
+    "order": 540,
+    "ingest": {
+      "source": "hae",
+      "metric": "heart_rate_variability"
+    },
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{ms}",
+        "unit": "ms",
+        "trendArrow": { "field": "ms" }
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "ms"
+    },
+    "writeable": { "fromWebapp": false }
+  },
+  "description": "Daily heart rate variability (SDNN) from Apple Watch. Populated by the iPhone Health Auto Export webhook; see docs/HEALTH-AUTO-EXPORT.md for setup. Ingest-only: no webapp writes.",
+  "data": []
+}

--- a/templates/mindful-minutes.klebb.json
+++ b/templates/mindful-minutes.klebb.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "template": {
+      "id": "mindful-minutes",
+      "title": "Mindful minutes (Apple Health)",
+      "summary": "Daily meditation minutes logged to Apple Health, populated by the iPhone Health Auto Export webhook.",
+      "category": "imported",
+      "tags": ["mindfulness", "apple-health", "hae", "ingest-only"]
+    },
+    "id": "{{string:id}}",
+    "label": "{{string:label}}",
+    "emoji": "🧘",
+    "order": 560,
+    "ingest": {
+      "source": "hae",
+      "metric": "mindful_minutes"
+    },
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{minutes}",
+        "unit": "min",
+        "trendArrow": { "field": "minutes" }
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "minutes"
+    },
+    "writeable": { "fromWebapp": false }
+  },
+  "description": "Total daily mindful minutes from the Apple Health Mindfulness category (Meditation app, Breathe sessions, third-party apps that log to Health). Populated by the iPhone Health Auto Export webhook; see docs/HEALTH-AUTO-EXPORT.md for setup. Ingest-only: no webapp writes.",
+  "data": []
+}

--- a/templates/resting-heart-rate-hae.klebb.json
+++ b/templates/resting-heart-rate-hae.klebb.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "template": {
+      "id": "resting-heart-rate-hae",
+      "title": "Resting heart rate (Apple Health)",
+      "summary": "Resting bpm populated by the iPhone Health Auto Export webhook.",
+      "category": "imported",
+      "tags": ["vitals", "cardiac", "apple-health", "hae", "ingest-only"]
+    },
+    "id": "{{string:id}}",
+    "label": "{{string:label}}",
+    "emoji": "❤️",
+    "order": 545,
+    "ingest": {
+      "source": "hae",
+      "metric": "resting_heart_rate"
+    },
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{bpm}",
+        "unit": "bpm",
+        "trendArrow": { "field": "bpm" }
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "bpm"
+    },
+    "writeable": { "fromWebapp": false }
+  },
+  "description": "Resting heart rate in beats per minute, derived from Apple Watch. Populated by the iPhone Health Auto Export webhook; see docs/HEALTH-AUTO-EXPORT.md for setup. Ingest-only: no webapp writes. If you'd rather log RHR by hand, use the 'Resting heart rate' manual-entry template instead.",
+  "data": []
+}

--- a/templates/sleep-hours.klebb.json
+++ b/templates/sleep-hours.klebb.json
@@ -12,6 +12,10 @@
     "label": "{{string:label}}",
     "emoji": "😴",
     "order": 500,
+    "ingest": {
+      "source": "hae",
+      "metric": "sleep_analysis"
+    },
     "view": {
       "enabled": true,
       "component": "generic-card",

--- a/templates/steps.klebb.json
+++ b/templates/steps.klebb.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "template": {
+      "id": "steps",
+      "title": "Steps (Apple Health)",
+      "summary": "Daily step count, populated by the iPhone Health Auto Export webhook.",
+      "category": "imported",
+      "tags": ["activity", "apple-health", "hae", "ingest-only"]
+    },
+    "id": "{{string:id}}",
+    "label": "{{string:label}}",
+    "emoji": "👣",
+    "order": 520,
+    "ingest": {
+      "source": "hae",
+      "metric": "step_count"
+    },
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{count}",
+        "unit": "steps",
+        "trendArrow": { "field": "count" }
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "count"
+    },
+    "writeable": { "fromWebapp": false }
+  },
+  "description": "Daily step count. Populated by the iPhone Health Auto Export webhook; see docs/HEALTH-AUTO-EXPORT.md for setup. Ingest-only: no webapp writes.",
+  "data": []
+}

--- a/templates/walking-heart-rate-average.klebb.json
+++ b/templates/walking-heart-rate-average.klebb.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "template": {
+      "id": "walking-heart-rate-average",
+      "title": "Walking heart rate average (Apple Health)",
+      "summary": "Average bpm while walking, populated by the iPhone Health Auto Export webhook.",
+      "category": "imported",
+      "tags": ["vitals", "cardiac", "activity", "apple-health", "hae", "ingest-only"]
+    },
+    "id": "{{string:id}}",
+    "label": "{{string:label}}",
+    "emoji": "🚶",
+    "order": 550,
+    "ingest": {
+      "source": "hae",
+      "metric": "walking_heart_rate_average"
+    },
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{bpm}",
+        "unit": "bpm",
+        "trendArrow": { "field": "bpm" }
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "bpm"
+    },
+    "writeable": { "fromWebapp": false }
+  },
+  "description": "Walking heart rate average from Apple Watch. Populated by the iPhone Health Auto Export webhook; see docs/HEALTH-AUTO-EXPORT.md for setup. Ingest-only: no webapp writes.",
+  "data": []
+}

--- a/templates/workouts.klebb.json
+++ b/templates/workouts.klebb.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "template": {
+      "id": "workouts",
+      "title": "Workout today (Apple Health)",
+      "summary": "Yes/no training tracker based on whether any workout was logged to Apple Health that day.",
+      "category": "imported",
+      "tags": ["activity", "apple-health", "hae", "ingest-only"]
+    },
+    "id": "{{string:id}}",
+    "label": "{{string:label}}",
+    "emoji": "🏋️",
+    "order": 530,
+    "ingest": {
+      "source": "hae",
+      "metric": "workouts"
+    },
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{trained?✅ Trained:❌ Rest}",
+        "secondary": "{type|}"
+      }
+    },
+    "writeable": { "fromWebapp": false }
+  },
+  "description": "Simple yes/no training tracker derived from Apple Health workout records. Populated by the iPhone Health Auto Export webhook; see docs/HEALTH-AUTO-EXPORT.md for setup. Ingest-only: no webapp writes.",
+  "data": []
+}

--- a/tests/health-auto-export.dispatcher.test.js
+++ b/tests/health-auto-export.dispatcher.test.js
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/health-auto-export.dispatcher.test.js
+// Unit tests for the HAE dispatcher in isolation from the HTTP layer.
+// Uses a fake registry so we can assert dispatch shape + behaviour
+// without spinning up a server or writing to disk.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { dispatch, findSubscribers } = require('../health-auto-export/ingest.js');
+
+// Build a minimal registry stub that looks enough like the real one to
+// satisfy dispatch(): list(), data(id), writeData(id, rows).
+function makeRegistry(manifests) {
+  const state = new Map();
+  for (const m of manifests) state.set(m.id, { ...m, data: m.data ?? [] });
+  return {
+    list() {
+      return [...state.values()].map(e => ({ id: e.id, meta: e.meta }));
+    },
+    data(id) {
+      const e = state.get(id);
+      return e ? e.data : null;
+    },
+    writeData(id, rows) {
+      const e = state.get(id);
+      if (!e) throw new Error(`unknown: ${id}`);
+      e.data = rows;
+    },
+    _snapshot(id) {
+      return state.get(id)?.data;
+    },
+  };
+}
+
+describe('findSubscribers', () => {
+  test('returns only manifests with meta.ingest.source === "hae"', () => {
+    const reg = makeRegistry([
+      { id: 'a', meta: { id: 'a', ingest: { source: 'hae', metric: 'step_count' } } },
+      { id: 'b', meta: { id: 'b' } },
+      { id: 'c', meta: { id: 'c', ingest: { source: 'other', metric: 'x' } } },
+    ]);
+    assert.deepEqual(findSubscribers(reg), [{ id: 'a', metric: 'step_count' }]);
+  });
+});
+
+describe('dispatch: happy path', () => {
+  test('routes step_count to a subscriber', () => {
+    const reg = makeRegistry([
+      { id: 'my-steps', meta: { id: 'my-steps',
+          ingest: { source: 'hae', metric: 'step_count' } } },
+    ]);
+    const payload = { data: { metrics: [
+      { name: 'step_count', data: [
+        { date: '2026-05-04 08:00:00 +1000', qty: 1200 },
+        { date: '2026-05-04 12:00:00 +1000', qty: 3200 },
+        { date: '2026-05-05 10:00:00 +1000', qty: 2000 },
+      ]},
+    ]}};
+
+    const summary = dispatch(reg, payload);
+
+    assert.equal(summary.subscribers.length, 1);
+    assert.equal(summary.subscribers[0].rowsWritten, 2);
+    assert.deepEqual(summary.availableUnsubscribed, []);
+
+    const rows = reg._snapshot('my-steps');
+    const byDate = Object.fromEntries(rows.map(r => [r.date, r.count]));
+    assert.equal(byDate['2026-05-04'], 4400);
+    assert.equal(byDate['2026-05-05'], 2000);
+  });
+});
+
+describe('dispatch: no subscribers', () => {
+  test('unsubscribed payload lists availableUnsubscribed', () => {
+    const reg = makeRegistry([]);
+    const payload = { data: { metrics: [
+      { name: 'sleep_analysis', data: [{ date: '2026-05-04', totalSleep: 7 }] },
+      { name: 'step_count', data: [{ date: '2026-05-04', qty: 1000 }] },
+    ]}};
+
+    const summary = dispatch(reg, payload);
+
+    assert.deepEqual(summary.subscribers, []);
+    assert.deepEqual(summary.availableUnsubscribed.sort(),
+      ['sleep_analysis', 'step_count']);
+  });
+});
+
+describe('dispatch: subscribed metric absent from payload', () => {
+  test('records zero rows with a no-entries note; no availableUnsubscribed entry', () => {
+    const reg = makeRegistry([
+      { id: 'my-hrv', meta: { id: 'my-hrv',
+          ingest: { source: 'hae', metric: 'heart_rate_variability' } } },
+    ]);
+    const payload = { data: { metrics: [
+      { name: 'step_count', data: [{ date: '2026-05-04', qty: 1000 }] },
+    ]}};
+
+    const summary = dispatch(reg, payload);
+    assert.equal(summary.subscribers[0].rowsWritten, 0);
+    assert.match(summary.subscribers[0].note, /no entries/);
+    assert.deepEqual(summary.availableUnsubscribed, ['step_count']);
+  });
+});
+
+describe('dispatch: unknown metric in meta.ingest', () => {
+  test('records a warning, does not throw', () => {
+    const reg = makeRegistry([
+      { id: 'my-typo', meta: { id: 'my-typo',
+          ingest: { source: 'hae', metric: 'no_such_metric' } } },
+    ]);
+    const payload = { data: { metrics: [] }};
+    const summary = dispatch(reg, payload);
+    assert.equal(summary.subscribers[0].rowsWritten, 0);
+    assert.match(summary.warnings[0], /not in catalogue/);
+  });
+});
+
+describe('dispatch: multiple subscribers to same metric', () => {
+  test('both receive the same rows', () => {
+    const reg = makeRegistry([
+      { id: 'sleep-a', meta: { id: 'sleep-a',
+          ingest: { source: 'hae', metric: 'sleep_analysis' } } },
+      { id: 'sleep-b', meta: { id: 'sleep-b',
+          ingest: { source: 'hae', metric: 'sleep_analysis' } } },
+    ]);
+    const payload = { data: { metrics: [
+      { name: 'sleep_analysis', data: [
+        { date: '2026-05-04', totalSleep: 7.5 },
+      ]},
+    ]}};
+
+    dispatch(reg, payload);
+    assert.equal(reg._snapshot('sleep-a')[0].hours, 7.5);
+    assert.equal(reg._snapshot('sleep-b')[0].hours, 7.5);
+  });
+});
+
+describe('dispatch: workouts pseudo-metric', () => {
+  test('reads from data.workouts[]', () => {
+    const reg = makeRegistry([
+      { id: 'workouts', meta: { id: 'workouts',
+          ingest: { source: 'hae', metric: 'workouts' } } },
+    ]);
+    const payload = { data: { workouts: [
+      { name: 'Running', start: '2026-05-04 07:00:00 +1000' },
+      { name: 'Walking', start: '2026-05-04 18:00:00 +1000' },
+      { name: 'Functional Strength Training', start: '2026-05-05 11:00:00 +1000' },
+    ]}};
+
+    dispatch(reg, payload);
+    const rows = reg._snapshot('workouts');
+    assert.equal(rows.length, 2);
+    const byDate = Object.fromEntries(rows.map(r => [r.date, r]));
+    assert.equal(byDate['2026-05-04'].trained, true);
+    assert.equal(byDate['2026-05-04'].type, 'Running');
+    assert.equal(byDate['2026-05-05'].trained, true);
+  });
+});
+
+describe('dispatch: malformed entries dropped silently', () => {
+  test('mixed valid + invalid: only valid rows upserted', () => {
+    const reg = makeRegistry([
+      { id: 'steps', meta: { id: 'steps',
+          ingest: { source: 'hae', metric: 'step_count' } } },
+    ]);
+    const payload = { data: { metrics: [
+      { name: 'step_count', data: [
+        { date: '2026-05-04', qty: 100 },
+        { qty: 200 },                          // no date
+        { date: '2026-05-04', qty: 'nope' },   // bad qty
+        { date: '2026-05-05', qty: 500 },
+      ]},
+    ]}};
+
+    dispatch(reg, payload);
+    const rows = reg._snapshot('steps');
+    assert.equal(rows.length, 2);
+    const byDate = Object.fromEntries(rows.map(r => [r.date, r.count]));
+    assert.equal(byDate['2026-05-04'], 100);
+    assert.equal(byDate['2026-05-05'], 500);
+  });
+
+  test('all entries malformed: manifest not touched', () => {
+    const reg = makeRegistry([
+      { id: 'steps', meta: { id: 'steps',
+          ingest: { source: 'hae', metric: 'step_count' } },
+        data: [{ date: '2026-04-01', count: 9999 }] },
+    ]);
+    const payload = { data: { metrics: [
+      { name: 'step_count', data: [
+        { qty: 200 },
+        { date: '2026-05-04', qty: 'nope' },
+      ]},
+    ]}};
+
+    dispatch(reg, payload);
+    // Pre-existing data preserved; the "all-malformed" branch doesn't write.
+    const rows = reg._snapshot('steps');
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].count, 9999);
+  });
+});
+
+describe('dispatch: merge preserves prior dates', () => {
+  test('re-posting a new date does not wipe earlier dates', () => {
+    const reg = makeRegistry([
+      { id: 'steps', meta: { id: 'steps',
+          ingest: { source: 'hae', metric: 'step_count' } },
+        data: [{ date: '2026-05-01', count: 5000 }] },
+    ]);
+    const payload = { data: { metrics: [
+      { name: 'step_count', data: [{ date: '2026-05-02', qty: 7000 }] },
+    ]}};
+
+    dispatch(reg, payload);
+    const rows = reg._snapshot('steps');
+    const byDate = Object.fromEntries(rows.map(r => [r.date, r.count]));
+    assert.equal(byDate['2026-05-01'], 5000);
+    assert.equal(byDate['2026-05-02'], 7000);
+  });
+
+  test('re-posting same date overwrites the row for that date only', () => {
+    const reg = makeRegistry([
+      { id: 'steps', meta: { id: 'steps',
+          ingest: { source: 'hae', metric: 'step_count' } },
+        data: [{ date: '2026-05-01', count: 5000 }] },
+    ]);
+    const payload = { data: { metrics: [
+      { name: 'step_count', data: [{ date: '2026-05-01', qty: 9001 }] },
+    ]}};
+
+    dispatch(reg, payload);
+    const rows = reg._snapshot('steps');
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].count, 9001);
+  });
+});

--- a/tests/health-auto-export.ingest.test.js
+++ b/tests/health-auto-export.ingest.test.js
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
 // tests/health-auto-export.ingest.test.js
-// End-to-end ingest test: POST canned HAE payload, assert manifests upserted.
+// End-to-end ingest test: POST canned HAE payload, assert subscriber
+// manifests upsert correctly. No auto-seed: a fresh sandbox with no
+// subscribers ingests nothing and creates no files.
 
 const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert');
@@ -33,12 +35,61 @@ const CANNED_PAYLOAD = {
   },
 };
 
+// Minimal subscriber manifests — written into the sandbox so the
+// dispatcher has targets to route into.
+const SUBSCRIBERS = {
+  'sleep-hours.json': {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'sleep-hours', label: 'Sleep', emoji: '😴', order: 500,
+      ingest: { source: 'hae', metric: 'sleep_analysis' },
+      view: { enabled: true, component: 'generic-card',
+              display: { template: '{hours:round(1)}', unit: 'hrs' } },
+      writeable: { fromWebapp: false },
+    },
+    data: [],
+  },
+  'steps.json': {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'steps', label: 'Steps', emoji: '👣', order: 520,
+      ingest: { source: 'hae', metric: 'step_count' },
+      view: { enabled: true, component: 'generic-card',
+              display: { template: '{count}', unit: 'steps' } },
+      writeable: { fromWebapp: false },
+    },
+    data: [],
+  },
+  'active-minutes.json': {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'active-minutes', label: 'Active Minutes', emoji: '⏱️', order: 525,
+      ingest: { source: 'hae', metric: 'apple_exercise_time' },
+      view: { enabled: true, component: 'generic-card',
+              display: { template: '{minutes}', unit: 'min' } },
+      writeable: { fromWebapp: false },
+    },
+    data: [],
+  },
+  'workouts.json': {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'workouts', label: 'Workout Today', emoji: '🏋️', order: 530,
+      ingest: { source: 'hae', metric: 'workouts' },
+      view: { enabled: true, component: 'generic-card',
+              display: { template: '{trained?✅ Trained:❌ Rest}',
+                         secondary: '{type|}' } },
+      writeable: { fromWebapp: false },
+    },
+    data: [],
+  },
+};
+
 describe('POST /api/health-auto-export', () => {
   describe('with token unset', () => {
     let sandbox, server;
     before(async () => {
-      sandbox = createSandbox();
-      // Spawn WITHOUT the token env var
+      sandbox = createSandbox({ seed: SUBSCRIBERS });
       server = await spawnServer(sandbox, { HEALTH_AUTO_EXPORT_TOKEN: '' });
     });
     after(async () => { if (server) await server.kill(); if (sandbox) cleanupSandbox(sandbox); });
@@ -53,12 +104,12 @@ describe('POST /api/health-auto-export', () => {
     });
   });
 
-  describe('with token set', () => {
+  describe('with token set and subscribers present', () => {
     let sandbox, server;
     const TOKEN = 'test-hae-token-hex-123456789abcdef';
 
     before(async () => {
-      sandbox = createSandbox();
+      sandbox = createSandbox({ seed: SUBSCRIBERS });
       server = await spawnServer(sandbox, { HEALTH_AUTO_EXPORT_TOKEN: TOKEN });
     });
     after(async () => { if (server) await server.kill(); if (sandbox) cleanupSandbox(sandbox); });
@@ -80,7 +131,7 @@ describe('POST /api/health-auto-export', () => {
       assert.equal(res.status, 401);
     });
 
-    test('200 with correct bearer + upserts four manifests', async () => {
+    test('200 with correct bearer + upserts subscribed manifests', async () => {
       const res = await req(server.baseUrl, '/api/health-auto-export', {
         method: 'POST',
         body: CANNED_PAYLOAD,
@@ -93,12 +144,10 @@ describe('POST /api/health-auto-export', () => {
       assert.equal(res.json.ingested['active-minutes'], 1);
       assert.equal(res.json.ingested.workouts, 1);
 
-      // Raw payload was archived
       const rawDir = path.join(sandbox, 'data', 'auto-export', 'raw');
       const files = fs.readdirSync(rawDir).filter(f => f.endsWith('.json'));
       assert.ok(files.length >= 1, 'raw file was archived');
 
-      // Each atomic manifest exists on disk and carries the expected row
       const sleepMan = JSON.parse(fs.readFileSync(
         path.join(sandbox, 'data', 'sleep-hours.json'), 'utf8'));
       assert.equal(sleepMan.data[0].date, '2026-05-04');
@@ -121,8 +170,6 @@ describe('POST /api/health-auto-export', () => {
     });
 
     test('re-POSTing same date overwrites only that date', async () => {
-      // First push: 2026-05-04 with 7700 steps (from the previous test).
-      // Second push: 2026-05-05, new date.
       const second = {
         data: {
           metrics: [
@@ -139,12 +186,10 @@ describe('POST /api/health-auto-export', () => {
       });
       assert.equal(res.status, 200);
 
-      // Give the fs.watch reload a tick
       await new Promise(r => setTimeout(r, 200));
 
       const stepsMan = JSON.parse(fs.readFileSync(
         path.join(sandbox, 'data', 'steps.json'), 'utf8'));
-      // Should still have both dates
       const byDate = Object.fromEntries(stepsMan.data.map(r => [r.date, r.count]));
       assert.equal(byDate['2026-05-04'], 7700, 'prior date row preserved');
       assert.equal(byDate['2026-05-05'], 9001, 'new date row appended');
@@ -165,6 +210,45 @@ describe('POST /api/health-auto-export', () => {
 
       const after = fs.readdirSync(rawDir).length;
       assert.ok(after > before, 'raw file archived on parse failure');
+    });
+  });
+
+  describe('with no subscribers', () => {
+    let sandbox, server;
+    const TOKEN = 'test-hae-token-hex-123456789abcdef';
+
+    before(async () => {
+      // Empty data dir — no subscribers at all.
+      sandbox = createSandbox({ seed: {} });
+      server = await spawnServer(sandbox, { HEALTH_AUTO_EXPORT_TOKEN: TOKEN });
+    });
+    after(async () => { if (server) await server.kill(); if (sandbox) cleanupSandbox(sandbox); });
+
+    test('payload archived, nothing upserted, available metrics reported', async () => {
+      const res = await req(server.baseUrl, '/api/health-auto-export', {
+        method: 'POST',
+        body: CANNED_PAYLOAD,
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      });
+      assert.equal(res.status, 200);
+      assert.equal(res.json.ok, true);
+      assert.deepEqual(res.json.ingested, {});
+      assert.ok(Array.isArray(res.json.availableUnsubscribed));
+      assert.ok(res.json.availableUnsubscribed.includes('sleep_analysis'));
+      assert.ok(res.json.availableUnsubscribed.includes('step_count'));
+      assert.ok(res.json.availableUnsubscribed.includes('workouts'));
+
+      // None of the four previously auto-seeded manifests were materialised.
+      const dataDir = path.join(sandbox, 'data');
+      for (const f of ['sleep-hours.json', 'steps.json',
+                       'active-minutes.json', 'workouts.json']) {
+        assert.ok(!fs.existsSync(path.join(dataDir, f)),
+          `${f} should not be auto-created`);
+      }
+
+      // Raw archive still happens.
+      const rawDir = path.join(sandbox, 'data', 'auto-export', 'raw');
+      assert.ok(fs.readdirSync(rawDir).length >= 1);
     });
   });
 });

--- a/tests/health-auto-export.parser.test.js
+++ b/tests/health-auto-export.parser.test.js
@@ -1,14 +1,16 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
 // tests/health-auto-export.parser.test.js
-// Pure parser unit tests. No HTTP, no filesystem.
+// Pure unit tests for the catalogue entries + helpers. No HTTP, no filesystem.
 
 const { test, describe } = require('node:test');
 const assert = require('node:assert');
 
-const { parseHAEPayload, mergeByDate, toDate } = require('../health-auto-export/ingest.js');
+const { toDate, numeric } = require('../health-auto-export/helpers.js');
+const catalogue = require('../health-auto-export/catalogue.js');
+const { aggregate, mergeByDate } = require('../health-auto-export/ingest.js');
 
-describe('toDate', () => {
+describe('helpers: toDate', () => {
   test('extracts YYYY-MM-DD from HAE-style stamp', () => {
     assert.equal(toDate('2026-05-04 14:23:00 +1000'), '2026-05-04');
   });
@@ -23,117 +25,193 @@ describe('toDate', () => {
   });
 });
 
-describe('parseHAEPayload', () => {
-  test('empty payload returns empty row sets', () => {
-    const r = parseHAEPayload({});
-    assert.deepEqual(r.sleepRows, []);
-    assert.deepEqual(r.stepsRows, []);
-    assert.deepEqual(r.activeMinutesRows, []);
-    assert.deepEqual(r.workoutsRows, []);
+describe('helpers: numeric', () => {
+  test('parses numbers and numeric strings', () => {
+    assert.equal(numeric(42), 42);
+    assert.equal(numeric('42.5'), 42.5);
+    assert.equal(numeric(0), 0);
+  });
+  test('returns null for NaN / empty / undefined', () => {
+    assert.equal(numeric(undefined), null);
+    assert.equal(numeric(null), null);
+    assert.equal(numeric(''), null);
+    assert.equal(numeric('not a number'), null);
+    assert.equal(numeric(NaN), null);
+  });
+});
+
+describe('catalogue: sleep_analysis', () => {
+  const cat = catalogue.sleep_analysis;
+
+  test('prefers totalSleep, then asleep, then inBed, then qty', () => {
+    assert.deepEqual(cat.row({ date: '2026-05-04', totalSleep: 7.8, asleep: 7.3 }),
+      { date: '2026-05-04', hours: 7.8 });
+    assert.deepEqual(cat.row({ date: '2026-05-04', asleep: 7.3, inBed: 8.1 }),
+      { date: '2026-05-04', hours: 7.3 });
+    assert.deepEqual(cat.row({ date: '2026-05-04', inBed: 8.1 }),
+      { date: '2026-05-04', hours: 8.1 });
+    assert.deepEqual(cat.row({ date: '2026-05-04', qty: 6.5 }),
+      { date: '2026-05-04', hours: 6.5 });
   });
 
-  test('sleep_analysis -> sleep-hours rows', () => {
-    const r = parseHAEPayload({
-      data: {
-        metrics: [
-          { name: 'sleep_analysis', data: [
-            { date: '2026-05-04 00:00:00 +1000', totalSleep: 7.6, asleep: 7.3,
-              inBed: 8.1, source: 'Apple Watch' },
-          ]},
-        ],
-      },
-    });
-    assert.equal(r.sleepRows.length, 1);
-    assert.equal(r.sleepRows[0].date, '2026-05-04');
-    assert.equal(r.sleepRows[0].hours, 7.6);
-    assert.equal(r.sleepRows[0].source, 'Apple Watch');
+  test('attaches source when present', () => {
+    assert.deepEqual(cat.row({ date: '2026-05-04', totalSleep: 7, source: 'Apple Watch' }),
+      { date: '2026-05-04', hours: 7, source: 'Apple Watch' });
   });
 
-  test('sleep: falls back to asleep then inBed when totalSleep missing', () => {
-    const r = parseHAEPayload({ data: { metrics: [
-      { name: 'sleep_analysis', data: [
-        { date: '2026-05-04 00:00:00 +1000', asleep: 7.2, inBed: 8.0 },
-        { date: '2026-05-05 00:00:00 +1000', inBed: 9.0 },
-      ]},
-    ]}});
-    const byDate = Object.fromEntries(r.sleepRows.map(r => [r.date, r.hours]));
-    assert.equal(byDate['2026-05-04'], 7.2);
-    assert.equal(byDate['2026-05-05'], 9.0);
+  test('drops entries with no date or no numeric hours', () => {
+    assert.equal(cat.row({ totalSleep: 7 }), null);
+    assert.equal(cat.row({ date: '2026-05-04', totalSleep: 'zzz' }), null);
+  });
+});
+
+describe('catalogue: step_count', () => {
+  const cat = catalogue.step_count;
+  test('maps qty -> count', () => {
+    assert.deepEqual(cat.row({ date: '2026-05-04 08:00:00 +1000', qty: 1200 }),
+      { date: '2026-05-04', count: 1200 });
+  });
+  test('drops malformed entries', () => {
+    assert.equal(cat.row({ qty: 100 }), null);
+    assert.equal(cat.row({ date: '2026-05-04', qty: 'lots' }), null);
+  });
+});
+
+describe('catalogue: apple_exercise_time', () => {
+  const cat = catalogue.apple_exercise_time;
+  test('maps qty -> minutes', () => {
+    assert.deepEqual(cat.row({ date: '2026-05-04', qty: 1 }),
+      { date: '2026-05-04', minutes: 1 });
+  });
+});
+
+describe('catalogue: workouts pseudo-metric', () => {
+  const cat = catalogue.workouts;
+  test('declares from: workouts', () => {
+    assert.equal(cat.from, 'workouts');
+  });
+  test('derives trained: true from a workout record', () => {
+    assert.deepEqual(cat.row({ name: 'Running', start: '2026-05-04 11:00:00 +1000' }),
+      { date: '2026-05-04', trained: true, type: 'Running' });
+  });
+  test('drops records with no date', () => {
+    assert.equal(cat.row({ name: 'Running' }), null);
+  });
+});
+
+describe('catalogue: HRV + resting HR', () => {
+  test('heart_rate_variability maps qty -> ms', () => {
+    assert.deepEqual(catalogue.heart_rate_variability.row(
+      { date: '2026-05-04', qty: 55 }),
+      { date: '2026-05-04', ms: 55 });
+  });
+  test('resting_heart_rate maps qty -> bpm', () => {
+    assert.deepEqual(catalogue.resting_heart_rate.row(
+      { date: '2026-05-04', qty: 58 }),
+      { date: '2026-05-04', bpm: 58 });
+  });
+});
+
+describe('catalogue: SpO2 + body fat normalise fraction to percent', () => {
+  test('blood_oxygen: 0.97 -> 97', () => {
+    assert.deepEqual(catalogue.blood_oxygen_saturation.row(
+      { date: '2026-05-04', qty: 0.97 }),
+      { date: '2026-05-04', pct: 97 });
+  });
+  test('blood_oxygen: 97 -> 97 (already percent)', () => {
+    assert.deepEqual(catalogue.blood_oxygen_saturation.row(
+      { date: '2026-05-04', qty: 97 }),
+      { date: '2026-05-04', pct: 97 });
+  });
+  test('body_fat_percentage: 0.18 -> 18', () => {
+    assert.deepEqual(catalogue.body_fat_percentage.row(
+      { date: '2026-05-04', qty: 0.18 }),
+      { date: '2026-05-04', pct: 18 });
+  });
+});
+
+describe('catalogue: body_mass + mindful_minutes + blood_pressure', () => {
+  test('body_mass maps qty -> kg', () => {
+    assert.deepEqual(catalogue.body_mass.row(
+      { date: '2026-05-04', qty: 78.5 }),
+      { date: '2026-05-04', kg: 78.5 });
+  });
+  test('mindful_minutes maps qty -> minutes', () => {
+    assert.deepEqual(catalogue.mindful_minutes.row(
+      { date: '2026-05-04', qty: 10 }),
+      { date: '2026-05-04', minutes: 10 });
+  });
+  test('blood_pressure_systolic / _diastolic are separate entries', () => {
+    assert.deepEqual(catalogue.blood_pressure_systolic.row(
+      { date: '2026-05-04', qty: 118 }),
+      { date: '2026-05-04', systolic: 118 });
+    assert.deepEqual(catalogue.blood_pressure_diastolic.row(
+      { date: '2026-05-04', qty: 76 }),
+      { date: '2026-05-04', diastolic: 76 });
+  });
+});
+
+describe('aggregate', () => {
+  test('last-per-date: last row wins', () => {
+    const out = aggregate([
+      { date: '2026-05-04', hours: 6 },
+      { date: '2026-05-04', hours: 7 },
+    ], 'last-per-date');
+    assert.equal(out.length, 1);
+    assert.equal(out[0].hours, 7);
   });
 
-  test('step_count: sums per-date samples', () => {
-    const r = parseHAEPayload({ data: { metrics: [
-      { name: 'step_count', data: [
-        { date: '2026-05-04 08:00:00 +1000', qty: 1200.5 },
-        { date: '2026-05-04 12:30:00 +1000', qty: 3200 },
-        { date: '2026-05-04 18:15:00 +1000', qty: 500.3 },
-        { date: '2026-05-05 09:00:00 +1000', qty: 2000 },
-      ]},
-    ]}});
-    const byDate = Object.fromEntries(r.stepsRows.map(r => [r.date, r.count]));
-    assert.equal(byDate['2026-05-04'], 4901);  // 1200.5 + 3200 + 500.3 = 4900.8 -> round 4901
+  test('sum-per-date: sums numeric fields, rounds to int', () => {
+    const out = aggregate([
+      { date: '2026-05-04', count: 1200.5 },
+      { date: '2026-05-04', count: 3200 },
+      { date: '2026-05-04', count: 500.3 },
+      { date: '2026-05-05', count: 2000 },
+    ], 'sum-per-date');
+    const byDate = Object.fromEntries(out.map(r => [r.date, r.count]));
+    assert.equal(byDate['2026-05-04'], 4901);   // 1200.5 + 3200 + 500.3 = 4900.8 -> 4901
     assert.equal(byDate['2026-05-05'], 2000);
   });
 
-  test('apple_exercise_time: sums qty per date', () => {
-    const r = parseHAEPayload({ data: { metrics: [
-      { name: 'apple_exercise_time', data: [
-        { date: '2026-05-04 09:29:00 +1000', qty: 1 },
-        { date: '2026-05-04 09:35:00 +1000', qty: 1 },
-        { date: '2026-05-04 16:01:00 +1000', qty: 1 },
-      ]},
-    ]}});
-    assert.equal(r.activeMinutesRows.length, 1);
-    assert.equal(r.activeMinutesRows[0].date, '2026-05-04');
-    assert.equal(r.activeMinutesRows[0].minutes, 3);
+  test('mean-per-date: averages numeric fields, one decimal', () => {
+    const out = aggregate([
+      { date: '2026-05-04', bpm: 58 },
+      { date: '2026-05-04', bpm: 62 },
+    ], 'mean-per-date');
+    assert.equal(out[0].bpm, 60);
   });
 
-  test('workouts[]: one row per date with trained:true', () => {
-    const r = parseHAEPayload({ data: { workouts: [
-      { name: 'Functional Strength Training', start: '2026-05-04 11:06:02 +1000', duration: 1463 },
-      { name: 'Walking', start: '2026-05-04 16:00:00 +1000', duration: 600 },
-      { name: 'Running', start: '2026-05-05 07:00:00 +1000', duration: 1800 },
-    ]}});
-    assert.equal(r.workoutsRows.length, 2);
-    const byDate = Object.fromEntries(r.workoutsRows.map(r => [r.date, r]));
-    assert.equal(byDate['2026-05-04'].trained, true);
-    assert.equal(byDate['2026-05-04'].type, 'Functional Strength Training');
-    assert.equal(byDate['2026-05-05'].trained, true);
-    assert.equal(byDate['2026-05-05'].type, 'Running');
+  test('max-per-date', () => {
+    const out = aggregate([
+      { date: '2026-05-04', v: 3 },
+      { date: '2026-05-04', v: 7 },
+      { date: '2026-05-04', v: 5 },
+    ], 'max-per-date');
+    assert.equal(out[0].v, 7);
   });
 
-  test('ignores unrelated metric names', () => {
-    const r = parseHAEPayload({ data: { metrics: [
-      { name: 'blood_oxygen', data: [{ date: '2026-05-04', qty: 98 }] },
-      { name: 'heart_rate', data: [{ date: '2026-05-04', qty: 62 }] },
-    ]}});
-    assert.deepEqual(r.sleepRows, []);
-    assert.deepEqual(r.stepsRows, []);
-    assert.deepEqual(r.activeMinutesRows, []);
-    assert.deepEqual(r.workoutsRows, []);
+  test('boolean-any-per-date: any truthy boolean wins', () => {
+    const out = aggregate([
+      { date: '2026-05-04', trained: true, type: 'Running' },
+      { date: '2026-05-04', trained: true, type: 'Walking' },
+    ], 'boolean-any-per-date');
+    assert.equal(out.length, 1);
+    assert.equal(out[0].trained, true);
+    assert.equal(out[0].type, 'Running');   // head wins for scalar fields
   });
 
-  test('malformed samples (missing date or qty) are skipped, not thrown', () => {
-    const r = parseHAEPayload({ data: { metrics: [
-      { name: 'step_count', data: [
-        { date: '2026-05-04', qty: 100 },
-        { qty: 200 },              // missing date
-        { date: '2026-05-05', qty: 'not-a-number' },
-        { date: '2026-05-05', qty: 300 },
-      ]},
-    ]}});
-    const byDate = Object.fromEntries(r.stepsRows.map(r => [r.date, r.count]));
-    assert.equal(byDate['2026-05-04'], 100);
-    assert.equal(byDate['2026-05-05'], 300);
+  test('empty input returns empty array', () => {
+    assert.deepEqual(aggregate([], 'sum-per-date'), []);
+    assert.deepEqual(aggregate(null, 'sum-per-date'), []);
   });
 
-  test('accepts raw payload without outer data wrapper', () => {
-    // Some HAE versions send {metrics:[...]} at the top level
-    const r = parseHAEPayload({
-      metrics: [{ name: 'step_count', data: [{ date: '2026-05-04', qty: 1500 }] }],
-    });
-    assert.equal(r.stepsRows.length, 1);
-    assert.equal(r.stepsRows[0].count, 1500);
+  test('sorted by date ascending', () => {
+    const out = aggregate([
+      { date: '2026-05-05', count: 1 },
+      { date: '2026-05-03', count: 2 },
+      { date: '2026-05-04', count: 3 },
+    ], 'sum-per-date');
+    assert.deepEqual(out.map(r => r.date), ['2026-05-03', '2026-05-04', '2026-05-05']);
   });
 });
 
@@ -144,8 +222,6 @@ describe('mergeByDate', () => {
       [{ date: '2026-05-02', hours: 8 }],
     );
     assert.equal(merged.length, 2);
-    assert.equal(merged[0].date, '2026-05-01');
-    assert.equal(merged[1].date, '2026-05-02');
   });
 
   test('overwrites row for same date', () => {
@@ -157,19 +233,6 @@ describe('mergeByDate', () => {
     assert.equal(merged[0].hours, 9);
   });
 
-  test('sorted by date ascending', () => {
-    const merged = mergeByDate(
-      [{ date: '2026-05-03', hours: 7 }],
-      [{ date: '2026-05-01', hours: 8 }, { date: '2026-05-02', hours: 7.5 }],
-    );
-    assert.deepEqual(merged.map(r => r.date), ['2026-05-01', '2026-05-02', '2026-05-03']);
-  });
-
-  test('handles missing existing data', () => {
-    const merged = mergeByDate(null, [{ date: '2026-05-01', hours: 7 }]);
-    assert.equal(merged.length, 1);
-  });
-
   test('drops new rows with no date', () => {
     const merged = mergeByDate(
       [{ date: '2026-05-01', hours: 7 }],
@@ -177,5 +240,10 @@ describe('mergeByDate', () => {
     );
     assert.equal(merged.length, 2);
     assert.ok(merged.every(r => r.date));
+  });
+
+  test('handles null existing', () => {
+    const merged = mergeByDate(null, [{ date: '2026-05-01', hours: 7 }]);
+    assert.equal(merged.length, 1);
   });
 });

--- a/tests/migration-scripts.test.js
+++ b/tests/migration-scripts.test.js
@@ -19,6 +19,7 @@ const REPO_ROOT = path.resolve(__dirname, '..');
 const SCHEMA_SCRIPT = path.join(REPO_ROOT, 'scripts', 'migrate-to-klebb.js');
 const CARDS_SCRIPT  = path.join(REPO_ROOT, 'scripts', 'migrate-cards-to-generic.js');
 const V1_SCRIPT     = path.join(REPO_ROOT, 'scripts', 'migrate-v1-to-v2.js');
+const HAE_INGEST_SCRIPT = path.join(REPO_ROOT, 'scripts', 'migrate-hae-ingest.js');
 
 function run(script, args = []) {
   return execSync(`node ${script} ${args.join(' ')}`, {
@@ -336,6 +337,87 @@ describe('migrate-v1-to-v2.js (bare-array → v2 manifest)', () => {
       assert.ok(stamps.length >= 1, 'should have at least one migration-<date> dir');
       assert.ok(fs.existsSync(path.join(archiveRoot, stamps[0], 'weight.json')),
         'original file should be archived');
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+});
+
+describe('migrate-hae-ingest.js (adds meta.ingest to HAE-backed manifests)', () => {
+  function writeManifest(dir, id, extraMeta = {}) {
+    fs.writeFileSync(path.join(dir, `${id}.json`), JSON.stringify({
+      $schema: 'klebb.datafile.v1',
+      meta: { id, label: id, order: 100, ...extraMeta },
+      data: [{ date: '2026-04-20', v: 1 }],
+    }, null, 2));
+  }
+
+  test('adds meta.ingest to the four HAE manifests', () => {
+    const sandbox = createSandbox();
+    const dataDir = path.join(sandbox, 'data');
+    writeManifest(dataDir, 'sleep-hours');
+    writeManifest(dataDir, 'steps');
+    writeManifest(dataDir, 'active-minutes');
+    writeManifest(dataDir, 'workouts');
+    try {
+      execSync(`node ${HAE_INGEST_SCRIPT} ${dataDir}`, { encoding: 'utf8' });
+
+      const check = (id, metric) => {
+        const parsed = JSON.parse(fs.readFileSync(path.join(dataDir, `${id}.json`), 'utf8'));
+        assert.deepEqual(parsed.meta.ingest, { source: 'hae', metric });
+        assert.equal(parsed.data[0].v, 1);
+      };
+      check('sleep-hours', 'sleep_analysis');
+      check('steps', 'step_count');
+      check('active-minutes', 'apple_exercise_time');
+      check('workouts', 'workouts');
+
+      const backups = fs.readdirSync(dataDir).filter(f => f.includes('.pre-hae-'));
+      assert.equal(backups.length, 4);
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('idempotent: re-run is a no-op', () => {
+    const sandbox = createSandbox();
+    const dataDir = path.join(sandbox, 'data');
+    writeManifest(dataDir, 'sleep-hours',
+      { ingest: { source: 'hae', metric: 'sleep_analysis' } });
+    try {
+      const out = execSync(`node ${HAE_INGEST_SCRIPT} ${dataDir}`, { encoding: 'utf8' });
+      assert.ok(out.includes('already migrated'));
+      const backups = fs.readdirSync(dataDir).filter(f => f.includes('.pre-hae-'));
+      assert.equal(backups.length, 0);
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('--dry-run does not mutate files', () => {
+    const sandbox = createSandbox();
+    const dataDir = path.join(sandbox, 'data');
+    writeManifest(dataDir, 'sleep-hours');
+    const before = fs.readFileSync(path.join(dataDir, 'sleep-hours.json'), 'utf8');
+    try {
+      const out = execSync(`node ${HAE_INGEST_SCRIPT} ${dataDir} --dry-run`, { encoding: 'utf8' });
+      assert.ok(out.includes('would migrate'));
+      const after = fs.readFileSync(path.join(dataDir, 'sleep-hours.json'), 'utf8');
+      assert.equal(before, after);
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('skips files that are not in the HAE mapping', () => {
+    const sandbox = createSandbox();
+    const dataDir = path.join(sandbox, 'data');
+    writeManifest(dataDir, 'weight');
+    const before = fs.readFileSync(path.join(dataDir, 'weight.json'), 'utf8');
+    try {
+      execSync(`node ${HAE_INGEST_SCRIPT} ${dataDir}`, { encoding: 'utf8' });
+      const after = fs.readFileSync(path.join(dataDir, 'weight.json'), 'utf8');
+      assert.equal(before, after, 'non-HAE manifest untouched');
     } finally {
       cleanupSandbox(sandbox);
     }


### PR DESCRIPTION
# What changed

Ship template manifests (`templates/*.klebb.json`) for the nine HAE catalogue metrics that gained support in #150 but lacked a pre-built example: HRV, resting HR, walking HR avg, SpO₂, mindful minutes, body mass, body fat, systolic BP, diastolic BP.

# Why

Fixes #155. Refs #150.

PR #154 landed the catalogue and the `meta.ingest` contract, but shipped templates only for the four historical manifests. Without a template, a user who wants to track HRV or SpO₂ either has to hand-author the JSON or ask klebbius. Templates make the gallery the fast path for every supported catalogue metric.

# How

Each template is a minimal `generic-card` renderer matched to its row shape:

| Template id | Catalogue metric | Display |
|---|---|---|
| `hrv` | `heart_rate_variability` | `{ms}` ms, trend line |
| `resting-heart-rate-hae` | `resting_heart_rate` | `{bpm}` bpm, trend line |
| `walking-heart-rate-average` | `walking_heart_rate_average` | `{bpm}` bpm, trend line |
| `blood-oxygen-saturation` | `blood_oxygen_saturation` | `{pct:round(0)}%`, trend line |
| `mindful-minutes` | `mindful_minutes` | `{minutes}` min, trend line |
| `body-mass-hae` | `body_mass` | `{kg:round(1)}` kg, trend line |
| `body-fat-percentage` | `body_fat_percentage` | `{pct:round(1)}%`, trend line |
| `blood-pressure-systolic` | `blood_pressure_systolic` | `{systolic}` mmHg, trend line |
| `blood-pressure-diastolic` | `blood_pressure_diastolic` | `{diastolic}` mmHg, trend line |

All carry `writeable.fromWebapp: false`. The two templates that collide with existing manual-entry cards (`resting-heart-rate`, `weight`) ship under distinct ids (`-hae` suffix and `body-mass-hae` respectively) so users can pick one model or the other.

Blood pressure is two separate templates, matching the one-metric-per-catalogue-entry decision in #150. Users who want the familiar "120/80" display combine them with a combination card.

# Testing

- [x] `npm test` passes locally. No code changes, so no behaviour shifts; `content-api.test.js` exercises the templates loader against the full directory.
- [x] Each template round-trips `JSON.parse` cleanly.
- [ ] Manual QA: open Settings → Templates on a dev instance, verify each of the nine entries renders in the gallery and instantiates into a valid manifest.

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [ ] CHANGELOG.md updated — not touched; this is a pure-additive extension of the feature shipped in #154 and folded under the same Unreleased entry.
- [x] Docs already cover the catalogue + authoring flow in `docs/HEALTH-AUTO-EXPORT.md` (landed in #154)
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens

# Breaking changes

None.