### PR TITLE
feat(chat): inject HAE catalogue row shapes into system prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
   listens for `manifest-data-changed` and `klebb-cards-changed` so
   it re-fetches without a page reload. (Fixes #160)
 
+- **Chat agent now writes HAE manifests using catalogue field names.**
+  Previously the agent would reach for field names it remembered from
+  HAE's raw payload schema (`asleep`, `deep`, `rmssd`) when building a
+  subscriber manifest, and klebb's catalogue would emit different
+  fields (`hours`, `ms`), leaving the card face rendering empty. The
+  chat system prompt now carries a runtime-generated summary of every
+  catalogue metric's row shape, reconstructed from `catalogue.js` via
+  a probe-based introspection so it stays correct as the catalogue
+  evolves. Carries an explicit rule: "only reference fields from the
+  catalogue row shape; do not invent fields." (Fixes #164)
+
 ### Changed
 
 - **`sleep_analysis` catalogue entry preserves stage breakdown.** Each

--- a/health-auto-export/describe.js
+++ b/health-auto-export/describe.js
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// health-auto-export/describe.js
+//
+// Introspects catalogue.js at runtime to produce a human-readable
+// summary of supported HAE metrics + the row fields each one emits.
+// Consumed by the chat system prompt so the agent writes display
+// templates referencing fields the catalogue actually produces, not
+// fields it infers from HAE's raw payload schema.
+//
+// Introspection strategy: pass a probe entry that exposes common HAE
+// field names, plus a broad set of numeric + string fallbacks. The
+// catalogue's pure row() maps the probe to the output shape; we then
+// read the output keys. This is more accurate than parsing source
+// code and stays correct as row() evolves.
+
+const catalogue = require('./catalogue');
+
+// A single probe entry that's generous enough to trigger every field
+// any current or plausible-future catalogue row() might copy through.
+// Values are chosen so numeric() returns a finite number.
+function makeProbe() {
+  return {
+    // Date fields (different catalogue entries pick different ones).
+    date:       '2026-01-01 00:00:00 +0000',
+    sleepStart: '2026-01-01 00:00:00 +0000',
+    start:      '2026-01-01 00:00:00 +0000',
+
+    // Numeric generics.
+    qty: 1,
+
+    // Sleep-specific fields.
+    totalSleep: 7.5,
+    asleep:     7.3,
+    inBed:      8.1,
+    deep:       1.2,
+    rem:        1.5,
+    core:       4.3,
+    awake:      0.3,
+
+    // Attribution + labels.
+    source: 'probe',
+    name:   'probe',
+  };
+}
+
+function describeMetric(key, entry) {
+  const probe = makeProbe();
+  let row;
+  try {
+    row = entry.row(probe);
+  } catch {
+    row = null;
+  }
+
+  const from = entry.from || 'metrics';
+  if (!row || typeof row !== 'object') {
+    return `${key} (from data.${from}): row shape indeterminate`;
+  }
+
+  // Partition keys: `date` is always first; everything else alphabetical.
+  const keys = Object.keys(row);
+  const rest = keys.filter(k => k !== 'date').sort();
+  const orderedKeys = ['date', ...rest];
+
+  // Drop-pattern detection: fields our probe always fills and that
+  // every entry copies through aren't particularly informative to the
+  // agent — but since the row shape is literally what ends up on disk,
+  // it's clearer to list them all.
+  const fields = orderedKeys.join(', ');
+  const source = from === 'workouts'
+    ? 'data.workouts[]'
+    : `data.metrics[name="${key}"].data[]`;
+  return `${key} (reads ${source}, ${entry.aggregate}): row = { ${fields} }`;
+}
+
+// Produces the full catalogue summary block suitable for inclusion in
+// a chat system prompt. Returns a single string with a header, a short
+// rule, and one line per catalogue metric.
+function describeCatalogue() {
+  const lines = [];
+  lines.push('## Health Auto Export catalogue');
+  lines.push('');
+  lines.push('When writing a manifest with `meta.ingest.source: "hae"`, the');
+  lines.push('`display.template`, `trends.field`, and any other field');
+  lines.push('references MUST only use fields from the row shape below.');
+  lines.push('Klebb\'s catalogue is the authoritative source of what fields');
+  lines.push('end up in `data[]`; do not invent fields from HAE\'s raw');
+  lines.push('payload. Optional fields may be absent on any given row.');
+  lines.push('');
+
+  const keys = Object.keys(catalogue).sort();
+  for (const key of keys) {
+    lines.push(`- ${describeMetric(key, catalogue[key])}`);
+  }
+  return lines.join('\n');
+}
+
+module.exports = { describeCatalogue, describeMetric };

--- a/server.js
+++ b/server.js
@@ -21,6 +21,7 @@ const { buildDateContextBlock } = require('./chat/date-context');
 const hae = require('./health-auto-export/ingest');
 const haeDiagnostics = require('./health-auto-export/diagnostics');
 const haeDiscoveries = require('./health-auto-export/discoveries');
+const { describeCatalogue: describeHaeCatalogue } = require('./health-auto-export/describe');
 
 // chat endpoint config (env-driven; see config/env.js)
 const CHAT_ENDPOINT_URL = ENV.CHAT_ENDPOINT_URL;
@@ -1295,7 +1296,12 @@ const server = http.createServer(async (req, res) => {
           // answer rather than asking them to compute it.
           const todayBlock = buildDateContextBlock({ tz: ENV.TZ });
 
-          let systemPrompt = HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock;
+          // Inject the HAE catalogue's row shapes so the chat agent writes
+          // display templates referencing fields the dispatcher actually
+          // emits, rather than guessing from HAE's raw payload schema.
+          const haeCatalogueBlock = '\n\n' + describeHaeCatalogue() + '\n';
+
+          let systemPrompt = HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock + haeCatalogueBlock;
           if (voiceMode) {
             systemPrompt = `You are ${process.env.CHAT_AGENT_NAME || 'Chat'}, a health assistant.
 Voice mode is active: the user is speaking to you and will hear your reply aloud.
@@ -1328,7 +1334,7 @@ Return STRICTLY the JSON object. No leading/trailing text. No markdown fences.
 
 Original system prompt follows:
 
-` + HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock;
+` + HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock + haeCatalogueBlock;
           }
 
           // Prepend system prompt

--- a/tests/chat-prompt-hae-catalogue.test.js
+++ b/tests/chat-prompt-hae-catalogue.test.js
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/chat-prompt-hae-catalogue.test.js
+// Verifies the chat proxy injects the HAE catalogue's row shapes into the
+// system prompt so the agent writes display templates matching the data
+// the dispatcher actually emits. Mirrors the card-list injection test's
+// stub-gateway pattern.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('http');
+const { createSandbox, cleanupSandbox, spawnServer, req } = require('./helpers/sandbox');
+
+function startStubGateway() {
+  let lastSystemPrompt = null;
+  const server = http.createServer((request, response) => {
+    let body = '';
+    request.on('data', c => { body += c; });
+    request.on('end', () => {
+      try {
+        const parsed = JSON.parse(body);
+        const sys = parsed.messages?.find(m => m.role === 'system');
+        lastSystemPrompt = sys?.content || null;
+      } catch {}
+      response.writeHead(200, { 'Content-Type': 'application/json' });
+      response.end(JSON.stringify({
+        choices: [{ message: { role: 'assistant', content: 'ack' } }],
+      }));
+    });
+  });
+  return new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => {
+      const port = server.address().port;
+      resolve({
+        port,
+        close: () => new Promise(r => server.close(r)),
+        getLastPrompt: () => lastSystemPrompt,
+      });
+    });
+  });
+}
+
+describe('chat proxy injects HAE catalogue into system prompt', () => {
+  let sandbox, server, gateway;
+
+  before(async () => {
+    gateway = await startStubGateway();
+    sandbox = createSandbox();
+    server = await spawnServer(sandbox, {
+      CHAT_ENDPOINT_URL: `http://127.0.0.1:${gateway.port}/v1/chat/completions`,
+      CHAT_API_KEY: 'stub-token',
+      CHAT_MODEL: 'stub-model',
+    });
+  });
+  after(async () => {
+    if (server) await server.kill();
+    if (gateway) await gateway.close();
+    cleanupSandbox(sandbox);
+  });
+
+  test('system prompt includes the catalogue block header', async () => {
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'hello' }] },
+    });
+    assert.equal(res.status, 200);
+    const prompt = gateway.getLastPrompt();
+    assert.ok(prompt, 'stub gateway did not capture a prompt');
+    assert.match(prompt, /Health Auto Export catalogue/);
+  });
+
+  test('system prompt lists specific catalogue metrics', async () => {
+    await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'hello' }] },
+    });
+    const prompt = gateway.getLastPrompt();
+    assert.match(prompt, /sleep_analysis/);
+    assert.match(prompt, /step_count/);
+    assert.match(prompt, /heart_rate_variability/);
+    assert.match(prompt, /workouts/);
+  });
+
+  test('system prompt carries the "only use catalogue fields" rule', async () => {
+    await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'hello' }] },
+    });
+    const prompt = gateway.getLastPrompt();
+    assert.match(prompt, /only use fields/i);
+    assert.match(prompt, /do not invent fields/i);
+  });
+});

--- a/tests/health-auto-export.describe.test.js
+++ b/tests/health-auto-export.describe.test.js
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/health-auto-export.describe.test.js
+// Pure unit tests for the catalogue describe helper.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { describeCatalogue, describeMetric } = require('../health-auto-export/describe');
+const catalogue = require('../health-auto-export/catalogue');
+
+describe('describeCatalogue', () => {
+  test('produces a non-empty multi-line block', () => {
+    const out = describeCatalogue();
+    assert.equal(typeof out, 'string');
+    assert.ok(out.split('\n').length > 10);
+  });
+
+  test('includes the rule about using catalogue fields only', () => {
+    const out = describeCatalogue();
+    assert.match(out, /catalogue/i);
+    assert.match(out, /only use fields/i);
+    assert.match(out, /do not invent fields/i);
+  });
+
+  test('lists every catalogue metric', () => {
+    const out = describeCatalogue();
+    for (const key of Object.keys(catalogue)) {
+      assert.ok(out.includes(key), `describe missing metric: ${key}`);
+    }
+  });
+
+  test('each metric line names its aggregate and source', () => {
+    const out = describeCatalogue();
+    assert.match(out, /step_count.*sum-per-date/);
+    assert.match(out, /heart_rate_variability.*mean-per-date/);
+    assert.match(out, /workouts.*boolean-any-per-date/);
+    assert.match(out, /data\.workouts\[\]/);
+  });
+});
+
+describe('describeMetric', () => {
+  test('step_count exposes {date, count}', () => {
+    const line = describeMetric('step_count', catalogue.step_count);
+    assert.match(line, /date/);
+    assert.match(line, /count/);
+    assert.match(line, /sum-per-date/);
+  });
+
+  test('blood_oxygen_saturation exposes {date, pct}', () => {
+    const line = describeMetric('blood_oxygen_saturation', catalogue.blood_oxygen_saturation);
+    assert.match(line, /pct/);
+  });
+
+  test('workouts marks its source as data.workouts[]', () => {
+    const line = describeMetric('workouts', catalogue.workouts);
+    assert.match(line, /data\.workouts\[\]/);
+    assert.match(line, /trained/);
+  });
+
+  test('output includes date first in the field list', () => {
+    const line = describeMetric('step_count', catalogue.step_count);
+    // "row = { date, count }" — date before count
+    const match = line.match(/row = \{ ([^}]+) \}/);
+    assert.ok(match, 'should match row = { ... }');
+    const fields = match[1].split(',').map(s => s.trim());
+    assert.equal(fields[0], 'date');
+  });
+});


### PR DESCRIPTION
# What changed

The chat proxy now injects a runtime-generated summary of the HAE catalogue into the chat system prompt, so the agent writes manifests with display templates referencing fields the dispatcher actually produces.

# Why

Fixes #164. Refs #150, #160, #162.

Surfaced during QA: discovery card → Build a card for Sleep → klebbius writes a plausible sleep manifest with `display.template: "{asleep}h asleep · {deep}h deep · {rem}h REM"` — and the catalogue's `sleep_analysis` row was only emitting `{date, hours, source?}`. The card rendered empty. The agent wasn't hallucinating in the usual sense; it was recalling HAE's *raw payload* field names (which are true of HAE) and had no visibility into what klebb's catalogue actually maps those into.

Two follow-up PRs exist:
- #163 enriches `sleep_analysis` specifically to preserve the stage breakdown (`asleep`, `deep`, `rem`, etc.).
- This PR (#164) is the general fix: give the agent the catalogue's row shapes every request, for *every* metric, so the failure doesn't recur on HRV, body fat, SpO₂, etc.

# How

New module `health-auto-export/describe.js`:
- `describeMetric(key, entry)` — passes a generous probe to the catalogue entry's `row()`, reads the output keys, formats one line.
- `describeCatalogue()` — iterates every catalogue entry, produces a multi-line block with a header, an explicit rule, and one line per metric.

Introspection-by-probe is deliberate: it stays correct as `row()` evolves. When #163 lands and `sleep_analysis.row()` starts preserving `{asleep, inBed, deep, rem, core, awake}`, the probe sees those keys in the output and the summary auto-updates. No prompt edit required.

`server.js` appends the block after the existing `cardListBlock` in both normal and voice-mode system prompts.

Example block (current catalogue):
```
## Health Auto Export catalogue

When writing a manifest with `meta.ingest.source: "hae"`, the
`display.template`, `trends.field`, and any other field references
MUST only use fields from the row shape below...

- step_count (reads data.metrics[name="step_count"].data[], sum-per-date): row = { date, count }
- heart_rate_variability (reads data.metrics[name="heart_rate_variability"].data[], mean-per-date): row = { date, ms }
- workouts (reads data.workouts[], boolean-any-per-date): row = { date, trained, type }
...
```

# Testing

- [x] `npm test` passes locally (741/742; the one pre-existing `no-personal-refs` failure is unchanged on this branch and fails identically on main).
- [x] 8 unit tests for the describe helper: non-empty output, rule carried, every catalogue metric named, aggregate + source annotated, specific metric shapes (step_count, blood_oxygen, workouts), date-first ordering.
- [x] 3 integration tests via stub chat gateway (same pattern as `chat-prompt-cards.test.js`): system prompt carries the catalogue header, lists specific metrics, carries the "only use catalogue fields" rule. Runs against both the normal chat path.
- [ ] Manual QA on klebbtest after merging + #161 + #163: hit Build a card for Sleep via discovery, verify klebbius writes a manifest using `{hours}` + whichever stage fields #163 enriches in.

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [x] Docs updated — none needed; the prompt is a server-internal surface, not user-facing
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens
- [x] New source files carry SPDX AGPL-3.0-only header

# Breaking changes

None. Prompt change only; no API, schema, or behaviour changes visible to clients.