### PR TITLE
fix(hae): backfill new subscriber manifests from raw archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Fixed
+
+- **New HAE-backed manifests backfill from the raw archive.** Before
+  this fix, a card created after an HAE push arrived stayed empty
+  until the next push, because the dispatcher only routed to
+  subscribers present at push time. The discovery card's "Build a
+  card" flow hit this every time, leaving users staring at an empty
+  card. `createManifest` now replays `$HEALTH_HOME/data/auto-export/raw/*.json`
+  against any new HAE-backed manifest with empty `data[]`, producing
+  aggregated rows just as if the pushes had arrived after the card
+  existed. Idempotent: skipped when `data[]` is non-empty. Also
+  graduates the metric out of `discovered.json` so the discovery
+  card drops the row on its next refresh. The discovery card now
+  listens for `manifest-data-changed` and `klebb-cards-changed` so
+  it re-fetches without a page reload. (Fixes #160)
+
 ### Added
 
 - **Health Auto Export panel in Settings.** The Settings view now

--- a/docs/HEALTH-AUTO-EXPORT.md
+++ b/docs/HEALTH-AUTO-EXPORT.md
@@ -211,6 +211,26 @@ automation should be posting to.
 
 ---
 
+## Backfill on card create
+
+When you create an HAE-backed manifest — whether via klebbius, a
+template, or by dropping a file in `$HEALTH_HOME/data/` — klebb
+replays its raw archive for that manifest's metric and populates
+`data[]` in one go. So "the iPhone pushed yesterday, I built the
+card today" still ends up with yesterday's data visible on the
+card.
+
+The replay is per-metric: it only affects the freshly-created
+manifest, and only if `data[]` is empty. Creating a card over an
+existing manifest that already has data is a no-op.
+
+True historical backfill (multi-year Apple Health export) still
+comes from a manual export in the HAE app: set the date range,
+tap export, the app POSTs one big push, klebb upserts everything
+by date into whichever subscribers exist.
+
+---
+
 ## Discovering new metrics
 
 When a push contains metrics that no manifest subscribes to, klebb

--- a/health-auto-export/replay.js
+++ b/health-auto-export/replay.js
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// health-auto-export/replay.js
+//
+// Backfill a newly-created HAE-backed manifest from the raw-archive
+// directory. The dispatcher only routes to subscribers present at the
+// time of a push, so a card created after a push misses data that's
+// already on disk. This module re-reads every archived payload, runs
+// the catalogue row() + aggregate pipeline for the manifest's metric,
+// and upserts the merged rows into the manifest's data[].
+//
+// Pure-ish: takes (registry, manifestId), reads from disk, writes via
+// registry.writeData. Idempotent at the caller layer: skip when the
+// manifest already has data[].
+
+const fs = require('fs');
+const path = require('path');
+const PATHS = require('../config/paths');
+const catalogue = require('./catalogue');
+const { aggregate, mergeByDate, extractEntries } = require('./ingest');
+
+const RAW_DIR = path.join(PATHS.AUTO_EXPORT_DIR, 'raw');
+
+function listRawFilesAscending() {
+  try {
+    return fs.readdirSync(RAW_DIR)
+      .filter(f => f.endsWith('.json'))
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+function readJsonSafe(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+// Replay archived HAE pushes into a single manifest.
+//
+// Returns { rowsWritten, pushesScanned, skipped }.
+//   skipped === true if the manifest is not HAE-backed, has non-empty
+//              data[], or its metric is not in the catalogue. No writes.
+function replayFromArchive(registry, manifestId) {
+  const entry = registry.get(manifestId);
+  if (!entry) return { rowsWritten: 0, pushesScanned: 0, skipped: true };
+
+  const ing = entry.meta?.ingest;
+  if (!ing || ing.source !== 'hae' || !ing.metric) {
+    return { rowsWritten: 0, pushesScanned: 0, skipped: true };
+  }
+  const cat = catalogue[ing.metric];
+  if (!cat) return { rowsWritten: 0, pushesScanned: 0, skipped: true };
+
+  const existing = Array.isArray(entry.data) ? entry.data : [];
+  if (existing.length > 0) {
+    return { rowsWritten: 0, pushesScanned: 0, skipped: true };
+  }
+
+  const files = listRawFilesAscending();
+  let mapped = [];
+  let pushesScanned = 0;
+
+  for (const file of files) {
+    const payload = readJsonSafe(path.join(RAW_DIR, file));
+    if (!payload) continue;
+    pushesScanned += 1;
+    const entries = extractEntries(payload, { ...cat, _metricName: ing.metric });
+    if (!entries || entries.length === 0) continue;
+    for (const raw of entries) {
+      const row = cat.row(raw);
+      if (row && row.date) mapped.push(row);
+    }
+  }
+
+  if (mapped.length === 0) {
+    return { rowsWritten: 0, pushesScanned, skipped: false };
+  }
+
+  const aggregated = aggregate(mapped, cat.aggregate);
+  const merged = mergeByDate([], aggregated);
+  registry.writeData(manifestId, merged);
+  return { rowsWritten: aggregated.length, pushesScanned, skipped: false };
+}
+
+module.exports = { replayFromArchive };

--- a/manifests/registry.js
+++ b/manifests/registry.js
@@ -395,7 +395,36 @@ function createManifest(manifestObj) {
   // so a user who later re-enables it in Settings won't have the system
   // fight them on their next Add Card.
   const autoHidden = maybeAutoHideWelcome(id);
-  return { id, source: targetPath, welcomeAutoHidden: autoHidden };
+
+  // Backfill HAE-backed manifests from the raw archive. The dispatcher
+  // only routes to subscribers present at push time, so a card created
+  // after a push would otherwise miss data already on disk. Lazy-require
+  // to avoid circular imports; idempotent (skips if data[] is non-empty).
+  let replayed = null;
+  const ing = parsed.meta?.ingest;
+  if (ing && ing.source === 'hae' && ing.metric) {
+    try {
+      const { replayFromArchive } = require('../health-auto-export/replay');
+      const summary = replayFromArchive(module.exports, id);
+      if (!summary.skipped && summary.rowsWritten > 0) {
+        replayed = summary;
+        // Graduate the metric out of discoveries, same as a live push would.
+        try {
+          const discoveries = require('../health-auto-export/discoveries');
+          discoveries.sync({
+            seen: [],
+            subscribed: [ing.metric],
+          });
+        } catch (e) {
+          console.warn('[hae] discovery sync after replay failed:', e.message);
+        }
+      }
+    } catch (e) {
+      console.warn('[hae] replay on createManifest failed:', e.message);
+    }
+  }
+
+  return { id, source: targetPath, welcomeAutoHidden: autoHidden, replayed };
 }
 
 function maybeAutoHideWelcome(createdId) {

--- a/public/js/components/eh-hae-discovery-card.js
+++ b/public/js/components/eh-hae-discovery-card.js
@@ -57,10 +57,26 @@ export class EhHaeDiscoveryCard extends LitElement {
     this._entries = [];
     this._loading = true;
     this._busyMetric = null;
+    this._onManifestChanged = this._onManifestChanged.bind(this);
   }
 
   connectedCallback() {
     super.connectedCallback();
+    this._load();
+    // Re-fetch discoveries when a manifest is created / changed — this
+    // covers the "build a card" flow where the server replays archive
+    // data and graduates the metric out of discovered.json.
+    window.addEventListener('manifest-data-changed', this._onManifestChanged);
+    window.addEventListener('klebb-cards-changed', this._onManifestChanged);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    window.removeEventListener('manifest-data-changed', this._onManifestChanged);
+    window.removeEventListener('klebb-cards-changed', this._onManifestChanged);
+  }
+
+  _onManifestChanged() {
     this._load();
   }
 

--- a/tests/health-auto-export.replay-integration.test.js
+++ b/tests/health-auto-export.replay-integration.test.js
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/health-auto-export.replay-integration.test.js
+// End-to-end: push arrives → later a subscriber is created → subscriber
+// manifest materialises with the archived data already in place.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const { createSandbox, cleanupSandbox, spawnServer, req } = require('./helpers/sandbox');
+
+const TOKEN = 'replay-token-hex-0123456789abcdef';
+
+const PAYLOAD = {
+  data: {
+    metrics: [
+      { name: 'sleep_analysis', data: [
+        { date: '2026-05-06 00:00:00 +1000', totalSleep: 7.2, source: 'Apple Watch' },
+      ]},
+      { name: 'step_count', data: [
+        { date: '2026-05-06 08:00:00 +1000', qty: 4200 },
+      ]},
+    ],
+  },
+};
+
+describe('createManifest → replay from archive', () => {
+  let sandbox, server;
+  before(async () => {
+    sandbox = createSandbox();
+    server = await spawnServer(sandbox, { HEALTH_AUTO_EXPORT_TOKEN: TOKEN });
+  });
+  after(async () => { if (server) await server.kill(); cleanupSandbox(sandbox); });
+
+  test('manifest created after a push is backfilled with archived data', async () => {
+    // Step 1: push with no subscribers → raw archive populated, no
+    // manifest files.
+    const pushRes = await req(server.baseUrl, '/api/health-auto-export', {
+      method: 'POST', body: PAYLOAD,
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    assert.equal(pushRes.status, 200);
+    assert.deepEqual(pushRes.json.ingested, {});
+
+    // Confirm raw file exists, no manifest created.
+    const rawDir = path.join(sandbox, 'data', 'auto-export', 'raw');
+    assert.ok(fs.readdirSync(rawDir).length >= 1);
+    assert.equal(fs.existsSync(path.join(sandbox, 'data', 'sleep-hours.json')), false);
+
+    // Step 2: create a sleep-analysis subscriber via the manifest-create API.
+    const createRes = await req(server.baseUrl, '/api/manifests', {
+      method: 'POST',
+      body: {
+        $schema: 'klebb.datafile.v1',
+        meta: {
+          id: 'sleep-hours',
+          label: 'Sleep',
+          emoji: '😴',
+          ingest: { source: 'hae', metric: 'sleep_analysis' },
+          view: { enabled: true, component: 'generic-card',
+                  display: { template: '{hours:round(1)}', unit: 'hrs' } },
+          writeable: { fromWebapp: false },
+        },
+        data: [],
+      },
+    });
+    assert.ok(createRes.status === 200 || createRes.status === 201,
+      `create failed (${createRes.status}): ${createRes.body}`);
+
+    // Step 3: manifest should already have data from the replay.
+    await new Promise(r => setTimeout(r, 200));
+    const dataRes = await req(server.baseUrl, '/api/manifests/sleep-hours/data');
+    assert.equal(dataRes.status, 200);
+    assert.ok(Array.isArray(dataRes.json.data));
+    assert.equal(dataRes.json.data.length, 1);
+    assert.equal(dataRes.json.data[0].hours, 7.2);
+    assert.equal(dataRes.json.data[0].source, 'Apple Watch');
+  });
+
+  test('creating a subscriber graduates the metric out of discoveries', async () => {
+    // At this point sleep-hours exists; discoveries should not include
+    // sleep_analysis (it was graduated). The original push also had
+    // step_count, which is still unsubscribed — assert it stays present
+    // to confirm we only graduate the newly-subscribed one.
+    const discRes = await req(server.baseUrl, '/api/health-auto-export/discoveries');
+    const undismissed = discRes.json.undismissed.map(e => e.metric);
+    assert.ok(!undismissed.includes('sleep_analysis'),
+      'sleep_analysis should have graduated');
+    assert.ok(undismissed.includes('step_count'),
+      'step_count is still unsubscribed; should remain a discovery');
+  });
+
+  test('re-creating fails cleanly; existing data untouched', async () => {
+    // Attempt to re-create with same id — should fail with duplicate.
+    const r = await req(server.baseUrl, '/api/manifests', {
+      method: 'POST',
+      body: {
+        $schema: 'klebb.datafile.v1',
+        meta: {
+          id: 'sleep-hours',
+          label: 'Sleep again',
+          ingest: { source: 'hae', metric: 'sleep_analysis' },
+          view: { enabled: true, component: 'generic-card',
+                  display: { template: '{hours}' } },
+        },
+        data: [],
+      },
+    });
+    assert.ok(r.status >= 400);
+
+    // Existing data is preserved.
+    const dataRes = await req(server.baseUrl, '/api/manifests/sleep-hours/data');
+    assert.equal(dataRes.json.data.length, 1);
+  });
+});

--- a/tests/health-auto-export.replay.test.js
+++ b/tests/health-auto-export.replay.test.js
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/health-auto-export.replay.test.js
+// Unit tests for the replay-from-archive module.
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+let tmp;
+let replay;
+
+function reloadModule() {
+  delete require.cache[require.resolve('../config/paths')];
+  delete require.cache[require.resolve('../health-auto-export/replay')];
+  delete require.cache[require.resolve('../health-auto-export/ingest')];
+  delete require.cache[require.resolve('../health-auto-export/catalogue')];
+  delete require.cache[require.resolve('../health-auto-export/helpers')];
+  replay = require('../health-auto-export/replay');
+}
+
+// Minimal registry stub with data() + get() + writeData() + list().
+function makeRegistry(manifests) {
+  const state = new Map();
+  for (const m of manifests) state.set(m.id, { ...m, data: m.data ?? [] });
+  return {
+    list() {
+      return [...state.values()].map(e => ({ id: e.id, meta: e.meta }));
+    },
+    get(id) {
+      const e = state.get(id);
+      if (!e) return null;
+      return { meta: e.meta, data: e.data, description: null, schema: null, version: 'klebb.datafile.v1' };
+    },
+    data(id) {
+      const e = state.get(id);
+      return e ? e.data : null;
+    },
+    writeData(id, rows) {
+      const e = state.get(id);
+      if (!e) throw new Error(`unknown: ${id}`);
+      e.data = rows;
+    },
+    _snapshot(id) { return state.get(id)?.data; },
+  };
+}
+
+function writeRawPayload(stampMs, payload) {
+  const rawDir = path.join(tmp, 'data', 'auto-export', 'raw');
+  fs.mkdirSync(rawDir, { recursive: true });
+  const stamp = new Date(stampMs).toISOString().replace(/[:.]/g, '');
+  fs.writeFileSync(path.join(rawDir, `${stamp}.json`), JSON.stringify(payload));
+}
+
+describe('replayFromArchive', () => {
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'eh-replay-'));
+    process.env.HEALTH_HOME = tmp;
+    process.env.HEALTH_HOME_WARNED = '1';
+    reloadModule();
+  });
+
+  afterEach(() => {
+    try { fs.rmSync(tmp, { recursive: true, force: true }); } catch {}
+    delete process.env.HEALTH_HOME;
+  });
+
+  test('no archive: zero rows, no writes', () => {
+    const reg = makeRegistry([
+      { id: 'steps', meta: { id: 'steps', ingest: { source: 'hae', metric: 'step_count' } } },
+    ]);
+    const r = replay.replayFromArchive(reg, 'steps');
+    assert.equal(r.rowsWritten, 0);
+    assert.equal(r.pushesScanned, 0);
+    assert.equal(r.skipped, false);
+    assert.deepEqual(reg._snapshot('steps'), []);
+  });
+
+  test('single archived push: replays into empty subscriber', () => {
+    writeRawPayload(Date.parse('2026-05-06T00:00:00Z'), { data: { metrics: [
+      { name: 'step_count', data: [{ date: '2026-05-06 08:00:00 +1000', qty: 4200 }] },
+    ]}});
+
+    const reg = makeRegistry([
+      { id: 'steps', meta: { id: 'steps', ingest: { source: 'hae', metric: 'step_count' } } },
+    ]);
+    const r = replay.replayFromArchive(reg, 'steps');
+    assert.equal(r.rowsWritten, 1);
+    assert.equal(r.pushesScanned, 1);
+    assert.equal(r.skipped, false);
+    const rows = reg._snapshot('steps');
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].count, 4200);
+  });
+
+  test('multiple pushes merge by date; aggregation applied per metric', () => {
+    writeRawPayload(Date.parse('2026-05-06T00:00:00Z'), { data: { metrics: [
+      { name: 'step_count', data: [{ date: '2026-05-06', qty: 4200 }] },
+    ]}});
+    writeRawPayload(Date.parse('2026-05-07T00:00:00Z'), { data: { metrics: [
+      { name: 'step_count', data: [
+        { date: '2026-05-06', qty: 500 },   // extra steps for same date
+        { date: '2026-05-07', qty: 7700 },
+      ]},
+    ]}});
+
+    const reg = makeRegistry([
+      { id: 'steps', meta: { id: 'steps', ingest: { source: 'hae', metric: 'step_count' } } },
+    ]);
+    replay.replayFromArchive(reg, 'steps');
+    const rows = reg._snapshot('steps');
+    const byDate = Object.fromEntries(rows.map(r => [r.date, r.count]));
+    // step_count aggregate is sum-per-date: 4200 + 500 = 4700 on 2026-05-06
+    assert.equal(byDate['2026-05-06'], 4700);
+    assert.equal(byDate['2026-05-07'], 7700);
+  });
+
+  test('idempotent: skips when data is non-empty', () => {
+    writeRawPayload(Date.parse('2026-05-06T00:00:00Z'), { data: { metrics: [
+      { name: 'step_count', data: [{ date: '2026-05-06', qty: 4200 }] },
+    ]}});
+    const reg = makeRegistry([
+      { id: 'steps',
+        meta: { id: 'steps', ingest: { source: 'hae', metric: 'step_count' } },
+        data: [{ date: '2025-01-01', count: 99999 }] },
+    ]);
+    const r = replay.replayFromArchive(reg, 'steps');
+    assert.equal(r.skipped, true);
+    assert.equal(r.rowsWritten, 0);
+    // Pre-existing data untouched.
+    const rows = reg._snapshot('steps');
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].count, 99999);
+  });
+
+  test('not HAE-backed: skipped with no writes', () => {
+    writeRawPayload(Date.parse('2026-05-06T00:00:00Z'), { data: { metrics: [
+      { name: 'step_count', data: [{ date: '2026-05-06', qty: 4200 }] },
+    ]}});
+    const reg = makeRegistry([
+      { id: 'plain', meta: { id: 'plain' } }, // no ingest
+    ]);
+    const r = replay.replayFromArchive(reg, 'plain');
+    assert.equal(r.skipped, true);
+    assert.equal(r.rowsWritten, 0);
+  });
+
+  test('unknown catalogue metric: skipped', () => {
+    writeRawPayload(Date.parse('2026-05-06T00:00:00Z'), { data: {}});
+    const reg = makeRegistry([
+      { id: 'x', meta: { id: 'x', ingest: { source: 'hae', metric: 'no_such_metric' } } },
+    ]);
+    const r = replay.replayFromArchive(reg, 'x');
+    assert.equal(r.skipped, true);
+  });
+
+  test('workouts pseudo-metric replays from data.workouts[]', () => {
+    writeRawPayload(Date.parse('2026-05-06T00:00:00Z'), { data: { workouts: [
+      { name: 'Running', start: '2026-05-06 07:00:00 +1000' },
+      { name: 'Walking', start: '2026-05-07 18:00:00 +1000' },
+    ]}});
+    const reg = makeRegistry([
+      { id: 'w', meta: { id: 'w', ingest: { source: 'hae', metric: 'workouts' } } },
+    ]);
+    replay.replayFromArchive(reg, 'w');
+    const rows = reg._snapshot('w');
+    assert.equal(rows.length, 2);
+    assert.equal(rows[0].trained, true);
+  });
+
+  test('corrupt raw file is skipped, not fatal', () => {
+    const rawDir = path.join(tmp, 'data', 'auto-export', 'raw');
+    fs.mkdirSync(rawDir, { recursive: true });
+    fs.writeFileSync(path.join(rawDir, 'bad.json'), '{ not json');
+    // Valid file alongside.
+    writeRawPayload(Date.parse('2026-05-06T00:00:00Z'), { data: { metrics: [
+      { name: 'step_count', data: [{ date: '2026-05-06', qty: 4200 }] },
+    ]}});
+
+    const reg = makeRegistry([
+      { id: 'steps', meta: { id: 'steps', ingest: { source: 'hae', metric: 'step_count' } } },
+    ]);
+    const r = replay.replayFromArchive(reg, 'steps');
+    assert.equal(r.rowsWritten, 1);
+    // pushesScanned counts only successfully-parsed files.
+    assert.ok(r.pushesScanned >= 1);
+  });
+});


### PR DESCRIPTION
# What changed

New HAE-backed manifests now replay the raw push archive on creation, so the discovery card → "Build a card" flow produces a populated card immediately instead of an empty one waiting for the next push. Discovery card also re-fetches on manifest change so the stale "Build a card" row disappears automatically.

# Why

Fixes #160. Refs #150.

Surfaced during manual QA on the fresh klebbtest instance: I sent a canned HAE push with sleep + steps + HRV + workouts, saw the discovery card correctly list six new metrics, clicked "Build a card" on Sleep, watched klebbius write a `sleep-analysis.json` manifest — then stared at an empty card. The discovery card still showed Sleep as available. Both were artefacts of the dispatcher only routing to subscribers present at push time; the data was sitting in `auto-export/raw/*.json` the whole time.

This is the first interaction any user has with the HAE ingest path. "Click Build → card appears empty" is a dealbreaker UX-wise.

# How

Server:
- `health-auto-export/replay.js` — new module. `replayFromArchive(registry, manifestId)` reads every `raw/*.json` in chronological order, runs the catalogue's `row()` mapper + aggregator for the manifest's subscribed metric, and writes merged rows via `registry.writeData`. Returns `{ rowsWritten, pushesScanned, skipped }`.
- `manifests/registry.js:createManifest` — after the new manifest lands on disk, if `meta.ingest.source === 'hae'` and `data[]` is empty, lazy-require the replay module and run it. Graduates the metric out of `discoveries.sync({subscribed: [metric]})`. Non-fatal on replay failure (new card still exists, just empty like before).
- Idempotent by design: the replay skips when `data[]` is non-empty, so a hand-authored manifest that ships with pre-seeded data isn't clobbered.

Client:
- `eh-hae-discovery-card.js` listens for `manifest-data-changed` and `klebb-cards-changed` (both already used elsewhere in the app) and re-fetches `/api/health-auto-export/discoveries`. Stale "Build a card" rows vanish after the server-side graduation completes.

# Not fixed in this PR

The related failure mode where klebbius writes display templates referencing fields the catalogue doesn't produce. Our `sleep_analysis` catalogue entry emits `{date, hours, source?}`, but the manifest klebbius wrote during QA used `{asleep}h asleep · {deep}h deep · {rem}h REM`. Even with replay populating `data[]`, the card face will render empty. That's a separate issue — klebbius needs the catalogue's row shapes in its system prompt or via a tool. Flagged for follow-up.

# Testing

- [x] `npm test` passes locally (741/742; the one pre-existing `no-personal-refs` failure is unchanged on this branch and fails identically on main).
- [x] 8 unit tests covering: no archive, single push, multi-push merge with aggregation, idempotency (non-empty `data[]` skipped), non-HAE-backed manifests skipped, unknown catalogue metric skipped, workouts pseudo-metric, corrupt raw file survived.
- [x] 3 integration tests: push-then-create populates new manifest; creating a subscriber graduates the metric out of discoveries while leaving unrelated unsubscribed metrics untouched; re-create with duplicate id fails cleanly and preserves existing data.
- [ ] Manual QA on klebbtest: rebuild from this branch, push fake HAE data, build a card via klebbius, confirm the card shows data immediately and the discovery row disappears.

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [x] Docs updated — new "Backfill on card create" section in `docs/HEALTH-AUTO-EXPORT.md`
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens
- [x] New source files carry SPDX AGPL-3.0-only header

# Breaking changes

None. Pure additive server hook + new client listener; no API or schema changes. An unrelated behaviour change would be detectable only as "a newly-created HAE manifest is non-empty on first render," which is the intended fix.