### PR TITLE
feat(chat): CC-specific embellishment chips + entry-point prompt tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **CC-specific embellishment chips after create/edit.** When the chat
+  agent creates or edits a `component: "combination-card"` manifest,
+  the reply carries clickable chips offering the embellishments that
+  are the actual point of CCs: switch layout (stack ↔ rings), promote
+  a donor to primary, add daily goals to ring segments, colour-code
+  ring segments. Chip filtering is fully field-gated so users don't
+  see "Add a goal" when every ring segment has one. The CC-suggestion
+  card's "Ask klebbius" prompt and the blank-chat "Combine cards"
+  starter chip both nudge the agent to propose embellishments after
+  writing the manifest, so the chip flow has something to act on.
+  (Fixes #177)
+
 - **Combination-card suggestion surface.** Two new discovery paths for
   CCs, both routing to the existing "describe it to klebbius" flow.
   (a) A pinned suggestion card on Today fires whenever 3+ enabled

--- a/chat/embellish.js
+++ b/chat/embellish.js
@@ -9,10 +9,18 @@
 // offer something already set.
 
 const MAX_OFFERS = 3;
+// CCs have fewer meaningfully-different embellishments but they're the
+// whole point of the renderer, so give them a slightly higher cap.
+const MAX_CC_OFFERS = 4;
 
 const INTRO = {
   create: 'Want to flesh it out?',
   edit: 'Anything else while we are here?',
+};
+
+const INTRO_CC = {
+  create: 'CCs shine with embellishments. Try one:',
+  edit: 'Anything else to layer on?',
 };
 
 // Each entry is { id, label, buildPrompt(label), eligible(meta) }.
@@ -107,9 +115,98 @@ function renderer(meta) {
   return (meta && meta.view && meta.view.component) || null;
 }
 
+// CC-specific embellishment picks. Runs when the just-modified manifest
+// is a combination card. Order matters (priority, not random): we offer
+// layout switch first because it changes the shape of every other
+// embellishment, then per-donor promotions, then per-donor polish.
+//
+// Returns a { text, embellishments } tuple in the same shape pickEmbellishments
+// returns for atomic cards, or null when nothing applies.
+function pickCcEmbellishments(manifest, { flow = 'create' } = {}) {
+  const meta = manifest.meta;
+  const label = meta.label || meta.id || 'card';
+  const view = meta.view || {};
+  const combines = Array.isArray(view.combines) ? view.combines : [];
+  if (combines.length === 0) return null;
+
+  const chips = [];
+
+  // 1. Layout switch — the shape-level choice.
+  const layout = view.layout || 'stack';
+  if (layout === 'stack') {
+    chips.push({
+      id: 'cc-switch-to-rings',
+      label: 'Switch to rings layout',
+      prompt: `Change the ${label} card's layout to rings. For each ring segment, ask me for a sensible daily goal and pick a colour.`,
+    });
+  } else if (layout === 'rings') {
+    chips.push({
+      id: 'cc-switch-to-stack',
+      label: 'Switch to stack layout',
+      prompt: `Change the ${label} card back to the stack layout.`,
+    });
+  }
+
+  // 2. Promote a donor to primary when nothing is primary yet. Pick the
+  // first donor as the suggestion target; klebbius can ask the user to
+  // pick a different one.
+  const hasPrimary = combines.some(c => c && c.role === 'primary');
+  if (!hasPrimary && combines[0]) {
+    const donor = combines[0];
+    const donorLabel = donor.label || donor.sourceId;
+    chips.push({
+      id: 'cc-set-primary',
+      label: `Make ${donorLabel} primary`,
+      prompt: `On the ${label} card, make "${donor.sourceId}" the primary donor so it renders larger than the others. If another donor would be a better primary, propose it instead.`,
+    });
+  }
+
+  // 3. For any ring-segment donor missing goalDaily, offer goals.
+  const ringSegmentsNoGoal = combines.filter(c =>
+    c && c.role === 'ring-segment' && c.goalDaily === undefined);
+  if (ringSegmentsNoGoal.length > 0) {
+    // One chip covering all ungoaled ring segments at once — less noisy
+    // than one chip per donor when users just switched to rings.
+    const names = ringSegmentsNoGoal.map(c => c.label || c.sourceId);
+    chips.push({
+      id: 'cc-add-goals',
+      label: ringSegmentsNoGoal.length === 1
+        ? `Add a goal for ${names[0]}`
+        : 'Add daily goals to the rings',
+      prompt: `On the ${label} card, set a sensible daily goal (goalDaily) for each ring segment: ${names.join(', ')}. Ask me what I'm aiming for if unclear.`,
+    });
+  }
+
+  // 4. Colour-code ring segments that don't have a colour yet.
+  const ringSegmentsNoColour = combines.filter(c =>
+    c && c.role === 'ring-segment' && !c.colour);
+  if (ringSegmentsNoColour.length > 0) {
+    chips.push({
+      id: 'cc-set-colours',
+      label: 'Colour-code the rings',
+      prompt: `On the ${label} card, pick a distinct colour for each ring segment so they're easy to tell apart at a glance.`,
+    });
+  }
+
+  if (chips.length === 0) return null;
+
+  return {
+    text: (INTRO_CC[flow] || INTRO_CC.create),
+    embellishments: chips.slice(0, MAX_CC_OFFERS),
+  };
+}
+
 function pickEmbellishments(manifest, { rng = Math.random, flow = 'create' } = {}) {
   if (!manifest || !manifest.meta) return null;
   const meta = manifest.meta;
+
+  // CCs have their own branch — the atomic-card catalogue doesn't have
+  // meaningful options for them (e.g. "add a trend arrow" doesn't apply
+  // to a combination-card renderer).
+  if (renderer(meta) === 'combination-card') {
+    return pickCcEmbellishments(manifest, { flow });
+  }
+
   const label = meta.label || meta.id || 'card';
 
   const eligible = CATALOG.filter(e => {
@@ -137,4 +234,12 @@ function shuffle(arr, rng) {
   return out;
 }
 
-module.exports = { pickEmbellishments, CATALOG, MAX_OFFERS, INTRO };
+module.exports = {
+  pickEmbellishments,
+  pickCcEmbellishments,
+  CATALOG,
+  MAX_OFFERS,
+  MAX_CC_OFFERS,
+  INTRO,
+  INTRO_CC,
+};

--- a/public/js/components/eh-cc-suggestion-card.js
+++ b/public/js/components/eh-cc-suggestion-card.js
@@ -29,7 +29,7 @@ const CATEGORY_META = {
 function buildPrompt(category, cards) {
   const label = CATEGORY_META[category]?.label || category;
   const names = cards.map(c => `"${c.label || c.id}"`).join(', ');
-  return `I'd like to combine my ${label.toLowerCase()} cards into a single combination card. I have ${cards.length} relevant cards: ${names}. Which combination-card layout would work best (rings, stack, etc.), which card should be the primary, and what embellishments could we add? Please propose a plan before writing the manifest.`;
+  return `I'd like to combine my ${label.toLowerCase()} cards into a single combination card. I have ${cards.length} relevant cards: ${names}. Which combination-card layout would work best (rings, stack, etc.), which card should be the primary, and what embellishments could we add? Please propose a plan before writing the manifest. After writing the card, also suggest 2-3 specific embellishments I could layer on — like switching to a rings layout with goals, setting a primary donor, or colour coding segments.`;
 }
 
 export class EhCcSuggestionCard extends LitElement {

--- a/public/js/components/health-chat.js
+++ b/public/js/components/health-chat.js
@@ -1172,7 +1172,7 @@ class HealthChat extends LitElement {
             <span class="suggestion" @click=${() => this._useSuggestion("Change the mood card to allow multiple entries per day")}>Tweak mood card</span>
             <span
               class="suggestion combine"
-              @click=${() => this._useSuggestion("I'd like to combine some of my cards into a single view. Which cards do I have that could work well together in a combination card, and what embellishments (rings, sparklines, progress bars) could we add?")}
+              @click=${() => this._useSuggestion("I'd like to combine some of my cards into a single view. Which cards do I have that could work well together in a combination card, and what combination-card layout (rings, stack) would fit best? After writing the card, also suggest 2-3 specific embellishments I could layer on — like switching layout, setting a primary donor, adding daily goals, or colour coding segments.")}
             >✨ Combine cards</span>
           </div>
         </div>

--- a/tests/cc-embellish.test.js
+++ b/tests/cc-embellish.test.js
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/cc-embellish.test.js
+// CC-specific branch of the post-create embellishment chip generator.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { pickEmbellishments, pickCcEmbellishments, MAX_CC_OFFERS } = require('../chat/embellish');
+
+function cc(meta = {}, combines = [], layout = null) {
+  const view = {
+    enabled: true,
+    component: 'combination-card',
+    combines,
+  };
+  if (layout) view.layout = layout;
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: { id: 'recovery-ring', label: 'Recovery', view, ...meta },
+    data: [],
+  };
+}
+
+describe('pickCcEmbellishments: combination-card branch', () => {
+  test('no donors: returns null', () => {
+    assert.equal(pickCcEmbellishments(cc({}, [])), null);
+  });
+
+  test('stack layout: offers rings-switch as first chip', () => {
+    const out = pickCcEmbellishments(cc({}, [
+      { sourceId: 'a' }, { sourceId: 'b' }, { sourceId: 'c' },
+    ], 'stack'));
+    assert.ok(out);
+    assert.equal(out.embellishments[0].id, 'cc-switch-to-rings');
+  });
+
+  test('rings layout: offers stack-switch and ungoaled-rings goal chip', () => {
+    const out = pickCcEmbellishments(cc({}, [
+      { sourceId: 'a', role: 'ring-segment' },
+      { sourceId: 'b', role: 'ring-segment' },
+      { sourceId: 'c', role: 'ring-segment' },
+    ], 'rings'));
+    assert.ok(out);
+    const ids = out.embellishments.map(e => e.id);
+    assert.ok(ids.includes('cc-switch-to-stack'));
+    assert.ok(ids.includes('cc-add-goals'));
+  });
+
+  test('primary promotion offered when no donor is primary', () => {
+    const out = pickCcEmbellishments(cc({}, [
+      { sourceId: 'hrv', label: 'HRV' },
+      { sourceId: 'rhr' },
+    ]));
+    const ids = out.embellishments.map(e => e.id);
+    assert.ok(ids.includes('cc-set-primary'));
+    const primary = out.embellishments.find(e => e.id === 'cc-set-primary');
+    assert.match(primary.label, /HRV/);
+    assert.match(primary.prompt, /"hrv"/);
+  });
+
+  test('primary NOT offered when one donor is already primary', () => {
+    const out = pickCcEmbellishments(cc({}, [
+      { sourceId: 'a', role: 'primary' },
+      { sourceId: 'b' },
+    ]));
+    const ids = out.embellishments.map(e => e.id);
+    assert.ok(!ids.includes('cc-set-primary'));
+  });
+
+  test('goal chip NOT offered when every ring segment has goalDaily', () => {
+    const out = pickCcEmbellishments(cc({}, [
+      { sourceId: 'a', role: 'ring-segment', goalDaily: 10000 },
+      { sourceId: 'b', role: 'ring-segment', goalDaily: 30 },
+    ], 'rings'));
+    const ids = out ? out.embellishments.map(e => e.id) : [];
+    assert.ok(!ids.includes('cc-add-goals'));
+  });
+
+  test('colour chip NOT offered when every ring segment has a colour', () => {
+    const out = pickCcEmbellishments(cc({}, [
+      { sourceId: 'a', role: 'ring-segment', goalDaily: 10, colour: '#f00' },
+      { sourceId: 'b', role: 'ring-segment', goalDaily: 5, colour: '#0f0' },
+    ], 'rings'));
+    const ids = out ? out.embellishments.map(e => e.id) : [];
+    assert.ok(!ids.includes('cc-set-colours'));
+  });
+
+  test('single-donor ungoaled ring: label names that donor specifically', () => {
+    const out = pickCcEmbellishments(cc({}, [
+      { sourceId: 'steps', label: 'Steps', role: 'ring-segment', colour: '#f00' },
+      { sourceId: 'sleep', role: 'ring-segment', goalDaily: 8, colour: '#0f0' },
+    ], 'rings'));
+    const goalChip = out.embellishments.find(e => e.id === 'cc-add-goals');
+    assert.ok(goalChip);
+    assert.match(goalChip.label, /Steps/);
+  });
+
+  test('capped at MAX_CC_OFFERS', () => {
+    // Build a scenario that emits 5 chips and assert cap.
+    // Stack layout (rings switch), no primary (set-primary), and two
+    // ungoaled ring segments + two uncoloured ones — but ring chips are
+    // offered once per category (goals and colours), so realistically
+    // the max is 4 anyway. Cap is defensive.
+    const out = pickCcEmbellishments(cc({}, [
+      { sourceId: 'a', role: 'ring-segment' },
+      { sourceId: 'b', role: 'ring-segment' },
+    ], 'stack'));  // will offer switch-to-rings; ring-segment goals/colours
+                   // don't apply while layout is stack
+    assert.ok(out.embellishments.length <= MAX_CC_OFFERS);
+  });
+
+  test('intro text differs for CCs vs atomic cards', () => {
+    const out = pickCcEmbellishments(cc({}, [
+      { sourceId: 'a' },
+    ]));
+    assert.match(out.text, /CC|combination|embellish/i);
+  });
+});
+
+describe('pickEmbellishments dispatches CC branch when component === combination-card', () => {
+  test('a CC manifest goes through the CC branch, not the atomic catalogue', () => {
+    const manifest = cc({ emoji: undefined }, [
+      { sourceId: 'a' }, { sourceId: 'b' }, { sourceId: 'c' },
+    ], 'stack');
+    const out = pickEmbellishments(manifest, { flow: 'create' });
+    assert.ok(out);
+    // Atomic-catalogue chips (add-emoji, add-trend-arrow, ...) should
+    // NOT appear. CC-specific chips should.
+    const ids = out.embellishments.map(e => e.id);
+    for (const id of ids) assert.ok(id.startsWith('cc-'),
+      `atomic chip leaked into CC branch: ${id}`);
+  });
+
+  test('an atomic (generic-card) manifest still goes through the atomic branch', () => {
+    const manifest = {
+      $schema: 'klebb.datafile.v1',
+      meta: {
+        id: 'weight',
+        label: 'Weight',
+        view: { enabled: true, component: 'generic-card',
+                display: { template: '{kg}' } },
+      },
+      data: [],
+    };
+    const out = pickEmbellishments(manifest, { flow: 'create' });
+    assert.ok(out);
+    const ids = out.embellishments.map(e => e.id);
+    // At least one non-cc chip should appear.
+    assert.ok(ids.some(id => !id.startsWith('cc-')));
+  });
+});


### PR DESCRIPTION
# What changed

Extends the post-create embellishment chip generator (`chat/embellish.js`) with a CC-specific branch, so building or editing a combination card in chat produces clickable chips offering the renderer-level embellishments that are the actual value of CCs. Updates the two CC-entry prompts to also ask the agent to propose embellishments in its reply.

# Why

Fixes #177. Refs #174.

PR #175 shipped two ways to introduce CCs to users (cluster suggestion card, blank-chat starter chip). Both route into klebbius which writes a CC manifest. But the manifest that lands is usually the bare minimum (stack layout, no per-donor roles, no goals). The *point* of a CC isn't just decluttering — it's the rings-with-goals, the colour coding, the primary donor. Without nudging the user toward those, we ship a feature half-used.

The chip infra for post-create embellishments already exists (shipped with #142 for atomic cards). Extending it with a CC branch was the right move (you chose "infra over prompt" explicitly).

# How

### `chat/embellish.js`

`pickEmbellishments()` branches on `meta.view.component`:

- `combination-card` → new `pickCcEmbellishments()` path.
- Everything else → existing atomic CATALOG.

CC chips, priority-ordered (not random):

1. **Switch layout** — stack ↔ rings. Rings-switch is offered first for stack-layout CCs because it changes the shape of everything else.
2. **Make <donor> primary** — when no donor currently has `role: "primary"`.
3. **Add daily goals** — one chip covering all ring-segment donors that lack `goalDaily`.
4. **Colour-code the rings** — one chip covering all ring segments that lack `colour`.

Cap: 4 chips (vs 3 for atomic cards — CCs have more meaningful options). All chips are field-gated so we don't re-offer what's already applied.

### Prompts

Both CC entry points get an appendix asking klebbius to suggest 2-3 embellishments after writing the manifest:

- `eh-cc-suggestion-card.js → buildPrompt()`
- `health-chat.js` blank-state "✨ Combine cards" starter chip

Also: the old starter-chip prompt referenced "sparklines, progress bars" as embellishment examples, but neither is actually implemented in the CC renderer yet. Removed those to keep klebbius from proposing things the renderer can't render.

# Testing

- [x] `npm test` passes locally (803/804; the pre-existing `no-personal-refs` failure is unchanged).
- [x] 12 new unit tests on `pickCcEmbellishments`: layout branching, primary gating, goal gating, colour gating, single-donor label specificity, cap enforcement, intro text, dispatch correctness (CC manifests go through CC branch; atomic manifests go through CATALOG and never surface `cc-*` chips).

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [x] Docs — self-documenting surface; chips describe what they do
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens

# Breaking changes

None. The embellishment-chip infra was already CC-unaware before this PR (would either produce atomic-catalogue chips that don't apply to a CC, or nothing). This PR just makes that case produce sensible output.