### PR TITLE
fix(docker): include meta/ in the runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ COPY --chown=klebb:klebb auth ./auth
 COPY --chown=klebb:klebb chat ./chat
 COPY --chown=klebb:klebb config ./config
 COPY --chown=klebb:klebb manifests ./manifests
+COPY --chown=klebb:klebb meta ./meta
 COPY --chown=klebb:klebb public ./public
 COPY --chown=klebb:klebb scripts ./scripts
 COPY --chown=klebb:klebb voice ./voice


### PR DESCRIPTION
Quick hotfix. PR #175's new \`meta/cc-suggestions.js\` module is required at startup by server.js, but the Dockerfile's explicit per-directory COPY list didn't include \`meta/\`, so the freshly-built image crashed on boot with \`MODULE_NOT_FOUND\`.

Caught when rebuilding klebbtest after merging #175.

The Docker build CI job does \`docker build\` without running the image, so it passed CI. Not opening a follow-up issue to add a smoke-boot step — the underlying risk here is "did someone add a new top-level directory to the repo" which is a rare event, and the fix is a one-line addition to the COPY list.