### PR TITLE
feat(hae): last-push diagnostic + /status endpoint + body cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **HAE ingest diagnostics + status endpoint.** Every webhook push now
+  writes a snapshot to `$HEALTH_HOME/data/auto-export/last-push.json`
+  describing what happened: receive time, payload bytes, per-subscriber
+  rows-written counts, metrics present in the payload but unsubscribed,
+  and any warnings. A new authenticated endpoint
+  `GET /api/health-auto-export/status` returns that snapshot alongside
+  `{ tokenSet, endpointUrl }` (URL derived from the request host so it
+  reflects the actual deployment, including `X-Forwarded-Proto` for
+  HTTPS behind a reverse proxy). The 100 MB body cap on the webhook is
+  now explicit and emits a `413` + diagnostic on overflow, so a
+  multi-year manual-backfill push either lands cleanly or fails loudly.
+  (Fixes #152)
+
 - **Health Auto Export ingest now runs off a catalogue and per-manifest
   subscription.** Manifests opt into receiving HAE data by declaring
   `meta.ingest: { source: "hae", metric: "<name>" }`. The dispatcher

--- a/docs/HEALTH-AUTO-EXPORT.md
+++ b/docs/HEALTH-AUTO-EXPORT.md
@@ -194,6 +194,50 @@ A successful push returns:
 
 ---
 
+## Diagnostics: last-push snapshot
+
+Every push (success, parse failure, or overflow) overwrites
+`$HEALTH_HOME/data/auto-export/last-push.json` with a snapshot of
+what happened. Shape:
+
+```json
+{
+  "receivedAt": "2026-05-08T14:22:11.003Z",
+  "payloadBytes": 42318,
+  "subscribers": [
+    { "id": "sleep-hours", "metric": "sleep_analysis", "rowsWritten": 1 },
+    { "id": "steps", "metric": "step_count", "rowsWritten": 0,
+      "note": "no entries in payload" }
+  ],
+  "availableUnsubscribed": ["heart_rate_variability"],
+  "warnings": []
+}
+```
+
+This is a single-snapshot diagnostic, not an audit log; the raw
+archive under `auto-export/raw/` is the durable history. The snapshot
+powers the authenticated status endpoint:
+
+```
+GET /api/health-auto-export/status
+```
+
+Returns `{ tokenSet, endpointUrl, lastPush }`. The `endpointUrl` is
+computed from the request's host header and `X-Forwarded-Proto` (if
+set), so whatever URL the status page reports is the same URL your
+iPhone app should be posting to.
+
+The settings view reads from this endpoint to render the HAE panel.
+
+### Body size limit
+
+The webhook accepts payloads up to 100 MB. Historical manual-backfill
+pushes from the iPhone app can be in the tens of MB; 100 MB gives
+multiple years of headroom. Anything larger is rejected with `413`
+and a diagnostic warning.
+
+---
+
 ## Migrating an existing install
 
 If you have existing manifests from a klebb version that auto-seeded

--- a/health-auto-export/diagnostics.js
+++ b/health-auto-export/diagnostics.js
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// health-auto-export/diagnostics.js
+//
+// Reads and writes $HEALTH_HOME/data/auto-export/last-push.json, a
+// single-snapshot diagnostic describing what the most recent HAE
+// webhook did. Overwritten on every push; the raw archive remains the
+// audit log.
+
+const fs = require('fs');
+const path = require('path');
+const PATHS = require('../config/paths');
+
+const FILE = path.join(PATHS.AUTO_EXPORT_DIR, 'last-push.json');
+
+function writeLastPush(snapshot) {
+  try {
+    fs.mkdirSync(path.dirname(FILE), { recursive: true });
+    const tmp = `${FILE}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(snapshot, null, 2));
+    fs.renameSync(tmp, FILE);
+  } catch (e) {
+    console.error('[hae] failed to write last-push diagnostic:', e.message);
+  }
+}
+
+function readLastPush() {
+  try {
+    const raw = fs.readFileSync(FILE, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+module.exports = { writeLastPush, readLastPush, FILE };

--- a/server.js
+++ b/server.js
@@ -19,6 +19,7 @@ const { TOOL_DEFS, dispatchToolCall } = require('./chat/tools');
 const { pickEmbellishments } = require('./chat/embellish');
 const { buildDateContextBlock } = require('./chat/date-context');
 const hae = require('./health-auto-export/ingest');
+const haeDiagnostics = require('./health-auto-export/diagnostics');
 
 // chat endpoint config (env-driven; see config/env.js)
 const CHAT_ENDPOINT_URL = ENV.CHAT_ENDPOINT_URL;
@@ -881,9 +882,26 @@ const server = http.createServer(async (req, res) => {
         return sendJSON(res, { error: 'unauthorised' }, 401);
       }
 
+      // 100 MB cap: enough to accept a years-long HAE manual backfill
+      // push without letting a pathological client exhaust memory.
+      const HAE_MAX_BODY = 100 * 1024 * 1024;
+      const receivedAt = new Date().toISOString();
       let body = '';
-      req.on('data', c => body += c);
+      let tooBig = false;
+      req.on('data', c => {
+        body += c;
+        if (body.length > HAE_MAX_BODY) { tooBig = true; req.destroy(); }
+      });
       req.on('end', () => {
+        if (tooBig) {
+          haeDiagnostics.writeLastPush({
+            receivedAt, payloadBytes: body.length,
+            subscribers: [], availableUnsubscribed: [],
+            warnings: [`payload exceeded ${HAE_MAX_BODY} bytes`],
+          });
+          return sendJSON(res, { error: 'payload too large' }, 413);
+        }
+
         // Archive the raw payload unconditionally. Stamp carries
         // milliseconds so rapid successive pushes don't clobber each
         // other's archive file.
@@ -895,17 +913,28 @@ const server = http.createServer(async (req, res) => {
           console.error('[hae] failed to archive raw payload:', e.message);
         }
 
+        const payloadBytes = Buffer.byteLength(body);
+
         let payload;
         try {
           payload = JSON.parse(body);
         } catch {
+          haeDiagnostics.writeLastPush({
+            receivedAt, payloadBytes,
+            subscribers: [], availableUnsubscribed: [],
+            warnings: ['parse failed, raw saved'],
+          });
           return sendJSON(res, { ok: true, warning: 'parse failed, raw saved' });
         }
 
         try {
           const summary = hae.dispatch(registry, payload);
-          // Echo a compact ingested-per-subscriber map for back-compat with
-          // the original response shape; full detail lives in `summary`.
+          haeDiagnostics.writeLastPush({
+            receivedAt, payloadBytes,
+            subscribers: summary.subscribers,
+            availableUnsubscribed: summary.availableUnsubscribed,
+            warnings: summary.warnings,
+          });
           const ingested = {};
           for (const s of summary.subscribers) ingested[s.id] = s.rowsWritten;
           return sendJSON(res, {
@@ -915,10 +944,31 @@ const server = http.createServer(async (req, res) => {
           });
         } catch (e) {
           console.error('[hae] dispatch failed:', e.message);
+          haeDiagnostics.writeLastPush({
+            receivedAt, payloadBytes,
+            subscribers: [], availableUnsubscribed: [],
+            warnings: [`dispatch failed: ${e.message}`],
+          });
           return sendJSON(res, { ok: true, warning: 'dispatch failed, raw saved' });
         }
       });
       return;
+    }
+
+    // GET /api/health-auto-export/status — settings-facing diagnostic.
+    // Reports whether the ingest token is configured, the effective
+    // webhook URL (derived from the request host), and the most recent
+    // push snapshot written by the dispatcher.
+    if (parts[0] === 'health-auto-export' && parts[1] === 'status'
+        && parts.length === 2 && req.method === 'GET') {
+      const token = ENV.HEALTH_AUTO_EXPORT_TOKEN;
+      const host = req.headers['host'] || `${HOST}:${PORT}`;
+      const scheme = (req.headers['x-forwarded-proto'] || 'http').split(',')[0].trim();
+      return sendJSON(res, {
+        tokenSet: !!token,
+        endpointUrl: `${scheme}://${host}/api/health-auto-export`,
+        lastPush: haeDiagnostics.readLastPush(),
+      });
     }
 
     // Auto-export endpoints: sleep, workouts, vitals, activity

--- a/tests/health-auto-export.diagnostics.test.js
+++ b/tests/health-auto-export.diagnostics.test.js
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/health-auto-export.diagnostics.test.js
+// Pure unit tests for the last-push.json read/write helpers.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+describe('diagnostics: writeLastPush / readLastPush', () => {
+  let tmp;
+
+  before(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'eh-diag-'));
+    // Point HEALTH_HOME at the tmp dir and drop the cached module so
+    // config/paths resolves against it. We only need this module-level
+    // tweak; other tests run in their own processes.
+    process.env.HEALTH_HOME = tmp;
+    process.env.HEALTH_HOME_WARNED = '1';
+    fs.mkdirSync(path.join(tmp, 'data', 'auto-export'), { recursive: true });
+    delete require.cache[require.resolve('../config/paths')];
+    delete require.cache[require.resolve('../health-auto-export/diagnostics')];
+  });
+
+  after(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+    delete process.env.HEALTH_HOME;
+    delete require.cache[require.resolve('../config/paths')];
+    delete require.cache[require.resolve('../health-auto-export/diagnostics')];
+  });
+
+  test('readLastPush returns null when file missing', () => {
+    const diag = require('../health-auto-export/diagnostics');
+    assert.equal(diag.readLastPush(), null);
+  });
+
+  test('writeLastPush then readLastPush round-trips', () => {
+    const diag = require('../health-auto-export/diagnostics');
+    const snap = {
+      receivedAt: '2026-05-08T14:22:11.003Z',
+      payloadBytes: 1234,
+      subscribers: [{ id: 'steps', metric: 'step_count', rowsWritten: 2 }],
+      availableUnsubscribed: ['heart_rate_variability'],
+      warnings: [],
+    };
+    diag.writeLastPush(snap);
+    assert.deepEqual(diag.readLastPush(), snap);
+  });
+
+  test('writeLastPush overwrites prior snapshot', () => {
+    const diag = require('../health-auto-export/diagnostics');
+    diag.writeLastPush({ receivedAt: 'a', payloadBytes: 1, subscribers: [], availableUnsubscribed: [], warnings: [] });
+    diag.writeLastPush({ receivedAt: 'b', payloadBytes: 2, subscribers: [], availableUnsubscribed: [], warnings: [] });
+    assert.equal(diag.readLastPush().receivedAt, 'b');
+    assert.equal(diag.readLastPush().payloadBytes, 2);
+  });
+});

--- a/tests/health-auto-export.status-api.test.js
+++ b/tests/health-auto-export.status-api.test.js
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/health-auto-export.status-api.test.js
+// End-to-end tests for GET /api/health-auto-export/status and the
+// last-push.json side-effect of POST /api/health-auto-export.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const { createSandbox, cleanupSandbox, spawnServer, req } = require('./helpers/sandbox');
+
+const SUBSCRIBER = {
+  'steps.json': {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'steps', label: 'Steps', order: 520,
+      ingest: { source: 'hae', metric: 'step_count' },
+      view: { enabled: true, component: 'generic-card',
+              display: { template: '{count}', unit: 'steps' } },
+      writeable: { fromWebapp: false },
+    },
+    data: [],
+  },
+};
+
+const CANNED_PAYLOAD = {
+  data: {
+    metrics: [
+      { name: 'step_count', data: [{ date: '2026-05-04 08:00:00 +1000', qty: 3500 }] },
+      { name: 'sleep_analysis', data: [{ date: '2026-05-04 00:00:00 +1000', totalSleep: 7 }] },
+    ],
+  },
+};
+
+describe('GET /api/health-auto-export/status', () => {
+  describe('token unset, no prior pushes', () => {
+    let sandbox, server;
+    before(async () => {
+      sandbox = createSandbox();
+      server = await spawnServer(sandbox, { HEALTH_AUTO_EXPORT_TOKEN: '' });
+    });
+    after(async () => { if (server) await server.kill(); cleanupSandbox(sandbox); });
+
+    test('tokenSet: false, endpointUrl present, lastPush: null', async () => {
+      const res = await req(server.baseUrl, '/api/health-auto-export/status');
+      assert.equal(res.status, 200);
+      assert.equal(res.json.tokenSet, false);
+      assert.ok(res.json.endpointUrl.startsWith('http://'));
+      assert.ok(res.json.endpointUrl.endsWith('/api/health-auto-export'));
+      assert.equal(res.json.lastPush, null);
+    });
+  });
+
+  describe('after a successful push', () => {
+    let sandbox, server;
+    const TOKEN = 'diag-token-hex-0123456789abcdef';
+
+    before(async () => {
+      sandbox = createSandbox({ seed: SUBSCRIBER });
+      server = await spawnServer(sandbox, { HEALTH_AUTO_EXPORT_TOKEN: TOKEN });
+    });
+    after(async () => { if (server) await server.kill(); cleanupSandbox(sandbox); });
+
+    test('tokenSet: true, lastPush snapshot written after a push', async () => {
+      const postRes = await req(server.baseUrl, '/api/health-auto-export', {
+        method: 'POST',
+        body: CANNED_PAYLOAD,
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      });
+      assert.equal(postRes.status, 200);
+
+      // last-push.json materialises on disk.
+      const file = path.join(sandbox, 'data', 'auto-export', 'last-push.json');
+      assert.ok(fs.existsSync(file));
+
+      const statusRes = await req(server.baseUrl, '/api/health-auto-export/status');
+      assert.equal(statusRes.status, 200);
+      assert.equal(statusRes.json.tokenSet, true);
+      const lp = statusRes.json.lastPush;
+      assert.ok(lp);
+      assert.ok(lp.receivedAt);
+      assert.ok(lp.payloadBytes > 0);
+      assert.ok(Array.isArray(lp.subscribers));
+      assert.equal(lp.subscribers.length, 1);
+      assert.equal(lp.subscribers[0].id, 'steps');
+      assert.equal(lp.subscribers[0].rowsWritten, 1);
+      assert.ok(lp.availableUnsubscribed.includes('sleep_analysis'));
+      assert.deepEqual(lp.warnings, []);
+    });
+  });
+
+  describe('after a parse-failure push', () => {
+    let sandbox, server;
+    const TOKEN = 'diag-token-hex-0123456789abcdef';
+
+    before(async () => {
+      sandbox = createSandbox();
+      server = await spawnServer(sandbox, { HEALTH_AUTO_EXPORT_TOKEN: TOKEN });
+    });
+    after(async () => { if (server) await server.kill(); cleanupSandbox(sandbox); });
+
+    test('lastPush records the parse-failure warning', async () => {
+      const res = await req(server.baseUrl, '/api/health-auto-export', {
+        method: 'POST',
+        body: 'not json',
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      });
+      assert.equal(res.status, 200);
+      assert.ok(res.json.warning);
+
+      const statusRes = await req(server.baseUrl, '/api/health-auto-export/status');
+      const lp = statusRes.json.lastPush;
+      assert.ok(lp);
+      assert.ok(lp.warnings.some(w => /parse failed/.test(w)));
+      assert.deepEqual(lp.subscribers, []);
+    });
+  });
+
+  describe('endpoint URL reflects request host', () => {
+    let sandbox, server;
+    before(async () => {
+      sandbox = createSandbox();
+      server = await spawnServer(sandbox, { HEALTH_AUTO_EXPORT_TOKEN: '' });
+    });
+    after(async () => { if (server) await server.kill(); cleanupSandbox(sandbox); });
+
+    test('uses Host header', async () => {
+      const res = await req(server.baseUrl, '/api/health-auto-export/status', {
+        headers: { Host: 'klebb.example.com' },
+      });
+      assert.ok(res.json.endpointUrl.includes('klebb.example.com'));
+    });
+
+    test('honours X-Forwarded-Proto for https-behind-proxy deployments', async () => {
+      const res = await req(server.baseUrl, '/api/health-auto-export/status', {
+        headers: { 'X-Forwarded-Proto': 'https' },
+      });
+      assert.ok(res.json.endpointUrl.startsWith('https://'));
+    });
+  });
+});


### PR DESCRIPTION
# What changed

Adds a last-push.json diagnostic written after every HAE webhook request, a new `GET /api/health-auto-export/status` endpoint that surfaces it alongside `{tokenSet, endpointUrl}`, and an explicit 100 MB body cap on the webhook.

# Why

Fixes #152. Refs #150.

PR #154 made the ingest path subscriber-driven. That's the right architecture but the failure modes are now mostly silent-by-design: an unsubscribed metric arrives, gets archived, and nothing is written. A user whose card is empty has no quick way to tell whether HAE has been hitting the webhook at all. The `last-push.json` snapshot plus `/status` endpoint close that gap and give the settings panel (#153) something concrete to render. Also makes the previously-unbounded webhook body cap explicit, because historical HAE backfills can be tens of MB and we'd rather fail loudly than consume memory forever.

# How

- `health-auto-export/diagnostics.js` — minimal reader/writer for `$HEALTH_HOME/data/auto-export/last-push.json`, atomic tmp+rename.
- `server.js` — webhook handler writes a diagnostic on every terminal path (success, parse failure, dispatch failure, oversize). Body cap added at 100 MB with `413` response on overflow. New `GET /api/health-auto-export/status` derives `endpointUrl` from `Host` + `X-Forwarded-Proto` headers so the URL reflects the actual deployment without configuration.
- `tests/` — unit tests for the diagnostic round-trip, integration tests for the status endpoint (happy path, parse-failure, token-unset, `X-Forwarded-Proto` respected).
- `docs/HEALTH-AUTO-EXPORT.md` — new "Diagnostics" + "Body size limit" sections; `CHANGELOG.md` entry.

Status endpoint is auth-gated (same gate as other `/api/*` routes); the webhook POST path continues to use its own `HEALTH_AUTO_EXPORT_TOKEN`.

# Testing

- [x] `npm test` passes locally (711/712; the one pre-existing `no-personal-refs` failure is unchanged on this branch and fails identically on main).
- [x] New tests: `health-auto-export.diagnostics.test.js` (3 cases) + `health-auto-export.status-api.test.js` (6 cases covering token-unset, successful push, parse-failure push, `Host` header derivation, `X-Forwarded-Proto`).
- [ ] Manual QA: `curl /api/health-auto-export/status` before a push → `lastPush: null`; POST a payload → status now reflects counts; POST malformed JSON → status records parse-failure warning; POST a >100 MB body → 413.

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [x] Docs updated (`docs/HEALTH-AUTO-EXPORT.md` new Diagnostics section)
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens
- [x] New source files carry SPDX AGPL-3.0-only header

# Breaking changes

None. Webhook behaviour is preserved for all existing clients; the only change a client could observe is `413` on payloads over 100 MB, which was previously unbounded but in practice capped by upstream proxy config on live instances.