### PR TITLE
fix(hae): replay processes pushes individually to match live dispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Fixed
+
+- **HAE replay no longer double-counts overlapping pushes.** Surfaced
+  by live QA with 10+ scheduled HAE exports: each push re-sends
+  running-total samples for the current day, and the replay was
+  flattening entries across all pushes into a single list and
+  aggregating once — producing 5× step counts, wrong means for HRV,
+  and wrong "last wins" for sleep. Replay now processes each push
+  independently (aggregate → mergeByDate against running state),
+  matching the live dispatcher's semantics. A new `force: true` opt
+  on `replayFromArchive` bypasses the "skip if data non-empty" guard
+  for operator re-runs. `scripts/reingest-hae.js` walks every
+  HAE-backed manifest, backs it up, and force-replays to fix
+  historical over-summed data. Chat system prompt also gains explicit
+  guidance for the agent to use `{field:round(N)}` and
+  `view.dateContext: "latest"` on HAE cards so newly-built cards
+  don't render as "No data yet" or "7.28333..." out of the box.
+  (Fixes #168)
+
 ### Changed
 
 - **HAE discovery card filters to catalogue-supported metrics and groups

--- a/health-auto-export/describe.js
+++ b/health-auto-export/describe.js
@@ -85,6 +85,15 @@ function describeCatalogue() {
   lines.push('end up in `data[]`; do not invent fields from HAE\'s raw');
   lines.push('payload. Optional fields may be absent on any given row.');
   lines.push('');
+  lines.push('Display template guidance for HAE-backed cards:');
+  lines.push('- Always use `{field:round(N)}` for numeric values. A bare');
+  lines.push('  `{hours}` renders as "7.283333333..."; `{hours:round(1)}`');
+  lines.push('  renders as "7.3".');
+  lines.push('- Set `view.dateContext: "latest"` unless the user explicitly');
+  lines.push('  wants per-day data. HAE pushes arrive on schedules, so');
+  lines.push('  today\'s date often has no row yet and a per-day card reads');
+  lines.push('  as "No data yet" when data from yesterday is fine to show.');
+  lines.push('');
 
   const keys = Object.keys(catalogue).sort();
   for (const key of keys) {

--- a/health-auto-export/replay.js
+++ b/health-auto-export/replay.js
@@ -41,10 +41,19 @@ function readJsonSafe(file) {
 
 // Replay archived HAE pushes into a single manifest.
 //
+// Pushes are processed one at a time — aggregate within a push, then
+// mergeByDate the running state against that push's result — so
+// overlapping pushes (scheduled HAE exports re-send the current day's
+// samples) don't double-count. This mirrors the live dispatcher's
+// per-push semantics: the end state matches what would have happened
+// if this manifest had existed at the time of each push.
+//
 // Returns { rowsWritten, pushesScanned, skipped }.
 //   skipped === true if the manifest is not HAE-backed, has non-empty
-//              data[], or its metric is not in the catalogue. No writes.
-function replayFromArchive(registry, manifestId) {
+//              data[] (unless opts.force), or its metric is not in the
+//              catalogue. No writes when skipped.
+function replayFromArchive(registry, manifestId, opts = {}) {
+  const { force = false } = opts;
   const entry = registry.get(manifestId);
   if (!entry) return { rowsWritten: 0, pushesScanned: 0, skipped: true };
 
@@ -56,12 +65,12 @@ function replayFromArchive(registry, manifestId) {
   if (!cat) return { rowsWritten: 0, pushesScanned: 0, skipped: true };
 
   const existing = Array.isArray(entry.data) ? entry.data : [];
-  if (existing.length > 0) {
+  if (existing.length > 0 && !force) {
     return { rowsWritten: 0, pushesScanned: 0, skipped: true };
   }
 
   const files = listRawFilesAscending();
-  let mapped = [];
+  let merged = [];
   let pushesScanned = 0;
 
   for (const file of files) {
@@ -70,20 +79,25 @@ function replayFromArchive(registry, manifestId) {
     pushesScanned += 1;
     const entries = extractEntries(payload, { ...cat, _metricName: ing.metric });
     if (!entries || entries.length === 0) continue;
+    const mapped = [];
     for (const raw of entries) {
       const row = cat.row(raw);
       if (row && row.date) mapped.push(row);
     }
+    if (mapped.length === 0) continue;
+    const aggregated = aggregate(mapped, cat.aggregate);
+    merged = mergeByDate(merged, aggregated);
   }
 
-  if (mapped.length === 0) {
+  // Always write when force is true (callers expect the manifest
+  // reflects the replay's result even if it produced zero rows, so
+  // stale data is cleared). Otherwise, skip when nothing was merged.
+  if (merged.length === 0 && !force) {
     return { rowsWritten: 0, pushesScanned, skipped: false };
   }
 
-  const aggregated = aggregate(mapped, cat.aggregate);
-  const merged = mergeByDate([], aggregated);
   registry.writeData(manifestId, merged);
-  return { rowsWritten: aggregated.length, pushesScanned, skipped: false };
+  return { rowsWritten: merged.length, pushesScanned, skipped: false };
 }
 
 module.exports = { replayFromArchive };

--- a/scripts/reingest-hae.js
+++ b/scripts/reingest-hae.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// scripts/reingest-hae.js
+// ---------------------------------------------------------------
+// Walks every manifest in $HEALTH_HOME/data/ with
+// meta.ingest.source === 'hae', backs it up, wipes data[], and
+// force-replays the raw archive against it. Use after fixing a
+// catalogue row shape or dispatcher semantics when you want the
+// on-disk data to reflect the new behaviour instead of the historical
+// (possibly wrong) state.
+//
+// Usage:
+//   node scripts/reingest-hae.js               # live
+//   node scripts/reingest-hae.js --dry-run     # list what would change
+//   node scripts/reingest-hae.js --id=<id>     # single manifest
+//
+// Backs up each touched file to <file>.pre-reingest-<ts>.json before
+// writing. Idempotent: re-running gives the same final state.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const idArg = process.argv.find(a => a.startsWith('--id='));
+const onlyId = idArg ? idArg.slice(5) : null;
+
+// Lazy-require the registry + replay so we pick up live config.
+const registry = require('../manifests/registry');
+const { replayFromArchive } = require('../health-auto-export/replay');
+
+registry.init();
+
+const stamp = new Date().toISOString().replace(/[:.]/g, '');
+const cards = registry.list();
+const targets = cards.filter(c =>
+  c?.meta?.ingest?.source === 'hae' && c?.meta?.ingest?.metric);
+
+if (onlyId) {
+  const m = targets.find(c => c.id === onlyId);
+  if (!m) {
+    console.error(`no HAE-backed manifest with id '${onlyId}'`);
+    process.exit(1);
+  }
+  targets.length = 0;
+  targets.push(m);
+}
+
+if (targets.length === 0) {
+  console.log('no HAE-backed manifests found; nothing to re-ingest');
+  process.exit(0);
+}
+
+console.log(`${DRY_RUN ? 'would re-ingest' : 're-ingesting'} ${targets.length} manifest(s):`);
+
+let ok = 0;
+let failed = 0;
+
+for (const c of targets) {
+  const entry = registry.get(c.id);
+  if (!entry) { failed += 1; continue; }
+  const file = path.join(
+    process.env.HEALTH_DATA_DIR ||
+      path.join(process.env.HEALTH_HOME || '', 'data'),
+    `${c.id}.json`);
+
+  if (DRY_RUN) {
+    console.log(`  - ${c.id} (metric=${c.meta.ingest.metric}, currently ${(entry.data || []).length} rows)`);
+    continue;
+  }
+
+  try {
+    // Back up the file verbatim before any writes.
+    if (fs.existsSync(file)) {
+      fs.copyFileSync(file, `${file}.pre-reingest-${stamp}.json`);
+    }
+
+    const summary = replayFromArchive(registry, c.id, { force: true });
+    console.log(`  - ${c.id}: rowsWritten=${summary.rowsWritten}, pushesScanned=${summary.pushesScanned}`);
+    ok += 1;
+  } catch (e) {
+    console.error(`  - ${c.id}: FAILED — ${e.message}`);
+    failed += 1;
+  }
+}
+
+console.log('');
+console.log(`done. ${ok} succeeded, ${failed} failed.`);
+if (!DRY_RUN && ok > 0) {
+  console.log(`backups stamped ${stamp}. Restart klebb for the in-memory cache to pick up the new data (fs.watch should pick it up automatically within a second).`);
+}

--- a/tests/health-auto-export.describe.test.js
+++ b/tests/health-auto-export.describe.test.js
@@ -38,6 +38,12 @@ describe('describeCatalogue', () => {
     assert.match(out, /data\.workouts\[\]/);
   });
 
+  test('carries display-template guidance for HAE-backed cards', () => {
+    const out = describeCatalogue();
+    assert.match(out, /round\(N\)/);
+    assert.match(out, /dateContext.*latest/i);
+  });
+
   test('each metric line prefixes its category in brackets', () => {
     const out = describeCatalogue();
     assert.match(out, /\[sleep\] sleep_analysis/);

--- a/tests/health-auto-export.replay.test.js
+++ b/tests/health-auto-export.replay.test.js
@@ -95,13 +95,15 @@ describe('replayFromArchive', () => {
     assert.equal(rows[0].count, 4200);
   });
 
-  test('multiple pushes merge by date; aggregation applied per metric', () => {
+  test('multiple pushes merge by date: later push replaces earlier for same date', () => {
+    // Push 1: today's running total is 4200.
     writeRawPayload(Date.parse('2026-05-06T00:00:00Z'), { data: { metrics: [
       { name: 'step_count', data: [{ date: '2026-05-06', qty: 4200 }] },
     ]}});
+    // Push 2: HAE re-sends today as 8000 (later running total) and adds 2026-05-07.
     writeRawPayload(Date.parse('2026-05-07T00:00:00Z'), { data: { metrics: [
       { name: 'step_count', data: [
-        { date: '2026-05-06', qty: 500 },   // extra steps for same date
+        { date: '2026-05-06', qty: 8000 },
         { date: '2026-05-07', qty: 7700 },
       ]},
     ]}});
@@ -112,12 +114,63 @@ describe('replayFromArchive', () => {
     replay.replayFromArchive(reg, 'steps');
     const rows = reg._snapshot('steps');
     const byDate = Object.fromEntries(rows.map(r => [r.date, r.count]));
-    // step_count aggregate is sum-per-date: 4200 + 500 = 4700 on 2026-05-06
-    assert.equal(byDate['2026-05-06'], 4700);
+    // Per-push semantics (matching the live dispatcher): push 2's 2026-05-06
+    // REPLACES push 1's, rather than being summed on top of it. Historical
+    // double-summing was the root cause of #168.
+    assert.equal(byDate['2026-05-06'], 8000);
     assert.equal(byDate['2026-05-07'], 7700);
   });
 
-  test('idempotent: skips when data is non-empty', () => {
+  test('overlapping pushes do not double-count sum-per-date metrics (#168)', () => {
+    // Simulates the real-world HAE scheduled-push pattern: each push
+    // contains a running-total view of today's samples. Push 1 says
+    // today=1000, push 2 says today=2000, push 3 says today=2000.
+    // Correct end state is 2000 (the last push wins, matching live
+    // dispatch). Before #168 the flattened aggregator would sum all
+    // samples across pushes and report 5000.
+    writeRawPayload(Date.parse('2026-05-09T00:00:00Z'), { data: { metrics: [
+      { name: 'step_count', data: [{ date: '2026-05-09', qty: 1000 }] },
+    ]}});
+    writeRawPayload(Date.parse('2026-05-09T06:00:00Z'), { data: { metrics: [
+      { name: 'step_count', data: [{ date: '2026-05-09', qty: 2000 }] },
+    ]}});
+    writeRawPayload(Date.parse('2026-05-09T12:00:00Z'), { data: { metrics: [
+      { name: 'step_count', data: [{ date: '2026-05-09', qty: 2000 }] },
+    ]}});
+
+    const reg = makeRegistry([
+      { id: 'steps', meta: { id: 'steps', ingest: { source: 'hae', metric: 'step_count' } } },
+    ]);
+    replay.replayFromArchive(reg, 'steps');
+    const rows = reg._snapshot('steps');
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].count, 2000);
+  });
+
+  test('overlapping pushes honour last-per-date correctly for sleep_analysis', () => {
+    // Push 1: initial sleep sample for the night.
+    writeRawPayload(Date.parse('2026-05-09T06:00:00Z'), { data: { metrics: [
+      { name: 'sleep_analysis', data: [
+        { date: '2026-05-09', totalSleep: 6.5, source: 'Apple Watch' },
+      ]},
+    ]}});
+    // Push 2: corrected/refined sample for the same night — "last wins".
+    writeRawPayload(Date.parse('2026-05-09T12:00:00Z'), { data: { metrics: [
+      { name: 'sleep_analysis', data: [
+        { date: '2026-05-09', totalSleep: 7.2, source: 'Apple Watch' },
+      ]},
+    ]}});
+
+    const reg = makeRegistry([
+      { id: 'sleep', meta: { id: 'sleep', ingest: { source: 'hae', metric: 'sleep_analysis' } } },
+    ]);
+    replay.replayFromArchive(reg, 'sleep');
+    const rows = reg._snapshot('sleep');
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].hours, 7.2);
+  });
+
+  test('idempotent: skips when data is non-empty (default)', () => {
     writeRawPayload(Date.parse('2026-05-06T00:00:00Z'), { data: { metrics: [
       { name: 'step_count', data: [{ date: '2026-05-06', qty: 4200 }] },
     ]}});
@@ -133,6 +186,24 @@ describe('replayFromArchive', () => {
     const rows = reg._snapshot('steps');
     assert.equal(rows.length, 1);
     assert.equal(rows[0].count, 99999);
+  });
+
+  test('force: true overrides the non-empty guard and rewrites data[]', () => {
+    writeRawPayload(Date.parse('2026-05-06T00:00:00Z'), { data: { metrics: [
+      { name: 'step_count', data: [{ date: '2026-05-06', qty: 4200 }] },
+    ]}});
+    const reg = makeRegistry([
+      { id: 'steps',
+        meta: { id: 'steps', ingest: { source: 'hae', metric: 'step_count' } },
+        data: [{ date: '2025-01-01', count: 99999 }] },
+    ]);
+    const r = replay.replayFromArchive(reg, 'steps', { force: true });
+    assert.equal(r.skipped, false);
+    assert.equal(r.rowsWritten, 1);
+    const rows = reg._snapshot('steps');
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].date, '2026-05-06');
+    assert.equal(rows[0].count, 4200);
   });
 
   test('not HAE-backed: skipped with no writes', () => {


### PR DESCRIPTION
# What changed

`replayFromArchive` now processes each archived push one at a time (aggregate within a push, then `mergeByDate` the running state against it) instead of flattening all entries into a single list and aggregating once at the end. Matches the live dispatcher's semantics. New `scripts/reingest-hae.js` re-applies the fixed logic to already-populated manifests. Chat prompt gains display-template guidance.

# Why

Fixes #168. Refs #150, #160.

Caught during live QA on klebbtest with a real iPhone HAE export. With 10+ scheduled pushes, each re-sending the current day's running-total samples, replay was reporting 41,372 steps for today. Actual plausible value: ~8,700. The flattened aggregation path summed every push's contribution to today as if they were independent samples. Also subtly wrong for `mean-per-date` (mean over union ≠ mean over latest push) and `last-per-date` (last-in-union depends on iteration order, not the user-meaningful "most recent reading").

# How

### replay.js

```js
// Before (broken):
for each push: flatten entries into one list
aggregate(list) once
write

// After (fixed):
merged = []
for each push:
  push_aggregated = aggregate(push.entries)
  merged = mergeByDate(merged, push_aggregated)   // later wins
write merged
```

This is exactly what the live dispatcher does per push. End state matches "what would be on disk if this manifest had existed at the time of each push".

Added a `{ force: true }` option that bypasses the "skip if `data[]` non-empty" guard, needed for operators re-running against already-populated manifests.

### scripts/reingest-hae.js

New CLI: walks every HAE-backed manifest, backs each file up to `<file>.pre-reingest-<ts>.json`, wipes `data[]`, force-replays. Flags: `--dry-run` for inspection, `--id=<id>` to target one manifest. Idempotent.

### describe.js

Chat system prompt gains two sentences of display-template guidance: use `{field:round(N)}` for numeric values, set `view.dateContext: "latest"` on HAE cards. Both failure modes surfaced repeatedly in QA ("7.283333..." headline; "No data yet" on today because HAE hasn't pushed today yet).

# Testing

- [x] `npm test` passes locally (762/763; the one pre-existing `no-personal-refs` failure is unchanged on this branch and fails identically on main).
- [x] Existing "multiple pushes merge by date" test updated — its assertion (4200 + 500 = 4700 for same date) was asserting the pre-fix buggy behaviour. Now asserts per-push replacement.
- [x] New: "overlapping pushes do not double-count sum-per-date metrics (#168)" — three pushes each claiming today=1000/2000/2000, expects 2000 not 5000.
- [x] New: "overlapping pushes honour last-per-date correctly for sleep_analysis" — later push's totalSleep wins.
- [x] New: "force: true overrides the non-empty guard and rewrites data[]" — essential for the reingest script.
- [x] New: describe helper surfaces the round/dateContext guidance.
- [ ] Manual QA on klebbtest: pull latest main, run `node scripts/reingest-hae.js`, reload, confirm today's step count is plausible (~8k not ~41k) and sleep card shows a headline instead of "No data yet".

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [x] Docs — the reingest script self-documents via `--help`-style top-of-file comments; no user-facing doc change needed beyond the changelog entry
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens
- [x] New source files carry SPDX AGPL-3.0-only header

# Breaking changes

None for clients. Replay's output shape is unchanged; the values it produces are now correct. One existing test updated because its assertion was encoding the pre-fix bug.