### PR TITLE
fix(calendar): field-emoji markers inherit display.emojiMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Calendar `field-emoji` markers now inherit the card's
+  `display.emojiMap`.** Previously the resolver required `emojiMap`
+  on the marker spec itself, so manifests following the existing
+  pattern of declaring the map once under `meta.view.display.emojiMap`
+  saw no per-day emoji on the calendar — every date fell back to the
+  card's `meta.emoji` (the same face on every day). The resolver now
+  consults `ctx.display.emojiMap` when the spec omits one. Spec-level
+  overrides still win when both are present. (Fixes #183)
+
 - **HAE ingest no longer persists IEEE754 floating-point tails.** Apple
   Health passes numeric values through averaging pipelines that can
   produce round-trip values like `62.00000000000001` or

--- a/public/js/lib/calendar-marker.esm.js
+++ b/public/js/lib/calendar-marker.esm.js
@@ -70,14 +70,21 @@ export function resolveMarker(spec, ctx) {
 
   switch (spec.type) {
     case 'field-emoji': {
-      if (!spec.field || !spec.emojiMap || !row) {
+      // Resolve emojiMap from the spec first, then fall back to
+      // ctx.display.emojiMap so manifests can keep a single source of
+      // truth on meta.view.display.emojiMap and reuse it on the
+      // calendar without duplication. See #183.
+      const emojiMap = spec.emojiMap
+        || (ctx && ctx.display && ctx.display.emojiMap)
+        || null;
+      if (!spec.field || !emojiMap || !row) {
         return spec.fallback || fallback;
       }
       const v = getValue(row, spec.field);
       if (v === null || v === undefined || v === '') {
         return spec.fallback || fallback;
       }
-      const hit = spec.emojiMap[String(v)] ?? spec.emojiMap[v];
+      const hit = emojiMap[String(v)] ?? emojiMap[v];
       if (hit) return hit;
       return spec.fallback || fallback;
     }

--- a/public/js/lib/calendar-marker.js
+++ b/public/js/lib/calendar-marker.js
@@ -21,8 +21,9 @@
 //     ctx = { date, row, sortedRows, fallback, display, renderTemplate }
 //     sortedRows: dated rows ascending by date (for trend-arrow).
 //     fallback: glyph used if the spec yields nothing.
-//     display: the card's meta.view.display block (for template type to
-//       reuse its emojiMap).
+//     display: the card's meta.view.display block. field-emoji
+//       markers inherit display.emojiMap when the marker spec itself
+//       omits one; template markers can reference it for {key:emoji}.
 //     renderTemplate: an injected string-template render function
 //       (same signature as display-template.renderTemplate). Injected
 //       rather than imported to keep this lib dependency-free and
@@ -103,14 +104,21 @@
 
     switch (spec.type) {
       case 'field-emoji': {
-        if (!spec.field || !spec.emojiMap || !row) {
+        // Resolve emojiMap from the spec first, then fall back to
+        // ctx.display.emojiMap so manifests can keep a single source of
+        // truth on meta.view.display.emojiMap and reuse it on the
+        // calendar without duplication. See #183.
+        const emojiMap = spec.emojiMap
+          || (ctx && ctx.display && ctx.display.emojiMap)
+          || null;
+        if (!spec.field || !emojiMap || !row) {
           return spec.fallback || fallback;
         }
         const v = getValue(row, spec.field);
         if (v === null || v === undefined || v === '') {
           return spec.fallback || fallback;
         }
-        const hit = spec.emojiMap[String(v)] ?? spec.emojiMap[v];
+        const hit = emojiMap[String(v)] ?? emojiMap[v];
         if (hit) return hit;
         return spec.fallback || fallback;
       }

--- a/tests/calendar-marker.test.js
+++ b/tests/calendar-marker.test.js
@@ -136,12 +136,48 @@ describe('resolveMarker', () => {
       assert.equal(r, '🙂');
     });
 
-    test('no emojiMap returns fallback', () => {
+    test('no emojiMap on spec, no display fallback, returns spec.fallback', () => {
       const r = resolveMarker(
         { type: 'field-emoji', field: 'mood', fallback: 'X' },
         { row: { mood: 4 } }
       );
       assert.equal(r, 'X');
+    });
+
+    // #183: when the marker spec omits emojiMap, the resolver should
+    // consult `ctx.display.emojiMap` so manifests can keep a single
+    // source of truth (meta.view.display.emojiMap) and reuse it on the
+    // calendar. Without this, calendars show ctx.fallback (the card's
+    // meta.emoji) on every day, which looks like "same emoji for every
+    // date" — the original bug report.
+    test('no emojiMap on spec — inherits ctx.display.emojiMap', () => {
+      const r = resolveMarker(
+        { type: 'field-emoji', field: 'mood' },
+        {
+          row: { mood: 4 },
+          display: { emojiMap: { '1': '😩', '2': '😔', '3': '😐', '4': '🙂', '5': '😄' } },
+        }
+      );
+      assert.equal(r, '🙂');
+    });
+
+    test('no emojiMap on spec — display emojiMap resolves different values per row', () => {
+      const display = { emojiMap: { '1': '😩', '2': '😔', '3': '😐', '4': '🙂', '5': '😄' } };
+      const barespec = { type: 'field-emoji', field: 'mood' };
+      assert.equal(resolveMarker(barespec, { row: { mood: 1 }, display }), '😩');
+      assert.equal(resolveMarker(barespec, { row: { mood: 3 }, display }), '😐');
+      assert.equal(resolveMarker(barespec, { row: { mood: 5 }, display }), '😄');
+    });
+
+    test('spec.emojiMap wins over ctx.display.emojiMap when both present', () => {
+      const r = resolveMarker(
+        { type: 'field-emoji', field: 'mood', emojiMap: { '4': 'SPEC' } },
+        {
+          row: { mood: 4 },
+          display: { emojiMap: { '4': 'DISPLAY' } },
+        }
+      );
+      assert.equal(r, 'SPEC');
     });
 
     test('dotted-path field', () => {


### PR DESCRIPTION
# What changed

The \`field-emoji\` calendar marker resolver now consults
\`ctx.display.emojiMap\` when the marker spec itself doesn't carry
one. Single file change in the resolver (both Node + ESM twins) and
a matching bump in the unit-test suite.

Fixes #183.

# Why

The mood manifest declares its emoji map once under
\`meta.view.display.emojiMap\` (used by the card headline) and points
the calendar at it with \`{ type: \"field-emoji\", field: \"mood\" }\`.
The old resolver required \`emojiMap\` on the marker spec itself, so
that lookup bailed. \`ctx.fallback\` is the card's \`meta.emoji\` — the
smiley used in the card header — which meant every calendar day
showed the same face regardless of the per-day mood value.

Surfaced in 2026-05-11 QA. Rerun of klebbtest after this change
should show 😩/😔/😐/🙂/😄 per day on the Mood calendar, matching the
display-template on the card face.

# How

Single branch in \`resolveMarker\`'s \`field-emoji\` case:

\`\`\`js
const emojiMap = spec.emojiMap
  || (ctx && ctx.display && ctx.display.emojiMap)
  || null;
\`\`\`

Spec-level \`emojiMap\` still wins when both are present, so
existing manifests that configure the map only on the marker
continue to behave identically.

Both \`calendar-marker.js\` (Node) and \`calendar-marker.esm.js\`
(browser) were updated per the \"keep in sync\" note in the file
header.

# Testing

\`tests/calendar-marker.test.js\` updated:

- The existing \"no emojiMap returns fallback\" test kept its intent
  but was reframed as \"no spec emojiMap + no display emojiMap
  returns fallback\" so the new inheritance doesn't accidentally
  make it green for the wrong reason.
- Three new assertions cover:
  - inheritance of \`ctx.display.emojiMap\` when spec omits one;
  - per-row resolution (mood 1 → 😩, mood 3 → 😐, mood 5 → 😄)
    proving the resolver genuinely reads per-row values;
  - spec.emojiMap wins over ctx.display.emojiMap when both present.

All three new tests failed against \`main\` before the fix (verified)
and pass with it.

- [x] \`npm test\` — 815/816 pass locally (same pre-existing
      \`no-personal-refs\` Windows-local flake from earlier PRs; CI
      green)
- [x] \`npm run test:e2e\` — 5/5 pass
- [x] Fail-on-main verified before adding the fix
- [x] Deliberately did NOT modify any manifest — the mood manifest
      on disk is already correctly shaped

# Deployment note

No data migration required. Next page reload on any instance will
pick up the fixed renderer and the calendar will display per-day
emoji automatically.

# Checklist

- [x] Commit messages follow conventions
- [x] \`CHANGELOG.md\` updated
- [x] Inline doc in \`calendar-marker.js\` header updated to mention
      the inheritance contract
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Follow-up

- #197 (manifest loader backup-file guard) is next on the M3 list.
- Then #185-192 (M2 UX gaps).