### PR TITLE
fix(chat): inject combination-card schema into system prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Chat agent no longer hallucinates the combination-card manifest
+  schema.** Observed in live QA: asked to build a Sleep CC, the agent
+  wrote `view.sources[]` keyed on `id`; asked to build a Lifestyle
+  CC, it wrote `view.slots[]` keyed on `cardId`. Neither shape is
+  accepted by the CC renderer (which reads `view.combines[]` with
+  `sourceId`), so both cards rendered empty with "no source info".
+  Same failure mode as #164 (HAE field hallucination) — fixed by
+  injecting the CC schema contract into the chat system prompt,
+  including an explicit FORBIDDEN list naming the two observed
+  hallucinations (`view.slots`, `view.sources`) so the agent learns
+  what to avoid as well as what to use. (Fixes #179)
+
 ### Added
 
 - **CC-specific embellishment chips after create/edit.** When the chat

--- a/chat/describe-cc-schema.js
+++ b/chat/describe-cc-schema.js
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// chat/describe-cc-schema.js
+//
+// Produces a compact, agent-facing description of the combination-card
+// manifest contract. Injected into the chat system prompt so the agent
+// writes CC manifests that match what the eh-combination-card renderer
+// actually reads, instead of hallucinating plausible-looking keys like
+// view.slots[] or view.sources[].
+//
+// The renderer's accepted shape is authoritative; this file mirrors
+// what public/js/components/eh-combination-card.js parses. If that
+// contract changes, update here too.
+
+function describeCcSchema() {
+  return [
+    '## Combination cards',
+    '',
+    'A combination card (CC) is a manifest whose view is backed by the',
+    '`combination-card` renderer. It composes existing atomic cards as',
+    '"donors" rather than holding its own `data[]`.',
+    '',
+    'CANONICAL SHAPE — copy exactly:',
+    '',
+    '```json',
+    '{',
+    '  "$schema": "klebb.datafile.v1",',
+    '  "meta": {',
+    '    "id": "recovery-ring",',
+    '    "label": "Recovery",',
+    '    "emoji": "💓",',
+    '    "category": "recovery",',
+    '    "view": {',
+    '      "enabled": true,',
+    '      "component": "combination-card",',
+    '      "layout": "stack",                       // "stack" or "rings"',
+    '      "combines": [',
+    '        {',
+    '          "sourceId": "hrv",                   // required; matches another manifest\'s meta.id',
+    '          "role": "primary",                   // "primary" | "secondary" | "annotation" | "ring-segment"',
+    '          "label": "HRV",                      // optional display override',
+    '          "unit": "ms"                         // optional display unit',
+    '        },',
+    '        {',
+    '          "sourceId": "resting-heart-rate",',
+    '          "role": "secondary"',
+    '        }',
+    '      ]',
+    '    }',
+    '  },',
+    '  "description": "...",',
+    '  "data": []',
+    '}',
+    '```',
+    '',
+    'RULES:',
+    '- Donors live in `meta.view.combines`. The key on each donor is',
+    '  `sourceId` (the referenced manifest\'s meta.id). No other key',
+    '  is accepted.',
+    '- Layouts: `"stack"` renders a vertical list; `"rings"` renders',
+    '  concentric progress gauges. Only donors with `role: "ring-segment"`',
+    '  appear in the ring when layout is `"rings"`.',
+    '- `role` chooses visual weight: `"primary"` renders larger,',
+    '  `"secondary"` is medium, `"annotation"` is subdued.',
+    '- Ring segments require `goalDaily` (number) and optionally accept',
+    '  `colour` (hex/CSS colour string). Example:',
+    '    `{ "sourceId": "steps", "role": "ring-segment", "goalDaily": 10000, "colour": "#44ff88" }`',
+    '- A CC\'s own `data[]` MUST be an empty array. All values come',
+    '  from the donor manifests via the registry at render time.',
+    '- Do NOT inline per-donor display templates on combines[]. Each',
+    '  donor row renders via the donor manifest\'s own',
+    '  `meta.view.display.template`; the CC renderer ignores any',
+    '  `display` block nested inside a combines[] entry.',
+    '',
+    'FORBIDDEN — observed hallucinations that must not be used:',
+    '- `view.slots[]` with `cardId` — not a real shape.',
+    '- `view.sources[]` with `id` — not a real shape.',
+    '- Inlining a per-donor `display` or `thresholds` block inside a',
+    '  combines[] entry.',
+    '- Putting `data[]` entries on the CC itself.',
+    '',
+    'The CC manifest should carry `meta.category` matching the cluster',
+    'it represents (e.g. a Recovery CC gets `"category": "recovery"`).',
+    '',
+  ].join('\n');
+}
+
+module.exports = { describeCcSchema };

--- a/server.js
+++ b/server.js
@@ -24,6 +24,7 @@ const haeDiscoveries = require('./health-auto-export/discoveries');
 const { describeCatalogue: describeHaeCatalogue } = require('./health-auto-export/describe');
 const { CATEGORIES: MANIFEST_CATEGORIES } = require('./config/categories');
 const ccSuggestions = require('./meta/cc-suggestions');
+const { describeCcSchema } = require('./chat/describe-cc-schema');
 
 // chat endpoint config (env-driven; see config/env.js)
 const CHAT_ENDPOINT_URL = ENV.CHAT_ENDPOINT_URL;
@@ -1336,6 +1337,11 @@ const server = http.createServer(async (req, res) => {
           // emits, rather than guessing from HAE's raw payload schema.
           const haeCatalogueBlock = '\n\n' + describeHaeCatalogue() + '\n';
 
+          // Inject the combination-card manifest contract so the agent
+          // writes `view.combines[]` with `sourceId` instead of
+          // hallucinating view.slots[]/view.sources[] shapes.
+          const ccSchemaBlock = '\n\n' + describeCcSchema() + '\n';
+
           // Constrain meta.category to the canonical enum. Klebb uses the
           // field for clustering heuristics (e.g. CC suggestions); unknown
           // values are silently dropped by the registry, so agent-invented
@@ -1365,7 +1371,7 @@ const server = http.createServer(async (req, res) => {
             '',
           ].join('\n');
 
-          let systemPrompt = HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock + haeCatalogueBlock + categoryBlock;
+          let systemPrompt = HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock + haeCatalogueBlock + ccSchemaBlock + categoryBlock;
           if (voiceMode) {
             systemPrompt = `You are ${process.env.CHAT_AGENT_NAME || 'Chat'}, a health assistant.
 Voice mode is active: the user is speaking to you and will hear your reply aloud.
@@ -1398,7 +1404,7 @@ Return STRICTLY the JSON object. No leading/trailing text. No markdown fences.
 
 Original system prompt follows:
 
-` + HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock + haeCatalogueBlock + categoryBlock;
+` + HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock + haeCatalogueBlock + ccSchemaBlock + categoryBlock;
           }
 
           // Prepend system prompt

--- a/tests/chat-prompt-cc-schema.test.js
+++ b/tests/chat-prompt-cc-schema.test.js
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/chat-prompt-cc-schema.test.js
+// Verifies the combination-card schema block reaches the chat agent's
+// system prompt, and that the helper names known hallucinations as
+// forbidden.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('http');
+const { createSandbox, cleanupSandbox, spawnServer, req } = require('./helpers/sandbox');
+
+const { describeCcSchema } = require('../chat/describe-cc-schema');
+
+describe('describeCcSchema (unit)', () => {
+  test('names the canonical view.combines + sourceId shape', () => {
+    const out = describeCcSchema();
+    assert.match(out, /view\.combines/);
+    assert.match(out, /sourceId/);
+    assert.match(out, /"combination-card"/);
+  });
+
+  test('declares "stack" and "rings" as the two layouts', () => {
+    const out = describeCcSchema();
+    assert.match(out, /"stack"/);
+    assert.match(out, /"rings"/);
+  });
+
+  test('names the known hallucinations as FORBIDDEN', () => {
+    const out = describeCcSchema();
+    assert.match(out, /FORBIDDEN/);
+    assert.match(out, /view\.slots/);
+    assert.match(out, /view\.sources/);
+  });
+
+  test('mentions ring-segment, goalDaily, colour for the rings layout', () => {
+    const out = describeCcSchema();
+    assert.match(out, /ring-segment/);
+    assert.match(out, /goalDaily/);
+    assert.match(out, /colour/);
+  });
+
+  test('tells the agent that data[] on a CC must stay empty', () => {
+    const out = describeCcSchema();
+    assert.match(out, /empty array|MUST be an empty/i);
+  });
+});
+
+describe('chat proxy injects CC schema into system prompt', () => {
+  let sandbox, server, gateway;
+
+  function startStubGateway() {
+    let lastSystemPrompt = null;
+    const s = http.createServer((request, response) => {
+      let body = '';
+      request.on('data', c => { body += c; });
+      request.on('end', () => {
+        try {
+          const parsed = JSON.parse(body);
+          const sys = parsed.messages?.find(m => m.role === 'system');
+          lastSystemPrompt = sys?.content || null;
+        } catch {}
+        response.writeHead(200, { 'Content-Type': 'application/json' });
+        response.end(JSON.stringify({
+          choices: [{ message: { role: 'assistant', content: 'ack' } }],
+        }));
+      });
+    });
+    return new Promise(resolve => {
+      s.listen(0, '127.0.0.1', () => {
+        resolve({
+          port: s.address().port,
+          close: () => new Promise(r => s.close(r)),
+          getLastPrompt: () => lastSystemPrompt,
+        });
+      });
+    });
+  }
+
+  before(async () => {
+    gateway = await startStubGateway();
+    sandbox = createSandbox();
+    server = await spawnServer(sandbox, {
+      CHAT_ENDPOINT_URL: `http://127.0.0.1:${gateway.port}/v1/chat/completions`,
+      CHAT_API_KEY: 'stub-token',
+      CHAT_MODEL: 'stub-model',
+    });
+  });
+  after(async () => {
+    if (server) await server.kill();
+    if (gateway) await gateway.close();
+    cleanupSandbox(sandbox);
+  });
+
+  test('system prompt contains the CC schema block', async () => {
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'hello' }] },
+    });
+    assert.equal(res.status, 200);
+    const prompt = gateway.getLastPrompt();
+    assert.ok(prompt);
+    assert.match(prompt, /## Combination cards/);
+    assert.match(prompt, /view\.combines/);
+    assert.match(prompt, /sourceId/);
+    assert.match(prompt, /FORBIDDEN/);
+    assert.match(prompt, /view\.slots/);
+    assert.match(prompt, /view\.sources/);
+  });
+});


### PR DESCRIPTION
# What changed

Adds a CC-schema block to the chat system prompt so klebbius writes manifests with the actual `view.combines[]` / `sourceId` contract instead of hallucinating `view.slots[]` / `view.sources[]`.

# Why

Fixes #179. Refs #164.

Live QA produced two broken CCs across two conversations: Sleep used `view.sources[]` with `id`, Lifestyle used `view.slots[]` with `cardId`. Neither is a real shape; both rendered empty. The agent had general knowledge that CCs exist but no knowledge of the specific keys the renderer reads.

Same pattern as the HAE field hallucination in #164. Same fix shape.

# How

New `chat/describe-cc-schema.js` emits a compact contract description:

- Canonical JSON block (actual valid CC manifest) the agent can copy.
- Rules for layout (`stack`/`rings`), role values, ring-segment requirements (`goalDaily`, optional `colour`).
- **FORBIDDEN section** naming the two observed hallucinations explicitly. Teaching what NOT to write is cheaper than hoping the agent infers it.
- Explicit callouts for two other observed misreadings: per-donor `display` blocks inside `combines[]` (ignored by renderer); `data[]` rows on the CC itself (CCs have no data — values come from donors).

Wired into `server.js` in both normal and voice-mode system prompts, alongside the existing HAE catalogue + category enum blocks.

# Testing

- [x] `npm test` passes locally (809/810; the pre-existing `no-personal-refs` failure is unchanged).
- [x] 5 unit tests on the describe helper: names `view.combines`/`sourceId`/`"combination-card"`, declares `stack`/`rings`, names the two hallucinations in FORBIDDEN, covers ring-segment fields, tells the agent `data[]` must be empty.
- [x] 1 integration test via stub gateway: confirms the block reaches the agent's system prompt end-to-end.
- [ ] Manual QA: rebuild klebbtest, ask klebbius to build a Sleep CC and a Lifestyle CC via the suggestion cards, confirm both land with `view.combines[]` + `sourceId` and actually render donor rows.

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [x] Docs — the agent is self-instructed via the prompt; no user-facing doc change needed
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens
- [x] New source files carry SPDX AGPL-3.0-only header

# Breaking changes

None. Prompt-side only. Existing correctly-shaped CC manifests are unaffected.