### PR TITLE
feat(hae): group discoveries by category + hide unsupported metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Changed
+
+- **HAE discovery card filters to catalogue-supported metrics and groups
+  by category.** Previously the card listed every metric HAE pushed
+  that no manifest subscribed to — on a real iPhone export that was
+  ~20 rows, most of them (`vo2_max`, `heart_rate`, `respiratory_rate`,
+  `flights_climbed`, etc.) not in klebb's catalogue at all, so clicking
+  "Build a card" would produce a manifest the dispatcher silently
+  logged as "unknown metric" on every subsequent push. Now supported
+  metrics group into six categories (Sleep, Recovery, Activity,
+  Vitals, Body, Mindfulness) with a per-category "Dismiss all". A
+  collapsible footer shows the unsupported metrics with a link to
+  open an issue for catalogue additions. Each catalogue entry gains a
+  `category` string; `describeCatalogue()` surfaces it in the chat
+  system prompt; `GET /api/health-auto-export/discoveries` now returns
+  `{ undismissed: { supported: {[category]: [...]}, unsupported: [...] }, dismissed }`. (Fixes #166)
+
 ### Fixed
 
 - **New HAE-backed manifests backfill from the raw archive.** Before

--- a/health-auto-export/catalogue.js
+++ b/health-auto-export/catalogue.js
@@ -9,6 +9,7 @@
 //
 // Shape:
 //   <metricKey>: {
+//     category:   'sleep' | 'recovery' | 'activity' | 'vitals' | 'body' | 'mindfulness'
 //     from?:      'metrics' | 'workouts'          // default 'metrics'
 //     aggregate:  'last-per-date' | 'sum-per-date' | 'mean-per-date'
 //               | 'max-per-date'  | 'boolean-any-per-date'
@@ -33,6 +34,7 @@ module.exports = {
   // --- Sleep / recovery ---------------------------------------------------
 
   sleep_analysis: {
+    category: 'sleep',
     aggregate: 'last-per-date',
     row(entry) {
       const date = toDate(entry.date || entry.sleepStart);
@@ -54,6 +56,7 @@ module.exports = {
   },
 
   heart_rate_variability: {
+    category: 'recovery',
     aggregate: 'mean-per-date',
     row(entry) {
       const date = toDate(entry.date);
@@ -64,6 +67,7 @@ module.exports = {
   },
 
   resting_heart_rate: {
+    category: 'recovery',
     aggregate: 'last-per-date',
     row(entry) {
       const date = toDate(entry.date);
@@ -74,6 +78,7 @@ module.exports = {
   },
 
   walking_heart_rate_average: {
+    category: 'activity',
     aggregate: 'last-per-date',
     row(entry) {
       const date = toDate(entry.date);
@@ -84,6 +89,7 @@ module.exports = {
   },
 
   blood_oxygen_saturation: {
+    category: 'vitals',
     aggregate: 'mean-per-date',
     row(entry) {
       const date = toDate(entry.date);
@@ -99,6 +105,7 @@ module.exports = {
   // --- Activity / movement ------------------------------------------------
 
   step_count: {
+    category: 'activity',
     aggregate: 'sum-per-date',
     row(entry) {
       const date = toDate(entry.date);
@@ -109,6 +116,7 @@ module.exports = {
   },
 
   apple_exercise_time: {
+    category: 'activity',
     aggregate: 'sum-per-date',
     row(entry) {
       const date = toDate(entry.date);
@@ -121,6 +129,7 @@ module.exports = {
   // --- Mindfulness --------------------------------------------------------
 
   mindful_minutes: {
+    category: 'mindfulness',
     aggregate: 'sum-per-date',
     row(entry) {
       const date = toDate(entry.date);
@@ -133,6 +142,7 @@ module.exports = {
   // --- Body composition ---------------------------------------------------
 
   body_mass: {
+    category: 'body',
     aggregate: 'last-per-date',
     row(entry) {
       const date = toDate(entry.date);
@@ -143,6 +153,7 @@ module.exports = {
   },
 
   body_fat_percentage: {
+    category: 'body',
     aggregate: 'last-per-date',
     row(entry) {
       const date = toDate(entry.date);
@@ -158,6 +169,7 @@ module.exports = {
   // --- Blood pressure (two separate entries; compose via a CC if wanted) --
 
   blood_pressure_systolic: {
+    category: 'vitals',
     aggregate: 'last-per-date',
     row(entry) {
       const date = toDate(entry.date);
@@ -168,6 +180,7 @@ module.exports = {
   },
 
   blood_pressure_diastolic: {
+    category: 'vitals',
     aggregate: 'last-per-date',
     row(entry) {
       const date = toDate(entry.date);
@@ -180,6 +193,7 @@ module.exports = {
   // --- Workouts (from data.workouts[], not data.metrics[]) ----------------
 
   workouts: {
+    category: 'activity',
     from: 'workouts',
     aggregate: 'boolean-any-per-date',
     row(entry) {

--- a/health-auto-export/describe.js
+++ b/health-auto-export/describe.js
@@ -63,15 +63,12 @@ function describeMetric(key, entry) {
   const rest = keys.filter(k => k !== 'date').sort();
   const orderedKeys = ['date', ...rest];
 
-  // Drop-pattern detection: fields our probe always fills and that
-  // every entry copies through aren't particularly informative to the
-  // agent — but since the row shape is literally what ends up on disk,
-  // it's clearer to list them all.
   const fields = orderedKeys.join(', ');
   const source = from === 'workouts'
     ? 'data.workouts[]'
     : `data.metrics[name="${key}"].data[]`;
-  return `${key} (reads ${source}, ${entry.aggregate}): row = { ${fields} }`;
+  const catLabel = entry.category ? `[${entry.category}] ` : '';
+  return `${catLabel}${key} (reads ${source}, ${entry.aggregate}): row = { ${fields} }`;
 }
 
 // Produces the full catalogue summary block suitable for inclusion in

--- a/health-auto-export/discoveries.js
+++ b/health-auto-export/discoveries.js
@@ -96,21 +96,50 @@ function unhide(metric) {
 }
 
 // Consumed by GET /api/health-auto-export/discoveries and the UI.
+// Partitions undismissed entries into catalogue-supported (grouped by
+// category) vs unsupported (flat list). Dismissed entries remain flat.
+// Shape:
+//   {
+//     undismissed: {
+//       supported:   { [category]: [{metric, firstSeenAt}, ...] },
+//       unsupported: [{metric, firstSeenAt}, ...]
+//     },
+//     dismissed: [{metric, firstSeenAt, dismissedAt}, ...]
+//   }
 function list() {
+  // Lazy-require to avoid any circular import surprise.
+  const catalogue = require('./catalogue');
   const state = load();
-  const undismissed = [];
+  const supported = {};
+  const unsupported = [];
   const dismissed = [];
+
   for (const [metric, entry] of Object.entries(state)) {
     const row = { metric, firstSeenAt: entry.firstSeenAt };
     if (entry.dismissed) {
       dismissed.push({ ...row, dismissedAt: entry.dismissedAt });
+      continue;
+    }
+    const cat = catalogue[metric];
+    if (cat && cat.category) {
+      (supported[cat.category] ||= []).push(row);
     } else {
-      undismissed.push(row);
+      unsupported.push(row);
     }
   }
-  undismissed.sort((a, b) => a.firstSeenAt.localeCompare(b.firstSeenAt));
+
+  // Stable orderings: by firstSeenAt within each group, metric name in
+  // the unsupported + dismissed lists.
+  for (const group of Object.values(supported)) {
+    group.sort((a, b) => a.firstSeenAt.localeCompare(b.firstSeenAt));
+  }
+  unsupported.sort((a, b) => a.metric.localeCompare(b.metric));
   dismissed.sort((a, b) => a.metric.localeCompare(b.metric));
-  return { undismissed, dismissed };
+
+  return {
+    undismissed: { supported, unsupported },
+    dismissed,
+  };
 }
 
 module.exports = { load, sync, dismiss, unhide, list, FILE };

--- a/public/js/components/eh-hae-discovery-card.js
+++ b/public/js/components/eh-hae-discovery-card.js
@@ -13,14 +13,14 @@
 //   "Dismiss"      — permanently hides this metric (can be un-hidden
 //                    from Settings).
 //
-// The card self-hides when no undismissed discoveries remain. It is
-// not a klebb.datafile.v1 manifest — it exists only as a UI surface,
-// pinned by the date view when mode === 'today'.
+// Supported metrics are grouped by catalogue category (sleep, recovery,
+// activity, vitals, body, mindfulness). Unsupported-but-received metrics
+// (those HAE sends but the catalogue doesn't know about) collapse into
+// a footer so the actionable surface stays focused on what klebb can
+// actually produce cards for.
 
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
 
-// Human-readable labels for the catalogue keys we know about. Unknown
-// keys fall back to the raw metric name.
 const METRIC_LABELS = {
   sleep_analysis: 'Sleep',
   step_count: 'Steps',
@@ -37,6 +37,15 @@ const METRIC_LABELS = {
   blood_pressure_diastolic: 'Diastolic blood pressure',
 };
 
+const CATEGORY_META = {
+  sleep:       { label: 'Sleep',        emoji: '😴', order: 10 },
+  recovery:    { label: 'Recovery',     emoji: '💓', order: 20 },
+  activity:    { label: 'Activity',     emoji: '🏃', order: 30 },
+  vitals:      { label: 'Vitals',       emoji: '🩺', order: 40 },
+  body:        { label: 'Body',         emoji: '⚖️', order: 50 },
+  mindfulness: { label: 'Mindfulness',  emoji: '🧘', order: 60 },
+};
+
 function labelFor(metric) {
   return METRIC_LABELS[metric] || metric;
 }
@@ -47,25 +56,24 @@ function buildPrompt(metric) {
 
 export class EhHaeDiscoveryCard extends LitElement {
   static properties = {
-    _entries: { state: true },
+    _data: { state: true },
     _loading: { state: true },
     _busyMetric: { state: true },
+    _unsupportedOpen: { state: true },
   };
 
   constructor() {
     super();
-    this._entries = [];
+    this._data = null;
     this._loading = true;
     this._busyMetric = null;
+    this._unsupportedOpen = false;
     this._onManifestChanged = this._onManifestChanged.bind(this);
   }
 
   connectedCallback() {
     super.connectedCallback();
     this._load();
-    // Re-fetch discoveries when a manifest is created / changed — this
-    // covers the "build a card" flow where the server replays archive
-    // data and graduates the metric out of discovered.json.
     window.addEventListener('manifest-data-changed', this._onManifestChanged);
     window.addEventListener('klebb-cards-changed', this._onManifestChanged);
   }
@@ -84,11 +92,10 @@ export class EhHaeDiscoveryCard extends LitElement {
     this._loading = true;
     try {
       const r = await fetch('/api/health-auto-export/discoveries');
-      if (!r.ok) { this._entries = []; return; }
-      const body = await r.json();
-      this._entries = Array.isArray(body.undismissed) ? body.undismissed : [];
+      if (!r.ok) { this._data = null; return; }
+      this._data = await r.json();
     } catch {
-      this._entries = [];
+      this._data = null;
     } finally {
       this._loading = false;
     }
@@ -106,22 +113,68 @@ export class EhHaeDiscoveryCard extends LitElement {
       const r = await fetch(
         `/api/health-auto-export/discoveries/${encodeURIComponent(metric)}/dismiss`,
         { method: 'POST' });
-      if (r.ok) {
-        this._entries = this._entries.filter(e => e.metric !== metric);
-      }
+      if (r.ok) this._removeLocally(metric);
     } finally {
       this._busyMetric = null;
     }
   }
 
-  render() {
-    if (this._loading) return html``;
-    if (!this._entries.length) return html``;
+  // Fan-out: dismiss every metric in a category in one click. No new
+  // endpoint needed — we just call the existing dismiss endpoint once
+  // per metric and update local state.
+  async _dismissCategory(category) {
+    const supported = this._data?.undismissed?.supported || {};
+    const metrics = (supported[category] || []).map(e => e.metric);
+    if (metrics.length === 0) return;
+    this._busyMetric = `::${category}`;
+    try {
+      await Promise.all(metrics.map(m =>
+        fetch(`/api/health-auto-export/discoveries/${encodeURIComponent(m)}/dismiss`,
+          { method: 'POST' })));
+      for (const m of metrics) this._removeLocally(m);
+    } finally {
+      this._busyMetric = null;
+    }
+  }
 
-    const n = this._entries.length;
-    const headline = n === 1
+  _removeLocally(metric) {
+    if (!this._data) return;
+    const d = this._data;
+    const supported = { ...(d.undismissed?.supported || {}) };
+    for (const cat of Object.keys(supported)) {
+      supported[cat] = supported[cat].filter(e => e.metric !== metric);
+      if (supported[cat].length === 0) delete supported[cat];
+    }
+    const unsupported = (d.undismissed?.unsupported || []).filter(e => e.metric !== metric);
+    this._data = {
+      ...d,
+      undismissed: { supported, unsupported },
+    };
+  }
+
+  _totalUndismissed() {
+    const supported = this._data?.undismissed?.supported || {};
+    const unsupported = this._data?.undismissed?.unsupported || [];
+    const supportedCount = Object.values(supported)
+      .reduce((acc, arr) => acc + arr.length, 0);
+    return { supportedCount, unsupportedCount: unsupported.length };
+  }
+
+  render() {
+    if (this._loading || !this._data) return html``;
+    const { supportedCount, unsupportedCount } = this._totalUndismissed();
+    if (supportedCount === 0 && unsupportedCount === 0) return html``;
+
+    const supported = this._data.undismissed.supported || {};
+    const unsupported = this._data.undismissed.unsupported || [];
+    const categories = Object.keys(supported)
+      .sort((a, b) => (CATEGORY_META[a]?.order ?? 999) - (CATEGORY_META[b]?.order ?? 999));
+
+    const headline = supportedCount === 1
       ? 'New Apple Health data spotted'
-      : `${n} new Apple Health metrics spotted`;
+      : supportedCount > 1
+        ? `${supportedCount} new Apple Health metrics spotted`
+        : 'Apple Health push received';
 
     return html`
       <div class="card">
@@ -129,13 +182,43 @@ export class EhHaeDiscoveryCard extends LitElement {
           <span class="emoji">✨</span>
           <span class="title">${headline}</span>
         </div>
-        <p class="intro">
-          Recent pushes from Health Auto Export include data nothing on your
-          dashboard subscribes to yet. Build a card for what you want; dismiss
-          what you don't.
-        </p>
+        ${supportedCount > 0 ? html`
+          <p class="intro">
+            Recent pushes from Health Auto Export include data your dashboard
+            isn't tracking yet. Build a card for what you want; dismiss what
+            you don't.
+          </p>
+          ${categories.map(cat => this._renderCategory(cat, supported[cat]))}
+        ` : html`
+          <p class="intro muted">
+            No catalogue-supported metrics in recent pushes.
+          </p>
+        `}
+        ${unsupported.length > 0 ? this._renderUnsupportedFooter(unsupported) : ''}
+      </div>
+    `;
+  }
+
+  _renderCategory(category, entries) {
+    const meta = CATEGORY_META[category] || { label: category, emoji: '•', order: 999 };
+    const busy = this._busyMetric === `::${category}`;
+    return html`
+      <div class="group">
+        <div class="group-header">
+          <span class="group-label">
+            <span class="group-emoji">${meta.emoji}</span>
+            ${meta.label}
+          </span>
+          ${entries.length > 1 ? html`
+            <button
+              class="group-dismiss"
+              ?disabled=${busy}
+              @click=${() => this._dismissCategory(category)}
+            >Dismiss all</button>
+          ` : ''}
+        </div>
         <ul class="rows">
-          ${this._entries.map(e => this._renderRow(e))}
+          ${entries.map(e => this._renderRow(e))}
         </ul>
       </div>
     `;
@@ -165,6 +248,46 @@ export class EhHaeDiscoveryCard extends LitElement {
     `;
   }
 
+  _renderUnsupportedFooter(entries) {
+    const open = this._unsupportedOpen;
+    const n = entries.length;
+    return html`
+      <div class="unsupported">
+        <button
+          class="unsupported-toggle"
+          @click=${() => { this._unsupportedOpen = !this._unsupportedOpen; }}
+          aria-expanded=${open}
+        >
+          ${n} more ${n === 1 ? 'metric' : 'metrics'} received but not supported yet
+          <span class="chev">${open ? '▴' : '▾'}</span>
+        </button>
+        ${open ? html`
+          <p class="unsupported-hint">
+            Klebb doesn't have a catalogue entry for these yet. They're archived
+            in the raw push data but not ingested into any card.
+            <a href="https://github.com/Aristocles/klebb/issues/new" target="_blank" rel="noopener">Request support →</a>
+          </p>
+          <ul class="rows compact">
+            ${entries.map(e => html`
+              <li class="row muted-row">
+                <span class="row-label">
+                  <span class="metric-key">${e.metric}</span>
+                </span>
+                <span class="row-actions">
+                  <button
+                    class="btn"
+                    ?disabled=${this._busyMetric === e.metric}
+                    @click=${() => this._dismiss(e.metric)}
+                  >Dismiss</button>
+                </span>
+              </li>
+            `)}
+          </ul>
+        ` : ''}
+      </div>
+    `;
+  }
+
   static styles = css`
     :host {
       display: block;
@@ -189,11 +312,51 @@ export class EhHaeDiscoveryCard extends LitElement {
     }
     .emoji { font-size: 16px; }
     .intro {
-      margin: 8px 0 10px;
+      margin: 8px 0 12px;
       font-size: 13px;
       line-height: 1.45;
       color: var(--text-primary);
     }
+    .intro.muted { color: var(--text-muted, var(--text-secondary)); font-style: italic; }
+
+    .group { margin-bottom: 12px; }
+    .group:last-child { margin-bottom: 0; }
+    .group-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      margin-bottom: 4px;
+      padding: 0 2px;
+    }
+    .group-label {
+      font-size: 11px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.6px;
+      color: var(--text-muted, var(--text-secondary));
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .group-emoji { font-size: 13px; }
+    .group-dismiss {
+      font: inherit;
+      font-size: 11px;
+      font-weight: 500;
+      background: transparent;
+      border: none;
+      color: var(--text-muted, var(--text-secondary));
+      cursor: pointer;
+      padding: 2px 4px;
+      border-radius: 4px;
+    }
+    .group-dismiss:hover:not(:disabled) {
+      color: var(--text-primary);
+      background: var(--bg-hover, rgba(0, 0, 0, 0.03));
+    }
+    .group-dismiss:disabled { opacity: 0.4; cursor: not-allowed; }
+
     .rows {
       list-style: none;
       padding: 0;
@@ -265,15 +428,51 @@ export class EhHaeDiscoveryCard extends LitElement {
       outline: 2px solid var(--accent, #00d4aa);
       outline-offset: 2px;
     }
+
+    .unsupported {
+      margin-top: 12px;
+      padding-top: 10px;
+      border-top: 1px solid var(--border);
+    }
+    .unsupported-toggle {
+      font: inherit;
+      font-size: 12px;
+      font-weight: 500;
+      padding: 4px 6px;
+      border-radius: 6px;
+      border: none;
+      background: transparent;
+      color: var(--text-muted, var(--text-secondary));
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .unsupported-toggle:hover {
+      color: var(--text-primary);
+      background: var(--bg-hover, rgba(0, 0, 0, 0.03));
+    }
+    .chev { font-size: 10px; }
+    .unsupported-hint {
+      font-size: 12px;
+      color: var(--text-muted, var(--text-secondary));
+      margin: 6px 0 8px;
+    }
+    .unsupported-hint a {
+      color: var(--accent, #00d4aa);
+      text-decoration: underline;
+    }
+    .rows.compact { gap: 4px; }
+    .muted-row { opacity: 0.75; }
+    .muted-row .metric-key { font-size: 12px; }
+
     @media (max-width: 480px) {
       .row {
         flex-direction: column;
         align-items: stretch;
         gap: 8px;
       }
-      .row-actions {
-        justify-content: flex-end;
-      }
+      .row-actions { justify-content: flex-end; }
     }
   `;
 }

--- a/tests/health-auto-export.describe.test.js
+++ b/tests/health-auto-export.describe.test.js
@@ -37,6 +37,16 @@ describe('describeCatalogue', () => {
     assert.match(out, /workouts.*boolean-any-per-date/);
     assert.match(out, /data\.workouts\[\]/);
   });
+
+  test('each metric line prefixes its category in brackets', () => {
+    const out = describeCatalogue();
+    assert.match(out, /\[sleep\] sleep_analysis/);
+    assert.match(out, /\[activity\] step_count/);
+    assert.match(out, /\[recovery\] heart_rate_variability/);
+    assert.match(out, /\[vitals\] blood_oxygen_saturation/);
+    assert.match(out, /\[body\] body_mass/);
+    assert.match(out, /\[mindfulness\] mindful_minutes/);
+  });
 });
 
 describe('describeMetric', () => {

--- a/tests/health-auto-export.discoveries-api.test.js
+++ b/tests/health-auto-export.discoveries-api.test.js
@@ -9,6 +9,19 @@ const fs = require('fs');
 const path = require('path');
 const { createSandbox, cleanupSandbox, spawnServer, req } = require('./helpers/sandbox');
 
+// Flatten the grouped+partitioned undismissed shape into a single array
+// of metric names so tests can remain readable.
+function allUndismissed(body) {
+  const supportedGroups = body?.undismissed?.supported || {};
+  const unsupported = body?.undismissed?.unsupported || [];
+  const out = [];
+  for (const group of Object.values(supportedGroups)) {
+    for (const e of group) out.push(e.metric);
+  }
+  for (const e of unsupported) out.push(e.metric);
+  return out;
+}
+
 const TOKEN = 'disc-token-hex-0123456789abcdef';
 
 const STEPS_SUBSCRIBER = {
@@ -59,10 +72,10 @@ describe('GET /api/health-auto-export/discoveries', () => {
     });
     after(async () => { if (server) await server.kill(); cleanupSandbox(sandbox); });
 
-    test('returns empty arrays', async () => {
+    test('returns empty partitions', async () => {
       const res = await req(server.baseUrl, '/api/health-auto-export/discoveries');
       assert.equal(res.status, 200);
-      assert.deepEqual(res.json.undismissed, []);
+      assert.deepEqual(res.json.undismissed, { supported: {}, unsupported: [] });
       assert.deepEqual(res.json.dismissed, []);
     });
   });
@@ -75,7 +88,7 @@ describe('GET /api/health-auto-export/discoveries', () => {
     });
     after(async () => { if (server) await server.kill(); cleanupSandbox(sandbox); });
 
-    test('lists sleep_analysis + heart_rate_variability as undismissed', async () => {
+    test('lists sleep_analysis + heart_rate_variability as undismissed, grouped by category', async () => {
       await req(server.baseUrl, '/api/health-auto-export', {
         method: 'POST', body: CANNED_PAYLOAD,
         headers: { Authorization: `Bearer ${TOKEN}` },
@@ -83,8 +96,12 @@ describe('GET /api/health-auto-export/discoveries', () => {
 
       const res = await req(server.baseUrl, '/api/health-auto-export/discoveries');
       assert.equal(res.status, 200);
-      const metrics = res.json.undismissed.map(e => e.metric).sort();
-      assert.deepEqual(metrics, ['heart_rate_variability', 'sleep_analysis']);
+      assert.deepEqual(allUndismissed(res.json).sort(),
+        ['heart_rate_variability', 'sleep_analysis']);
+      // sleep_analysis lives under `sleep`, HRV under `recovery`.
+      const supported = res.json.undismissed.supported;
+      assert.deepEqual(supported.sleep.map(e => e.metric), ['sleep_analysis']);
+      assert.deepEqual(supported.recovery.map(e => e.metric), ['heart_rate_variability']);
       assert.deepEqual(res.json.dismissed, []);
 
       // File materialised on disk.
@@ -100,8 +117,7 @@ describe('GET /api/health-auto-export/discoveries', () => {
       assert.equal(d.json.ok, true);
 
       const res = await req(server.baseUrl, '/api/health-auto-export/discoveries');
-      assert.equal(res.json.undismissed.length, 1);
-      assert.equal(res.json.undismissed[0].metric, 'heart_rate_variability');
+      assert.deepEqual(allUndismissed(res.json), ['heart_rate_variability']);
       assert.equal(res.json.dismissed.length, 1);
       assert.equal(res.json.dismissed[0].metric, 'sleep_analysis');
       assert.ok(res.json.dismissed[0].dismissedAt);
@@ -115,8 +131,8 @@ describe('GET /api/health-auto-export/discoveries', () => {
       assert.equal(u.json.ok, true);
 
       const res = await req(server.baseUrl, '/api/health-auto-export/discoveries');
-      const metrics = res.json.undismissed.map(e => e.metric).sort();
-      assert.deepEqual(metrics, ['heart_rate_variability', 'sleep_analysis']);
+      assert.deepEqual(allUndismissed(res.json).sort(),
+        ['heart_rate_variability', 'sleep_analysis']);
       assert.deepEqual(res.json.dismissed, []);
     });
 
@@ -153,8 +169,7 @@ describe('GET /api/health-auto-export/discoveries', () => {
       const res = await req(server.baseUrl, '/api/health-auto-export/discoveries');
       const dismissedMetrics = res.json.dismissed.map(e => e.metric);
       assert.ok(dismissedMetrics.includes('heart_rate_variability'));
-      const undismissedMetrics = res.json.undismissed.map(e => e.metric);
-      assert.ok(!undismissedMetrics.includes('heart_rate_variability'));
+      assert.ok(!allUndismissed(res.json).includes('heart_rate_variability'));
     });
   });
 
@@ -173,7 +188,7 @@ describe('GET /api/health-auto-export/discoveries', () => {
         headers: { Authorization: `Bearer ${TOKEN}` },
       });
       let res = await req(server.baseUrl, '/api/health-auto-export/discoveries');
-      assert.ok(res.json.undismissed.some(e => e.metric === 'sleep_analysis'));
+      assert.ok(allUndismissed(res.json).includes('sleep_analysis'));
 
       // Drop a sleep subscriber on disk.
       fs.writeFileSync(
@@ -190,10 +205,44 @@ describe('GET /api/health-auto-export/discoveries', () => {
       });
 
       res = await req(server.baseUrl, '/api/health-auto-export/discoveries');
-      assert.ok(!res.json.undismissed.some(e => e.metric === 'sleep_analysis'),
+      assert.ok(!allUndismissed(res.json).includes('sleep_analysis'),
         'sleep_analysis should have graduated out of undismissed');
       assert.ok(!res.json.dismissed.some(e => e.metric === 'sleep_analysis'),
         'sleep_analysis should also not linger in dismissed');
+    });
+  });
+
+  describe('catalogue-unsupported metrics land in the unsupported bucket', () => {
+    let sandbox, server;
+    before(async () => {
+      sandbox = createSandbox();
+      server = await spawnServer(sandbox, { HEALTH_AUTO_EXPORT_TOKEN: TOKEN });
+    });
+    after(async () => { if (server) await server.kill(); cleanupSandbox(sandbox); });
+
+    test('vo2_max and respiratory_rate are unsupported; step_count is supported', async () => {
+      const payload = { data: { metrics: [
+        { name: 'step_count',       data: [{ date: '2026-05-09', qty: 4000 }] },
+        { name: 'vo2_max',          data: [{ date: '2026-05-09', qty: 42 }] },
+        { name: 'respiratory_rate', data: [{ date: '2026-05-09', qty: 16 }] },
+      ]}};
+      await req(server.baseUrl, '/api/health-auto-export', {
+        method: 'POST', body: payload,
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      });
+
+      const res = await req(server.baseUrl, '/api/health-auto-export/discoveries');
+      const supported = res.json.undismissed.supported;
+      const unsupported = res.json.undismissed.unsupported;
+
+      assert.ok(supported.activity, 'activity group should exist for step_count');
+      assert.deepEqual(
+        supported.activity.map(e => e.metric),
+        ['step_count']);
+
+      assert.deepEqual(
+        unsupported.map(e => e.metric).sort(),
+        ['respiratory_rate', 'vo2_max']);
     });
   });
 });

--- a/tests/health-auto-export.discoveries.test.js
+++ b/tests/health-auto-export.discoveries.test.js
@@ -99,15 +99,48 @@ describe('discoveries module', () => {
     assert.equal(discoveries.unhide('nope'), false);
   });
 
-  test('list() partitions by dismissed flag and sorts', () => {
-    discoveries.sync({ seen: ['a', 'b', 'c'], subscribed: [], now: 't1' });
-    discoveries.dismiss('b');
-    discoveries.dismiss('c');
+  test('list() groups supported by category, partitions unsupported, dismissed flat', () => {
+    // Mix of catalogue-supported and unsupported metrics.
+    discoveries.sync({
+      seen: ['step_count', 'sleep_analysis', 'heart_rate_variability',
+             'vo2_max', 'respiratory_rate', 'dismissed_supported', 'unknown_metric'],
+      subscribed: [],
+      now: 't1',
+    });
+    discoveries.dismiss('dismissed_supported');
+    discoveries.dismiss('unknown_metric');
+
     const out = discoveries.list();
-    assert.equal(out.undismissed.length, 1);
-    assert.equal(out.undismissed[0].metric, 'a');
-    assert.equal(out.dismissed.length, 2);
-    assert.deepEqual(out.dismissed.map(e => e.metric), ['b', 'c']);
+
+    // Supported grouped by category.
+    assert.ok(out.undismissed.supported);
+    assert.ok(out.undismissed.supported.activity);
+    assert.deepEqual(
+      out.undismissed.supported.activity.map(e => e.metric).sort(),
+      ['step_count']);
+    assert.deepEqual(
+      out.undismissed.supported.sleep.map(e => e.metric),
+      ['sleep_analysis']);
+    assert.deepEqual(
+      out.undismissed.supported.recovery.map(e => e.metric),
+      ['heart_rate_variability']);
+
+    // Unsupported flat.
+    assert.ok(Array.isArray(out.undismissed.unsupported));
+    assert.deepEqual(
+      out.undismissed.unsupported.map(e => e.metric).sort(),
+      ['respiratory_rate', 'vo2_max']);
+
+    // Dismissed stays flat, regardless of supported/unsupported.
+    assert.deepEqual(
+      out.dismissed.map(e => e.metric).sort(),
+      ['dismissed_supported', 'unknown_metric']);
+  });
+
+  test('list() with no entries returns empty partitions', () => {
+    const out = discoveries.list();
+    assert.deepEqual(out.undismissed, { supported: {}, unsupported: [] });
+    assert.deepEqual(out.dismissed, []);
   });
 
   test('sync() lazily creates the file (not present before first write)', () => {

--- a/tests/health-auto-export.replay-integration.test.js
+++ b/tests/health-auto-export.replay-integration.test.js
@@ -84,10 +84,11 @@ describe('createManifest → replay from archive', () => {
     // step_count, which is still unsubscribed — assert it stays present
     // to confirm we only graduate the newly-subscribed one.
     const discRes = await req(server.baseUrl, '/api/health-auto-export/discoveries');
-    const undismissed = discRes.json.undismissed.map(e => e.metric);
-    assert.ok(!undismissed.includes('sleep_analysis'),
+    const supported = discRes.json.undismissed.supported || {};
+    const allSupported = Object.values(supported).flat().map(e => e.metric);
+    assert.ok(!allSupported.includes('sleep_analysis'),
       'sleep_analysis should have graduated');
-    assert.ok(undismissed.includes('step_count'),
+    assert.ok(allSupported.includes('step_count'),
       'step_count is still unsubscribed; should remain a discovery');
   });
 


### PR DESCRIPTION
# What changed

The discovery card now filters to catalogue-supported metrics, groups them by category (Sleep, Recovery, Activity, Vitals, Body, Mindfulness), and collapses unsupported metrics into a footer with a "request support" link.

# Why

Fixes #166. Refs #151, #164.

Live QA on klebbtest with a real iPhone HAE export showed 20 metrics in the discovery card, most of them (`vo2_max`, `heart_rate`, `respiratory_rate`, `flights_climbed`, `atrial_fibrillation_burden`, etc.) not in klebb's catalogue. Clicking "Build a card" on any of those produced a manifest the dispatcher silently logged as "unknown metric" every push — a permanent ghost card the user couldn't tell was broken. The discovery surface should be a trustworthy "here's what you can track right now" signal, not a raw dump of HAE's payload schema.

# How

### Catalogue

Each entry gains a `category` string (`'sleep' | 'recovery' | 'activity' | 'vitals' | 'body' | 'mindfulness'`). No other changes to row shape or aggregation.

### Discoveries module

`list()` now partitions `undismissed` into `{ supported: { [category]: [...] }, unsupported: [...] }`. Unsupported metrics (no catalogue entry) still persist in `discovered.json` so they appear in the footer; dismissed metrics stay flat.

### API

`GET /api/health-auto-export/discoveries` returns the grouped+partitioned shape:
```json
{
  "undismissed": {
    "supported":   { "sleep": [...], "activity": [...], ... },
    "unsupported": [{"metric": "vo2_max", ...}, ...]
  },
  "dismissed": [...]
}
```

### UI

Discovery card renders supported groups under category headings with emojis (😴 Sleep, 💓 Recovery, 🏃 Activity, 🩺 Vitals, ⚖️ Body, 🧘 Mindfulness). Per-group "Dismiss all" button fan-outs to the existing dismiss endpoint. Unsupported metrics collapse into `N more metrics received but not supported yet ▾` that expands to the list plus a GitHub issues link. Individual unsupported metrics are still dismissable.

### Chat prompt

`describeCatalogue()` prefixes each metric line with its category in brackets (`[sleep] sleep_analysis ...`) so the agent sees the grouping context.

# Testing

- [x] `npm test` passes locally (759/760; the one pre-existing `no-personal-refs` failure is unchanged on this branch and fails identically on main).
- [x] New unit tests: `discoveries.list()` partitioning (supported-grouped, unsupported-flat, dismissed-flat); empty-state returns correct empty partitions.
- [x] New integration test: push with mix of supported + unsupported metrics lands each in the correct bucket.
- [x] New describe-helper test: every metric line prefixed with its category label.
- [x] Updated 6 existing assertions to walk the new shape via a small `allUndismissed()` flattening helper.
- [ ] Manual QA on klebbtest: rebuild, push synthetic data with mixed supported + unsupported metrics, confirm grouping renders, Dismiss-all works per category, footer collapse + unsupported dismiss both work.

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [x] Docs — none needed beyond the changelog; discovery card behaviour is self-explanatory in the UI
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens

# Breaking changes

API consumers of `/api/health-auto-export/discoveries` that expected `undismissed` to be a flat array (previously `[{metric, firstSeenAt}, ...]`) will break. The only consumer is klebb's own UI, which this PR updates. No external callers.