### PR TITLE
feat(hae): sleep_analysis preserves stage breakdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
   listens for `manifest-data-changed` and `klebb-cards-changed` so
   it re-fetches without a page reload. (Fixes #160)
 
+### Changed
+
+- **`sleep_analysis` catalogue entry preserves stage breakdown.** Each
+  sleep row now carries whichever of `asleep`, `inBed`, `deep`, `rem`,
+  `core`, `awake` hours HAE provided for that night, alongside the
+  existing `hours` + `source`. Fields are omitted when absent rather
+  than zeroed, so display templates can distinguish "no REM data" from
+  "0 REM hours". The shipped `sleep-hours` template now shows deep +
+  REM as a secondary line under the total hours. Backward compatible:
+  any template reading just `{hours}` keeps working. (Fixes #162)
+
 ### Added
 
 - **Health Auto Export panel in Settings.** The Settings view now

--- a/docs/HEALTH-AUTO-EXPORT.md
+++ b/docs/HEALTH-AUTO-EXPORT.md
@@ -50,7 +50,7 @@ whether parsing succeeds. Safe to delete if disk space is tight.
 
 | Metric key (use in `meta.ingest.metric`) | Row shape | Aggregation |
 |---|---|---|
-| `sleep_analysis` | `{ date, hours, source? }` | last per date |
+| `sleep_analysis` | `{ date, hours, asleep?, inBed?, deep?, rem?, core?, awake?, source? }` | last per date |
 | `step_count` | `{ date, count }` | sum per date |
 | `apple_exercise_time` | `{ date, minutes }` | sum per date |
 | `workouts` (pseudo-metric, reads from `data.workouts[]`) | `{ date, trained, type? }` | any-true per date |

--- a/health-auto-export/catalogue.js
+++ b/health-auto-export/catalogue.js
@@ -39,6 +39,15 @@ module.exports = {
       const hours = numeric(entry.totalSleep ?? entry.asleep ?? entry.inBed ?? entry.qty);
       if (!date || hours === null) return null;
       const row = { date, hours };
+      // Stage breakdown: preserve whichever fields HAE provides. Absent
+      // fields are omitted entirely rather than set to 0/null so display
+      // templates can distinguish "no REM data for this night" from
+      // "0 REM hours". Values are hours.
+      const stages = ['asleep', 'inBed', 'deep', 'rem', 'core', 'awake'];
+      for (const key of stages) {
+        const v = numeric(entry[key]);
+        if (v !== null) row[key] = v;
+      }
       if (entry.source) row.source = entry.source;
       return row;
     },

--- a/templates/sleep-hours.klebb.json
+++ b/templates/sleep-hours.klebb.json
@@ -22,6 +22,7 @@
       "display": {
         "template": "{hours:round(1)}",
         "unit": "hrs",
+        "secondary": "{deep:round(1)|}h deep · {rem:round(1)|}h REM",
         "trendArrow": { "field": "hours" }
       }
     },

--- a/tests/health-auto-export.parser.test.js
+++ b/tests/health-auto-export.parser.test.js
@@ -43,13 +43,17 @@ describe('helpers: numeric', () => {
 describe('catalogue: sleep_analysis', () => {
   const cat = catalogue.sleep_analysis;
 
-  test('prefers totalSleep, then asleep, then inBed, then qty', () => {
+  test('prefers totalSleep for hours, preserves other fields passed alongside', () => {
+    // asleep=7.3 is kept as a stage-breakdown field; hours comes from totalSleep.
     assert.deepEqual(cat.row({ date: '2026-05-04', totalSleep: 7.8, asleep: 7.3 }),
-      { date: '2026-05-04', hours: 7.8 });
+      { date: '2026-05-04', hours: 7.8, asleep: 7.3 });
+  });
+
+  test('falls back to asleep, then inBed, then qty when totalSleep absent', () => {
     assert.deepEqual(cat.row({ date: '2026-05-04', asleep: 7.3, inBed: 8.1 }),
-      { date: '2026-05-04', hours: 7.3 });
+      { date: '2026-05-04', hours: 7.3, asleep: 7.3, inBed: 8.1 });
     assert.deepEqual(cat.row({ date: '2026-05-04', inBed: 8.1 }),
-      { date: '2026-05-04', hours: 8.1 });
+      { date: '2026-05-04', hours: 8.1, inBed: 8.1 });
     assert.deepEqual(cat.row({ date: '2026-05-04', qty: 6.5 }),
       { date: '2026-05-04', hours: 6.5 });
   });
@@ -62,6 +66,37 @@ describe('catalogue: sleep_analysis', () => {
   test('drops entries with no date or no numeric hours', () => {
     assert.equal(cat.row({ totalSleep: 7 }), null);
     assert.equal(cat.row({ date: '2026-05-04', totalSleep: 'zzz' }), null);
+  });
+
+  test('preserves full stage breakdown when HAE provides it', () => {
+    assert.deepEqual(cat.row({
+      date: '2026-05-04 00:00:00 +1000',
+      totalSleep: 7.8, asleep: 7.6, inBed: 8.4,
+      deep: 1.2, rem: 1.8, core: 4.6, awake: 0.2,
+      source: 'Apple Watch',
+    }), {
+      date: '2026-05-04',
+      hours: 7.8, asleep: 7.6, inBed: 8.4,
+      deep: 1.2, rem: 1.8, core: 4.6, awake: 0.2,
+      source: 'Apple Watch',
+    });
+  });
+
+  test('stage fields with non-numeric values are omitted, not zeroed', () => {
+    const row = cat.row({
+      date: '2026-05-04', totalSleep: 7, deep: 'unknown', rem: null,
+    });
+    assert.equal(row.hours, 7);
+    assert.equal(row.deep, undefined);
+    assert.equal(row.rem, undefined);
+    assert.ok(!('deep' in row));
+    assert.ok(!('rem' in row));
+  });
+
+  test('partial stage breakdown: only present fields are copied', () => {
+    assert.deepEqual(cat.row({
+      date: '2026-05-04', totalSleep: 7, deep: 1.1, rem: 1.5,
+    }), { date: '2026-05-04', hours: 7, deep: 1.1, rem: 1.5 });
   });
 });
 


### PR DESCRIPTION
# What changed

The `sleep_analysis` catalogue entry now preserves the per-night stage breakdown (asleep, inBed, deep, rem, core, awake) in addition to `hours`. Shipped `sleep-hours` template gains a secondary line showing deep + REM.

# Why

Fixes #162. Refs #150, #160.

HAE already pushes the full stage breakdown per night, but the catalogue was dropping everything except `{hours, source?}` — a deliberate v1 conservatism that didn't survive first contact with real use. Surfaced during QA: the chat agent built a sleep card with `display.template: "{asleep}h asleep · {deep}h deep · {rem}h REM"` because those fields are plainly visible in HAE's payload, then the card rendered empty because none of those fields existed in the ingested rows. Keeping them is essentially free (row() copies a handful of already-numeric fields) and matches the shape a thoughtful user would want regardless of agent assistance.

# How

- `health-auto-export/catalogue.js` — `sleep_analysis.row()` iterates over `['asleep', 'inBed', 'deep', 'rem', 'core', 'awake']`, copies each numeric value, omits absent ones. `date` + `hours` remain mandatory; `source` remains optional. Same backward-compat fallback chain for `hours` (`totalSleep ?? asleep ?? inBed ?? qty`).
- Absent fields are *omitted from the row*, not set to `null` or `0`, so templates can distinguish "no REM data for this night" (key missing) from "0 REM hours" (key present, value 0).
- `templates/sleep-hours.klebb.json` display gains a `secondary: "{deep:round(1)|}h deep · {rem:round(1)|}h REM"` line. The pipe-fallback renders cleanly for nights with stage data; for nights without it the secondary shows "h deep · h REM" which is mildly ugly but honest.
- `docs/HEALTH-AUTO-EXPORT.md` supported-metrics table updated to show the new row shape with all optional fields marked.

# Testing

- [x] `npm test` passes locally (734/735; the one pre-existing `no-personal-refs` failure is unchanged on this branch and fails identically on main).
- [x] Updated 2 existing parser tests to assert the new shape when stage data is passed alongside hours.
- [x] 3 new parser tests: full stage breakdown preserved; non-numeric stage values omitted (not zeroed); partial breakdown where only some stages are present.
- [x] Existing ingest + dispatcher integration tests still green — new fields pass through `last-per-date` aggregation correctly.
- [ ] Manual QA: rebuild klebbtest with this branch, push an HAE payload with stage data, verify the Sleep card's secondary line shows deep + REM hours.

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [x] Docs updated — supported-metrics table in `docs/HEALTH-AUTO-EXPORT.md`
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens

# Breaking changes

Technically a shape change for any caller that strictly expected `{date, hours, source?}` and nothing else. In practice: the row is a superset of before, so any template that read only `{hours}` still works. The dispatcher's `last-per-date` aggregation handles extra fields transparently (via `{...list[last]}`). No migration needed.