### PR TITLE
refactor(manifests): loader skips timestamped backup files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Manifest loader now skips timestamped backup files.** Migration and
+  re-ingest scripts drop backup files beside the canonical manifest
+  (`foo.json.pre-reingest-*.json`, `.pre-hae-*`, etc.). Previously the
+  loader globbed every `*.json` in the data dir, parsed the backups
+  as manifests, and either (a) emitted duplicate-id warnings when the
+  canonical sibling loaded too, or (b) — worse — silently created a
+  card from the backup if no canonical existed, serving stale data
+  to the operator. The scan now recognises the shared backup shape
+  (two `.json` segments in the filename) and skips it outright.
+  Makes the reingest workflow introduced with #184 safe to repeat.
+  (Fixes #197)
+
 - **Calendar `field-emoji` markers now inherit the card's
   `display.emojiMap`.** Previously the resolver required `emojiMap`
   on the marker spec itself, so manifests following the existing

--- a/manifests/registry.js
+++ b/manifests/registry.js
@@ -34,6 +34,13 @@ let _entries = new Map();   // id -> { meta, description, schema, data, source, 
 let _errors = [];           // [{file, error}]
 let _watcher = null;
 
+// Backup files created by scripts/migrate-* and scripts/reingest-hae
+// land beside the canonical manifest with a timestamped suffix before
+// the final `.json` — e.g. `mood.json.pre-reingest-2026-05-10T...json`.
+// The shared shape is "two .json segments in the filename", which this
+// regex captures without hard-coding every known suffix. See #197.
+const BACKUP_NAME_RE = /\.json\.[^/\\]+\.json$/i;
+
 function _scanDir(dir) {
   const found = [];
   let entries;
@@ -51,6 +58,7 @@ function _scanDir(dir) {
       continue;
     }
     if (!ent.name.endsWith('.json')) continue;
+    if (BACKUP_NAME_RE.test(ent.name)) continue;
     found.push(path.join(dir, ent.name));
   }
   return found;

--- a/tests/api/loader-ignores-backup-files.test.js
+++ b/tests/api/loader-ignores-backup-files.test.js
@@ -1,17 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
 // tests/api/loader-ignores-backup-files.test.js
-// Regression test for #197 (QA-BUGS.md B10): the manifest loader must
-// not treat timestamped backup files (e.g. foo.json.pre-reingest-*.json)
-// as canonical manifests. Today, the loader globs `*.json` in the
-// manifests dir, which includes such backups and produces duplicate-id
-// errors that drop the canonical card.
-//
-// Currently `describe.skip` pending the #197 fix. Un-skip on that
-// PR to prove the fix; the test then locks in the behaviour.
+// Regression tests for #197: the manifest loader must skip timestamped
+// backup files (e.g. foo.json.pre-reingest-*.json) outright rather
+// than parsing them and hitting duplicate-id errors. The previous
+// behaviour produced noisy startup logs and was fragile — if the
+// canonical file ever failed to load first, the backup would "win"
+// and the user would silently be served stale data.
 
-const fs = require('fs');
-const path = require('path');
 const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert');
 const {
@@ -22,7 +18,7 @@ const {
   fakeAuthState,
 } = require('../helpers/sandbox');
 
-function moodManifest() {
+function moodManifest(mood) {
   return {
     $schema: 'klebb.datafile.v1',
     meta: {
@@ -39,43 +35,81 @@ function moodManifest() {
       },
     },
     description: 'Daily mood rating.',
-    data: [{ date: '2026-05-09', mood: 4 }],
+    data: [{ date: '2026-05-09', mood }],
   };
 }
 
-describe.skip('M3/#197: loader ignores timestamped backup files (SKIP until fix)', () => {
-  let sandbox, server, auth;
+describe('M3/#197: loader skips timestamped backup files', () => {
+  describe('canonical present + backup present', () => {
+    let sandbox, server, auth;
 
-  before(async () => {
-    auth = fakeAuthState('e2e-user');
-    sandbox = createSandbox({
-      seed: {
-        'mood.json': moodManifest(),
-        // Drop a backup file next to the canonical one. Same $schema,
-        // same meta.id — would currently trigger duplicate-id error
-        // and drop the canonical card too.
-        'mood.json.pre-reingest-2026-05-10T000000000Z.json': moodManifest(),
-      },
-      credentials: auth.credentials,
-      sessions: auth.sessions,
+    before(async () => {
+      auth = fakeAuthState('e2e-user');
+      sandbox = createSandbox({
+        seed: {
+          'mood.json': moodManifest(4),
+          // Distinct data value so we can prove which file was loaded.
+          'mood.json.pre-reingest-2026-05-10T000000000Z.json': moodManifest(1),
+        },
+        credentials: auth.credentials,
+        sessions: auth.sessions,
+      });
+      server = await spawnServer(sandbox);
     });
-    server = await spawnServer(sandbox);
+
+    after(async () => {
+      if (server) await server.kill();
+      cleanupSandbox(sandbox);
+    });
+
+    test('mood loads exactly once with canonical data', async () => {
+      const res = await req(server.baseUrl, '/api/manifests', { cookie: auth.cookie });
+      assert.equal(res.status, 200);
+      const ids = res.json.entries.map(e => e.id);
+      const moodEntries = res.json.entries.filter(e => e.id === 'mood');
+      assert.equal(moodEntries.length, 1, 'mood loaded exactly once');
+      assert.ok(ids.includes('mood'));
+
+      // Authoritatively read the canonical data via the API.
+      const dataRes = await req(server.baseUrl, '/api/manifests/mood/data', {
+        cookie: auth.cookie,
+      });
+      assert.equal(dataRes.status, 200);
+      // Canonical has mood=4; backup has mood=1. If the backup won,
+      // this assertion flips.
+      assert.equal(dataRes.json.data[0].mood, 4, 'canonical file won, not backup');
+    });
   });
 
-  after(async () => {
-    if (server) await server.kill();
-    cleanupSandbox(sandbox);
-  });
+  describe('backup only (canonical missing)', () => {
+    let sandbox, server, auth;
 
-  test('canonical mood card loads; backup file ignored', async () => {
-    const res = await req(server.baseUrl, '/api/manifests', { cookie: auth.cookie });
-    assert.equal(res.status, 200);
-    const ids = res.json.entries.map(e => e.id);
-    assert.ok(ids.includes('mood'), 'mood card was loaded');
-    assert.equal(
-      res.json.entries.filter(e => e.id === 'mood').length,
-      1,
-      'mood loaded exactly once',
-    );
+    before(async () => {
+      auth = fakeAuthState('e2e-user');
+      sandbox = createSandbox({
+        // No canonical mood.json; only the backup. The loader should
+        // NOT resurrect the card from the backup — backups are not
+        // manifests and must be ignored regardless of what sits beside
+        // them.
+        seed: {
+          'mood.json.pre-reingest-2026-05-10T000000000Z.json': moodManifest(1),
+        },
+        credentials: auth.credentials,
+        sessions: auth.sessions,
+      });
+      server = await spawnServer(sandbox);
+    });
+
+    after(async () => {
+      if (server) await server.kill();
+      cleanupSandbox(sandbox);
+    });
+
+    test('mood is absent — backup files never populate the registry', async () => {
+      const res = await req(server.baseUrl, '/api/manifests', { cookie: auth.cookie });
+      assert.equal(res.status, 200);
+      const ids = res.json.entries.map(e => e.id);
+      assert.ok(!ids.includes('mood'), 'backup file must not create a card');
+    });
   });
 });


### PR DESCRIPTION
# What changed

\`manifests/registry.js\` \`_scanDir\` now filters out files whose name
contains two \`.json\` segments (e.g.
\`mood.json.pre-reingest-2026-05-10T...json\`). Un-skips the
pre-seeded regression tests in \`tests/api/loader-ignores-backup-files.test.js\`
and adds a second assertion catching the higher-severity form of the
bug.

Fixes #197.

# Why

Re-ingest and migration scripts drop backup files beside the canonical
manifest with a second \`.json\` segment as the distinguishing marker.
Previously the loader globbed every \`*.json\` in the data dir:

- Noisy: duplicate-id warnings at boot when the canonical sibling
  loaded. Observed in klebbtest logs after running \`reingest-hae.js\`
  (itself introduced for the #184 cleanup).
- Dangerous: if the canonical were deleted or failed schema validation,
  the backup would \"win\" and the operator would silently get
  pre-fix data through an otherwise working card.

Important now specifically because #184 instructs operators to run
\`reingest-hae.js\` to clean IEEE754 tails from legacy rows. Without
this fix, every reingest leaves the data dir littered with
duplicate-id noise.

# How

One file change, four lines:

\`\`\`js
const BACKUP_NAME_RE = /\.json\.[^/\\]+\.json\$/i;
...
if (BACKUP_NAME_RE.test(ent.name)) continue;
\`\`\`

Matches every backup suffix the scripts currently produce
(\`.pre-reingest-\`, \`.pre-hae-\`, \`.pre-d-\`, \`.pre-migrate-\`) plus any
future ones without hard-coding each; the shared property is the two
\`.json\` segments.

# Testing

\`tests/api/loader-ignores-backup-files.test.js\` (un-skipped, expanded):

- **canonical + backup present**: canonical loads, API returns its
  data, mood loads exactly once. Was passing on main (pre-existing
  duplicate-id guard keeps the first one that loads), kept as
  protection against future reordering.
- **backup only**: mood is absent from the registry. This was the
  failing case on main — the loader treated the backup as a manifest
  and created a card from it. Now passes.

- [x] \`npm test\` — 817/818 pass locally (the same pre-existing
      \`no-personal-refs\` Windows-local flake from earlier PRs; CI green)
- [x] \`npm run test:e2e\` — 5/5 pass
- [x] Fail-on-main verified before writing the fix

# Checklist

- [x] Commit messages follow conventions
- [x] \`CHANGELOG.md\` updated
- [x] Inline comment in \`_scanDir\` explains the regex shape
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Follow-up

M1 milestone is fully closed with #182 + #183 + #184 + this PR.

Next up: M2 UX gaps. Starting with the schedule-card pair (#185 modal
shape + #186 empty render) because they're related and share code.