### PR TITLE
chore(docs): codify testing expectations across contributor surface

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,10 +14,17 @@ weren't obvious.
 
 # Testing
 
-- [ ] `npm test` passes locally
-- [ ] New tests added where applicable
-- [ ] Manual QA against a local dev instance (describe what you
-      clicked/tried)
+- [ ] `npm test` passes locally (Node 20 and 22)
+- [ ] `npm run test:e2e` passes locally (headless Playwright)
+- [ ] New regression test added at the right layer:
+  - Backend / manifest / schema change → `tests/api/*.test.js`
+  - User-visible interaction / navigation → `tests-e2e/*.spec.js`
+  - Pure logic → `tests/*.test.js`
+  - No test? Explain why (doc-only change, pure rename, etc.)
+- [ ] Test fails against `main` before the fix and passes with it
+      (for bug-fix PRs)
+- [ ] Manual QA against a local dev instance or the klebbtest
+      container (describe what you clicked/tried)
 
 # Checklist
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
   hallucinations (`view.slots`, `view.sources`) so the agent learns
   what to avoid as well as what to use. (Fixes #179)
 
+### Changed
+
+- **Testing discipline documented across the contributor surface.**
+  `docs/TESTING.md` gains a "PR expectations" section with the
+  bug-fix workflow (fail-on-main first, then fix, then show pass)
+  and a clear list of "no test needed" vs "nice try" justifications.
+  `CONTRIBUTING.md` points at the three-layer rubric and repeats
+  the commands every contributor needs. The PR template adds a
+  layer-picker checklist so reviewers can confirm coverage at a
+  glance. (Fixes #200)
+
 ### Added
 
 - **`tests/api/` regression layer.** New directory under `tests/` for

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,10 +20,11 @@ npm start
 # → http://localhost:8080
 ```
 
-Run the test suite before every commit:
+Run the test suites before every commit:
 
 ```bash
-npm test
+npm test           # unit + API integration (~15s)
+npm run test:e2e   # end-to-end (Playwright, headless, ~10s)
 ```
 
 All tests should pass on Node 20 and Node 22. CI enforces both.
@@ -39,7 +40,8 @@ Short version:
 - `auth/` — WebAuthn + invites
 - `voice/` — Fish Audio TTS/ASR (optional)
 - `public/` — frontend (Lit web components)
-- `tests/` — Node built-in `node --test` suite
+- `tests/` — Node built-in `node --test` suite (unit + API integration)
+- `tests-e2e/` — Playwright end-to-end suite
 - `scripts/` — CLI tools (migrate, invite, deploy, verify-install)
 - `docs/` — user + contributor docs
 
@@ -86,22 +88,43 @@ review. We prefer a clean history.
 
 ## Tests
 
-- New features ship with tests. Integration tests use
-  `tests/helpers/sandbox.js` for ephemeral `$HEALTH_HOME` + server.
-- Pure-function libraries get unit tests. See `tests/display-template.test.js`
-  for the shape.
-- Lit web components are not unit-tested in CI (DOM required). Manual QA
-  + integration via the HTTP API covers them in practice.
-- Don't add test dependencies — the stdlib `node --test` + assert is
-  enough.
+Klebb has three test layers. Pick the right one for your change. Full
+rubric in [`docs/TESTING.md`](docs/TESTING.md); short version here.
+
+| Layer | Location | Runs | Use when |
+|-------|----------|------|----------|
+| Unit / lib | `tests/*.test.js` | `npm test` | Pure logic — manifest parsing, date maths, template evaluation, merge-patch |
+| API integration | `tests/*.test.js` + `tests/api/*.test.js` | `npm test` | HTTP API contract, manifest write / patch, HAE ingest, auth |
+| End-to-end | `tests-e2e/*.spec.js` | `npm run test:e2e` | Rendering, navigation, form interaction, chat widget state |
+
+**Every non-trivial PR ships a test.** The right one for the right
+change:
+
+- Bug fix → regression test at the matching layer, shown failing
+  against `main` before your fix, passing after.
+- New feature → happy-path coverage plus one edge case.
+- Doc-only change or pure rename → no test needed; say so in the PR
+  body.
+
+Per-bug regression seeds live in `tests/api/` (one file per issue,
+named after the bug). If you open a bug fix PR and there's already a
+`describe.skip`-d seed for it in `tests/api/`, un-skip and extend it
+rather than writing a parallel file.
+
+No new test dependencies without a PR justification — stdlib
+`node --test` + Playwright are enough.
 
 ## Pull requests
 
 1. Fork, create a branch off `main`
 2. Keep commits focused (one logical change per commit)
 3. Update `CHANGELOG.md` under `## Unreleased`
-4. Run `npm test` locally before pushing
-5. Open a PR; CI runs automatically
+4. Run both test suites locally before pushing:
+   ```bash
+   npm test           # unit + API integration
+   npm run test:e2e   # end-to-end (Playwright, headless)
+   ```
+5. Open a PR; CI runs both suites automatically
 6. Address review comments with additional commits (don't force-push
    during review — we can squash at merge time)
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -142,11 +142,47 @@ GitHub Actions runs all three layers on every PR:
 
 ## PR expectations
 
-Every non-trivial PR should include regression coverage at the right
-layer. If you're fixing a bug, write the test that proves the fix
-first (fails on current `main`, passes with the fix). If you're
-adding a feature, cover the happy path + one edge case.
+Every non-trivial PR ships with regression coverage at the right
+layer. The PR template encodes this as a checklist; CI runs both
+suites on every PR regardless.
 
-If a change legitimately doesn't need a new test, say so in the PR
-body. "No new tests because this is a pure doc change" is fine. "No
-new tests because I ran it locally" is not.
+### Bug-fix PRs
+
+1. Check `tests/api/` for an existing `describe.skip`-d seed matching
+   your issue. If one exists, you un-skip that file. If not, write a
+   new one named after the bug.
+2. Show the test **fails against current `main`**. This is the proof
+   that the test is actually wired up to the bug, not just adjacent
+   to it.
+3. Make the fix.
+4. Show the test now passes.
+5. Run the full suite (`npm test` + `npm run test:e2e`) to confirm
+   no regressions elsewhere.
+6. Push. CI re-runs everything.
+
+A test that skips on main and still skips on your branch is not
+coverage; it's decoration.
+
+### Feature PRs
+
+Happy path + at least one edge case. Choose the layer that matches
+what the feature actually does:
+- New API route → `tests/api/`.
+- New renderer / UX flow → `tests-e2e/`.
+- New pure-logic helper → `tests/`.
+
+If the feature touches multiple layers (new API + new renderer),
+cover each.
+
+### When a test genuinely isn't needed
+
+Say so in the PR body, with the reason. Accepted forms:
+- "Doc-only change."
+- "Pure rename, no behaviour change."
+- "Comment tweak."
+- "Dependency bump, covered by existing suite."
+
+Not accepted:
+- "I ran it locally."
+- "Too hard to test."
+- "Will add later."


### PR DESCRIPTION
# What changed

Documents the three-layer testing discipline in the four places a
contributor actually sees. No behavioural changes; docs only.

Fixes #200.

# Why

Phase B #3 of the testing automation plan. Depends on PRs #201 (E2E
scaffold) and #202 (\`tests/api/\` regression layer), both merged. With
the harness in place, this PR makes "every PR ships with coverage at
the right layer" the visible default rather than a tribal norm.

Without this, the harness decays: future PRs land with "tests later"
debt and the automation becomes ornamental.

# How

Four surfaces updated:

1. **\`docs/TESTING.md\`** gains a "PR expectations" section with:
   - Bug-fix workflow (check for a skipped seed, show it fails on
     main, fix, show it passes, run both suites).
   - Feature workflow (happy path + one edge case at the matching
     layer).
   - Accept/reject examples for "no test needed" justifications so
     the bar is concrete.
2. **\`CONTRIBUTING.md\`** points at the three-layer rubric with a
   quick-reference table, updates the pre-push command block to
   include \`npm run test:e2e\`, and adds \`tests-e2e/\` to the project
   layout.
3. **\`.github/PULL_REQUEST_TEMPLATE.md\`** adds a layer-picker
   checklist under Testing with an explicit "no test? explain why"
   line. The template is what a PR author fills in first; this is
   the highest-leverage surface.
4. **\`CHANGELOG.md\`** entry under \`## Unreleased\`.

# Testing

- [x] \`npm test\` — pre-existing Windows-only flakes (see #201 notes);
      CI is green for docs-only diffs.
- [x] \`npm run test:e2e\` — 2 pass, 7.6s
- [x] No test required: this is a doc-only change with no runtime
      behaviour.

# Checklist

- [x] Commit messages follow conventions
- [x] \`CHANGELOG.md\` updated
- [x] Docs updated (this is the docs update)
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Follow-up

This closes out Phase B. Next up: M1 bug fixes, starting with #181
(mood pencil-edit) which is client-side and will un-skip the
placeholder in \`tests/api/mood-edit-single-date.test.js\` by adding
an E2E test that asserts the full click-edit-save loop writes only
the target date.

Then #182 (BP past-date display), #183 (mood calendar per-day emoji),
#184 (HAE FP rounding — un-skips its regression seed), in whatever
order makes sense.