### PR TITLE
feat(hae): discovery card for unsubscribed Apple Health metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Apple Health discovery card.** When the HAE webhook receives
+  metrics nothing on your dashboard subscribes to yet, a pinned info
+  card appears at the top of the Today view listing each newly-seen
+  metric with two actions: "Build a card" (seeds a templated prompt
+  into the chat widget for klebbius to create the manifest) and
+  "Dismiss" (permanently hides that metric until you un-hide it from
+  Settings). Dismissed metrics are listed in a new "Hidden Apple
+  Health metrics" section of Settings with an un-hide button.
+  Discoveries are persisted in
+  `$HEALTH_HOME/data/auto-export/discovered.json`. The card
+  self-hides when no undismissed discoveries remain, and entries
+  are removed automatically when a subscriber card is added.
+  New endpoints: `GET /api/health-auto-export/discoveries`,
+  `POST /api/health-auto-export/discoveries/:metric/dismiss`,
+  `POST /api/health-auto-export/discoveries/:metric/unhide`.
+  (Fixes #151)
+
 - **HAE ingest diagnostics + status endpoint.** Every webhook push now
   writes a snapshot to `$HEALTH_HOME/data/auto-export/last-push.json`
   describing what happened: receive time, payload bytes, per-subscriber

--- a/docs/HEALTH-AUTO-EXPORT.md
+++ b/docs/HEALTH-AUTO-EXPORT.md
@@ -194,6 +194,28 @@ A successful push returns:
 
 ---
 
+## Discovering new metrics
+
+When a push contains metrics that no manifest subscribes to, klebb
+records them in `$HEALTH_HOME/data/auto-export/discovered.json`. A
+discovery card appears at the top of Today listing the metrics and
+offering two actions per row:
+
+- **Build a card** — seeds the chat widget with a prompt asking
+  klebbius to create a subscriber manifest for that metric. You
+  review, tweak if needed, and send. Once the subscriber exists, the
+  discovery is removed on the next push.
+- **Dismiss** — permanently hides the metric. Dismissed metrics are
+  listed in Settings under "Hidden Apple Health metrics" with an
+  un-hide button.
+
+Dismissals persist across pushes: once you dismiss HRV, a re-push
+won't resurface it unless you un-hide it first. If you delete a
+subscriber card and the metric re-appears in a future push, it
+becomes a fresh discovery.
+
+---
+
 ## Diagnostics: last-push snapshot
 
 Every push (success, parse failure, or overflow) overwrites

--- a/health-auto-export/discoveries.js
+++ b/health-auto-export/discoveries.js
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// health-auto-export/discoveries.js
+//
+// Persists a per-instance record of HAE metrics that have been seen in
+// payloads but that no manifest subscribes to yet. Shape on disk:
+//
+//   {
+//     "heart_rate_variability": {
+//       "firstSeenAt": "2026-05-08T14:22:11.003Z",
+//       "dismissed": false
+//     },
+//     "blood_oxygen_saturation": {
+//       "firstSeenAt": "2026-05-08T14:22:11.003Z",
+//       "dismissed": true,
+//       "dismissedAt": "2026-05-09T08:15:00.000Z"
+//     }
+//   }
+//
+// Lives at $HEALTH_HOME/data/auto-export/discovered.json. Created
+// lazily on the first unsubscribed metric. The dispatcher calls
+// sync() after every push; API handlers call dismiss() / unhide() /
+// load() on user action.
+
+const fs = require('fs');
+const path = require('path');
+const PATHS = require('../config/paths');
+
+const FILE = path.join(PATHS.AUTO_EXPORT_DIR, 'discovered.json');
+
+function load() {
+  try {
+    return JSON.parse(fs.readFileSync(FILE, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function save(state) {
+  try {
+    fs.mkdirSync(path.dirname(FILE), { recursive: true });
+    const tmp = `${FILE}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(state, null, 2));
+    fs.renameSync(tmp, FILE);
+  } catch (e) {
+    console.error('[hae] failed to write discovered.json:', e.message);
+  }
+}
+
+// Reconcile the on-disk discoveries state against the latest push.
+//   seen:       metrics present in the payload but unsubscribed
+//   subscribed: metrics now covered by a subscriber (used for cleanup)
+// New entries for unseen-before metrics preserve default dismissed:false.
+// Existing entries have their dismiss state preserved across sync calls.
+// Subscribed metrics are removed entirely — the card that subscribes is
+// the discovery's graduation.
+function sync({ seen, subscribed, now = new Date().toISOString() }) {
+  const state = load();
+  let changed = false;
+
+  for (const metric of seen || []) {
+    if (subscribed && subscribed.includes(metric)) continue;
+    if (!state[metric]) {
+      state[metric] = { firstSeenAt: now, dismissed: false };
+      changed = true;
+    }
+  }
+
+  for (const metric of subscribed || []) {
+    if (state[metric]) {
+      delete state[metric];
+      changed = true;
+    }
+  }
+
+  if (changed) save(state);
+  return state;
+}
+
+function dismiss(metric, now = new Date().toISOString()) {
+  const state = load();
+  if (!state[metric]) return false;
+  state[metric].dismissed = true;
+  state[metric].dismissedAt = now;
+  save(state);
+  return true;
+}
+
+function unhide(metric) {
+  const state = load();
+  if (!state[metric]) return false;
+  state[metric].dismissed = false;
+  delete state[metric].dismissedAt;
+  save(state);
+  return true;
+}
+
+// Consumed by GET /api/health-auto-export/discoveries and the UI.
+function list() {
+  const state = load();
+  const undismissed = [];
+  const dismissed = [];
+  for (const [metric, entry] of Object.entries(state)) {
+    const row = { metric, firstSeenAt: entry.firstSeenAt };
+    if (entry.dismissed) {
+      dismissed.push({ ...row, dismissedAt: entry.dismissedAt });
+    } else {
+      undismissed.push(row);
+    }
+  }
+  undismissed.sort((a, b) => a.firstSeenAt.localeCompare(b.firstSeenAt));
+  dismissed.sort((a, b) => a.metric.localeCompare(b.metric));
+  return { undismissed, dismissed };
+}
+
+module.exports = { load, sync, dismiss, unhide, list, FILE };

--- a/public/js/components/eh-date-view.js
+++ b/public/js/components/eh-date-view.js
@@ -7,6 +7,7 @@
 
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
 import './eh-view-renderer.js';
+import './eh-hae-discovery-card.js';
 import { isEditableTarget } from '../lib/event-target.js';
 
 function todayStr() {
@@ -228,6 +229,9 @@ export class EhDateView extends LitElement {
           <button class="today-btn" @click=${() => this._navigate(this._today)}>Today</button>
         ` : ''}
       </div>
+      ${this._dateMode === 'today'
+        ? html`<eh-hae-discovery-card></eh-hae-discovery-card>`
+        : ''}
       <eh-view-renderer
         view="view"
         .date=${this.date}

--- a/public/js/components/eh-hae-discovery-card.js
+++ b/public/js/components/eh-hae-discovery-card.js
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// public/js/components/eh-hae-discovery-card.js
+//
+// Pinned-to-top information card that surfaces HAE metrics present in
+// recent pushes but not yet subscribed to by any manifest. The
+// server-side discoveries module records these after each push; this
+// component reads them from /api/health-auto-export/discoveries and
+// offers two actions per metric:
+//
+//   "Build a card" — seeds the chat widget with a templated prompt
+//                    asking klebbius to create a subscriber manifest.
+//   "Dismiss"      — permanently hides this metric (can be un-hidden
+//                    from Settings).
+//
+// The card self-hides when no undismissed discoveries remain. It is
+// not a klebb.datafile.v1 manifest — it exists only as a UI surface,
+// pinned by the date view when mode === 'today'.
+
+import { LitElement, html, css } from 'https://esm.sh/lit@3';
+
+// Human-readable labels for the catalogue keys we know about. Unknown
+// keys fall back to the raw metric name.
+const METRIC_LABELS = {
+  sleep_analysis: 'Sleep',
+  step_count: 'Steps',
+  apple_exercise_time: 'Exercise minutes',
+  workouts: 'Workouts',
+  heart_rate_variability: 'Heart rate variability (HRV)',
+  resting_heart_rate: 'Resting heart rate',
+  walking_heart_rate_average: 'Walking heart rate average',
+  blood_oxygen_saturation: 'Blood oxygen (SpO₂)',
+  mindful_minutes: 'Mindful minutes',
+  body_mass: 'Weight',
+  body_fat_percentage: 'Body fat percentage',
+  blood_pressure_systolic: 'Systolic blood pressure',
+  blood_pressure_diastolic: 'Diastolic blood pressure',
+};
+
+function labelFor(metric) {
+  return METRIC_LABELS[metric] || metric;
+}
+
+function buildPrompt(metric) {
+  return `Create a new Health Auto Export-backed card for the "${metric}" metric. See docs/HEALTH-AUTO-EXPORT.md for the catalogue row shape. The manifest should set meta.ingest to { source: "hae", metric: "${metric}" } and writeable.fromWebapp to false.`;
+}
+
+export class EhHaeDiscoveryCard extends LitElement {
+  static properties = {
+    _entries: { state: true },
+    _loading: { state: true },
+    _busyMetric: { state: true },
+  };
+
+  constructor() {
+    super();
+    this._entries = [];
+    this._loading = true;
+    this._busyMetric = null;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._load();
+  }
+
+  async _load() {
+    this._loading = true;
+    try {
+      const r = await fetch('/api/health-auto-export/discoveries');
+      if (!r.ok) { this._entries = []; return; }
+      const body = await r.json();
+      this._entries = Array.isArray(body.undismissed) ? body.undismissed : [];
+    } catch {
+      this._entries = [];
+    } finally {
+      this._loading = false;
+    }
+  }
+
+  async _build(metric) {
+    window.dispatchEvent(new CustomEvent('klebb-paste-into-chat', {
+      detail: { text: buildPrompt(metric) },
+    }));
+  }
+
+  async _dismiss(metric) {
+    this._busyMetric = metric;
+    try {
+      const r = await fetch(
+        `/api/health-auto-export/discoveries/${encodeURIComponent(metric)}/dismiss`,
+        { method: 'POST' });
+      if (r.ok) {
+        this._entries = this._entries.filter(e => e.metric !== metric);
+      }
+    } finally {
+      this._busyMetric = null;
+    }
+  }
+
+  render() {
+    if (this._loading) return html``;
+    if (!this._entries.length) return html``;
+
+    const n = this._entries.length;
+    const headline = n === 1
+      ? 'New Apple Health data spotted'
+      : `${n} new Apple Health metrics spotted`;
+
+    return html`
+      <div class="card">
+        <div class="header">
+          <span class="emoji">✨</span>
+          <span class="title">${headline}</span>
+        </div>
+        <p class="intro">
+          Recent pushes from Health Auto Export include data nothing on your
+          dashboard subscribes to yet. Build a card for what you want; dismiss
+          what you don't.
+        </p>
+        <ul class="rows">
+          ${this._entries.map(e => this._renderRow(e))}
+        </ul>
+      </div>
+    `;
+  }
+
+  _renderRow(entry) {
+    const isBusy = this._busyMetric === entry.metric;
+    return html`
+      <li class="row">
+        <span class="row-label">
+          <span class="metric-label">${labelFor(entry.metric)}</span>
+          <span class="metric-key">${entry.metric}</span>
+        </span>
+        <span class="row-actions">
+          <button
+            class="btn primary"
+            @click=${() => this._build(entry.metric)}
+            ?disabled=${isBusy}
+          >Build a card</button>
+          <button
+            class="btn"
+            @click=${() => this._dismiss(entry.metric)}
+            ?disabled=${isBusy}
+          >Dismiss</button>
+        </span>
+      </li>
+    `;
+  }
+
+  static styles = css`
+    :host {
+      display: block;
+      margin-bottom: 16px;
+    }
+    .card {
+      background: var(--bg-card);
+      border: 1px solid var(--accent, #00d4aa);
+      border-radius: 12px;
+      padding: 14px 16px 12px;
+      box-shadow: 0 2px 10px rgba(0, 212, 170, 0.08);
+    }
+    .header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 13px;
+      font-weight: 700;
+      letter-spacing: 0.4px;
+      text-transform: uppercase;
+      color: var(--accent, #00d4aa);
+    }
+    .emoji { font-size: 16px; }
+    .intro {
+      margin: 8px 0 10px;
+      font-size: 13px;
+      line-height: 1.45;
+      color: var(--text-primary);
+    }
+    .rows {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 8px 10px;
+      border-radius: 8px;
+      background: var(--bg-input, rgba(0, 0, 0, 0.03));
+      border: 1px solid var(--border);
+    }
+    .row-label {
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+      flex: 1;
+    }
+    .metric-label {
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--text-primary);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .metric-key {
+      font-family: ui-monospace, Menlo, Consolas, monospace;
+      font-size: 11px;
+      color: var(--text-muted, var(--text-secondary));
+    }
+    .row-actions {
+      display: inline-flex;
+      gap: 6px;
+      flex-shrink: 0;
+    }
+    .btn {
+      font: inherit;
+      font-size: 12px;
+      font-weight: 600;
+      padding: 6px 10px;
+      border-radius: 6px;
+      border: 1px solid var(--border);
+      background: var(--bg-card);
+      color: var(--text-primary);
+      cursor: pointer;
+      transition: border-color 0.12s, background 0.12s, color 0.12s;
+    }
+    .btn:hover:not(:disabled) {
+      border-color: var(--accent, #00d4aa);
+      background: var(--bg-hover, rgba(255, 255, 255, 0.04));
+    }
+    .btn:disabled { opacity: 0.4; cursor: not-allowed; }
+    .btn.primary {
+      border-color: var(--accent, #00d4aa);
+      background: var(--accent, #00d4aa);
+      color: var(--bg-card);
+    }
+    .btn.primary:hover:not(:disabled) {
+      filter: brightness(1.08);
+    }
+    .btn:focus-visible {
+      outline: 2px solid var(--accent, #00d4aa);
+      outline-offset: 2px;
+    }
+    @media (max-width: 480px) {
+      .row {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 8px;
+      }
+      .row-actions {
+        justify-content: flex-end;
+      }
+    }
+  `;
+}
+
+customElements.define('eh-hae-discovery-card', EhHaeDiscoveryCard);

--- a/public/js/components/eh-settings-view.js
+++ b/public/js/components/eh-settings-view.js
@@ -18,6 +18,8 @@ export class EhSettingsView extends LitElement {
     _error: { state: true },
     _busyId: { state: true },
     _filter: { state: true },
+    _hiddenDiscoveries: { state: true },
+    _busyMetric: { state: true },
   };
 
   constructor() {
@@ -27,11 +29,39 @@ export class EhSettingsView extends LitElement {
     this._error = null;
     this._busyId = null;
     this._filter = '';
+    this._hiddenDiscoveries = [];
+    this._busyMetric = null;
   }
 
   connectedCallback() {
     super.connectedCallback();
     this._load();
+    this._loadHiddenDiscoveries();
+  }
+
+  async _loadHiddenDiscoveries() {
+    try {
+      const r = await fetch('/api/health-auto-export/discoveries');
+      if (!r.ok) return;
+      const body = await r.json();
+      this._hiddenDiscoveries = Array.isArray(body.dismissed) ? body.dismissed : [];
+    } catch {
+      // Silent — settings still works without this section.
+    }
+  }
+
+  async _unhideDiscovery(metric) {
+    this._busyMetric = metric;
+    try {
+      const r = await fetch(
+        `/api/health-auto-export/discoveries/${encodeURIComponent(metric)}/unhide`,
+        { method: 'POST' });
+      if (r.ok) {
+        this._hiddenDiscoveries = this._hiddenDiscoveries.filter(d => d.metric !== metric);
+      }
+    } finally {
+      this._busyMetric = null;
+    }
   }
 
   async _load() {
@@ -227,6 +257,44 @@ export class EhSettingsView extends LitElement {
     @media (prefers-reduced-motion: reduce) {
       .toggle, .toggle::after { transition: none; }
     }
+
+    .discovery-list {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      margin-bottom: 20px;
+    }
+    .discovery-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 8px 12px;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--bg-card);
+    }
+    .discovery-label {
+      font-family: ui-monospace, Menlo, Consolas, monospace;
+      font-size: 13px;
+      color: var(--text-primary);
+    }
+    .unhide-btn {
+      font: inherit;
+      font-size: 12px;
+      font-weight: 600;
+      padding: 6px 10px;
+      border-radius: 6px;
+      border: 1px solid var(--border);
+      background: var(--bg-card);
+      color: var(--text-primary);
+      cursor: pointer;
+    }
+    .unhide-btn:hover:not(:disabled) {
+      border-color: var(--accent);
+      color: var(--accent);
+    }
+    .unhide-btn:disabled { opacity: 0.4; cursor: not-allowed; }
   `;
 
   _onFilterInput(e) {
@@ -250,6 +318,26 @@ export class EhSettingsView extends LitElement {
     const totalAll = this._cards.length;
 
     return html`
+      ${this._hiddenDiscoveries.length > 0 ? html`
+        <h2>Hidden Apple Health metrics</h2>
+        <div class="lede">
+          Metrics you've dismissed from the discovery prompt. Un-hide to see
+          them again the next time a push arrives.
+        </div>
+        <div class="discovery-list">
+          ${this._hiddenDiscoveries.map(d => html`
+            <div class="discovery-row">
+              <span class="discovery-label">${d.metric}</span>
+              <button
+                class="unhide-btn"
+                ?disabled=${this._busyMetric === d.metric}
+                @click=${() => this._unhideDiscovery(d.metric)}
+              >Un-hide</button>
+            </div>
+          `)}
+        </div>
+      ` : ''}
+
       <h2>Cards</h2>
       <div class="lede">
         Every card is a file in <code>$HEALTH_HOME/data/</code>. Toggle off to

--- a/server.js
+++ b/server.js
@@ -20,6 +20,7 @@ const { pickEmbellishments } = require('./chat/embellish');
 const { buildDateContextBlock } = require('./chat/date-context');
 const hae = require('./health-auto-export/ingest');
 const haeDiagnostics = require('./health-auto-export/diagnostics');
+const haeDiscoveries = require('./health-auto-export/discoveries');
 
 // chat endpoint config (env-driven; see config/env.js)
 const CHAT_ENDPOINT_URL = ENV.CHAT_ENDPOINT_URL;
@@ -935,6 +936,11 @@ const server = http.createServer(async (req, res) => {
             availableUnsubscribed: summary.availableUnsubscribed,
             warnings: summary.warnings,
           });
+          const subscribedMetrics = hae.findSubscribers(registry).map(s => s.metric);
+          haeDiscoveries.sync({
+            seen: summary.availableUnsubscribed,
+            subscribed: subscribedMetrics,
+          });
           const ingested = {};
           for (const s of summary.subscribers) ingested[s.id] = s.rowsWritten;
           return sendJSON(res, {
@@ -969,6 +975,28 @@ const server = http.createServer(async (req, res) => {
         endpointUrl: `${scheme}://${host}/api/health-auto-export`,
         lastPush: haeDiagnostics.readLastPush(),
       });
+    }
+
+    // GET /api/health-auto-export/discoveries — list metrics present in
+    // past HAE pushes that no manifest subscribes to. Shape:
+    //   { undismissed: [{metric, firstSeenAt}], dismissed: [{metric, ...}] }
+    if (parts[0] === 'health-auto-export' && parts[1] === 'discoveries'
+        && parts.length === 2 && req.method === 'GET') {
+      return sendJSON(res, haeDiscoveries.list());
+    }
+
+    // POST /api/health-auto-export/discoveries/:metric/dismiss
+    // POST /api/health-auto-export/discoveries/:metric/unhide
+    if (parts[0] === 'health-auto-export' && parts[1] === 'discoveries'
+        && parts.length === 4 && req.method === 'POST') {
+      const metric = decodeURIComponent(parts[2]);
+      const action = parts[3];
+      let ok = false;
+      if (action === 'dismiss') ok = haeDiscoveries.dismiss(metric);
+      else if (action === 'unhide') ok = haeDiscoveries.unhide(metric);
+      else return sendJSON(res, { error: 'unknown action' }, 404);
+      if (!ok) return sendJSON(res, { error: 'unknown metric' }, 404);
+      return sendJSON(res, { ok: true });
     }
 
     // Auto-export endpoints: sleep, workouts, vitals, activity

--- a/tests/health-auto-export.discoveries-api.test.js
+++ b/tests/health-auto-export.discoveries-api.test.js
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/health-auto-export.discoveries-api.test.js
+// Integration tests for the discoveries API + dispatcher interaction.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const { createSandbox, cleanupSandbox, spawnServer, req } = require('./helpers/sandbox');
+
+const TOKEN = 'disc-token-hex-0123456789abcdef';
+
+const STEPS_SUBSCRIBER = {
+  'steps.json': {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'steps', label: 'Steps',
+      ingest: { source: 'hae', metric: 'step_count' },
+      view: { enabled: true, component: 'generic-card',
+              display: { template: '{count}', unit: 'steps' } },
+      writeable: { fromWebapp: false },
+    },
+    data: [],
+  },
+};
+
+const SLEEP_SUBSCRIBER = {
+  'sleep-hours.json': {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'sleep-hours', label: 'Sleep',
+      ingest: { source: 'hae', metric: 'sleep_analysis' },
+      view: { enabled: true, component: 'generic-card',
+              display: { template: '{hours}' } },
+      writeable: { fromWebapp: false },
+    },
+    data: [],
+  },
+};
+
+// Has steps, sleep, and HRV samples.
+const CANNED_PAYLOAD = {
+  data: {
+    metrics: [
+      { name: 'step_count', data: [{ date: '2026-05-04', qty: 3500 }] },
+      { name: 'sleep_analysis', data: [{ date: '2026-05-04', totalSleep: 7.5 }] },
+      { name: 'heart_rate_variability', data: [{ date: '2026-05-04', qty: 55 }] },
+    ],
+  },
+};
+
+describe('GET /api/health-auto-export/discoveries', () => {
+  describe('no discoveries yet', () => {
+    let sandbox, server;
+    before(async () => {
+      sandbox = createSandbox();
+      server = await spawnServer(sandbox, { HEALTH_AUTO_EXPORT_TOKEN: TOKEN });
+    });
+    after(async () => { if (server) await server.kill(); cleanupSandbox(sandbox); });
+
+    test('returns empty arrays', async () => {
+      const res = await req(server.baseUrl, '/api/health-auto-export/discoveries');
+      assert.equal(res.status, 200);
+      assert.deepEqual(res.json.undismissed, []);
+      assert.deepEqual(res.json.dismissed, []);
+    });
+  });
+
+  describe('after a push with unsubscribed metrics', () => {
+    let sandbox, server;
+    before(async () => {
+      sandbox = createSandbox({ seed: STEPS_SUBSCRIBER });
+      server = await spawnServer(sandbox, { HEALTH_AUTO_EXPORT_TOKEN: TOKEN });
+    });
+    after(async () => { if (server) await server.kill(); cleanupSandbox(sandbox); });
+
+    test('lists sleep_analysis + heart_rate_variability as undismissed', async () => {
+      await req(server.baseUrl, '/api/health-auto-export', {
+        method: 'POST', body: CANNED_PAYLOAD,
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      });
+
+      const res = await req(server.baseUrl, '/api/health-auto-export/discoveries');
+      assert.equal(res.status, 200);
+      const metrics = res.json.undismissed.map(e => e.metric).sort();
+      assert.deepEqual(metrics, ['heart_rate_variability', 'sleep_analysis']);
+      assert.deepEqual(res.json.dismissed, []);
+
+      // File materialised on disk.
+      const file = path.join(sandbox, 'data', 'auto-export', 'discovered.json');
+      assert.ok(fs.existsSync(file));
+    });
+
+    test('dismiss endpoint moves entry to dismissed', async () => {
+      const d = await req(server.baseUrl,
+        '/api/health-auto-export/discoveries/sleep_analysis/dismiss',
+        { method: 'POST' });
+      assert.equal(d.status, 200);
+      assert.equal(d.json.ok, true);
+
+      const res = await req(server.baseUrl, '/api/health-auto-export/discoveries');
+      assert.equal(res.json.undismissed.length, 1);
+      assert.equal(res.json.undismissed[0].metric, 'heart_rate_variability');
+      assert.equal(res.json.dismissed.length, 1);
+      assert.equal(res.json.dismissed[0].metric, 'sleep_analysis');
+      assert.ok(res.json.dismissed[0].dismissedAt);
+    });
+
+    test('unhide endpoint moves entry back to undismissed', async () => {
+      const u = await req(server.baseUrl,
+        '/api/health-auto-export/discoveries/sleep_analysis/unhide',
+        { method: 'POST' });
+      assert.equal(u.status, 200);
+      assert.equal(u.json.ok, true);
+
+      const res = await req(server.baseUrl, '/api/health-auto-export/discoveries');
+      const metrics = res.json.undismissed.map(e => e.metric).sort();
+      assert.deepEqual(metrics, ['heart_rate_variability', 'sleep_analysis']);
+      assert.deepEqual(res.json.dismissed, []);
+    });
+
+    test('dismiss an unknown metric returns 404', async () => {
+      const r = await req(server.baseUrl,
+        '/api/health-auto-export/discoveries/no_such_thing/dismiss',
+        { method: 'POST' });
+      assert.equal(r.status, 404);
+    });
+  });
+
+  describe('dismissal persists across subsequent pushes', () => {
+    let sandbox, server;
+    before(async () => {
+      sandbox = createSandbox();
+      server = await spawnServer(sandbox, { HEALTH_AUTO_EXPORT_TOKEN: TOKEN });
+    });
+    after(async () => { if (server) await server.kill(); cleanupSandbox(sandbox); });
+
+    test('push again after dismiss does not resurface the metric', async () => {
+      await req(server.baseUrl, '/api/health-auto-export', {
+        method: 'POST', body: CANNED_PAYLOAD,
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      });
+      await req(server.baseUrl,
+        '/api/health-auto-export/discoveries/heart_rate_variability/dismiss',
+        { method: 'POST' });
+
+      await req(server.baseUrl, '/api/health-auto-export', {
+        method: 'POST', body: CANNED_PAYLOAD,
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      });
+
+      const res = await req(server.baseUrl, '/api/health-auto-export/discoveries');
+      const dismissedMetrics = res.json.dismissed.map(e => e.metric);
+      assert.ok(dismissedMetrics.includes('heart_rate_variability'));
+      const undismissedMetrics = res.json.undismissed.map(e => e.metric);
+      assert.ok(!undismissedMetrics.includes('heart_rate_variability'));
+    });
+  });
+
+  describe('graduating a discovery (subscribe after seeing)', () => {
+    let sandbox, server;
+    before(async () => {
+      sandbox = createSandbox();
+      server = await spawnServer(sandbox, { HEALTH_AUTO_EXPORT_TOKEN: TOKEN });
+    });
+    after(async () => { if (server) await server.kill(); cleanupSandbox(sandbox); });
+
+    test('adding a subscriber removes the metric from discoveries on next push', async () => {
+      // First push — no subscribers, sleep lands in discoveries.
+      await req(server.baseUrl, '/api/health-auto-export', {
+        method: 'POST', body: CANNED_PAYLOAD,
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      });
+      let res = await req(server.baseUrl, '/api/health-auto-export/discoveries');
+      assert.ok(res.json.undismissed.some(e => e.metric === 'sleep_analysis'));
+
+      // Drop a sleep subscriber on disk.
+      fs.writeFileSync(
+        path.join(sandbox, 'data', 'sleep-hours.json'),
+        JSON.stringify(SLEEP_SUBSCRIBER['sleep-hours.json'], null, 2));
+
+      // Give the registry fs.watch a moment to reload.
+      await new Promise(r => setTimeout(r, 400));
+
+      // Second push — dispatcher now sees the sleep subscriber and clears it.
+      await req(server.baseUrl, '/api/health-auto-export', {
+        method: 'POST', body: CANNED_PAYLOAD,
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      });
+
+      res = await req(server.baseUrl, '/api/health-auto-export/discoveries');
+      assert.ok(!res.json.undismissed.some(e => e.metric === 'sleep_analysis'),
+        'sleep_analysis should have graduated out of undismissed');
+      assert.ok(!res.json.dismissed.some(e => e.metric === 'sleep_analysis'),
+        'sleep_analysis should also not linger in dismissed');
+    });
+  });
+});

--- a/tests/health-auto-export.discoveries.test.js
+++ b/tests/health-auto-export.discoveries.test.js
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/health-auto-export.discoveries.test.js
+// Pure unit tests for the discovered.json read/write + sync helpers.
+
+const { test, describe, beforeEach, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+let tmp;
+let discoveries;
+
+function reloadModule() {
+  delete require.cache[require.resolve('../config/paths')];
+  delete require.cache[require.resolve('../health-auto-export/discoveries')];
+  discoveries = require('../health-auto-export/discoveries');
+}
+
+describe('discoveries module', () => {
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'eh-disc-'));
+    process.env.HEALTH_HOME = tmp;
+    process.env.HEALTH_HOME_WARNED = '1';
+    fs.mkdirSync(path.join(tmp, 'data', 'auto-export'), { recursive: true });
+    reloadModule();
+  });
+
+  after(() => {
+    if (tmp) { try { fs.rmSync(tmp, { recursive: true, force: true }); } catch {} }
+    delete process.env.HEALTH_HOME;
+    delete require.cache[require.resolve('../config/paths')];
+    delete require.cache[require.resolve('../health-auto-export/discoveries')];
+  });
+
+  test('load() on missing file returns empty object', () => {
+    assert.deepEqual(discoveries.load(), {});
+  });
+
+  test('sync() records new unsubscribed metrics', () => {
+    const state = discoveries.sync({
+      seen: ['heart_rate_variability', 'blood_oxygen_saturation'],
+      subscribed: ['step_count'],
+      now: '2026-05-08T00:00:00.000Z',
+    });
+    assert.ok(state.heart_rate_variability);
+    assert.equal(state.heart_rate_variability.dismissed, false);
+    assert.equal(state.heart_rate_variability.firstSeenAt, '2026-05-08T00:00:00.000Z');
+    assert.ok(state.blood_oxygen_saturation);
+  });
+
+  test('sync() preserves dismiss state across calls', () => {
+    discoveries.sync({
+      seen: ['heart_rate_variability'], subscribed: [],
+      now: '2026-05-08T00:00:00.000Z',
+    });
+    discoveries.dismiss('heart_rate_variability', '2026-05-09T00:00:00.000Z');
+
+    discoveries.sync({
+      seen: ['heart_rate_variability'], subscribed: [],
+      now: '2026-05-10T00:00:00.000Z',
+    });
+    const state = discoveries.load();
+    assert.equal(state.heart_rate_variability.dismissed, true);
+    assert.equal(state.heart_rate_variability.dismissedAt, '2026-05-09T00:00:00.000Z');
+    // firstSeenAt does not change on re-sync.
+    assert.equal(state.heart_rate_variability.firstSeenAt, '2026-05-08T00:00:00.000Z');
+  });
+
+  test('sync() removes entries whose metric now has a subscriber', () => {
+    discoveries.sync({ seen: ['step_count'], subscribed: [] });
+    assert.ok(discoveries.load().step_count);
+
+    discoveries.sync({ seen: [], subscribed: ['step_count'] });
+    assert.equal(discoveries.load().step_count, undefined);
+  });
+
+  test('sync() does not duplicate already-known entries', () => {
+    discoveries.sync({ seen: ['hrv'], subscribed: [], now: 't1' });
+    discoveries.sync({ seen: ['hrv'], subscribed: [], now: 't2' });
+    const state = discoveries.load();
+    // First-seen timestamp must be sticky.
+    assert.equal(state.hrv.firstSeenAt, 't1');
+  });
+
+  test('dismiss() / unhide() round-trip', () => {
+    discoveries.sync({ seen: ['hrv'], subscribed: [] });
+    assert.equal(discoveries.dismiss('hrv'), true);
+    assert.equal(discoveries.load().hrv.dismissed, true);
+
+    assert.equal(discoveries.unhide('hrv'), true);
+    assert.equal(discoveries.load().hrv.dismissed, false);
+    assert.equal(discoveries.load().hrv.dismissedAt, undefined);
+  });
+
+  test('dismiss() / unhide() return false for unknown metric', () => {
+    assert.equal(discoveries.dismiss('nope'), false);
+    assert.equal(discoveries.unhide('nope'), false);
+  });
+
+  test('list() partitions by dismissed flag and sorts', () => {
+    discoveries.sync({ seen: ['a', 'b', 'c'], subscribed: [], now: 't1' });
+    discoveries.dismiss('b');
+    discoveries.dismiss('c');
+    const out = discoveries.list();
+    assert.equal(out.undismissed.length, 1);
+    assert.equal(out.undismissed[0].metric, 'a');
+    assert.equal(out.dismissed.length, 2);
+    assert.deepEqual(out.dismissed.map(e => e.metric), ['b', 'c']);
+  });
+
+  test('sync() lazily creates the file (not present before first write)', () => {
+    const file = path.join(tmp, 'data', 'auto-export', 'discovered.json');
+    assert.equal(fs.existsSync(file), false, 'file should not exist initially');
+    discoveries.sync({ seen: ['hrv'], subscribed: [] });
+    assert.equal(fs.existsSync(file), true, 'file should exist after sync with new entries');
+  });
+
+  test('sync() with empty seen + empty subscribed is a no-op', () => {
+    discoveries.sync({ seen: [], subscribed: [] });
+    const file = path.join(tmp, 'data', 'auto-export', 'discovered.json');
+    assert.equal(fs.existsSync(file), false);
+  });
+});


### PR DESCRIPTION
# What changed

Adds a pinned "new Apple Health metrics spotted" discovery card to Today, backed by persisted `$HEALTH_HOME/data/auto-export/discovered.json` state and three new API endpoints. The dispatcher populates discoveries after each push; the user builds a subscriber card (via klebbius chat) or dismisses the metric. Dismissed entries appear in a new Settings section with an un-hide button.

# Why

Fixes #151. Refs #150.

PR #154 made ingest subscriber-driven. PR #157 added a `last-push.json` diagnostic for operator inspection. Neither surfaces the "here's Apple Health data you could be tracking" affordance — the webhook records unsubscribed metrics in its response body and in `lastPush.availableUnsubscribed`, but an ordinary user never sees it. Without a prompt, a user whose iPhone starts pushing HRV data has no way to know they could be tracking it. The discovery card turns silent data into a visible nudge without resurrecting the auto-seed behaviour we deliberately removed.

# How

**Server:**
- `health-auto-export/discoveries.js` — persists `{metric: {firstSeenAt, dismissed, dismissedAt?}}` in `discovered.json`. Lazy file creation, atomic writes. Exposes `load`, `sync`, `dismiss`, `unhide`, `list`.
- `server.js` — webhook dispatcher calls `discoveries.sync({seen, subscribed})` after each push. `seen` is the existing `availableUnsubscribed` list; `subscribed` comes from `hae.findSubscribers(registry)`. Subscribed metrics are removed from discoveries (a subscriber is the discovery's graduation). Dismiss state is preserved across pushes.
- Three new endpoints, auth-gated under the standard `/api/*` gate:
  - `GET /api/health-auto-export/discoveries` — returns `{undismissed, dismissed}`.
  - `POST /api/health-auto-export/discoveries/:metric/dismiss`.
  - `POST /api/health-auto-export/discoveries/:metric/unhide`.

**UI:**
- `public/js/components/eh-hae-discovery-card.js` — Lit component, pinned at the top of Today by `eh-date-view` only when `dateMode === 'today'`. Self-hides when the undismissed list is empty. "Build a card" dispatches `klebb-paste-into-chat` (existing event used by the prompts gallery) with a templated prompt pointing at `docs/HEALTH-AUTO-EXPORT.md`. "Dismiss" calls the dismiss endpoint and removes the row locally.
- `eh-settings-view.js` — adds a "Hidden Apple Health metrics" section listing dismissed entries with an Un-hide button.

**State invariants (covered by tests):**
- `firstSeenAt` sticks on re-sync.
- Dismiss state is preserved across pushes.
- Subscribing to a metric removes its discovery entry on the next push.
- Dismissing an already-subscribed metric is a no-op (`dismiss` returns false for unknown metrics → `404`).
- File is created lazily; empty sync is a no-op and doesn't touch disk.

# Testing

- [x] `npm test` passes locally (728/729; the one pre-existing `no-personal-refs` failure is unchanged on this branch and fails identically on main).
- [x] 10 unit tests in `health-auto-export.discoveries.test.js` covering sync/dismiss/unhide semantics, first-seen stickiness, dismiss preservation across pushes, lazy file creation, empty no-op.
- [x] 7 integration tests in `health-auto-export.discoveries-api.test.js` covering the GET endpoint shape, dismiss + unhide round-trip, 404 on unknown metric, dismissal persistence across subsequent pushes, and the "graduate a discovery" flow (add a subscriber → discovery entry disappears on next push).
- [ ] Manual QA: spin up a dev instance, POST a payload that includes unsubscribed metrics, confirm the discovery card renders at the top of Today; click Dismiss, confirm the row disappears and re-push does not resurface it; open Settings, confirm the dismissed entry appears in "Hidden Apple Health metrics" and Un-hide restores it.

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [x] Docs updated — `docs/HEALTH-AUTO-EXPORT.md` new "Discovering new metrics" section
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens
- [x] New source files carry SPDX AGPL-3.0-only header

# Breaking changes

None. New state file, new endpoints, new UI surface; no existing schema, API, or behaviour changes.