### PR TITLE
fix(ui): discovery card moves below cards and suppresses empty-state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Discovery card now sits below the main card grid and suppresses
+  itself when there are no catalogue-supported metrics to surface.**
+  Previously it pinned above the welcome card on fresh installs
+  (wrong priority for new users) and rendered an empty accent-
+  bordered card whenever every supported metric already had a
+  subscriber (with only the unsupported-metrics footer as content).
+  Welcome card now renders above; discovery stays inline at the end
+  of Today when there's something actionable in it. (Fixes #170)
+
 - **HAE replay no longer double-counts overlapping pushes.** Surfaced
   by live QA with 10+ scheduled HAE exports: each push re-sends
   running-total samples for the current day, and the replay was

--- a/public/js/components/eh-date-view.js
+++ b/public/js/components/eh-date-view.js
@@ -229,14 +229,14 @@ export class EhDateView extends LitElement {
           <button class="today-btn" @click=${() => this._navigate(this._today)}>Today</button>
         ` : ''}
       </div>
-      ${this._dateMode === 'today'
-        ? html`<eh-hae-discovery-card></eh-hae-discovery-card>`
-        : ''}
       <eh-view-renderer
         view="view"
         .date=${this.date}
         .dateMode=${this._dateMode}
       ></eh-view-renderer>
+      ${this._dateMode === 'today'
+        ? html`<eh-hae-discovery-card></eh-hae-discovery-card>`
+        : ''}
     `;
   }
 }

--- a/public/js/components/eh-hae-discovery-card.js
+++ b/public/js/components/eh-hae-discovery-card.js
@@ -162,8 +162,14 @@ export class EhHaeDiscoveryCard extends LitElement {
 
   render() {
     if (this._loading || !this._data) return html``;
-    const { supportedCount, unsupportedCount } = this._totalUndismissed();
-    if (supportedCount === 0 && unsupportedCount === 0) return html``;
+    const { supportedCount } = this._totalUndismissed();
+    // Suppress the card entirely when there are no catalogue-supported
+    // metrics to surface. The unsupported-metrics footer is informational
+    // only; rendering an accent-bordered card around nothing but that
+    // footer creates visual noise on every Today view. Users who want
+    // to inspect the full received-metric list can reach it via the
+    // Settings panel.
+    if (supportedCount === 0) return html``;
 
     const supported = this._data.undismissed.supported || {};
     const unsupported = this._data.undismissed.unsupported || [];
@@ -172,9 +178,7 @@ export class EhHaeDiscoveryCard extends LitElement {
 
     const headline = supportedCount === 1
       ? 'New Apple Health data spotted'
-      : supportedCount > 1
-        ? `${supportedCount} new Apple Health metrics spotted`
-        : 'Apple Health push received';
+      : `${supportedCount} new Apple Health metrics spotted`;
 
     return html`
       <div class="card">
@@ -182,18 +186,12 @@ export class EhHaeDiscoveryCard extends LitElement {
           <span class="emoji">✨</span>
           <span class="title">${headline}</span>
         </div>
-        ${supportedCount > 0 ? html`
-          <p class="intro">
-            Recent pushes from Health Auto Export include data your dashboard
-            isn't tracking yet. Build a card for what you want; dismiss what
-            you don't.
-          </p>
-          ${categories.map(cat => this._renderCategory(cat, supported[cat]))}
-        ` : html`
-          <p class="intro muted">
-            No catalogue-supported metrics in recent pushes.
-          </p>
-        `}
+        <p class="intro">
+          Recent pushes from Health Auto Export include data your dashboard
+          isn't tracking yet. Build a card for what you want; dismiss what
+          you don't.
+        </p>
+        ${categories.map(cat => this._renderCategory(cat, supported[cat]))}
         ${unsupported.length > 0 ? this._renderUnsupportedFooter(unsupported) : ''}
       </div>
     `;


### PR DESCRIPTION
# What changed

Welcome card now renders above discovery on Today (discovery moved from above-the-view-renderer to below-the-view-renderer). Discovery card suppresses itself entirely when no catalogue-supported metrics are present, rather than rendering an accent-bordered card around a one-line empty notice + the unsupported-footer.

# Why

Fixes #170. Two UX nits from live QA on klebbtest.

# How

- `eh-date-view.js`: swap render order so `<eh-view-renderer>` (which includes the welcome card as a `slot: "top"` card) fires before `<eh-hae-discovery-card>`.
- `eh-hae-discovery-card.js`: render guard tightened to `supportedCount === 0 → return html\`\``. The unsupported-metrics footer is now only shown when there's also supported content; the full received-metric list remains visible via the Settings HAE panel.

# Testing

- [x] `npm test` passes locally (763/764; the one pre-existing `no-personal-refs` failure is unchanged on this branch and fails identically on main).
- [ ] Manual QA: reload klebbtest on a populated dashboard, confirm welcome sits above any other card and that the discovery card is absent when every supported metric has a subscriber. Add a new-to-the-catalogue metric via a test push; confirm discovery reappears with just that row.

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens

# Breaking changes

None. Two small visual tweaks to an existing surface.