### PR TITLE
fix(renderer): cards with dateContext:latest honour past-date nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Cards with `dateContext: "latest"` now honour past-date navigation.**
+  The `latest` resolver in `eh-generic-card._currentEntry()` used to
+  return the most recent row regardless of which date the user had
+  navigated to, so every past date on cards like Blood Pressure,
+  Mood, Weight, HRV, Resting HR, Walking HR, Exercise Time, Steps,
+  Daily Notes, and Sleep Analysis/Quality displayed (and, via the
+  pencil, edited) today's numbers. `"latest"` is now treated as a
+  Today-mode fallback: past/future navigation does exact-date
+  lookup. Verified: editing a past-date mood now writes to that
+  row, not today's. (Fixes #182; closes #181 as a duplicate)
+
 - **Chat agent no longer hallucinates the combination-card manifest
   schema.** Observed in live QA: asked to build a Sleep CC, the agent
   wrote `view.sources[]` keyed on `id`; asked to build a Lifestyle

--- a/public/js/components/eh-generic-card.js
+++ b/public/js/components/eh-generic-card.js
@@ -68,7 +68,11 @@ export class EhGenericCard extends EhBaseCard {
   _currentEntry() {
     const entries = this._entries();
     if (entries.length === 0) return null;
-    if (this._dateContext() === 'latest') {
+    // dateContext:"latest" is a Today-mode fallback — on any past/future
+    // date the card resolves by exact date match so navigation actually
+    // means what it says. See issue #182.
+    const isToday = this.dateMode === 'today' || !this.dateMode;
+    if (isToday && this._dateContext() === 'latest') {
       return [...entries].sort((a, b) => (b.date || '').localeCompare(a.date || ''))[0];
     }
     return entries.find(e => e.date === this.date) || null;

--- a/tests-e2e/helpers/seed-manifests.js
+++ b/tests-e2e/helpers/seed-manifests.js
@@ -4,8 +4,30 @@
 // Seed manifest content for the E2E sandbox. Minimal on purpose — just
 // enough for the smoke test. Specs that need richer fixtures can seed
 // extra cards via API calls in their own setup.
+//
+// Dates are anchored to "today" (local-date at setup time) so past-date
+// navigation tests behave consistently regardless of which day the
+// suite runs. `todayISO` + `shiftDays` are also exported for specs.
 
-function weight() {
+function todayISO() {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function shiftDays(isoDate, delta) {
+  const [y, m, d] = isoDate.split('-').map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  dt.setUTCDate(dt.getUTCDate() + delta);
+  const yy = dt.getUTCFullYear();
+  const mm = String(dt.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(dt.getUTCDate()).padStart(2, '0');
+  return `${yy}-${mm}-${dd}`;
+}
+
+function weight(today) {
   return {
     $schema: 'klebb.datafile.v1',
     meta: {
@@ -33,14 +55,14 @@ function weight() {
     },
     description: 'Body weight log for E2E sandbox.',
     data: [
-      { date: '2026-05-08', kg: 81.2 },
-      { date: '2026-05-09', kg: 81.0 },
-      { date: '2026-05-10', kg: 80.9 },
+      { date: shiftDays(today, -2), kg: 81.2 },
+      { date: shiftDays(today, -1), kg: 81.0 },
+      { date: today,                kg: 80.9 },
     ],
   };
 }
 
-function mood() {
+function mood(today) {
   return {
     $schema: 'klebb.datafile.v1',
     meta: {
@@ -72,18 +94,20 @@ function mood() {
     },
     description: 'Subjective daily mood log for E2E sandbox.',
     data: [
-      { date: '2026-05-08', mood: 3 },
-      { date: '2026-05-09', mood: 4 },
-      { date: '2026-05-10', mood: 5 },
+      { date: shiftDays(today, -3), mood: 2 },
+      { date: shiftDays(today, -2), mood: 3 },
+      { date: shiftDays(today, -1), mood: 4 },
+      { date: today,                mood: 5 },
     ],
   };
 }
 
 function seedManifests() {
+  const today = todayISO();
   return {
-    'weight.json': weight(),
-    'mood.json': mood(),
+    'weight.json': weight(today),
+    'mood.json': mood(today),
   };
 }
 
-module.exports = { seedManifests };
+module.exports = { seedManifests, todayISO, shiftDays };

--- a/tests-e2e/past-date-view-and-edit.spec.js
+++ b/tests-e2e/past-date-view-and-edit.spec.js
@@ -11,8 +11,6 @@
 // latest row and the pencil-edit writes to today's row regardless
 // of the date the user is viewing.
 
-const fs = require('fs');
-const path = require('path');
 const { test, expect } = require('./helpers/auth-fixture');
 const { todayISO, shiftDays } = require('./helpers/seed-manifests');
 
@@ -23,43 +21,49 @@ const twoDaysAgo = shiftDays(today, -2);
 test.describe('#182: cards with dateContext:latest honour past-date navigation', () => {
   test('mood card on yesterday shows yesterday\'s value, not today\'s', async ({ page }) => {
     await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible();
 
-    // Today shows latest: mood = 5.
     const moodCard = page.locator('eh-generic-card', { hasText: 'Mood' }).first();
-    await expect(moodCard).toBeVisible();
+    // Wait for TODAY's value to appear before clicking — avoids a race
+    // where the click fires before the app hydrates this.date.
     await expect(moodCard).toContainText('5');
 
-    // Navigate to yesterday via the left-arrow.
     await page.locator('.arrow-btn[aria-label="previous day"]').click();
-
-    // Yesterday's mood row is 4 (per seed). The card should now show 4.
     await expect(moodCard).toContainText('4');
   });
 
   test('weight card on two days ago shows that date\'s value', async ({ page }) => {
     await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible();
 
     const weightCard = page.locator('eh-generic-card', { hasText: 'Weight' }).first();
-    await expect(weightCard).toBeVisible();
-    // Today shows 80.9 kg.
     await expect(weightCard).toContainText('80.9');
 
-    // Step back twice.
     await page.locator('.arrow-btn[aria-label="previous day"]').click();
     await page.locator('.arrow-btn[aria-label="previous day"]').click();
 
-    // Two-days-ago seeded at 81.2.
     await expect(weightCard).toContainText('81.2');
   });
 
   test('pencil edit on yesterday writes only to that date', async ({ page, sandboxState }) => {
     await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible();
+
+    const moodCard = page.locator('eh-generic-card', { hasText: 'Mood' }).first();
+    // Wait for the mood card to render TODAY's value before navigating.
+    // Without this, on slower runners the click fires before _today is
+    // hydrated and the date shift lands on an unexpected day.
+    await expect(moodCard).toContainText('5');
 
     // Go to yesterday.
     await page.locator('.arrow-btn[aria-label="previous day"]').click();
-
-    const moodCard = page.locator('eh-generic-card', { hasText: 'Mood' }).first();
     await expect(moodCard).toContainText('4');
+
+    // Capture the POST the card sends so we can assert what it asked
+    // the server to write, independently of what lands on disk.
+    const writeRequest = page.waitForRequest(req =>
+      req.url().includes('/api/manifests/mood/data') && req.method() === 'POST',
+    );
 
     // Open the edit pencil inside the mood card.
     await moodCard.locator('.edit-btn').click();
@@ -72,14 +76,21 @@ test.describe('#182: cards with dateContext:latest honour past-date navigation',
     // Submit.
     await moodCard.locator('eh-input-form').getByRole('button', { name: /save|update/i }).click();
 
+    const sentRequest = await writeRequest;
+    const sentBody = JSON.parse(sentRequest.postData());
+    const sentByDate = Object.fromEntries(sentBody.data.map(r => [r.date, r.mood]));
+    expect(sentByDate[yesterday]).toBe(1);
+    expect(sentByDate[today]).toBe(5);
+
     // Wait for the card to reflect the new value.
     await expect(moodCard).toContainText('1', { timeout: 5000 });
 
-    // Verify the manifest on disk: ONLY yesterday's row has mood=1.
-    // Everything else is untouched.
-    const moodPath = path.join(sandboxState.sandbox, 'data', 'mood.json');
-    const onDisk = JSON.parse(fs.readFileSync(moodPath, 'utf8'));
-    const byDate = Object.fromEntries(onDisk.data.map(r => [r.date, r.mood]));
+    // Verify the manifest via the server (authoritative read — avoids
+    // any filesystem-buffering surprises with the direct file read).
+    const readRes = await page.request.get(`${sandboxState.baseUrl}/api/manifests/mood/data`);
+    expect(readRes.status()).toBe(200);
+    const onServer = await readRes.json();
+    const byDate = Object.fromEntries(onServer.data.map(r => [r.date, r.mood]));
 
     expect(byDate[yesterday]).toBe(1);
     expect(byDate[today]).toBe(5);

--- a/tests-e2e/past-date-view-and-edit.spec.js
+++ b/tests-e2e/past-date-view-and-edit.spec.js
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/past-date-view-and-edit.spec.js
+// Regression coverage for #182 (supersedes #181): cards with
+// `view.dateContext: "latest"` must honour past-date navigation.
+// On a past date the card should show THAT date's row (or empty
+// state if none), and the pencil-edit should write only to that
+// date's row.
+//
+// Before the fix, both mood and weight cards always render today's
+// latest row and the pencil-edit writes to today's row regardless
+// of the date the user is viewing.
+
+const fs = require('fs');
+const path = require('path');
+const { test, expect } = require('./helpers/auth-fixture');
+const { todayISO, shiftDays } = require('./helpers/seed-manifests');
+
+const today = todayISO();
+const yesterday = shiftDays(today, -1);
+const twoDaysAgo = shiftDays(today, -2);
+
+test.describe('#182: cards with dateContext:latest honour past-date navigation', () => {
+  test('mood card on yesterday shows yesterday\'s value, not today\'s', async ({ page }) => {
+    await page.goto('/');
+
+    // Today shows latest: mood = 5.
+    const moodCard = page.locator('eh-generic-card', { hasText: 'Mood' }).first();
+    await expect(moodCard).toBeVisible();
+    await expect(moodCard).toContainText('5');
+
+    // Navigate to yesterday via the left-arrow.
+    await page.locator('.arrow-btn[aria-label="previous day"]').click();
+
+    // Yesterday's mood row is 4 (per seed). The card should now show 4.
+    await expect(moodCard).toContainText('4');
+  });
+
+  test('weight card on two days ago shows that date\'s value', async ({ page }) => {
+    await page.goto('/');
+
+    const weightCard = page.locator('eh-generic-card', { hasText: 'Weight' }).first();
+    await expect(weightCard).toBeVisible();
+    // Today shows 80.9 kg.
+    await expect(weightCard).toContainText('80.9');
+
+    // Step back twice.
+    await page.locator('.arrow-btn[aria-label="previous day"]').click();
+    await page.locator('.arrow-btn[aria-label="previous day"]').click();
+
+    // Two-days-ago seeded at 81.2.
+    await expect(weightCard).toContainText('81.2');
+  });
+
+  test('pencil edit on yesterday writes only to that date', async ({ page, sandboxState }) => {
+    await page.goto('/');
+
+    // Go to yesterday.
+    await page.locator('.arrow-btn[aria-label="previous day"]').click();
+
+    const moodCard = page.locator('eh-generic-card', { hasText: 'Mood' }).first();
+    await expect(moodCard).toContainText('4');
+
+    // Open the edit pencil inside the mood card.
+    await moodCard.locator('.edit-btn').click();
+
+    // The form is an eh-input-form with a rating input of type "rating".
+    // The rating renderer emits buttons 1..5; click the "1" to change
+    // mood to 1. Scope to the mood card to avoid catching a weight input.
+    await moodCard.locator('eh-input-form').getByRole('button', { name: '1', exact: true }).click();
+
+    // Submit.
+    await moodCard.locator('eh-input-form').getByRole('button', { name: /save|update/i }).click();
+
+    // Wait for the card to reflect the new value.
+    await expect(moodCard).toContainText('1', { timeout: 5000 });
+
+    // Verify the manifest on disk: ONLY yesterday's row has mood=1.
+    // Everything else is untouched.
+    const moodPath = path.join(sandboxState.sandbox, 'data', 'mood.json');
+    const onDisk = JSON.parse(fs.readFileSync(moodPath, 'utf8'));
+    const byDate = Object.fromEntries(onDisk.data.map(r => [r.date, r.mood]));
+
+    expect(byDate[yesterday]).toBe(1);
+    expect(byDate[today]).toBe(5);
+    expect(byDate[twoDaysAgo]).toBe(3);
+    expect(byDate[shiftDays(today, -3)]).toBe(2);
+  });
+});


### PR DESCRIPTION
# What changed

Cards with \`meta.view.dateContext: \"latest\"\` now display and edit the
row for the navigated date on past/future navigation, instead of always
showing and editing today's latest row.

Fixes #182. Closes #181 as a duplicate — investigation during this PR
revealed the reported "mood edit writes to every date" symptom was
actually the visible consequence of the same render bug (\`_currentEntry()\`
always picked the latest row on past dates, so pencil-edits targeted
today's row while the UI suggested a past row was being edited).

# Why

Silent data-integrity trap: operator thinks they're editing a past
entry, overwrites today. Surfaced in 2026-05-11 manual QA on both BP
and Mood cards; confirmed against klebbtest by editing mood at "3 days
ago" and observing today's row mutate instead.

Past-date navigation is meant to support historical review + targeted
edits. Without this fix, it does neither — every past date renders as
if it were today.

# How

Single change in \`public/js/components/eh-generic-card.js\`:

\`\`\`js
_currentEntry() {
  const entries = this._entries();
  if (entries.length === 0) return null;
  // dateContext:\"latest\" is a Today-mode fallback — on any past/future
  // date the card resolves by exact date match so navigation actually
  // means what it says. See issue #182.
  const isToday = this.dateMode === 'today' || !this.dateMode;
  if (isToday && this._dateContext() === 'latest') {
    return [...entries].sort((a, b) => (b.date || '').localeCompare(a.date || ''))[0];
  }
  return entries.find(e => e.date === this.date) || null;
}
\`\`\`

\`dateMode\` is already plumbed from \`eh-date-view\` through
\`eh-view-renderer\` down to \`eh-base-card\`, so the wiring exists; this
just consults it.

The \`!this.dateMode\` fallback preserves backwards compatibility for
any code path that renders \`eh-generic-card\` without the dateMode
prop.

## Scope check — cards affected

Every card with \`dateContext: \"latest\"\`. In klebbtest's seed today:
blood-pressure, mood, weight, hrv, resting-heart-rate,
walking-heart-rate, apple-exercise-time, step-count, daily-notes,
sleep-analysis, sleep-quality. All behave correctly on Today and now
correctly on past/future too.

Cards using \`\"viewedDate\"\` (default) or \`\"exact-date\"\` are untouched.

# Testing

Added three E2E tests in \`tests-e2e/past-date-view-and-edit.spec.js\`:

1. Mood card on yesterday shows yesterday's seeded value (4), not
   today's (5).
2. Weight card two days back shows that date's seeded value (81.2),
   not today's (80.9).
3. Pencil edit on yesterday's mood writes only to yesterday's row on
   disk; today/two-days-ago/three-days-ago rows unchanged.

All three fail against current \`main\` (verified pre-fix) and pass
post-fix.

\`tests-e2e/helpers/seed-manifests.js\` re-shaped to anchor dates to
the test run's \"today\" so the suite doesn't go stale over time.

- [x] \`npm test\` — 810/811 pass locally (same pre-existing Windows
      flake as the earlier PRs; CI green)
- [x] \`npm run test:e2e\` — 5/5 pass locally, 6.0s
- [x] Fail-on-main verified before adding the fix
- [x] Manual QA against klebbtest is the origin report — fix addresses
      exactly what was described

# Checklist

- [x] Commit messages follow conventions
- [x] \`CHANGELOG.md\` updated under \`## Unreleased\`
- [x] Docs not required — no schema or behavioural contract change
      beyond what's documented in the \`dateContext\` comment in the
      source file
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Follow-up

- #183 (mood calendar per-day emoji) is the next M1 item.
- #184 (HAE FP rounding) un-skips its already-seeded API regression
  test in \`tests/api/hae-ingest-fp-rounding.test.js\`.