### PR TITLE
fix(hae): round numeric values at ingest to strip IEEE754 tails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **HAE ingest no longer persists IEEE754 floating-point tails.** Apple
+  Health passes numeric values through averaging pipelines that can
+  produce round-trip values like `62.00000000000001` or
+  `84.99999999999999`. The ingest catalogue now rounds every numeric
+  field at the `row()` level to a sensible per-metric precision
+  (integer for heart rates, step counts, exercise minutes, systolic/
+  diastolic BP; 1dp for HRV, walking HR, SpO2, body mass, body fat
+  percent; 3dp for sleep-stage hours). Existing on-disk values can be
+  cleaned with `node scripts/reingest-hae.js` from the raw archive.
+  (Fixes #184)
+
 - **Cards with `dateContext: "latest"` now honour past-date navigation.**
   The `latest` resolver in `eh-generic-card._currentEntry()` used to
   return the most recent row regardless of which date the user had

--- a/health-auto-export/catalogue.js
+++ b/health-auto-export/catalogue.js
@@ -28,7 +28,7 @@
 //   - Aggregation is applied by the dispatcher after mapping. Catalogue
 //     entries do not pre-aggregate.
 
-const { toDate, numeric } = require('./helpers');
+const { toDate, numeric, round } = require('./helpers');
 
 module.exports = {
   // --- Sleep / recovery ---------------------------------------------------
@@ -40,7 +40,7 @@ module.exports = {
       const date = toDate(entry.date || entry.sleepStart);
       const hours = numeric(entry.totalSleep ?? entry.asleep ?? entry.inBed ?? entry.qty);
       if (!date || hours === null) return null;
-      const row = { date, hours };
+      const row = { date, hours: round(hours, 3) };
       // Stage breakdown: preserve whichever fields HAE provides. Absent
       // fields are omitted entirely rather than set to 0/null so display
       // templates can distinguish "no REM data for this night" from
@@ -48,7 +48,7 @@ module.exports = {
       const stages = ['asleep', 'inBed', 'deep', 'rem', 'core', 'awake'];
       for (const key of stages) {
         const v = numeric(entry[key]);
-        if (v !== null) row[key] = v;
+        if (v !== null) row[key] = round(v, 3);
       }
       if (entry.source) row.source = entry.source;
       return row;
@@ -62,7 +62,7 @@ module.exports = {
       const date = toDate(entry.date);
       const ms = numeric(entry.qty);
       if (!date || ms === null) return null;
-      return { date, ms };
+      return { date, ms: round(ms, 1) };
     },
   },
 
@@ -73,7 +73,7 @@ module.exports = {
       const date = toDate(entry.date);
       const bpm = numeric(entry.qty);
       if (!date || bpm === null) return null;
-      return { date, bpm };
+      return { date, bpm: round(bpm, 0) };
     },
   },
 
@@ -84,7 +84,7 @@ module.exports = {
       const date = toDate(entry.date);
       const bpm = numeric(entry.qty);
       if (!date || bpm === null) return null;
-      return { date, bpm };
+      return { date, bpm: round(bpm, 1) };
     },
   },
 
@@ -98,7 +98,7 @@ module.exports = {
       let pct = numeric(entry.qty);
       if (pct === null || !date) return null;
       if (pct <= 1) pct = pct * 100;
-      return { date, pct };
+      return { date, pct: round(pct, 1) };
     },
   },
 
@@ -122,7 +122,7 @@ module.exports = {
       const date = toDate(entry.date);
       const minutes = numeric(entry.qty);
       if (!date || minutes === null) return null;
-      return { date, minutes };
+      return { date, minutes: round(minutes, 0) };
     },
   },
 
@@ -135,7 +135,7 @@ module.exports = {
       const date = toDate(entry.date);
       const minutes = numeric(entry.qty);
       if (!date || minutes === null) return null;
-      return { date, minutes };
+      return { date, minutes: round(minutes, 0) };
     },
   },
 
@@ -148,7 +148,7 @@ module.exports = {
       const date = toDate(entry.date);
       const kg = numeric(entry.qty);
       if (!date || kg === null) return null;
-      return { date, kg };
+      return { date, kg: round(kg, 1) };
     },
   },
 
@@ -162,7 +162,7 @@ module.exports = {
       let pct = numeric(entry.qty);
       if (pct === null || !date) return null;
       if (pct <= 1) pct = pct * 100;
-      return { date, pct };
+      return { date, pct: round(pct, 1) };
     },
   },
 
@@ -175,7 +175,7 @@ module.exports = {
       const date = toDate(entry.date);
       const systolic = numeric(entry.qty);
       if (!date || systolic === null) return null;
-      return { date, systolic };
+      return { date, systolic: round(systolic, 0) };
     },
   },
 
@@ -186,7 +186,7 @@ module.exports = {
       const date = toDate(entry.date);
       const diastolic = numeric(entry.qty);
       if (!date || diastolic === null) return null;
-      return { date, diastolic };
+      return { date, diastolic: round(diastolic, 0) };
     },
   },
 

--- a/health-auto-export/helpers.js
+++ b/health-auto-export/helpers.js
@@ -20,4 +20,14 @@ function numeric(v) {
   return Number.isFinite(n) ? n : null;
 }
 
-module.exports = { toDate, numeric };
+// Round a number to `decimals` places, tolerant of null (returns null).
+// HAE payloads routinely carry IEEE754 precision tails like 62.00000000000001
+// because Apple Health averages under the hood. The catalogue rounds values
+// at ingest time so manifest rows stay clean.
+function round(v, decimals = 0) {
+  if (v === null || v === undefined) return v;
+  const f = Math.pow(10, decimals);
+  return Math.round(v * f) / f;
+}
+
+module.exports = { toDate, numeric, round };

--- a/tests/api/hae-ingest-fp-rounding.test.js
+++ b/tests/api/hae-ingest-fp-rounding.test.js
@@ -87,7 +87,7 @@ function haePayloadWithFpTails() {
   };
 }
 
-describe.skip('M1/#184: HAE ingest rounds numeric values (SKIP until fix lands)', () => {
+describe('M1/#184: HAE ingest rounds numeric values', () => {
   let sandbox, server, auth;
   const token = 'test-hae-token';
 


### PR DESCRIPTION
# What changed

The ingest catalogue now rounds every numeric field at the \`row()\`
level to a sensible per-metric precision. Un-skips the already-seeded
regression test (\`tests/api/hae-ingest-fp-rounding.test.js\`), which
fails on \`main\` and passes with this change.

Fixes #184.

# Why

Apple Health pipelines produce round-trip residue like
\`62.00000000000001\` (resting HR) or \`84.99999999999999\` (walking HR
average). Before this PR the catalogue wrote the raw source value, so
manifest rows carried the noise through to display, Trends, CSV
exports, and anything that read them. Not a user-visible bug on Today
because the display templates round, but it's in the persisted data
and surfaces in Trends view.

Surfaced in 2026-05-11 QA when the operator spotted \"8-decimal\" values
on the Walking HR trends card.

# How

1. Added a shared \`round(v, decimals)\` helper in
   \`health-auto-export/helpers.js\`. Tolerates null (returns null).
2. Applied rounding per metric in \`health-auto-export/catalogue.js\`.
3. Un-skipped the test.

## Per-metric precision

| Metric | Precision | Rationale |
|--------|-----------|-----------|
| \`resting_heart_rate\` | 0 dp | integer bpm |
| \`apple_exercise_time\` | 0 dp | whole minutes |
| \`mindful_minutes\` | 0 dp | whole minutes |
| \`blood_pressure_systolic\` | 0 dp | integer mmHg |
| \`blood_pressure_diastolic\` | 0 dp | integer mmHg |
| \`heart_rate_variability\` | 1 dp | HAE sends whole ms, averaging adds noise |
| \`walking_heart_rate_average\` | 1 dp | HAE averages under the hood |
| \`blood_oxygen_saturation\` | 1 dp | already normalised to percent |
| \`body_mass\` | 1 dp | matches webapp weight input \`step: 0.1\` |
| \`body_fat_percentage\` | 1 dp | percent, one decimal is enough |
| \`sleep_analysis\` hours + stages | 3 dp | hours with sub-minute precision, not 15-dp noise |
| \`step_count\` | (no change) | \`sum-per-date\` aggregate already rounds |

# Testing

\`tests/api/hae-ingest-fp-rounding.test.js\` (un-skipped):

- \`walking HR rows are rounded, no IEEE754 tails\` — passes
- \`resting HR rows are rounded to integer\` — passes

Both failed on \`main\` before this PR (verified: \`Expected: 62 Received: 62.00000000000001\`).

- [x] \`npm test\` — 812/813 pass locally (the 1 flake is the pre-existing
      Windows-only \`no-personal-refs\` noise from earlier PRs; CI green)
- [x] \`npm test -- tests/health-auto-export.*.test.js\` — all 108 HAE
      tests pass, no regressions
- [x] \`npm run test:e2e\` — 5/5 pass
- [x] Fail-on-main verified before writing the fix

# Deployment note

Existing manifests on live instances carry the un-rounded values from
historical ingest. Operators can clean them by running:

\`\`\`bash
node scripts/reingest-hae.js
\`\`\`

This replays the raw archive (in \`\$HEALTH_HOME/data/auto-export/raw/\`)
through the now-rounding catalogue, producing clean rows. Each
manifest gets a timestamped backup (\`foo.json.pre-reingest-*.json\`)
before the replay.

Heads-up: those timestamped backups currently trip the manifest
loader (see #197). Workaround until #197 lands is to move them out
of \`data/\` after confirming the reingest worked.

# Checklist

- [x] Commit messages follow conventions
- [x] \`CHANGELOG.md\` updated
- [x] Docs not required (per-metric precision documented in the PR
      table above; catalogue.js source is the source of truth)
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Follow-up

- #183 (mood calendar per-day emoji) is the next M1 item.
- #197 (manifest loader backup-file guard) should come soon — it
  interacts with the reingest workflow above.