### PR TITLE
feat(hae): Settings panel — endpoint URL, token, last-push summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Health Auto Export panel in Settings.** The Settings view now
+  leads with a panel showing the webhook's endpoint URL (with a copy
+  button), token-configured status, a link to the setup guide, and a
+  last-push summary ("X rows across Y cards, N minutes ago") that
+  expands into a full diagnostic detail: receive time, payload size,
+  per-subscriber rows written + notes, metrics present but
+  unsubscribed, and any warnings. The panel reads from
+  `GET /api/health-auto-export/status`; the webhook URL is derived
+  from the request host so the panel always shows the URL the iPhone
+  app should be posting to. (Fixes #153)
+
 - **Apple Health discovery card.** When the HAE webhook receives
   metrics nothing on your dashboard subscribes to yet, a pinned info
   card appears at the top of the Today view listing each newly-seen

--- a/docs/HEALTH-AUTO-EXPORT.md
+++ b/docs/HEALTH-AUTO-EXPORT.md
@@ -194,6 +194,23 @@ A successful push returns:
 
 ---
 
+## Settings panel
+
+Klebb's Settings view leads with a Health Auto Export panel showing:
+
+- The effective webhook URL (copy to clipboard).
+- Whether `HEALTH_AUTO_EXPORT_TOKEN` is set.
+- Time and summary of the most recent push, expandable to show the
+  full diagnostic (rows per subscriber, unsubscribed metrics seen,
+  warnings).
+
+The panel is the first place to look when debugging "is my iPhone
+pushing?". The URL shown is derived from the request host and
+`X-Forwarded-Proto`, so whatever it shows is what your HAE
+automation should be posting to.
+
+---
+
 ## Discovering new metrics
 
 When a push contains metrics that no manifest subscribes to, klebb

--- a/public/js/components/eh-settings-view.js
+++ b/public/js/components/eh-settings-view.js
@@ -20,6 +20,9 @@ export class EhSettingsView extends LitElement {
     _filter: { state: true },
     _hiddenDiscoveries: { state: true },
     _busyMetric: { state: true },
+    _haeStatus: { state: true },
+    _haeLastPushExpanded: { state: true },
+    _haeCopied: { state: true },
   };
 
   constructor() {
@@ -31,12 +34,49 @@ export class EhSettingsView extends LitElement {
     this._filter = '';
     this._hiddenDiscoveries = [];
     this._busyMetric = null;
+    this._haeStatus = null;
+    this._haeLastPushExpanded = false;
+    this._haeCopied = false;
   }
 
   connectedCallback() {
     super.connectedCallback();
     this._load();
     this._loadHiddenDiscoveries();
+    this._loadHaeStatus();
+  }
+
+  async _loadHaeStatus() {
+    try {
+      const r = await fetch('/api/health-auto-export/status');
+      if (!r.ok) return;
+      this._haeStatus = await r.json();
+    } catch {
+      // Silent — settings still works without this section.
+    }
+  }
+
+  async _copyEndpoint() {
+    if (!this._haeStatus?.endpointUrl) return;
+    try {
+      await navigator.clipboard.writeText(this._haeStatus.endpointUrl);
+      this._haeCopied = true;
+      setTimeout(() => { this._haeCopied = false; }, 1800);
+    } catch {
+      // Fallback: hidden textarea selection.
+      const ta = document.createElement('textarea');
+      ta.value = this._haeStatus.endpointUrl;
+      document.body.appendChild(ta);
+      ta.select();
+      try { document.execCommand('copy'); } catch {}
+      document.body.removeChild(ta);
+      this._haeCopied = true;
+      setTimeout(() => { this._haeCopied = false; }, 1800);
+    }
+  }
+
+  _toggleLastPushDetail() {
+    this._haeLastPushExpanded = !this._haeLastPushExpanded;
   }
 
   async _loadHiddenDiscoveries() {
@@ -295,6 +335,173 @@ export class EhSettingsView extends LitElement {
       color: var(--accent);
     }
     .unhide-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+    .hae-panel {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      padding: 14px 16px;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: var(--bg-card);
+      margin-bottom: 20px;
+    }
+    .hae-row {
+      display: flex;
+      align-items: baseline;
+      gap: 10px;
+      font-size: 13px;
+      flex-wrap: wrap;
+    }
+    .hae-label {
+      font-size: 11px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: var(--text-muted, var(--text-secondary));
+      min-width: 80px;
+    }
+    .hae-endpoint {
+      display: inline-flex;
+      gap: 8px;
+      align-items: center;
+      flex: 1;
+      min-width: 0;
+      flex-wrap: wrap;
+    }
+    .endpoint-code {
+      font-family: ui-monospace, Menlo, Consolas, monospace;
+      font-size: 12px;
+      background: var(--bg-input, rgba(0, 0, 0, 0.04));
+      padding: 4px 8px;
+      border-radius: 6px;
+      color: var(--text-primary);
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .copy-btn {
+      font: inherit;
+      font-size: 11px;
+      font-weight: 600;
+      padding: 4px 8px;
+      border-radius: 6px;
+      border: 1px solid var(--border);
+      background: var(--bg-card);
+      color: var(--text-primary);
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+    .copy-btn:hover {
+      border-color: var(--accent);
+      color: var(--accent);
+    }
+    .hae-token {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--text-primary);
+    }
+    .hae-token .dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      display: inline-block;
+      flex-shrink: 0;
+    }
+    .hae-token.on .dot { background: var(--accent-green, #44ff88); }
+    .hae-token.off .dot { background: var(--accent-amber, #ffaa33); }
+    .hae-token code {
+      font-family: ui-monospace, Menlo, Consolas, monospace;
+      font-size: 11px;
+      padding: 1px 4px;
+      background: var(--bg-input, rgba(0, 0, 0, 0.04));
+      border-radius: 4px;
+    }
+    .hae-lastpush {
+      display: inline-flex;
+      gap: 8px;
+      align-items: baseline;
+      flex-wrap: wrap;
+      color: var(--text-primary);
+    }
+    .muted { color: var(--text-muted, var(--text-secondary)); font-style: italic; }
+    .warn-pill {
+      font-size: 11px;
+      padding: 2px 6px;
+      border-radius: 10px;
+      background: var(--accent-amber-bg, rgba(255, 170, 51, 0.15));
+      color: var(--accent-amber, #ffaa33);
+      font-weight: 600;
+    }
+    .hae-detail-row {
+      margin-top: 2px;
+    }
+    .detail-toggle {
+      font: inherit;
+      font-size: 12px;
+      padding: 2px 0;
+      background: transparent;
+      border: none;
+      color: var(--accent);
+      cursor: pointer;
+    }
+    .detail-toggle:hover { text-decoration: underline; }
+    .hae-detail {
+      margin-top: 6px;
+      padding: 10px 12px;
+      background: var(--bg-input, rgba(0, 0, 0, 0.02));
+      border-radius: 8px;
+      border: 1px solid var(--border);
+      font-size: 12px;
+    }
+    .detail-list {
+      display: grid;
+      grid-template-columns: 140px 1fr;
+      gap: 6px 12px;
+      margin: 0;
+    }
+    .detail-list dt {
+      font-weight: 600;
+      color: var(--text-muted, var(--text-secondary));
+    }
+    .detail-list dd {
+      margin: 0;
+      color: var(--text-primary);
+      min-width: 0;
+      overflow-wrap: anywhere;
+    }
+    .sub-list, .warn-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    .sub-list code {
+      font-family: ui-monospace, Menlo, Consolas, monospace;
+      font-size: 11px;
+    }
+    .sub-note { color: var(--text-muted, var(--text-secondary)); margin-left: 4px; }
+    .metric-tag-list {
+      font-family: ui-monospace, Menlo, Consolas, monospace;
+      font-size: 11px;
+      color: var(--text-primary);
+    }
+    .warn-list li {
+      color: var(--accent-amber, #ffaa33);
+      font-family: ui-monospace, Menlo, Consolas, monospace;
+    }
+    @media (max-width: 560px) {
+      .detail-list {
+        grid-template-columns: 1fr;
+        gap: 2px 0;
+      }
+      .detail-list dt { margin-top: 6px; }
+    }
   `;
 
   _onFilterInput(e) {
@@ -318,6 +525,8 @@ export class EhSettingsView extends LitElement {
     const totalAll = this._cards.length;
 
     return html`
+      ${this._renderHaePanel()}
+
       ${this._hiddenDiscoveries.length > 0 ? html`
         <h2>Hidden Apple Health metrics</h2>
         <div class="lede">
@@ -384,6 +593,141 @@ export class EhSettingsView extends LitElement {
 
       ${this._error ? html`<div class="error">${this._error}</div>` : ''}
     `;
+  }
+
+  _renderHaePanel() {
+    if (!this._haeStatus) return '';
+    const s = this._haeStatus;
+    const lp = s.lastPush;
+    return html`
+      <h2>Health Auto Export</h2>
+      <div class="lede">
+        Push iPhone health data into Klebb via the Health Auto Export app.
+        <a href="https://github.com/Aristocles/klebb/blob/main/docs/HEALTH-AUTO-EXPORT.md" target="_blank" rel="noopener">Setup guide →</a>
+      </div>
+      <div class="hae-panel">
+        <div class="hae-row">
+          <span class="hae-label">Endpoint</span>
+          <span class="hae-endpoint">
+            <code class="endpoint-code">${s.endpointUrl}</code>
+            <button
+              class="copy-btn"
+              @click=${this._copyEndpoint}
+              aria-label="Copy endpoint URL"
+            >${this._haeCopied ? 'Copied ✓' : 'Copy'}</button>
+          </span>
+        </div>
+        <div class="hae-row">
+          <span class="hae-label">Token</span>
+          <span class="hae-token ${s.tokenSet ? 'on' : 'off'}">
+            ${s.tokenSet
+              ? html`<span class="dot"></span>Set`
+              : html`<span class="dot"></span>Not set — add
+                  <code>HEALTH_AUTO_EXPORT_TOKEN</code> to your
+                  <code>.env</code>`}
+          </span>
+        </div>
+        <div class="hae-row">
+          <span class="hae-label">Last push</span>
+          <span class="hae-lastpush">
+            ${this._renderLastPushSummary(lp)}
+          </span>
+        </div>
+        ${lp ? html`
+          <div class="hae-detail-row">
+            <button
+              class="detail-toggle"
+              @click=${this._toggleLastPushDetail}
+              aria-expanded=${this._haeLastPushExpanded}
+            >${this._haeLastPushExpanded ? 'Hide detail ▲' : 'Show detail ▼'}</button>
+          </div>
+          ${this._haeLastPushExpanded ? html`
+            <div class="hae-detail">${this._renderLastPushDetail(lp)}</div>
+          ` : ''}
+        ` : ''}
+      </div>
+    `;
+  }
+
+  _renderLastPushSummary(lp) {
+    if (!lp) return html`<span class="muted">Nothing received yet</span>`;
+    const rowsTotal = (lp.subscribers || [])
+      .reduce((acc, s) => acc + (s.rowsWritten || 0), 0);
+    const subsWithRows = (lp.subscribers || [])
+      .filter(s => s.rowsWritten > 0).length;
+    const ago = this._relativeTime(lp.receivedAt);
+    const hasWarnings = Array.isArray(lp.warnings) && lp.warnings.length > 0;
+    return html`
+      <span>${rowsTotal} ${rowsTotal === 1 ? 'row' : 'rows'}
+             across ${subsWithRows} ${subsWithRows === 1 ? 'card' : 'cards'},
+             ${ago}</span>
+      ${hasWarnings ? html`<span class="warn-pill">${lp.warnings.length} warning${lp.warnings.length === 1 ? '' : 's'}</span>` : ''}
+    `;
+  }
+
+  _renderLastPushDetail(lp) {
+    return html`
+      <dl class="detail-list">
+        <dt>Received at</dt>
+        <dd>${lp.receivedAt}</dd>
+        <dt>Payload size</dt>
+        <dd>${this._formatBytes(lp.payloadBytes)}</dd>
+        <dt>Subscribers</dt>
+        <dd>
+          ${lp.subscribers && lp.subscribers.length
+            ? html`<ul class="sub-list">
+                ${lp.subscribers.map(s => html`
+                  <li>
+                    <code>${s.id}</code>
+                    <span class="muted"> ← ${s.metric}</span>:
+                    <strong>${s.rowsWritten} ${s.rowsWritten === 1 ? 'row' : 'rows'}</strong>
+                    ${s.note ? html`<span class="sub-note">(${s.note})</span>` : ''}
+                  </li>
+                `)}
+              </ul>`
+            : html`<span class="muted">none</span>`}
+        </dd>
+        <dt>Available but unsubscribed</dt>
+        <dd>
+          ${lp.availableUnsubscribed && lp.availableUnsubscribed.length
+            ? html`<code class="metric-tag-list">${lp.availableUnsubscribed.join(', ')}</code>`
+            : html`<span class="muted">none</span>`}
+        </dd>
+        ${lp.warnings && lp.warnings.length ? html`
+          <dt>Warnings</dt>
+          <dd>
+            <ul class="warn-list">
+              ${lp.warnings.map(w => html`<li>${w}</li>`)}
+            </ul>
+          </dd>
+        ` : ''}
+      </dl>
+    `;
+  }
+
+  _relativeTime(iso) {
+    try {
+      const then = new Date(iso).getTime();
+      if (!Number.isFinite(then)) return iso;
+      const diff = Date.now() - then;
+      const s = Math.round(diff / 1000);
+      if (s < 60) return 'just now';
+      const m = Math.round(s / 60);
+      if (m < 60) return `${m} minute${m === 1 ? '' : 's'} ago`;
+      const h = Math.round(m / 60);
+      if (h < 24) return `${h} hour${h === 1 ? '' : 's'} ago`;
+      const d = Math.round(h / 24);
+      return `${d} day${d === 1 ? '' : 's'} ago`;
+    } catch {
+      return iso;
+    }
+  }
+
+  _formatBytes(n) {
+    if (!Number.isFinite(n)) return '—';
+    if (n < 1024) return `${n} B`;
+    if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+    return `${(n / (1024 * 1024)).toFixed(2)} MB`;
   }
 
   _renderCard(c) {

--- a/tests/health-auto-export.status-api.settings-contract.test.js
+++ b/tests/health-auto-export.status-api.settings-contract.test.js
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/health-auto-export.status-api.settings-contract.test.js
+//
+// Pins the exact fields in /api/health-auto-export/status that the
+// settings-view Health Auto Export panel depends on. A regression here
+// would silently break the panel UI, so we assert the contract
+// explicitly — even though the shape is already covered more
+// functionally in health-auto-export.status-api.test.js.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const { createSandbox, cleanupSandbox, spawnServer, req } = require('./helpers/sandbox');
+
+const TOKEN = 'contract-token-hex-0123456789abcdef';
+
+const SUBSCRIBER = {
+  'steps.json': {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'steps', label: 'Steps',
+      ingest: { source: 'hae', metric: 'step_count' },
+      view: { enabled: true, component: 'generic-card',
+              display: { template: '{count}', unit: 'steps' } },
+      writeable: { fromWebapp: false },
+    },
+    data: [],
+  },
+};
+
+describe('Settings HAE panel ↔ /status contract', () => {
+  let sandbox, server;
+  before(async () => {
+    sandbox = createSandbox({ seed: SUBSCRIBER });
+    server = await spawnServer(sandbox, { HEALTH_AUTO_EXPORT_TOKEN: TOKEN });
+  });
+  after(async () => { if (server) await server.kill(); cleanupSandbox(sandbox); });
+
+  test('fresh install: status has {tokenSet, endpointUrl, lastPush:null}', async () => {
+    const res = await req(server.baseUrl, '/api/health-auto-export/status');
+    assert.equal(res.status, 200);
+    assert.equal(typeof res.json.tokenSet, 'boolean');
+    assert.equal(typeof res.json.endpointUrl, 'string');
+    assert.equal(res.json.lastPush, null);
+  });
+
+  test('post-push: lastPush has all fields the panel renders', async () => {
+    await req(server.baseUrl, '/api/health-auto-export', {
+      method: 'POST',
+      body: { data: { metrics: [
+        { name: 'step_count', data: [{ date: '2026-05-04', qty: 1234 }] },
+        { name: 'heart_rate_variability', data: [{ date: '2026-05-04', qty: 55 }] },
+      ]}},
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+
+    const res = await req(server.baseUrl, '/api/health-auto-export/status');
+    const lp = res.json.lastPush;
+
+    // Top-level fields the panel reads.
+    assert.equal(typeof lp.receivedAt, 'string');
+    assert.equal(typeof lp.payloadBytes, 'number');
+    assert.ok(Array.isArray(lp.subscribers));
+    assert.ok(Array.isArray(lp.availableUnsubscribed));
+    assert.ok(Array.isArray(lp.warnings));
+
+    // Subscriber rows carry the fields the panel prints.
+    const sub = lp.subscribers[0];
+    assert.equal(typeof sub.id, 'string');
+    assert.equal(typeof sub.metric, 'string');
+    assert.equal(typeof sub.rowsWritten, 'number');
+
+    // availableUnsubscribed is a flat string array (panel joins with ', ').
+    assert.ok(lp.availableUnsubscribed.every(m => typeof m === 'string'));
+  });
+});


### PR DESCRIPTION
# What changed

Adds a Health Auto Export panel to the top of the Settings view, surfacing the data the `/api/health-auto-export/status` endpoint already exposes. Renders the effective webhook URL (with copy button), token-configured status with hint, a last-push summary with optional warnings pill, and an expandable detail view showing per-subscriber row counts, available-but-unsubscribed metrics, and warnings.

# Why

Fixes #153. Refs #150.

The groundwork landed across #150 → #152: subscriber-driven ingest, `last-push.json` diagnostic, `/status` endpoint with request-host-derived URL. Until this PR, none of it was user-visible unless they were reading server logs or hand-curling the API. The Settings panel is the user-facing payoff that makes "did my iPhone push land?" a glance instead of a forensic exercise.

# How

- `eh-settings-view.js` gains `_haeStatus`, `_haeLastPushExpanded`, `_haeCopied` state; fetches `/api/health-auto-export/status` on connect; renders a new `_renderHaePanel()` block above the existing "Hidden Apple Health metrics" + "Cards" sections.
- Render helpers:
  - `_renderLastPushSummary(lp)` — "N rows across M cards, K minutes ago" + warnings pill.
  - `_renderLastPushDetail(lp)` — definition-list style grid with receive time, payload size, subscribers, availableUnsubscribed, warnings.
  - `_relativeTime(iso)` / `_formatBytes(n)` — small local helpers.
- Copy button uses `navigator.clipboard` with a textarea+`document.execCommand('copy')` fallback, matching the existing pattern in `eh-prompts-gallery.js`.
- Docs link points at `docs/HEALTH-AUTO-EXPORT.md` on GitHub (`docs/` is not served statically; this matches the existing "How to add a card" link pattern).
- New test file `health-auto-export.status-api.settings-contract.test.js` pins the exact `/status` field shapes the panel reads, so a regression that silently changes the API would fail the test before it broke the UI.

# Testing

- [x] `npm test` passes locally (730/731; the pre-existing `no-personal-refs` failure is unchanged on this branch and fails identically on main).
- [x] New contract test covers the fresh-install shape (`lastPush: null`) and the post-push shape (all fields the panel reads).
- [ ] Manual QA: open Settings on a fresh instance with no pushes → panel shows "Nothing received yet" + token-status hint; POST a payload with mixed subscribed/unsubscribed metrics → summary updates, warning pill appears if warnings emitted, expanding detail shows per-subscriber counts and the available-but-unsubscribed list; click the copy button → URL is on the clipboard.

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [x] Docs updated — `docs/HEALTH-AUTO-EXPORT.md` new "Settings panel" section
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens

# Breaking changes

None. Pure additive UI + one new test file; no server code changes.