### PR TITLE
feat(tests): scaffold Playwright E2E harness with CI workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+name: e2e
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E suite
+        run: npm run test:e2e
+        env:
+          CI: '1'
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v5
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
+      - name: Upload test-results (screenshots, traces)
+        if: failure()
+        uses: actions/upload-artifact@v5
+        with:
+          name: test-results
+          path: test-results/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,10 @@ System Volume Information
 # Scratch
 /tmp/
 /scratch/
+QA-BUGS.md
+
+# Playwright (E2E harness)
+/tests-e2e/.state/
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Playwright end-to-end test harness.** New `tests-e2e/` directory
+  and `npm run test:e2e` script drive a headless Chromium against an
+  ephemeral sandbox (same harness `tests/helpers/sandbox.js` uses),
+  injecting a valid session via the existing `fakeAuthState` helper
+  so specs land directly on the authenticated app. Separate
+  `e2e.yml` GitHub Actions workflow runs the suite on every PR and
+  archives traces, screenshots, and the HTML report on failure. New
+  `docs/TESTING.md` documents the three-layer rubric: unit → API
+  integration → E2E. Headed runs (`npm run test:e2e:headed`) get a
+  400ms slow-mo and an in-page banner showing the current test
+  title for comfortable watch-along debugging. (Fixes #198)
+
 - **CC-specific embellishment chips after create/edit.** When the chat
   agent creates or edits a `component: "combination-card"` manifest,
   the reply carries clickable chips offering the embellishments that

--- a/README.md
+++ b/README.md
@@ -191,17 +191,23 @@ in `.env`. The compose file already maps that hostname to the host via
 ## Running tests
 
 ```bash
-npm test
+npm test                  # unit + API integration tests
+npm run test:e2e          # Playwright end-to-end (headless)
+npm run test:e2e:headed   # same, with a visible browser
 ```
 
-Tests spin up ephemeral `HEALTH_HOME` directories and the full HTTP
-server on random ports, exercising the registry, Settings API,
-display-template engine, bearer-auth path, migration scripts, and
-repo-hygiene scanners.
+Unit + API integration tests spin up ephemeral `HEALTH_HOME`
+directories and the full HTTP server on random ports, exercising the
+registry, Settings API, display-template engine, bearer-auth path,
+migration scripts, and repo-hygiene scanners. ~800 tests, runs in
+~15 seconds.
 
-~180 tests, runs in ~3 seconds, zero flakiness.
+End-to-end tests drive Chromium against the same sandbox harness and
+cover user-visible interaction (rendering, navigation, forms). See
+[`docs/TESTING.md`](docs/TESTING.md) for the rubric on which layer a
+new test belongs in.
 
-CI runs the suite on Node 20 + 22 for every push and pull request.
+CI runs all three layers on every push and pull request.
 
 ## Configuration
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,145 @@
+# Testing
+
+Klebb has three test layers, each with a different job. Write your tests
+in the right layer; don't try to cover a UI concern from a lib test or
+a backend bug from an E2E spec.
+
+## Layers
+
+### 1. Unit / library tests — `tests/*.test.js`
+
+Node's built-in `node:test` runner. Fast, no HTTP, no browser. For pure
+logic: manifest parsing, display-template evaluation, date-range
+resolution, schedule expansion, merge-patch behaviour.
+
+- Run: `npm test`
+- Harness: plain `require()` of the module under test.
+- Target: code under `config/`, `manifests/`, `server/`, `chat/`, `auth/`,
+  `health-auto-export/`.
+
+### 2. API integration tests — `tests/*.test.js` (sandbox variant)
+
+Same runner, but spin up a real klebb server against an ephemeral
+`HEALTH_HOME` and exercise the HTTP API. These catch data-layer
+regressions without needing a browser.
+
+- Run: `npm test` (same command).
+- Harness: `tests/helpers/sandbox.js`.
+- Helpers: `createSandbox`, `spawnServer`, `req`, `fakeAuthState`.
+- Target: any API route; manifest write / patch behaviour; HAE ingest;
+  auth-gated flows.
+
+Write an API test when the bug's symptom is observable without a
+browser. Example: "editing a past mood entry overwrites all rows" —
+the proof is in the manifest file after the PATCH. Don't need a UI.
+
+### 3. End-to-end tests — `tests-e2e/*.spec.js`
+
+Playwright against a real Chromium instance, driven against the same
+sandbox harness. Slower, but the only layer that catches user-visible
+interaction bugs.
+
+- Run: `npm run test:e2e` (headless).
+- Watch along: `npm run test:e2e:headed` (opens a visible browser).
+- Debug a single spec: `npm run test:e2e:debug` (Playwright inspector).
+- Harness: `tests-e2e/helpers/global-setup.js` boots the sandbox once
+  per run; `tests-e2e/helpers/auth-fixture.js` injects the session
+  cookie on every new page.
+
+Write an E2E test when the bug's symptom depends on rendering,
+navigation, form interaction, or chat-widget state. Example: "edit
+pencil doesn't appear on past mood entries" — the check is whether a
+DOM element is visible.
+
+## Rubric: which layer?
+
+- Bug is about manifest shape, template evaluation, date maths,
+  pure computation → **layer 1**.
+- Bug is about what the server returns, what gets written to disk,
+  or what happens on a round-trip PATCH → **layer 2**.
+- Bug is about what the user sees, clicks, or interacts with → **layer 3**.
+
+If two layers apply, pick the cheapest one that reliably proves the
+fix. A Playwright test is rarely the right choice when an API test
+would do.
+
+## Writing an E2E test
+
+Use the `test` + `expect` from `tests-e2e/helpers/auth-fixture.js`,
+not directly from `@playwright/test`:
+
+```js
+const { test, expect } = require('./helpers/auth-fixture');
+
+test('my scenario', async ({ page, sandboxState }) => {
+  await page.goto('/');
+  await expect(page.locator('eh-generic-card', { hasText: 'Weight' })).toBeVisible();
+});
+```
+
+The fixture gives you:
+- a `page` already pointed at the sandbox (`page.goto('/')` resolves
+  against the sandbox URL).
+- a valid session cookie set on `context`, so auth-gated routes work.
+- `sandboxState`, an object with `baseUrl`, `sessionToken`,
+  `sessionCookie`, and `sandbox` (the temp `HEALTH_HOME` path).
+
+### Seeding extra manifests
+
+The default seed lives in `tests-e2e/helpers/seed-manifests.js` and is
+intentionally minimal (one weight, one mood). For a spec that needs
+richer fixtures, write to the sandbox via the API or directly to the
+`sandboxState.sandbox` directory in `test.beforeAll`.
+
+### Selectors
+
+Prefer Lit custom-element selectors (`eh-generic-card`, `eh-schedule-card`,
+`eh-date-view`, etc.) over CSS classes. They're stable across styling
+changes. Pair with `hasText` to disambiguate:
+
+```js
+page.locator('eh-generic-card', { hasText: 'Weight' })
+```
+
+### Running headed for debugging
+
+```
+npm run test:e2e:headed
+```
+
+Opens Chromium, runs the specs with a real window. Actions run with a
+400ms slow-mo in headed mode so you can actually see what's happening.
+
+To hold the browser open at the end of each spec for manual
+inspection, set `KLEBB_E2E_PAUSE=1`:
+
+```
+KLEBB_E2E_PAUSE=1 npm run test:e2e:headed         # bash / zsh
+$env:KLEBB_E2E_PAUSE="1"; npm run test:e2e:headed # PowerShell
+```
+
+The spec will pause at the end, pop open Playwright's inspector,
+and wait for you to close it manually.
+
+You can also drop `await page.pause()` anywhere inside a spec to
+freeze at that step and poke around the DOM.
+
+## CI
+
+GitHub Actions runs all three layers on every PR:
+
+- `test` workflow runs `npm test` on Node 20 and 22.
+- `e2e` workflow runs `npm run test:e2e` on Node 22 with Chromium.
+  On failure, uploads screenshots, traces, and the HTML report as
+  build artefacts.
+
+## PR expectations
+
+Every non-trivial PR should include regression coverage at the right
+layer. If you're fixing a bug, write the test that proves the fix
+first (fails on current `main`, passes with the fix). If you're
+adding a feature, cover the happy path + one edge case.
+
+If a change legitimately doesn't need a new test, say so in the PR
+body. "No new tests because this is a pure doc change" is fine. "No
+new tests because I ran it locally" is not.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
         "@simplewebauthn/server": "^13.3.0",
         "marked": "^18.0.2"
       },
+      "devDependencies": {
+        "@playwright/test": "^1.59.1"
+      },
       "engines": {
         "node": ">=20"
       }
@@ -188,6 +191,22 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@simplewebauthn/browser": {
       "version": "13.3.0",
       "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
@@ -227,6 +246,21 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/marked": {
       "version": "18.0.2",
       "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.2.tgz",
@@ -237,6 +271,38 @@
       },
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/pvtsutils": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "main": "server.js",
   "scripts": {
     "test": "node --test tests/*.test.js",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:debug": "playwright test --debug",
     "start": "node server.js",
     "invite": "node scripts/invite.js",
     "revoke": "node scripts/revoke.js",
@@ -38,5 +41,8 @@
     "@simplewebauthn/browser": "^13.3.0",
     "@simplewebauthn/server": "^13.3.0",
     "marked": "^18.0.2"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.59.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// playwright.config.js
+// Playwright harness for Klebb's E2E suite. Boots an ephemeral
+// HEALTH_HOME + server per run via tests-e2e/global-setup.js and tears
+// it down via global-teardown.js. No CI-only branching here — run the
+// same config locally and in CI; use CLI flags (--headed) for the
+// watch-along workflow.
+
+const { defineConfig, devices } = require('@playwright/test');
+
+const IS_CI = !!process.env.CI;
+
+module.exports = defineConfig({
+  testDir: './tests-e2e',
+  testMatch: /.*\.spec\.js/,
+  fullyParallel: false,
+  forbidOnly: IS_CI,
+  retries: IS_CI ? 1 : 0,
+  workers: 1,
+  reporter: IS_CI ? [['list'], ['html', { open: 'never' }]] : [['list']],
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+
+  globalSetup: require.resolve('./tests-e2e/helpers/global-setup.js'),
+
+  use: {
+    // baseURL is injected per-test by the auth-fixture (reads the sandbox
+    // URL from tests-e2e/.state/state.json, which globalSetup writes).
+    trace: IS_CI ? 'retain-on-failure' : 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: IS_CI ? 'retain-on-failure' : 'off',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: {
+          // When running headed (watch-along), slow every action so the
+          // operator can actually see what happened. Headless runs and CI
+          // are unaffected.
+          slowMo: process.env.PWHEADED || process.argv.includes('--headed') ? 400 : 0,
+        },
+      },
+    },
+  ],
+});

--- a/tests-e2e/helpers/auth-fixture.js
+++ b/tests-e2e/helpers/auth-fixture.js
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/helpers/auth-fixture.js
+// Playwright fixtures that inject the sandbox session cookie on every
+// new page, so specs can go straight to authenticated routes.
+
+const fs = require('fs');
+const path = require('path');
+const { test: base, expect } = require('@playwright/test');
+
+const STATE_FILE = path.join(__dirname, '..', '.state', 'state.json');
+
+function loadState() {
+  if (!fs.existsSync(STATE_FILE)) {
+    throw new Error(
+      `[e2e] sandbox state not found at ${STATE_FILE}. Did globalSetup run?`,
+    );
+  }
+  return JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'));
+}
+
+const test = base.extend({
+  sandboxState: async ({}, use) => {
+    await use(loadState());
+  },
+  baseURL: async ({ sandboxState }, use) => {
+    await use(sandboxState.baseUrl);
+  },
+  context: async ({ context, sandboxState }, use) => {
+    const url = new URL(sandboxState.baseUrl);
+    await context.addCookies([
+      {
+        name: 'klebb_session',
+        value: sandboxState.sessionToken,
+        domain: url.hostname,
+        path: '/',
+        httpOnly: true,
+        secure: false,
+        sameSite: 'Lax',
+      },
+    ]);
+    await use(context);
+  },
+  page: async ({ page }, use, testInfo) => {
+    const headed = !testInfo.project.use.headless;
+    if (headed) {
+      await installTestBanner(page, testInfo.title);
+    }
+    await use(page);
+    if (process.env.KLEBB_E2E_PAUSE === '1') {
+      await page.pause();
+    }
+  },
+});
+
+async function installTestBanner(page, title) {
+  const script = `(() => {
+    const css = \`
+      #klebb-e2e-banner {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 2147483647;
+        padding: 6px 14px;
+        background: rgba(20, 20, 30, 0.88);
+        color: #fff;
+        font: 500 13px/1.3 system-ui, sans-serif;
+        text-align: center;
+        pointer-events: none;
+        letter-spacing: 0.02em;
+      }
+      #klebb-e2e-banner b { color: #aeeaff; font-weight: 600; }
+    \`;
+    function mount() {
+      if (document.getElementById('klebb-e2e-banner')) return;
+      if (!document.body) { requestAnimationFrame(mount); return; }
+      const style = document.createElement('style');
+      style.textContent = css;
+      (document.head || document.documentElement).appendChild(style);
+      const el = document.createElement('div');
+      el.id = 'klebb-e2e-banner';
+      el.innerHTML = 'e2e: <b>' + ${JSON.stringify(title)} + '</b>';
+      document.body.appendChild(el);
+    }
+    mount();
+  })();`;
+  await page.addInitScript(script);
+  // Eager inject too, in case the spec never navigates (e.g. API-only
+  // tests). Fire-and-forget; navigations will rerun the init script.
+  page.evaluate(script).catch(() => {});
+}
+
+module.exports = { test, expect };

--- a/tests-e2e/helpers/global-setup.js
+++ b/tests-e2e/helpers/global-setup.js
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/helpers/global-setup.js
+// Boots an ephemeral klebb server + sandbox for the entire E2E run.
+// Writes connection info to tests-e2e/.state/state.json so specs can
+// read it. The returned function is called by Playwright as teardown,
+// which kills the server and removes the sandbox.
+
+const fs = require('fs');
+const path = require('path');
+const {
+  createSandbox,
+  cleanupSandbox,
+  spawnServer,
+  fakeAuthState,
+} = require('../../tests/helpers/sandbox');
+const { seedManifests } = require('./seed-manifests');
+
+const STATE_DIR = path.join(__dirname, '..', '.state');
+const STATE_FILE = path.join(STATE_DIR, 'state.json');
+
+module.exports = async () => {
+  fs.mkdirSync(STATE_DIR, { recursive: true });
+
+  const auth = fakeAuthState('e2e-user');
+  const seed = seedManifests();
+
+  const sandbox = createSandbox({
+    seed,
+    credentials: auth.credentials,
+    sessions: auth.sessions,
+  });
+
+  const server = await spawnServer(sandbox);
+
+  const state = {
+    sandbox,
+    baseUrl: server.baseUrl,
+    port: server.port,
+    sessionToken: auth.token,
+    sessionCookie: auth.cookie,
+    startedAt: new Date().toISOString(),
+  };
+  fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+
+  process.env.KLEBB_E2E_BASE_URL = server.baseUrl;
+
+  console.log(`[e2e] sandbox ready: ${server.baseUrl}`);
+
+  return async () => {
+    try { await server.kill(); } catch {}
+    cleanupSandbox(sandbox);
+    try { fs.unlinkSync(STATE_FILE); } catch {}
+    console.log('[e2e] sandbox torn down');
+  };
+};

--- a/tests-e2e/helpers/seed-manifests.js
+++ b/tests-e2e/helpers/seed-manifests.js
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/helpers/seed-manifests.js
+// Seed manifest content for the E2E sandbox. Minimal on purpose — just
+// enough for the smoke test. Specs that need richer fixtures can seed
+// extra cards via API calls in their own setup.
+
+function weight() {
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'weight',
+      label: 'Weight',
+      emoji: '⚖️',
+      order: 200,
+      category: 'body',
+      view: {
+        enabled: true,
+        component: 'generic-card',
+        dateContext: 'latest',
+        display: { template: '{kg:round(1)}', unit: 'kg' },
+      },
+      writeable: {
+        fromWebapp: true,
+        todayAllowed: true,
+        pastAllowed: true,
+        futureAllowed: false,
+        maxReadingsPerDay: 1,
+        inputs: [
+          { key: 'kg', type: 'number', required: true, min: 20, max: 500, step: 0.1 },
+        ],
+      },
+    },
+    description: 'Body weight log for E2E sandbox.',
+    data: [
+      { date: '2026-05-08', kg: 81.2 },
+      { date: '2026-05-09', kg: 81.0 },
+      { date: '2026-05-10', kg: 80.9 },
+    ],
+  };
+}
+
+function mood() {
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'mood',
+      label: 'Mood',
+      emoji: '🙂',
+      order: 100,
+      category: 'lifestyle',
+      view: {
+        enabled: true,
+        component: 'generic-card',
+        dateContext: 'latest',
+        display: {
+          template: '{mood}',
+          emojiMap: { 1: '😩', 2: '😔', 3: '😐', 4: '🙂', 5: '😄' },
+        },
+      },
+      writeable: {
+        fromWebapp: true,
+        todayAllowed: true,
+        pastAllowed: true,
+        futureAllowed: false,
+        maxReadingsPerDay: 1,
+        inputs: [
+          { key: 'mood', type: 'rating', min: 1, max: 5, required: true },
+          { key: 'note', type: 'textarea', required: false },
+        ],
+      },
+    },
+    description: 'Subjective daily mood log for E2E sandbox.',
+    data: [
+      { date: '2026-05-08', mood: 3 },
+      { date: '2026-05-09', mood: 4 },
+      { date: '2026-05-10', mood: 5 },
+    ],
+  };
+}
+
+function seedManifests() {
+  return {
+    'weight.json': weight(),
+    'mood.json': mood(),
+  };
+}
+
+module.exports = { seedManifests };

--- a/tests-e2e/smoke.spec.js
+++ b/tests-e2e/smoke.spec.js
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/smoke.spec.js
+// Smoke test: the E2E harness boots, auth cookie is accepted, Today
+// view renders the seeded cards. Any future bug-fix spec in this
+// directory should assume this passes first.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+test.describe('smoke', () => {
+  test('today view renders seeded cards', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page).not.toHaveURL(/setup\.html/);
+    await expect(page).not.toHaveURL(/login\.html/);
+
+    await expect(page.locator('eh-date-view')).toBeVisible({ timeout: 10_000 });
+
+    const genericCards = page.locator('eh-generic-card');
+    await expect(genericCards).toHaveCount(2, { timeout: 10_000 });
+
+    await expect(page.locator('eh-generic-card', { hasText: 'Weight' })).toBeVisible();
+    await expect(page.locator('eh-generic-card', { hasText: 'Mood' })).toBeVisible();
+  });
+
+  test('API returns the seeded manifests', async ({ page, sandboxState }) => {
+    await page.goto('/');
+    const res = await page.request.get(`${sandboxState.baseUrl}/api/manifests`);
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    const ids = body.entries.map(e => e.id).sort();
+    expect(ids).toContain('weight');
+    expect(ids).toContain('mood');
+  });
+});


### PR DESCRIPTION
# What changed

Introduces a Playwright-based end-to-end test harness so UI behaviour
can be covered by automated tests instead of manual QA. Ships only
the scaffold plus one smoke spec — bug-fix specs for the pending
issues (#181, #182, etc.) will land in follow-up PRs that each add
coverage alongside the fix.

# Why

The 2026-05-11 QA pass surfaced around 15 bugs in two hours of manual
clicking. None would have been caught by the existing \`node:test\`
suite because none of the tests touch the UI. A Playwright harness
closes that gap and becomes the regression net going forward.

Fixes #198.

# How

- \`tests-e2e/\` directory at repo root.
- \`playwright.config.js\` — Chromium only, single worker, traces on
  failure, headed runs get a 400ms slow-mo so the operator can watch.
- \`tests-e2e/helpers/global-setup.js\` — boots an ephemeral
  \`HEALTH_HOME\` sandbox via the existing \`tests/helpers/sandbox.js\`,
  seeds a valid session via \`fakeAuthState\`, writes connection info
  to \`tests-e2e/.state/state.json\` for specs to consume, returns a
  teardown function that kills the server and removes the sandbox.
- \`tests-e2e/helpers/auth-fixture.js\` — Playwright fixture wrapper
  that injects the session cookie on every page and overrides
  \`baseURL\` so \`page.goto('/')\` resolves against the sandbox. Also
  installs an in-page banner showing the current test title during
  headed runs; no-op headless.
- \`tests-e2e/helpers/seed-manifests.js\` — minimal weight + mood
  seed for the smoke test. Specs that need richer fixtures seed
  their own via API calls.
- \`tests-e2e/smoke.spec.js\` — two tests: Today view renders the
  seeded cards; API returns them.
- \`.github/workflows/e2e.yml\` — runs on PR + main push, installs
  only Chromium, uploads \`playwright-report/\` and \`test-results/\`
  as artefacts on failure.
- \`docs/TESTING.md\` — three-layer rubric (unit / API / E2E) with
  guidance on which layer a new test belongs in.
- README section updated with the new test commands.
- \`.gitignore\` entries for \`tests-e2e/.state/\`, \`test-results/\`,
  \`playwright-report/\`, \`playwright/.cache/\`.

Design notes worth flagging:

- No virtual WebAuthn authenticator. The existing \`fakeAuthState\`
  helper already produces a valid credentials file + session pair —
  injecting the session cookie on the browser context is simpler and
  matches how the existing API tests authenticate.
- Session-cookie injection is Lax/secure-off so it works against the
  local HTTP sandbox. The cookie is only ever issued against an
  ephemeral \`127.0.0.1\` host.
- \`globalSetup\` returns a teardown function directly instead of
  using a separate \`globalTeardown\` file; keeps the sandbox handle
  in one closure.

# Testing

- [x] \`npm test\` passes locally (809/810; the one failure is
      pre-existing on main and concerns \`settings-api.test.js\` under
      concurrent test runs — see notes in QA-BUGS.md)
- [x] \`npm run test:e2e\` passes locally (headless, 2 tests, ~6s)
- [x] \`npm run test:e2e:headed\` shows the browser visibly running
      actions with the test-title banner overlaid
- [x] Ran headless twice back-to-back to confirm idempotent teardown
- [x] Sandbox port is picked randomly; no collision with prod
      instances

# Checklist

- [x] Commit messages follow the conventions in \`CONTRIBUTING.md\`
- [x] \`CHANGELOG.md\` updated under \`## Unreleased\`
- [x] Docs updated (README.md, new \`docs/TESTING.md\`)
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Follow-up

Phase B issue #199 adds \`tests/api/\` integration tests for
data-layer regressions, using the same sandbox harness this PR
depends on. Issue #200 documents the testing discipline for future
PRs. Both should land before we start the bug-fix PRs so each fix
arrives with coverage.