### PR TITLE
feat(tests): add tests/api regression layer with three seed specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **`tests/api/` regression layer.** New directory under `tests/` for
+  per-bug API-level regression tests, using the existing sandbox
+  harness. Seeds three tests against the M1/M3 QA findings: one
+  passing today (documents the mood-write server contract for
+  #181), two `describe.skip`-d until their respective fixes land
+  (HAE FP rounding #184, loader backup-file guard #197). The skip
+  markers are the signal for which fix PR un-skips which test.
+  `npm test` now globs `tests/api/*.test.js` alongside the existing
+  `tests/*.test.js`. (Fixes #199)
+
 - **Playwright end-to-end test harness.** New `tests-e2e/` directory
   and `npm run test:e2e` script drive a headless Chromium against an
   ephemeral sandbox (same harness `tests/helpers/sandbox.js` uses),

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -17,7 +17,7 @@ resolution, schedule expansion, merge-patch behaviour.
 - Target: code under `config/`, `manifests/`, `server/`, `chat/`, `auth/`,
   `health-auto-export/`.
 
-### 2. API integration tests — `tests/*.test.js` (sandbox variant)
+### 2. API integration tests — `tests/*.test.js` + `tests/api/*.test.js`
 
 Same runner, but spin up a real klebb server against an ephemeral
 `HEALTH_HOME` and exercise the HTTP API. These catch data-layer
@@ -29,9 +29,16 @@ regressions without needing a browser.
 - Target: any API route; manifest write / patch behaviour; HAE ingest;
   auth-gated flows.
 
+Put broad API-surface tests in `tests/`. Put **per-bug regression
+tests** in `tests/api/` — one file per issue, named after the bug
+(`mood-edit-single-date.test.js`, `hae-ingest-fp-rounding.test.js`,
+etc.). When a fix lands, un-skip the test; when a new bug is
+reported, add a failing-then-passing seed here so the fix is
+locked in by CI.
+
 Write an API test when the bug's symptom is observable without a
-browser. Example: "editing a past mood entry overwrites all rows" —
-the proof is in the manifest file after the PATCH. Don't need a UI.
+browser. Example: "HAE ingest leaks IEEE754 tails" — the proof is
+in the manifest file after the push. Don't need a UI.
 
 ### 3. End-to-end tests — `tests-e2e/*.spec.js`
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A file-driven personal health dashboard. Every card is a JSON file.",
   "main": "server.js",
   "scripts": {
-    "test": "node --test tests/*.test.js",
+    "test": "node --test tests/*.test.js tests/api/*.test.js",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:debug": "playwright test --debug",

--- a/tests/api/hae-ingest-fp-rounding.test.js
+++ b/tests/api/hae-ingest-fp-rounding.test.js
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/api/hae-ingest-fp-rounding.test.js
+// Regression test for #184 (QA-BUGS.md B15): HAE ingest should not
+// persist IEEE754 precision tails (e.g. 88.00000000000001 bpm) into
+// manifest rows.
+//
+// Today this test is `test.skip`-d because the bug has not been fixed
+// yet — `aggregate: 'last-per-date'` copies the source value verbatim
+// in `health-auto-export/ingest.js`. When #184 lands, un-skip the
+// test; it will pass against the fixed ingest and fail-fast if the
+// behaviour regresses later.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const {
+  createSandbox,
+  cleanupSandbox,
+  spawnServer,
+  req,
+  fakeAuthState,
+} = require('../helpers/sandbox');
+
+function walkingHrManifest() {
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'walking-heart-rate',
+      label: 'Walking HR',
+      ingest: { source: 'hae', metric: 'walking_heart_rate_average' },
+      view: {
+        enabled: true,
+        component: 'generic-card',
+        display: { template: '{bpm:round(0)} bpm' },
+      },
+      writeable: { fromWebapp: false },
+    },
+    description: 'Walking heart rate average ingested from HAE.',
+    data: [],
+  };
+}
+
+function restingHrManifest() {
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'resting-heart-rate',
+      label: 'Resting HR',
+      ingest: { source: 'hae', metric: 'resting_heart_rate' },
+      view: {
+        enabled: true,
+        component: 'generic-card',
+        display: { template: '{bpm} bpm' },
+      },
+      writeable: { fromWebapp: false },
+    },
+    description: 'Resting heart rate ingested from HAE.',
+    data: [],
+  };
+}
+
+// Build a minimal HAE payload shape with FP-tail values typical of
+// Apple Health averages.
+function haePayloadWithFpTails() {
+  return {
+    data: {
+      metrics: [
+        {
+          name: 'walking_heart_rate_average',
+          units: 'bpm',
+          data: [
+            { date: '2026-05-01 00:00:00 +1000', qty: 88.00000000000001 },
+            { date: '2026-05-02 00:00:00 +1000', qty: 84.99999999999999 },
+            { date: '2026-05-03 00:00:00 +1000', qty: 91.5 },
+          ],
+        },
+        {
+          name: 'resting_heart_rate',
+          units: 'bpm',
+          data: [
+            { date: '2026-05-01 00:00:00 +1000', qty: 62.00000000000001 },
+            { date: '2026-05-02 00:00:00 +1000', qty: 67 },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+describe.skip('M1/#184: HAE ingest rounds numeric values (SKIP until fix lands)', () => {
+  let sandbox, server, auth;
+  const token = 'test-hae-token';
+
+  before(async () => {
+    auth = fakeAuthState('e2e-user');
+    sandbox = createSandbox({
+      seed: {
+        'walking-heart-rate.json': walkingHrManifest(),
+        'resting-heart-rate.json': restingHrManifest(),
+      },
+      credentials: auth.credentials,
+      sessions: auth.sessions,
+    });
+    server = await spawnServer(sandbox, {
+      HEALTH_AUTO_EXPORT_TOKEN: token,
+    });
+  });
+
+  after(async () => {
+    if (server) await server.kill();
+    cleanupSandbox(sandbox);
+  });
+
+  test('walking HR rows are rounded, no IEEE754 tails', async () => {
+    const pushRes = await req(server.baseUrl, '/api/health-auto-export', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: haePayloadWithFpTails(),
+    });
+    assert.equal(pushRes.status, 200, `push failed: ${pushRes.body}`);
+
+    const readRes = await req(server.baseUrl, '/api/manifests/walking-heart-rate/data', {
+      cookie: auth.cookie,
+    });
+    const rows = readRes.json.data;
+    for (const r of rows) {
+      const s = String(r.bpm);
+      assert.ok(
+        !s.includes('0000000') && !s.includes('9999999'),
+        `FP tail leaked into walking-heart-rate row: ${JSON.stringify(r)}`,
+      );
+    }
+  });
+
+  test('resting HR rows are rounded to integer', async () => {
+    const readRes = await req(server.baseUrl, '/api/manifests/resting-heart-rate/data', {
+      cookie: auth.cookie,
+    });
+    const rows = readRes.json.data;
+    for (const r of rows) {
+      assert.equal(
+        r.bpm,
+        Math.round(r.bpm),
+        `resting-heart-rate row not rounded to integer: ${JSON.stringify(r)}`,
+      );
+    }
+  });
+});

--- a/tests/api/loader-ignores-backup-files.test.js
+++ b/tests/api/loader-ignores-backup-files.test.js
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/api/loader-ignores-backup-files.test.js
+// Regression test for #197 (QA-BUGS.md B10): the manifest loader must
+// not treat timestamped backup files (e.g. foo.json.pre-reingest-*.json)
+// as canonical manifests. Today, the loader globs `*.json` in the
+// manifests dir, which includes such backups and produces duplicate-id
+// errors that drop the canonical card.
+//
+// Currently `describe.skip` pending the #197 fix. Un-skip on that
+// PR to prove the fix; the test then locks in the behaviour.
+
+const fs = require('fs');
+const path = require('path');
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const {
+  createSandbox,
+  cleanupSandbox,
+  spawnServer,
+  req,
+  fakeAuthState,
+} = require('../helpers/sandbox');
+
+function moodManifest() {
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'mood',
+      label: 'Mood',
+      view: {
+        enabled: true,
+        component: 'generic-card',
+        display: { template: '{mood}' },
+      },
+      writeable: {
+        fromWebapp: true,
+        inputs: [{ key: 'mood', type: 'rating', min: 1, max: 5 }],
+      },
+    },
+    description: 'Daily mood rating.',
+    data: [{ date: '2026-05-09', mood: 4 }],
+  };
+}
+
+describe.skip('M3/#197: loader ignores timestamped backup files (SKIP until fix)', () => {
+  let sandbox, server, auth;
+
+  before(async () => {
+    auth = fakeAuthState('e2e-user');
+    sandbox = createSandbox({
+      seed: {
+        'mood.json': moodManifest(),
+        // Drop a backup file next to the canonical one. Same $schema,
+        // same meta.id — would currently trigger duplicate-id error
+        // and drop the canonical card too.
+        'mood.json.pre-reingest-2026-05-10T000000000Z.json': moodManifest(),
+      },
+      credentials: auth.credentials,
+      sessions: auth.sessions,
+    });
+    server = await spawnServer(sandbox);
+  });
+
+  after(async () => {
+    if (server) await server.kill();
+    cleanupSandbox(sandbox);
+  });
+
+  test('canonical mood card loads; backup file ignored', async () => {
+    const res = await req(server.baseUrl, '/api/manifests', { cookie: auth.cookie });
+    assert.equal(res.status, 200);
+    const ids = res.json.entries.map(e => e.id);
+    assert.ok(ids.includes('mood'), 'mood card was loaded');
+    assert.equal(
+      res.json.entries.filter(e => e.id === 'mood').length,
+      1,
+      'mood loaded exactly once',
+    );
+  });
+});

--- a/tests/api/mood-edit-single-date.test.js
+++ b/tests/api/mood-edit-single-date.test.js
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/api/mood-edit-single-date.test.js
+// Regression test for the M1 bug tracked in #181 (see QA-BUGS.md B11):
+// editing a single past-date mood row must not overwrite other rows.
+//
+// The server accepts a full `data[]` replacement on POST /api/manifests/
+// :id/data. This test exercises a correct client payload (all rows
+// present, only target row changed) and asserts only that row's mood
+// value is different post-write. A broken client that sends the same
+// mood for every row would make this test pass — but the fix for #181
+// lives client-side (form submission path), and the E2E equivalent
+// in tests-e2e/ will cover that layer once it lands.
+//
+// In the meantime this test documents the server-side contract: the
+// write endpoint must round-trip a targeted edit faithfully. Regression
+// here means a server change that mangles data.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const {
+  createSandbox,
+  cleanupSandbox,
+  spawnServer,
+  req,
+  fakeAuthState,
+} = require('../helpers/sandbox');
+
+function moodManifest(data) {
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'mood',
+      label: 'Mood',
+      view: {
+        enabled: true,
+        component: 'generic-card',
+        dateContext: 'latest',
+        display: {
+          template: '{mood}',
+          emojiMap: { 1: '😩', 2: '😔', 3: '😐', 4: '🙂', 5: '😄' },
+        },
+      },
+      writeable: {
+        fromWebapp: true,
+        todayAllowed: true,
+        pastAllowed: true,
+        futureAllowed: false,
+        maxReadingsPerDay: 1,
+        inputs: [
+          { key: 'mood', type: 'rating', min: 1, max: 5, required: true },
+          { key: 'note', type: 'textarea', required: false },
+        ],
+      },
+    },
+    description: 'Daily mood rating.',
+    data,
+  };
+}
+
+describe('M1/#181: mood edit must affect only the targeted date', () => {
+  let sandbox, server, auth;
+
+  const seedData = [
+    { date: '2026-05-05', mood: 5 },
+    { date: '2026-05-06', mood: 3 },
+    { date: '2026-05-07', mood: 4 },
+    { date: '2026-05-08', mood: 2 },
+    { date: '2026-05-09', mood: 5 },
+  ];
+
+  before(async () => {
+    auth = fakeAuthState('e2e-user');
+    sandbox = createSandbox({
+      seed: { 'mood.json': moodManifest(seedData) },
+      credentials: auth.credentials,
+      sessions: auth.sessions,
+    });
+    server = await spawnServer(sandbox);
+  });
+
+  after(async () => {
+    if (server) await server.kill();
+    cleanupSandbox(sandbox);
+  });
+
+  test('editing 2026-05-06 leaves other dates intact', async () => {
+    const target = '2026-05-06';
+    const newMoodValue = 1;
+    const nextRows = seedData.map(r =>
+      r.date === target ? { ...r, mood: newMoodValue } : r,
+    );
+
+    const writeRes = await req(server.baseUrl, '/api/manifests/mood/data', {
+      method: 'POST',
+      cookie: auth.cookie,
+      body: { data: nextRows },
+    });
+    assert.equal(writeRes.status, 200, `write failed: ${writeRes.body}`);
+
+    const readRes = await req(server.baseUrl, '/api/manifests/mood/data', {
+      cookie: auth.cookie,
+    });
+    assert.equal(readRes.status, 200);
+    const rows = readRes.json.data;
+
+    const byDate = Object.fromEntries(rows.map(r => [r.date, r.mood]));
+    assert.equal(byDate[target], newMoodValue, 'target row updated');
+    assert.equal(byDate['2026-05-05'], 5, 'prior day untouched');
+    assert.equal(byDate['2026-05-07'], 4, 'next day untouched');
+    assert.equal(byDate['2026-05-08'], 2, 'untouched');
+    assert.equal(byDate['2026-05-09'], 5, 'latest untouched');
+  });
+});


### PR DESCRIPTION
# What changed

Introduces \`tests/api/\` as the home for per-bug API-level regression
tests, and seeds three tests against QA findings from 2026-05-11.
Depends on #201 (the E2E scaffold), now merged.

Fixes #199.

# Why

Phase B #2 of the testing automation plan. Complements the Playwright
scaffold (#198/PR #201): the E2E suite covers user-visible
interaction bugs, this layer covers data-layer regressions that don't
need a browser. Faster, cheaper, and strictly scoped to API
contracts.

Three seeds land now so the upcoming M1 fix PRs (#181, #184, #197)
each ship with a ready-to-un-skip regression test that proves the
fix and locks in the behaviour against future regressions.

# How

- **\`tests/api/mood-edit-single-date.test.js\`** — passes today. Writes
  a full \`data[]\` array via \`POST /api/manifests/mood/data\` with one
  row changed, asserts only that row's value differs post-write.
  Documents the server-side contract. #181 is a client-only bug
  (form submission path); the E2E equivalent will land with the fix
  and cover the full loop, but this test guards against any future
  server change that would mangle targeted edits.
- **\`tests/api/hae-ingest-fp-rounding.test.js\`** — \`describe.skip\`
  until #184 lands. Pushes an HAE payload with typical IEEE754 tail
  values (\`88.00000000000001\`, \`84.99999999999999\`), asserts
  persisted rows are free of those tails. When the fix rounds at
  ingest time (in \`health-auto-export/catalogue.js\` or
  \`ingest.js\`), un-skip.
- **\`tests/api/loader-ignores-backup-files.test.js\`** — \`describe.skip\`
  until #197 lands. Seeds a sandbox with both \`mood.json\` and a
  \`mood.json.pre-reingest-YYYYMMDD.json\` backup. Asserts the
  canonical \`mood\` card loads exactly once. Proves the loader
  ignores timestamped backup files. Un-skip on fix.

Other small additions:

- \`package.json\` test script globs both \`tests/*.test.js\` and the
  new \`tests/api/*.test.js\`.
- \`docs/TESTING.md\` documents the split: broad API-surface tests in
  \`tests/\`, per-bug regression seeds in \`tests/api/\`, one file per
  issue.
- \`CHANGELOG.md\` entry under \`## Unreleased\`.

Design notes:

- I deliberately chose \`describe.skip\` over \`test.todo\` because
  todo-tests render as passing with a different colour in most
  reporters — easy to miss. A skipped describe is visibly absent
  from the pass count, which is the right signal.
- The skipped tests carry a comment telling the fix PR to un-skip
  them, naming the file that'll need editing.

# Testing

- [x] \`node --test tests/api/*.test.js\` — 1 pass, 2 skipped,
      ~2.7s
- [x] \`npm test\` — 810/811 pass locally (one pre-existing
      settings-api.test.js flake, not this PR)
- [x] The \`no-personal-refs\` test fails on my local Windows host
      because it scans gitignored \`BRIEF-FOR-CC.md\`/\`CLAUDE.md\`
      which only exist on my machine. CI doesn't see these and
      passes clean. Verified the same failure occurs on pristine
      main.

# Checklist

- [x] Commit messages follow conventions
- [x] \`CHANGELOG.md\` updated
- [x] Docs updated (\`docs/TESTING.md\`)
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Follow-up

Issue #200 (testing discipline doc + PR template) is the next Phase B
item. After that, M1 fixes begin — each will un-skip its regression
test as part of the fix PR.