### PR TITLE
feat(cc): suggestion surfaces to introduce combination cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Combination-card suggestion surface.** Two new discovery paths for
+  CCs, both routing to the existing "describe it to klebbius" flow.
+  (a) A pinned suggestion card on Today fires whenever 3+ enabled
+  atomic cards share a `meta.category` value, naming the specific
+  cards and offering an "Ask klebbius" action that seeds a tailored
+  prompt. Cards already combined in an existing CC are excluded;
+  dismissal is cluster-scoped (adding a 4th card re-fires as a new
+  suggestion). (b) A distinctively-styled "Combine cards" starter
+  button in the blank-chat prompt row seeds a generic "help me build
+  a combination card" prompt, visible to every user regardless of
+  whether the cluster heuristic fires. New endpoints
+  `GET /api/cc-suggestions` and `POST /api/cc-suggestions/:category/dismiss`.
+  Dismissals persisted at `$HEALTH_HOME/data/_meta/cc-suggestions-dismissed.json`.
+  (Fixes #174)
+
 - **`meta.category` field on manifests.** Optional, constrained to a
   canonical enum (`sleep`, `recovery`, `activity`, `vitals`, `body`,
   `mindfulness`, `lifestyle`, `supplements`, `medication`). Unknown

--- a/meta/cc-suggestions.js
+++ b/meta/cc-suggestions.js
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// meta/cc-suggestions.js
+//
+// Combination-card suggestion heuristic + dismissal state.
+//
+// Surfaces clusters of >=3 enabled atomic cards that share a
+// meta.category value, excluding cards already combined in an
+// existing combination-card manifest and excluding CCs themselves.
+// Dismissal is keyed on `{category}::{sorted cardIds joined by ','}`
+// so adding a fourth card to the cluster re-fires as a new suggestion.
+//
+// Persisted state: $HEALTH_HOME/data/_meta/cc-suggestions-dismissed.json
+// Lazily created on first dismiss.
+
+const fs = require('fs');
+const path = require('path');
+const PATHS = require('../config/paths');
+
+const MIN_CLUSTER_SIZE = 3;
+const FILE = path.join(PATHS.DATA_DIR, '_meta', 'cc-suggestions-dismissed.json');
+
+function clusterKey(category, cardIds) {
+  return `${category}::${[...cardIds].sort().join(',')}`;
+}
+
+function loadDismissed() {
+  try {
+    return JSON.parse(fs.readFileSync(FILE, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function saveDismissed(state) {
+  try {
+    fs.mkdirSync(path.dirname(FILE), { recursive: true });
+    const tmp = `${FILE}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(state, null, 2));
+    fs.renameSync(tmp, FILE);
+  } catch (e) {
+    console.error('[cc-suggestions] failed to write dismissed state:', e.message);
+  }
+}
+
+// Collect the set of card IDs already used as donors in an existing
+// combination-card manifest. These are excluded from suggestion clusters
+// so a user who already combined HRV + Sleep + Resting HR doesn't get
+// re-nagged about the same cluster.
+function combinedSourceIds(registry) {
+  const used = new Set();
+  const all = typeof registry.list === 'function' ? registry.list() : [];
+  for (const c of all) {
+    const comp = c?.meta?.view?.component;
+    if (comp !== 'combination-card') continue;
+    const combines = c?.meta?.view?.combines || c?.meta?.viewConfig?.combines || [];
+    for (const donor of combines) {
+      if (donor?.sourceId) used.add(donor.sourceId);
+    }
+  }
+  return used;
+}
+
+// Build the suggestion list by clustering eligible cards by category.
+// Returns [{ category, cardIds }, ...] — the UI is responsible for
+// turning this into human-readable copy.
+function list(registry) {
+  const all = typeof registry.list === 'function' ? registry.list() : [];
+  const usedInCC = combinedSourceIds(registry);
+  const byCategory = {};
+
+  for (const c of all) {
+    const meta = c?.meta || {};
+    const comp = meta.view?.component;
+    if (comp === 'combination-card') continue;        // don't cluster CCs themselves
+    if (meta.enabled === false) continue;              // respect master disable
+    const cat = meta.category;
+    if (!cat) continue;                                // no category → invisible
+    if (usedInCC.has(c.id)) continue;                  // already combined
+    (byCategory[cat] ||= []).push(c.id);
+  }
+
+  const dismissed = loadDismissed();
+  const suggestions = [];
+  for (const [category, cardIds] of Object.entries(byCategory)) {
+    if (cardIds.length < MIN_CLUSTER_SIZE) continue;
+    const key = clusterKey(category, cardIds);
+    if (dismissed[key]) continue;
+    suggestions.push({
+      category,
+      cardIds: [...cardIds].sort(),
+    });
+  }
+
+  // Stable output: by category name.
+  suggestions.sort((a, b) => a.category.localeCompare(b.category));
+  return { suggestions };
+}
+
+function dismiss(category, cardIds, now = new Date().toISOString()) {
+  if (!category || !Array.isArray(cardIds) || cardIds.length === 0) return false;
+  const key = clusterKey(category, cardIds);
+  const state = loadDismissed();
+  state[key] = {
+    category,
+    cardIds: [...cardIds].sort(),
+    dismissedAt: now,
+  };
+  saveDismissed(state);
+  return true;
+}
+
+module.exports = {
+  list,
+  dismiss,
+  loadDismissed,
+  clusterKey,
+  MIN_CLUSTER_SIZE,
+  FILE,
+};

--- a/public/js/components/eh-cc-suggestion-card.js
+++ b/public/js/components/eh-cc-suggestion-card.js
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// public/js/components/eh-cc-suggestion-card.js
+//
+// Pinned suggestion surface for combination cards. Fires when the user
+// has >=3 enabled atomic cards sharing a meta.category value (e.g.
+// sleep + HRV + resting HR all categorised as 'recovery'). Each
+// suggestion names the specific cards and offers a single "Ask
+// klebbius" action that seeds a tailored chat prompt; the agent then
+// negotiates the CC manifest with the user.
+//
+// Server-side clustering in meta/cc-suggestions.js. This component
+// only renders + drives dismissal; no heuristic lives in the client.
+
+import { LitElement, html, css } from 'https://esm.sh/lit@3';
+
+const CATEGORY_META = {
+  sleep:       { label: 'Sleep',        emoji: '😴' },
+  recovery:    { label: 'Recovery',     emoji: '💓' },
+  activity:    { label: 'Activity',     emoji: '🏃' },
+  vitals:      { label: 'Vitals',       emoji: '🩺' },
+  body:        { label: 'Body',         emoji: '⚖️' },
+  mindfulness: { label: 'Mindfulness',  emoji: '🧘' },
+  lifestyle:   { label: 'Lifestyle',    emoji: '🌿' },
+  supplements: { label: 'Supplements',  emoji: '💊' },
+  medication:  { label: 'Medication',   emoji: '🧪' },
+};
+
+function buildPrompt(category, cards) {
+  const label = CATEGORY_META[category]?.label || category;
+  const names = cards.map(c => `"${c.label || c.id}"`).join(', ');
+  return `I'd like to combine my ${label.toLowerCase()} cards into a single combination card. I have ${cards.length} relevant cards: ${names}. Which combination-card layout would work best (rings, stack, etc.), which card should be the primary, and what embellishments could we add? Please propose a plan before writing the manifest.`;
+}
+
+export class EhCcSuggestionCard extends LitElement {
+  static properties = {
+    _suggestions: { state: true },
+    _loading: { state: true },
+    _busyKey: { state: true },
+    _cardLabels: { state: true },   // { [id]: {label, emoji} }
+  };
+
+  constructor() {
+    super();
+    this._suggestions = [];
+    this._loading = true;
+    this._busyKey = null;
+    this._cardLabels = {};
+    this._onManifestChanged = this._onManifestChanged.bind(this);
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._loadAll();
+    window.addEventListener('manifest-data-changed', this._onManifestChanged);
+    window.addEventListener('klebb-cards-changed', this._onManifestChanged);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    window.removeEventListener('manifest-data-changed', this._onManifestChanged);
+    window.removeEventListener('klebb-cards-changed', this._onManifestChanged);
+  }
+
+  _onManifestChanged() {
+    this._loadAll();
+  }
+
+  async _loadAll() {
+    this._loading = true;
+    try {
+      const [suggRes, cardsRes] = await Promise.all([
+        fetch('/api/cc-suggestions'),
+        fetch('/api/settings/cards'),
+      ]);
+      if (!suggRes.ok) { this._suggestions = []; return; }
+      const suggBody = await suggRes.json();
+      this._suggestions = Array.isArray(suggBody.suggestions) ? suggBody.suggestions : [];
+
+      const labels = {};
+      if (cardsRes.ok) {
+        const cardsBody = await cardsRes.json();
+        for (const c of (cardsBody.cards || [])) {
+          labels[c.id] = { label: c.label || c.id, emoji: c.emoji || '' };
+        }
+      }
+      this._cardLabels = labels;
+    } catch {
+      this._suggestions = [];
+    } finally {
+      this._loading = false;
+    }
+  }
+
+  _cardsFor(cardIds) {
+    return cardIds.map(id => ({
+      id,
+      label: this._cardLabels[id]?.label,
+      emoji: this._cardLabels[id]?.emoji || '',
+    }));
+  }
+
+  _keyFor(s) {
+    return `${s.category}::${[...s.cardIds].sort().join(',')}`;
+  }
+
+  async _ask(suggestion) {
+    const cards = this._cardsFor(suggestion.cardIds);
+    window.dispatchEvent(new CustomEvent('klebb-paste-into-chat', {
+      detail: { text: buildPrompt(suggestion.category, cards) },
+    }));
+  }
+
+  async _dismiss(suggestion) {
+    const key = this._keyFor(suggestion);
+    this._busyKey = key;
+    try {
+      const r = await fetch(
+        `/api/cc-suggestions/${encodeURIComponent(suggestion.category)}/dismiss`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ cardIds: suggestion.cardIds }),
+        });
+      if (r.ok) {
+        this._suggestions = this._suggestions.filter(s => this._keyFor(s) !== key);
+      }
+    } finally {
+      this._busyKey = null;
+    }
+  }
+
+  render() {
+    if (this._loading || this._suggestions.length === 0) return html``;
+
+    return html`
+      <div class="wrap">
+        ${this._suggestions.map(s => this._renderSuggestion(s))}
+      </div>
+    `;
+  }
+
+  _renderSuggestion(suggestion) {
+    const meta = CATEGORY_META[suggestion.category] || {
+      label: suggestion.category,
+      emoji: '✨',
+    };
+    const cards = this._cardsFor(suggestion.cardIds);
+    const key = this._keyFor(suggestion);
+    const busy = this._busyKey === key;
+
+    return html`
+      <div class="card">
+        <div class="header">
+          <span class="emoji">${meta.emoji}</span>
+          <span class="title">Combine into a ${meta.label} card?</span>
+        </div>
+        <p class="intro">
+          You have ${cards.length} ${meta.label.toLowerCase()} cards that could
+          work well together as a single combination card.
+        </p>
+        <ul class="cards">
+          ${cards.map(c => html`
+            <li class="card-chip">
+              ${c.emoji ? html`<span class="chip-emoji">${c.emoji}</span>` : ''}
+              <span class="chip-label">${c.label || c.id}</span>
+            </li>
+          `)}
+        </ul>
+        <div class="actions">
+          <button
+            class="btn primary"
+            @click=${() => this._ask(suggestion)}
+            ?disabled=${busy}
+          >Ask klebbius</button>
+          <button
+            class="btn"
+            @click=${() => this._dismiss(suggestion)}
+            ?disabled=${busy}
+          >Dismiss</button>
+        </div>
+      </div>
+    `;
+  }
+
+  static styles = css`
+    :host {
+      display: block;
+      margin-bottom: 16px;
+    }
+    .wrap {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    .card {
+      background: var(--bg-card);
+      border: 1px solid var(--accent-amber, #ffaa33);
+      border-radius: 12px;
+      padding: 14px 16px 12px;
+      box-shadow: 0 2px 10px rgba(255, 170, 51, 0.08);
+    }
+    .header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 13px;
+      font-weight: 700;
+      letter-spacing: 0.4px;
+      text-transform: uppercase;
+      color: var(--accent-amber, #ffaa33);
+    }
+    .emoji { font-size: 16px; }
+    .intro {
+      margin: 8px 0 10px;
+      font-size: 13px;
+      line-height: 1.45;
+      color: var(--text-primary);
+    }
+    .cards {
+      list-style: none;
+      padding: 0;
+      margin: 0 0 12px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+    .card-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 10px;
+      border-radius: 14px;
+      background: var(--bg-input, rgba(0, 0, 0, 0.04));
+      border: 1px solid var(--border);
+      font-size: 12px;
+      color: var(--text-primary);
+    }
+    .chip-emoji { font-size: 12px; }
+    .chip-label { font-weight: 500; }
+
+    .actions {
+      display: inline-flex;
+      gap: 8px;
+    }
+    .btn {
+      font: inherit;
+      font-size: 12px;
+      font-weight: 600;
+      padding: 6px 12px;
+      border-radius: 6px;
+      border: 1px solid var(--border);
+      background: var(--bg-card);
+      color: var(--text-primary);
+      cursor: pointer;
+      transition: border-color 0.12s, background 0.12s, color 0.12s;
+    }
+    .btn:hover:not(:disabled) {
+      border-color: var(--accent-amber, #ffaa33);
+      background: var(--bg-hover, rgba(255, 255, 255, 0.04));
+    }
+    .btn.primary {
+      border-color: var(--accent-amber, #ffaa33);
+      background: var(--accent-amber, #ffaa33);
+      color: var(--bg-card);
+    }
+    .btn.primary:hover:not(:disabled) { filter: brightness(1.08); }
+    .btn:disabled { opacity: 0.4; cursor: not-allowed; }
+    .btn:focus-visible {
+      outline: 2px solid var(--accent-amber, #ffaa33);
+      outline-offset: 2px;
+    }
+  `;
+}
+
+customElements.define('eh-cc-suggestion-card', EhCcSuggestionCard);

--- a/public/js/components/eh-date-view.js
+++ b/public/js/components/eh-date-view.js
@@ -8,6 +8,7 @@
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
 import './eh-view-renderer.js';
 import './eh-hae-discovery-card.js';
+import './eh-cc-suggestion-card.js';
 import { isEditableTarget } from '../lib/event-target.js';
 
 function todayStr() {
@@ -234,9 +235,10 @@ export class EhDateView extends LitElement {
         .date=${this.date}
         .dateMode=${this._dateMode}
       ></eh-view-renderer>
-      ${this._dateMode === 'today'
-        ? html`<eh-hae-discovery-card></eh-hae-discovery-card>`
-        : ''}
+      ${this._dateMode === 'today' ? html`
+        <eh-cc-suggestion-card></eh-cc-suggestion-card>
+        <eh-hae-discovery-card></eh-hae-discovery-card>
+      ` : ''}
     `;
   }
 }

--- a/public/js/components/health-chat.js
+++ b/public/js/components/health-chat.js
@@ -498,6 +498,17 @@ class HealthChat extends LitElement {
       color: var(--text-secondary);
     }
     .suggestion:hover { border-color: var(--accent); color: var(--accent); }
+    .suggestion.combine {
+      background: var(--accent-amber-bg, rgba(255, 170, 51, 0.12));
+      border-color: var(--accent-amber, #ffaa33);
+      color: var(--accent-amber, #ffaa33);
+      font-weight: 600;
+    }
+    .suggestion.combine:hover {
+      background: var(--accent-amber, #ffaa33);
+      color: var(--bg-card);
+      border-color: var(--accent-amber, #ffaa33);
+    }
     .embellish { margin-top: 10px; }
     .embellish-intro {
       font-size: 12px;
@@ -1159,6 +1170,10 @@ class HealthChat extends LitElement {
             <span class="suggestion" @click=${() => this._useSuggestion("Add a card for tracking water intake")}>Add water card</span>
             <span class="suggestion" @click=${() => this._useSuggestion("Add a card for tracking my daily steps")}>Add steps card</span>
             <span class="suggestion" @click=${() => this._useSuggestion("Change the mood card to allow multiple entries per day")}>Tweak mood card</span>
+            <span
+              class="suggestion combine"
+              @click=${() => this._useSuggestion("I'd like to combine some of my cards into a single view. Which cards do I have that could work well together in a combination card, and what embellishments (rings, sparklines, progress bars) could we add?")}
+            >✨ Combine cards</span>
           </div>
         </div>
       `;

--- a/server.js
+++ b/server.js
@@ -23,6 +23,7 @@ const haeDiagnostics = require('./health-auto-export/diagnostics');
 const haeDiscoveries = require('./health-auto-export/discoveries');
 const { describeCatalogue: describeHaeCatalogue } = require('./health-auto-export/describe');
 const { CATEGORIES: MANIFEST_CATEGORIES } = require('./config/categories');
+const ccSuggestions = require('./meta/cc-suggestions');
 
 // chat endpoint config (env-driven; see config/env.js)
 const CHAT_ENDPOINT_URL = ENV.CHAT_ENDPOINT_URL;
@@ -999,6 +1000,39 @@ const server = http.createServer(async (req, res) => {
       else return sendJSON(res, { error: 'unknown action' }, 404);
       if (!ok) return sendJSON(res, { error: 'unknown metric' }, 404);
       return sendJSON(res, { ok: true });
+    }
+
+    // --- Combination-card suggestions ---------------------------------
+    // GET /api/cc-suggestions — returns { suggestions: [{category, cardIds}] }.
+    // Clusters 3+ enabled atomic cards sharing a meta.category value,
+    // excludes cards already used as donors in existing CCs, honours
+    // dismissals.
+    if (parts[0] === 'cc-suggestions' && parts.length === 1 && req.method === 'GET') {
+      return sendJSON(res, ccSuggestions.list(registry));
+    }
+
+    // POST /api/cc-suggestions/:category/dismiss
+    // Body: { cardIds: [...] } — the cluster's card IDs at the moment of
+    // dismissal. Stored as part of the dismissal key so adding a new
+    // card to the cluster later re-fires as a fresh suggestion.
+    if (parts[0] === 'cc-suggestions' && parts[2] === 'dismiss'
+        && parts.length === 3 && req.method === 'POST') {
+      const category = decodeURIComponent(parts[1]);
+      let body = '';
+      req.on('data', c => body += c);
+      req.on('end', () => {
+        let parsed;
+        try { parsed = JSON.parse(body || '{}'); }
+        catch { return sendJSON(res, { error: 'invalid json' }, 400); }
+        const cardIds = Array.isArray(parsed.cardIds) ? parsed.cardIds : [];
+        if (cardIds.length === 0) {
+          return sendJSON(res, { error: 'cardIds required' }, 400);
+        }
+        const ok = ccSuggestions.dismiss(category, cardIds);
+        if (!ok) return sendJSON(res, { error: 'dismiss failed' }, 400);
+        return sendJSON(res, { ok: true });
+      });
+      return;
     }
 
     // Auto-export endpoints: sleep, workouts, vitals, activity

--- a/tests/cc-suggestions-api.test.js
+++ b/tests/cc-suggestions-api.test.js
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/cc-suggestions-api.test.js
+// End-to-end: CC-suggestion GET + dismiss endpoints backed by the live
+// registry on a sandbox.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const { createSandbox, cleanupSandbox, spawnServer, req } = require('./helpers/sandbox');
+
+function seedCard(id, category, extra = {}) {
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id,
+      label: id,
+      category,
+      view: { enabled: true, component: 'generic-card',
+              display: { template: 'x' } },
+      ...extra,
+    },
+    data: [],
+  };
+}
+
+describe('GET /api/cc-suggestions', () => {
+  describe('fewer than 3 same-category cards → empty', () => {
+    let sandbox, server;
+    before(async () => {
+      sandbox = createSandbox({ seed: {
+        'a.json': seedCard('a', 'recovery'),
+        'b.json': seedCard('b', 'recovery'),
+      }});
+      server = await spawnServer(sandbox);
+    });
+    after(async () => { if (server) await server.kill(); cleanupSandbox(sandbox); });
+
+    test('returns empty suggestions', async () => {
+      const res = await req(server.baseUrl, '/api/cc-suggestions');
+      assert.equal(res.status, 200);
+      assert.deepEqual(res.json.suggestions, []);
+    });
+  });
+
+  describe('3 same-category cards → single suggestion', () => {
+    let sandbox, server;
+    before(async () => {
+      sandbox = createSandbox({ seed: {
+        'hrv.json':   seedCard('hrv', 'recovery'),
+        'rhr.json':   seedCard('rhr', 'recovery'),
+        'sleep.json': seedCard('sleep', 'recovery'),
+      }});
+      server = await spawnServer(sandbox);
+    });
+    after(async () => { if (server) await server.kill(); cleanupSandbox(sandbox); });
+
+    test('returns one recovery suggestion with three card IDs', async () => {
+      const res = await req(server.baseUrl, '/api/cc-suggestions');
+      assert.equal(res.status, 200);
+      assert.equal(res.json.suggestions.length, 1);
+      const s = res.json.suggestions[0];
+      assert.equal(s.category, 'recovery');
+      assert.deepEqual(s.cardIds.sort(), ['hrv', 'rhr', 'sleep']);
+    });
+  });
+
+  describe('dismiss + re-check', () => {
+    let sandbox, server;
+    before(async () => {
+      sandbox = createSandbox({ seed: {
+        'hrv.json':   seedCard('hrv', 'recovery'),
+        'rhr.json':   seedCard('rhr', 'recovery'),
+        'sleep.json': seedCard('sleep', 'recovery'),
+      }});
+      server = await spawnServer(sandbox);
+    });
+    after(async () => { if (server) await server.kill(); cleanupSandbox(sandbox); });
+
+    test('dismiss endpoint persists and suppresses', async () => {
+      const d = await req(server.baseUrl,
+        '/api/cc-suggestions/recovery/dismiss', {
+          method: 'POST',
+          body: { cardIds: ['hrv', 'rhr', 'sleep'] },
+        });
+      assert.equal(d.status, 200);
+      assert.equal(d.json.ok, true);
+
+      // File created on disk.
+      const file = path.join(sandbox, 'data', '_meta', 'cc-suggestions-dismissed.json');
+      assert.ok(fs.existsSync(file));
+
+      const res = await req(server.baseUrl, '/api/cc-suggestions');
+      assert.deepEqual(res.json.suggestions, []);
+    });
+
+    test('dismiss with empty cardIds returns 400', async () => {
+      const r = await req(server.baseUrl,
+        '/api/cc-suggestions/recovery/dismiss',
+        { method: 'POST', body: {} });
+      assert.equal(r.status, 400);
+    });
+  });
+
+  describe('cards already in a CC are excluded', () => {
+    let sandbox, server;
+    before(async () => {
+      sandbox = createSandbox({ seed: {
+        'hrv.json':   seedCard('hrv', 'recovery'),
+        'rhr.json':   seedCard('rhr', 'recovery'),
+        'sleep.json': seedCard('sleep', 'recovery'),
+        'recovery-ring.json': {
+          $schema: 'klebb.datafile.v1',
+          meta: {
+            id: 'recovery-ring',
+            label: 'Recovery',
+            category: 'recovery',
+            view: {
+              enabled: true,
+              component: 'combination-card',
+              combines: [
+                { sourceId: 'hrv', role: 'primary' },
+                { sourceId: 'rhr', role: 'secondary' },
+                { sourceId: 'sleep', role: 'secondary' },
+              ],
+            },
+          },
+          data: [],
+        },
+      }});
+      server = await spawnServer(sandbox);
+    });
+    after(async () => { if (server) await server.kill(); cleanupSandbox(sandbox); });
+
+    test('the three donors are excluded; no cluster remains', async () => {
+      const res = await req(server.baseUrl, '/api/cc-suggestions');
+      assert.deepEqual(res.json.suggestions, []);
+    });
+  });
+});

--- a/tests/cc-suggestions.test.js
+++ b/tests/cc-suggestions.test.js
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/cc-suggestions.test.js
+// Unit tests for the CC-suggestion cluster heuristic + dismissal state.
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+let tmp;
+let ccs;
+
+function reloadModule() {
+  delete require.cache[require.resolve('../config/paths')];
+  delete require.cache[require.resolve('../meta/cc-suggestions')];
+  ccs = require('../meta/cc-suggestions');
+}
+
+function makeRegistry(cards) {
+  return {
+    list() {
+      return cards.map(c => ({ id: c.id, meta: c.meta || {} }));
+    },
+  };
+}
+
+function card(id, category, extraMeta = {}) {
+  return {
+    id,
+    meta: {
+      id,
+      label: id,
+      category,
+      view: { enabled: true, component: 'generic-card' },
+      ...extraMeta,
+    },
+  };
+}
+
+function cc(id, combines) {
+  return {
+    id,
+    meta: {
+      id,
+      label: id,
+      view: {
+        enabled: true,
+        component: 'combination-card',
+        combines: combines.map(sourceId => ({ sourceId })),
+      },
+    },
+  };
+}
+
+describe('cc-suggestions', () => {
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'eh-ccs-'));
+    process.env.HEALTH_HOME = tmp;
+    process.env.HEALTH_HOME_WARNED = '1';
+    fs.mkdirSync(path.join(tmp, 'data'), { recursive: true });
+    reloadModule();
+  });
+  afterEach(() => {
+    try { fs.rmSync(tmp, { recursive: true, force: true }); } catch {}
+    delete process.env.HEALTH_HOME;
+  });
+
+  describe('list()', () => {
+    test('returns empty when fewer than 3 cards in any category', () => {
+      const reg = makeRegistry([card('a', 'recovery'), card('b', 'recovery')]);
+      assert.deepEqual(ccs.list(reg), { suggestions: [] });
+    });
+
+    test('emits a suggestion when 3+ cards share a category', () => {
+      const reg = makeRegistry([
+        card('sleep', 'sleep'),
+        card('hrv', 'recovery'),
+        card('rhr', 'recovery'),
+        card('sleep2', 'recovery'),
+      ]);
+      const out = ccs.list(reg);
+      assert.equal(out.suggestions.length, 1);
+      assert.equal(out.suggestions[0].category, 'recovery');
+      assert.deepEqual(out.suggestions[0].cardIds.sort(),
+        ['hrv', 'rhr', 'sleep2']);
+    });
+
+    test('cards without meta.category are invisible to the heuristic', () => {
+      const reg = makeRegistry([
+        card('a', 'recovery'),
+        card('b', 'recovery'),
+        { id: 'c', meta: { id: 'c', label: 'C' } }, // no category
+      ]);
+      assert.deepEqual(ccs.list(reg), { suggestions: [] });
+    });
+
+    test('disabled cards are excluded', () => {
+      const reg = makeRegistry([
+        card('a', 'recovery'),
+        card('b', 'recovery'),
+        card('c', 'recovery', { enabled: false }),
+      ]);
+      assert.deepEqual(ccs.list(reg), { suggestions: [] });
+    });
+
+    test('cards already used in an existing CC are excluded', () => {
+      const reg = makeRegistry([
+        card('a', 'recovery'),
+        card('b', 'recovery'),
+        card('c', 'recovery'),
+        card('d', 'recovery'),
+        cc('recovery-ring', ['a', 'b', 'c']),
+      ]);
+      // a/b/c already combined; only d is left → no cluster.
+      assert.deepEqual(ccs.list(reg), { suggestions: [] });
+    });
+
+    test('combination cards themselves are not part of clusters', () => {
+      const reg = makeRegistry([
+        card('a', 'recovery'),
+        card('b', 'recovery'),
+        // CC with meta.category shouldn't slip through into its own cluster.
+        { id: 'rc', meta: {
+            id: 'rc', label: 'Recovery', category: 'recovery',
+            view: { enabled: true, component: 'combination-card' } } },
+      ]);
+      assert.deepEqual(ccs.list(reg), { suggestions: [] });
+    });
+
+    test('multiple categories produce multiple suggestions, sorted', () => {
+      const reg = makeRegistry([
+        card('s1', 'sleep'), card('s2', 'sleep'), card('s3', 'sleep'),
+        card('r1', 'recovery'), card('r2', 'recovery'), card('r3', 'recovery'),
+      ]);
+      const out = ccs.list(reg);
+      assert.equal(out.suggestions.length, 2);
+      assert.deepEqual(out.suggestions.map(s => s.category),
+        ['recovery', 'sleep']);
+    });
+
+    test('dismissed cluster is suppressed', () => {
+      const reg = makeRegistry([
+        card('a', 'recovery'), card('b', 'recovery'), card('c', 'recovery'),
+      ]);
+      ccs.dismiss('recovery', ['a', 'b', 'c']);
+      assert.deepEqual(ccs.list(reg), { suggestions: [] });
+    });
+
+    test('adding a 4th card to a dismissed cluster re-fires with new key', () => {
+      const reg3 = makeRegistry([
+        card('a', 'recovery'), card('b', 'recovery'), card('c', 'recovery'),
+      ]);
+      ccs.dismiss('recovery', ['a', 'b', 'c']);
+      assert.deepEqual(ccs.list(reg3), { suggestions: [] });
+
+      // Add a fourth card; the old dismissal key no longer matches.
+      const reg4 = makeRegistry([
+        card('a', 'recovery'), card('b', 'recovery'),
+        card('c', 'recovery'), card('d', 'recovery'),
+      ]);
+      const out = ccs.list(reg4);
+      assert.equal(out.suggestions.length, 1);
+      assert.deepEqual(out.suggestions[0].cardIds.sort(),
+        ['a', 'b', 'c', 'd']);
+    });
+  });
+
+  describe('dismiss()', () => {
+    test('persists the key to disk', () => {
+      ccs.dismiss('recovery', ['a', 'b', 'c']);
+      const state = ccs.loadDismissed();
+      const key = ccs.clusterKey('recovery', ['a', 'b', 'c']);
+      assert.ok(state[key]);
+      assert.equal(state[key].category, 'recovery');
+      assert.deepEqual(state[key].cardIds.sort(), ['a', 'b', 'c']);
+    });
+
+    test('rejects empty cardIds', () => {
+      assert.equal(ccs.dismiss('recovery', []), false);
+      assert.equal(ccs.dismiss('recovery', null), false);
+      assert.equal(ccs.dismiss('', ['a']), false);
+    });
+
+    test('cardIds order doesn\'t affect key (sorted in key)', () => {
+      ccs.dismiss('recovery', ['c', 'a', 'b']);
+      const state = ccs.loadDismissed();
+      const key = ccs.clusterKey('recovery', ['a', 'b', 'c']);
+      assert.ok(state[key]);
+    });
+  });
+
+  describe('lazy file creation', () => {
+    test('list() doesn\'t create the file', () => {
+      const reg = makeRegistry([card('a', 'recovery'), card('b', 'recovery')]);
+      ccs.list(reg);
+      assert.equal(fs.existsSync(ccs.FILE), false);
+    });
+    test('dismiss() creates the file on first call', () => {
+      assert.equal(fs.existsSync(ccs.FILE), false);
+      ccs.dismiss('recovery', ['a', 'b', 'c']);
+      assert.equal(fs.existsSync(ccs.FILE), true);
+    });
+  });
+});


### PR DESCRIPTION
# What changed

Two discovery paths for combination cards, both routing to the existing conversational flow with klebbius — no new wizard, no new templates, no bespoke CC authoring code.

1. **Cluster suggestion card** (pinned on Today) fires when ≥3 enabled atomic cards share a `meta.category` value, naming the specific cards and offering an "Ask klebbius" action.
2. **"Combine cards" starter button** in the chat's blank-state prompt row, styled distinctly so it reads as a different class of action.

# Why

Fixes #174. Refs #151, #172.

CCs have shipped for months but have no introduction. Users who don't already know to ask klebbius never find them. These two surfaces cover the two discovery archetypes: passively-guided (notices the cluster suggestion, clicks through) and actively-exploratory (sees the distinct button in the chat, tries it).

# How

### Heuristic — `meta/cc-suggestions.js`

Pure server-side clustering on `meta.category`. Excludes:
- Combination cards themselves (they're not donors-in-waiting).
- Disabled cards (respects the master enable/disable toggle).
- Cards without `meta.category` (uncategorised = invisible to heuristics, by design in #173).
- Cards already used as donors in an existing CC (walks `meta.view.combines[].sourceId`).

Dismissal key: `category + sorted(cardIds).join(',')`. This makes composition-change fire a fresh suggestion — user dismisses a 3-card cluster, adds a 4th card later, new suggestion appears. Same-cluster re-surfacing is *not* something I want (annoying); composition-change re-surfacing *is* (actually valuable).

### API

- `GET /api/cc-suggestions` → `{ suggestions: [{category, cardIds}] }`
- `POST /api/cc-suggestions/:category/dismiss` with body `{ cardIds: [...] }`

Dismissal state: `$HEALTH_HOME/data/_meta/cc-suggestions-dismissed.json`. Lazy-created.

### Client

- `eh-cc-suggestion-card.js`: Lit component pinned on Today between the view renderer and the HAE discovery card. Renders one card per suggestion (amber-accented to distinguish from the teal-accented HAE discovery). "Ask klebbius" dispatches `klebb-paste-into-chat` with a prompt that names the specific card labels; "Dismiss" calls the dismiss endpoint.
- `health-chat.js`: adds `<span class="suggestion combine">✨ Combine cards</span>` to the empty-state starter row. New `.suggestion.combine` CSS with amber background. Seeds a generic "help me combine some cards" prompt on click.

Both paths reuse `klebb-paste-into-chat` — the same event the prompts gallery and HAE discovery card already use.

# Testing

- [x] `npm test` passes locally (791/792; the pre-existing `no-personal-refs` failure is unchanged).
- [x] 14 unit tests on the heuristic: cluster threshold, category-absence filter, disabled-filter, CC-donor exclusion, CC-self-exclusion, multi-category stable sort, dismissal suppression, composition-change re-fire, key order-independence, lazy file creation, rejects empty dismiss calls.
- [x] 5 integration tests on the API: empty case, three-same-category cluster, dismiss + re-fetch, dismiss validation, CC-exclusion end-to-end.
- [ ] Manual QA on klebbtest: seed 3 recovery cards (HRV + RHR + sleep), reload Today, confirm amber suggestion card appears between cards and the HAE discovery card. Click Ask klebbius → chat opens with a tailored prompt naming the three cards. Dismiss → card disappears, re-fetch endpoint confirms. Open chat with no history → confirm "✨ Combine cards" amber chip appears alongside the other starter suggestions.

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [x] Docs — self-documenting; UI has intro copy on the surfaces themselves
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens
- [x] New source files carry SPDX AGPL-3.0-only header

# Breaking changes

None. Pure-additive surfaces + one new state file. Existing CCs and card flows unchanged.