### PR TITLE
feat(data): meta.category field with canonical enum + HAE auto-populate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Added
+
+- **`meta.category` field on manifests.** Optional, constrained to a
+  canonical enum (`sleep`, `recovery`, `activity`, `vitals`, `body`,
+  `mindfulness`, `lifestyle`, `supplements`, `medication`). Unknown
+  values are silently dropped at load time so the chat agent can't
+  fragment the clustering signal by inventing values. HAE-backed
+  cards auto-populate the category from their catalogue entry if the
+  author didn't set one. Chat system prompt constrains the agent to
+  the enum when writing new manifests. Foundational work for the
+  upcoming combination-card suggestion surface; no UI change in this
+  release. (Fixes #172)
+
 ### Fixed
 
 - **HAE replay no longer double-counts overlapping pushes.** Surfaced

--- a/MANIFEST-SCHEMA.md
+++ b/MANIFEST-SCHEMA.md
@@ -41,10 +41,12 @@ Klebb dashboard. For the human-friendly tour, see
                                       //   so inserts can use gaps (150, 250…)
   "enabled":  true,                   // optional bool, default true;
                                       //   false hides card from EVERY view
-  "category": "vitals",               // optional free-form grouping label;
-                                      //   pass-through (not used in core
-                                      //   layout today; surfaces as data
-                                      //   for agents and future filters)
+  "category": "vitals",               // optional; must be one of the
+                                      //   canonical enum. Used for
+                                      //   category-based heuristics (e.g.
+                                      //   CC suggestion clustering).
+                                      //   Unknown values are silently
+                                      //   dropped at load time.
   "view":     { ... },                // optional view config
   "trends":   { ... },                // optional trends config
   "calendar": { ... },                // optional calendar config
@@ -53,6 +55,30 @@ Klebb dashboard. For the human-friendly tour, see
   "ingest":   { ... }                 // optional ingest subscription
 }
 ```
+
+### Manifest category (`meta.category`)
+
+Optional. Groups a manifest for category-based heuristics such as the
+upcoming combination-card suggestion card. The value must be one of
+the canonical enum:
+
+| Value | Typical cards |
+|---|---|
+| `sleep` | total hours, stages, sleep quality |
+| `recovery` | HRV, resting HR, readiness |
+| `activity` | steps, exercise minutes, workouts, movement |
+| `vitals` | blood pressure, SpO₂, temperature, blood glucose |
+| `body` | weight, body fat, composition |
+| `mindfulness` | meditation, breath work |
+| `lifestyle` | mood, daily notes, qualitative journals |
+| `supplements` | vitamins, peptides, stacks |
+| `medication` | prescribed drugs, dosing schedules |
+
+Unknown values are silently dropped at load time (the manifest still
+loads; it just won't participate in category-based features). For
+HAE-backed cards created via `createManifest`, the category is
+auto-populated from the HAE catalogue entry when the author doesn't
+set one explicitly.
 
 ### Master `meta.enabled`
 

--- a/config/categories.js
+++ b/config/categories.js
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// config/categories.js
+//
+// Canonical list of manifest category values. An optional `meta.category`
+// field on a manifest groups it for downstream heuristics (e.g. surfacing
+// combination-card suggestions when three cards share a category). The
+// field is optional; absent means "no category", i.e. invisible to
+// category-based heuristics but still fully functional as a card.
+//
+// The enum is intentionally small and non-overlapping. Extensions should
+// be deliberate — adding a new category fragments the clustering signal,
+// so prefer mapping new card concepts onto an existing category where
+// the fit is reasonable.
+//
+// Anything outside this enum is silently dropped at load time
+// (validateManifestShape) so the chat agent can't fragment the set by
+// inventing values like `wellness` or `heart-health`.
+
+const CATEGORIES = Object.freeze([
+  'sleep',
+  'recovery',
+  'activity',
+  'vitals',
+  'body',
+  'mindfulness',
+  'lifestyle',
+  'supplements',
+  'medication',
+]);
+
+const CATEGORY_SET = new Set(CATEGORIES);
+
+function isValidCategory(value) {
+  return typeof value === 'string' && CATEGORY_SET.has(value);
+}
+
+module.exports = { CATEGORIES, isValidCategory };

--- a/manifests/registry.js
+++ b/manifests/registry.js
@@ -17,6 +17,8 @@ const path = require('path');
 const PATHS = require('../config/paths');
 const { mergePatch, isPlainObject } = require('./merge-patch');
 
+const { isValidCategory } = require('../config/categories');
+
 const SUPPORTED_SCHEMAS = ['klebb.datafile.v1'];
 const RESERVED_DIR_PREFIX = '_';
 
@@ -92,6 +94,12 @@ function validateManifestShape(parsed, opts = {}) {
   }
   if (!parsed.meta.label || typeof parsed.meta.label !== 'string') {
     throw new Error('missing meta.label');
+  }
+  // meta.category is optional but constrained to a known enum. Unknown
+  // values are silently dropped so the chat agent can't fragment the
+  // clustering signal by inventing values like 'wellness'.
+  if (parsed.meta.category !== undefined && !isValidCategory(parsed.meta.category)) {
+    delete parsed.meta.category;
   }
   return parsed;
 }
@@ -365,6 +373,19 @@ function createManifest(manifestObj) {
   const id = parsed.meta.id;
   if (_entries.has(id)) {
     throw new Error(`duplicate id: ${id}`);
+  }
+
+  // Auto-populate meta.category for HAE-backed manifests when the author
+  // didn't set one. The catalogue entry knows the category already; no
+  // point asking the chat agent to repeat it. Explicit user-set values
+  // win (after validation by validateManifestShape).
+  const ingForCat = parsed.meta?.ingest;
+  if (!parsed.meta.category && ingForCat?.source === 'hae' && ingForCat.metric) {
+    try {
+      const haeCatalogue = require('../health-auto-export/catalogue');
+      const catEntry = haeCatalogue[ingForCat.metric];
+      if (catEntry?.category) parsed.meta.category = catEntry.category;
+    } catch {}
   }
   const targetPath = path.join(PATHS.DATA_DIR, id + '.json');
   // Defence-in-depth: ID_PATTERN already blocks path separators, but

--- a/server.js
+++ b/server.js
@@ -22,6 +22,7 @@ const hae = require('./health-auto-export/ingest');
 const haeDiagnostics = require('./health-auto-export/diagnostics');
 const haeDiscoveries = require('./health-auto-export/discoveries');
 const { describeCatalogue: describeHaeCatalogue } = require('./health-auto-export/describe');
+const { CATEGORIES: MANIFEST_CATEGORIES } = require('./config/categories');
 
 // chat endpoint config (env-driven; see config/env.js)
 const CHAT_ENDPOINT_URL = ENV.CHAT_ENDPOINT_URL;
@@ -1301,7 +1302,36 @@ const server = http.createServer(async (req, res) => {
           // emits, rather than guessing from HAE's raw payload schema.
           const haeCatalogueBlock = '\n\n' + describeHaeCatalogue() + '\n';
 
-          let systemPrompt = HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock + haeCatalogueBlock;
+          // Constrain meta.category to the canonical enum. Klebb uses the
+          // field for clustering heuristics (e.g. CC suggestions); unknown
+          // values are silently dropped by the registry, so agent-invented
+          // values would simply be lost.
+          const categoryBlock = [
+            '',
+            '## Manifest categories',
+            '',
+            'Every manifest you create SHOULD set `meta.category` to exactly',
+            'one of the following values. Choose the best fit; invented',
+            'values are silently dropped by the registry and the card will',
+            'then be invisible to category-based features like combination-',
+            'card suggestions.',
+            '',
+            MANIFEST_CATEGORIES.map(c => `- ${c}`).join('\n'),
+            '',
+            'Rules of thumb:',
+            '- sleep: total hours, stages, sleep quality',
+            '- recovery: HRV, resting HR, readiness-style metrics',
+            '- activity: steps, exercise minutes, workouts, movement',
+            '- vitals: blood pressure, SpO₂, temperature, blood glucose',
+            '- body: weight, body fat, composition',
+            '- mindfulness: meditation, breath work, reflection',
+            '- lifestyle: mood, daily notes, qualitative journals',
+            '- supplements: vitamins, peptides, stacks',
+            '- medication: prescribed drugs, dosing schedules',
+            '',
+          ].join('\n');
+
+          let systemPrompt = HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock + haeCatalogueBlock + categoryBlock;
           if (voiceMode) {
             systemPrompt = `You are ${process.env.CHAT_AGENT_NAME || 'Chat'}, a health assistant.
 Voice mode is active: the user is speaking to you and will hear your reply aloud.
@@ -1334,7 +1364,7 @@ Return STRICTLY the JSON object. No leading/trailing text. No markdown fences.
 
 Original system prompt follows:
 
-` + HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock + haeCatalogueBlock;
+` + HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock + haeCatalogueBlock + categoryBlock;
           }
 
           // Prepend system prompt

--- a/tests/meta-category.test.js
+++ b/tests/meta-category.test.js
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/meta-category.test.js
+// Unit tests for the meta.category contract: enum validation (unknown
+// values silently dropped), HAE auto-population on create, and chat
+// system-prompt injection.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+const { createSandbox, cleanupSandbox, spawnServer, req } = require('./helpers/sandbox');
+
+const { CATEGORIES, isValidCategory } = require('../config/categories');
+
+describe('isValidCategory', () => {
+  test('accepts every canonical category', () => {
+    for (const c of CATEGORIES) assert.equal(isValidCategory(c), true);
+  });
+  test('rejects unknown values', () => {
+    assert.equal(isValidCategory('wellness'), false);
+    assert.equal(isValidCategory('heart-health'), false);
+    assert.equal(isValidCategory('fitness'), false);
+    assert.equal(isValidCategory(''), false);
+    assert.equal(isValidCategory(null), false);
+    assert.equal(isValidCategory(undefined), false);
+    assert.equal(isValidCategory(42), false);
+  });
+});
+
+describe('validateManifestShape: meta.category enum', () => {
+  let registry;
+  before(() => {
+    delete require.cache[require.resolve('../manifests/registry')];
+    registry = require('../manifests/registry');
+  });
+
+  test('valid category passes through untouched', () => {
+    const parsed = registry.validateManifestShape({
+      $schema: 'klebb.datafile.v1',
+      meta: { id: 'x', label: 'X', category: 'sleep' },
+    });
+    assert.equal(parsed.meta.category, 'sleep');
+  });
+
+  test('unknown category is silently dropped; card still validates', () => {
+    const parsed = registry.validateManifestShape({
+      $schema: 'klebb.datafile.v1',
+      meta: { id: 'x', label: 'X', category: 'wellness' },
+    });
+    assert.equal(parsed.meta.category, undefined);
+  });
+
+  test('absent category stays absent', () => {
+    const parsed = registry.validateManifestShape({
+      $schema: 'klebb.datafile.v1',
+      meta: { id: 'x', label: 'X' },
+    });
+    assert.equal(parsed.meta.category, undefined);
+  });
+});
+
+describe('createManifest: auto-populates category from HAE catalogue', () => {
+  let sandbox, server;
+  const TOKEN = 'meta-cat-token-hex-0123456789abcdef';
+
+  before(async () => {
+    sandbox = createSandbox();
+    server = await spawnServer(sandbox, { HEALTH_AUTO_EXPORT_TOKEN: TOKEN });
+  });
+  after(async () => { if (server) await server.kill(); cleanupSandbox(sandbox); });
+
+  test('HAE-backed card with no explicit category gets it from catalogue', async () => {
+    const r = await req(server.baseUrl, '/api/manifests', {
+      method: 'POST',
+      body: {
+        $schema: 'klebb.datafile.v1',
+        meta: {
+          id: 'my-hrv',
+          label: 'HRV',
+          ingest: { source: 'hae', metric: 'heart_rate_variability' },
+          view: { enabled: true, component: 'generic-card',
+                  display: { template: '{ms:round(0)}' } },
+          writeable: { fromWebapp: false },
+        },
+        data: [],
+      },
+    });
+    assert.ok(r.status === 200 || r.status === 201,
+      `create failed (${r.status}): ${r.body}`);
+
+    const fileContent = JSON.parse(fs.readFileSync(
+      path.join(sandbox, 'data', 'my-hrv.json'), 'utf8'));
+    assert.equal(fileContent.meta.category, 'recovery');
+  });
+
+  test('explicit category wins over catalogue auto-population', async () => {
+    const r = await req(server.baseUrl, '/api/manifests', {
+      method: 'POST',
+      body: {
+        $schema: 'klebb.datafile.v1',
+        meta: {
+          id: 'my-sleep',
+          label: 'Sleep',
+          category: 'vitals',  // unusual override
+          ingest: { source: 'hae', metric: 'sleep_analysis' },
+          view: { enabled: true, component: 'generic-card',
+                  display: { template: '{hours:round(1)}' } },
+          writeable: { fromWebapp: false },
+        },
+        data: [],
+      },
+    });
+    assert.ok(r.status === 200 || r.status === 201);
+
+    const fileContent = JSON.parse(fs.readFileSync(
+      path.join(sandbox, 'data', 'my-sleep.json'), 'utf8'));
+    assert.equal(fileContent.meta.category, 'vitals');
+  });
+
+  test('non-HAE card with no category stays uncategorised', async () => {
+    const r = await req(server.baseUrl, '/api/manifests', {
+      method: 'POST',
+      body: {
+        $schema: 'klebb.datafile.v1',
+        meta: {
+          id: 'my-notes',
+          label: 'Notes',
+          view: { enabled: true, component: 'generic-card' },
+        },
+        data: [],
+      },
+    });
+    assert.ok(r.status === 200 || r.status === 201);
+
+    const fileContent = JSON.parse(fs.readFileSync(
+      path.join(sandbox, 'data', 'my-notes.json'), 'utf8'));
+    assert.equal(fileContent.meta.category, undefined);
+  });
+});
+
+describe('chat system prompt: category constraint injection', () => {
+  // Reuse the stub-gateway pattern from chat-prompt-cards.test.js.
+  let sandbox, server, gateway;
+
+  function startStubGateway() {
+    let lastSystemPrompt = null;
+    const s = http.createServer((request, response) => {
+      let body = '';
+      request.on('data', c => { body += c; });
+      request.on('end', () => {
+        try {
+          const parsed = JSON.parse(body);
+          const sys = parsed.messages?.find(m => m.role === 'system');
+          lastSystemPrompt = sys?.content || null;
+        } catch {}
+        response.writeHead(200, { 'Content-Type': 'application/json' });
+        response.end(JSON.stringify({
+          choices: [{ message: { role: 'assistant', content: 'ack' } }],
+        }));
+      });
+    });
+    return new Promise(resolve => {
+      s.listen(0, '127.0.0.1', () => {
+        resolve({
+          port: s.address().port,
+          close: () => new Promise(r => s.close(r)),
+          getLastPrompt: () => lastSystemPrompt,
+        });
+      });
+    });
+  }
+
+  before(async () => {
+    gateway = await startStubGateway();
+    sandbox = createSandbox();
+    server = await spawnServer(sandbox, {
+      CHAT_ENDPOINT_URL: `http://127.0.0.1:${gateway.port}/v1/chat/completions`,
+      CHAT_API_KEY: 'stub-token',
+      CHAT_MODEL: 'stub-model',
+    });
+  });
+  after(async () => {
+    if (server) await server.kill();
+    if (gateway) await gateway.close();
+    cleanupSandbox(sandbox);
+  });
+
+  test('system prompt includes the category constraint block', async () => {
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'hello' }] },
+    });
+    assert.equal(res.status, 200);
+    const prompt = gateway.getLastPrompt();
+    assert.ok(prompt);
+    assert.match(prompt, /Manifest categories/);
+    assert.match(prompt, /meta\.category/);
+    for (const c of CATEGORIES) {
+      assert.ok(prompt.includes(c),
+        `system prompt missing category: ${c}`);
+    }
+    assert.match(prompt, /silently dropped/);
+  });
+});


### PR DESCRIPTION
# What changed

Introduces an optional `meta.category` field on manifests, constrained to a small canonical enum. Foundational groundwork for the upcoming combination-card suggestion surface. No UI changes.

# Why

Fixes #172.

The CC suggestion heuristic wants a reliable cluster signal: *"user has ≥3 cards in the same category → suggest combining them"*. The HAE catalogue already knows category for its metrics (shipped in PR #167). Manual-entry cards don't carry the field today; the chat agent needs to start setting it so the clustering signal works for both kinds.

# How

### Enum

`config/categories.js` exports the frozen list:
- `sleep` · `recovery` · `activity` · `vitals` · `body` · `mindfulness` · `lifestyle` · `supplements` · `medication`

Intentionally small. Non-overlapping. Adding a new value fragments the clustering signal, so the default stance is to map new concepts onto existing buckets.

### Validation

`validateManifestShape` drops `meta.category` if the value isn't in the enum. Mirrors the existing "optional, best-effort" pattern — card still loads without the field rather than erroring. Critically, this stops the chat agent from fragmenting the set by inventing `wellness`, `heart-health`, etc.

### Auto-population

`createManifest` detects `meta.ingest.source === "hae"` with no explicit category and copies the catalogue entry's category onto the manifest before writing. Explicit values win (post-validation), so a user who wants to override (`sleep_analysis` under `vitals`, say) still can.

### Chat prompt

New "Manifest categories" block appended to the system prompt with the enum values and one-line picker hints:
```
- sleep: total hours, stages, sleep quality
- recovery: HRV, resting HR, readiness-style metrics
- activity: steps, exercise minutes, workouts, movement
...
```

Applied to both normal and voice-mode prompts.

### Docs

`MANIFEST-SCHEMA.md` gains a "Manifest category" section with the enum table and a note on silent-drop semantics.

# Testing

- [x] `npm test` passes locally (772/773; the pre-existing `no-personal-refs` failure is unchanged).
- [x] 9 new unit/integration tests: `isValidCategory` enum boundaries; `validateManifestShape` drops unknown; HAE catalogue auto-population on create; explicit override wins; non-HAE card stays uncategorised; chat system prompt carries the constraint block.

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [x] Docs updated — `MANIFEST-SCHEMA.md` new "Manifest category" section
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens
- [x] New source files carry SPDX AGPL-3.0-only header

# Breaking changes

None. Existing manifests on disk stay valid (field is optional). Any manifest with a pre-existing `meta.category` value that happens to match the enum keeps it; anything outside the enum gets silently dropped on next load (no behaviour change since nothing currently *uses* the field).