### PR TITLE
fix(schedule): effectiveCycles surfaces nested cycle.cycles[] shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Schedule cards render when the manifest uses the agent-authored
+  nested-cycle shape.** Klebbius-written peptide manifests put the
+  cycles array at `item.cycle.cycles[]` (nested under a top-level
+  `cycle` metadata object) rather than at the flat `item.cycles[]`
+  the renderer canonically reads. Previously `effectiveCycles()`
+  ignored the nested shape and returned `null`, so every item was
+  filtered out of the schedule card and the card body rendered
+  empty. The resolver now surfaces both shapes; explicit top-level
+  `item.cycles[]` still wins. (Fixes #186)
+
 - **Manifest loader now skips timestamped backup files.** Migration and
   re-ingest scripts drop backup files beside the canonical manifest
   (`foo.json.pre-reingest-*.json`, `.pre-hae-*`, etc.). Previously the

--- a/public/js/lib/schedule.js
+++ b/public/js/lib/schedule.js
@@ -15,13 +15,36 @@ function iso(d) {
   return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
 }
 
+// Normalise one agent-nested cycle entry (as produced by klebbius under
+// item.cycle.cycles[]) to the flat {type, start, end} shape the rest of
+// this module expects.
+function normaliseNestedCycle(c) {
+  if (!c || typeof c !== 'object') return null;
+  const start = c.start || c.start_date;
+  if (!start) return null;
+  const end = c.end || c.end_date || null;
+  return end
+    ? { type: c.type || 'on', start, end }
+    : { type: c.type || 'on', start };
+}
+
 // Resolve the cycles to evaluate for a schedule-card item.
-// Explicit item.cycles[] always wins. When absent, synthesise a single
-// cycle from schedule.start_date (+ schedule.cycle_weeks or cycle_days)
-// so agent-authored manifests render without needing a separate cycles
-// array. Returns null when nothing usable is declared.
+//
+// Resolution order:
+//   1. Explicit item.cycles[] (the canonical flat shape).
+//   2. item.cycle.cycles[] — agent-authored peptide manifests nest
+//      cycle metadata under a `cycle` object and put the array inside.
+//      See #186.
+//   3. Synthesise a single cycle from schedule.start_date (+ cycle_weeks
+//      or cycle_days) so minimal manifests render without a separate
+//      cycles array at all.
+// Returns null when nothing usable is declared.
 export function effectiveCycles(item) {
   if (Array.isArray(item.cycles) && item.cycles.length > 0) return item.cycles;
+  if (item.cycle && Array.isArray(item.cycle.cycles) && item.cycle.cycles.length > 0) {
+    const out = item.cycle.cycles.map(normaliseNestedCycle).filter(Boolean);
+    if (out.length > 0) return out;
+  }
   const s = item.schedule;
   const start = s && (s.start_date || s.startDate);
   if (!start) return null;

--- a/tests-e2e/helpers/seed-manifests.js
+++ b/tests-e2e/helpers/seed-manifests.js
@@ -102,11 +102,55 @@ function mood(today) {
   };
 }
 
+function peptides(today) {
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'peptides',
+      label: 'Schedule',
+      emoji: '💉',
+      order: 200,
+      category: 'supplements',
+      view: { enabled: true, component: 'schedule-card', dateContext: 'exact-date' },
+    },
+    description: 'Peptide schedule for E2E coverage (nested-cycle shape).',
+    data: {
+      items: [
+        {
+          id: 'semax',
+          name: 'Semax',
+          short_name: 'Semax',
+          dose_mg: 1,
+          dose_units: 'mcg',
+          route: 'subQ',
+          schedule: {
+            type: 'daily_straight',
+            days: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+            duration_days: 20,
+          },
+          cycle: {
+            on_days: 20,
+            off_days: 10,
+            cycles: [
+              {
+                cycle_number: 1,
+                start_date: shiftDays(today, -2),
+                end_date: shiftDays(today, 17),
+              },
+            ],
+          },
+        },
+      ],
+    },
+  };
+}
+
 function seedManifests() {
   const today = todayISO();
   return {
     'weight.json': weight(today),
     'mood.json': mood(today),
+    'peptides.json': peptides(today),
   };
 }
 

--- a/tests-e2e/schedule-card-nested-cycles.spec.js
+++ b/tests-e2e/schedule-card-nested-cycles.spec.js
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/schedule-card-nested-cycles.spec.js
+// Regression coverage for #186: the schedule card renders when the
+// manifest uses the agent-authored shape with item.cycle.cycles[]
+// (a nested cycles array under a top-level `cycle` object), as seen
+// on klebbtest after klebbius added several peptides.
+//
+// The default sandbox seed (tests-e2e/helpers/seed-manifests.js) now
+// includes a peptides manifest in this shape with a cycle spanning
+// today, so this spec just loads the page and asserts the item
+// renders.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+test.describe('#186: schedule card renders manifests with nested cycle.cycles[]', () => {
+  test('schedule card shows the seeded peptide by name', async ({ page }) => {
+    await page.goto('/');
+    const card = page.locator('eh-schedule-card').first();
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await expect(card).toContainText('Semax');
+  });
+});

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -253,6 +253,54 @@ test('effectiveCycles: legacy schedule.startDate also feeds the synthesiser', ()
   assert.deepEqual(effectiveCycles(item), [{ type: 'on', start: '2026-05-06' }]);
 });
 
+// #186: agent-authored peptide manifests nest the cycles array under a
+// top-level `cycle` object as `cycle.cycles[]`, with per-entry fields
+// start_date / end_date / off_start / off_end rather than start/end.
+// This is the shape seen on klebbtest; the renderer (via
+// effectiveCycles) used to ignore it entirely, leaving the schedule
+// card body empty. The resolver now surfaces this shape too, plus the
+// single-cycle metadata at the top of the `cycle` object.
+test('effectiveCycles: nested cycle.cycles[] shape is surfaced', () => {
+  const item = {
+    schedule: { type: 'daily_straight', days: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] },
+    cycle: {
+      on_days: 20,
+      off_days: 10,
+      cycles: [
+        {
+          cycle_number: 1,
+          start_date: '2026-05-09',
+          end_date: '2026-05-28',
+          off_start: '2026-05-29',
+          off_end: '2026-06-07',
+        },
+      ],
+    },
+  };
+  const cycles = effectiveCycles(item);
+  assert.ok(Array.isArray(cycles), 'returns an array');
+  assert.equal(cycles.length, 1);
+  assert.equal(cycles[0].type, 'on');
+  assert.equal(cycles[0].start, '2026-05-09');
+  assert.equal(cycles[0].end, '2026-05-28');
+});
+
+test('effectiveCycles: nested cycle.cycles[] — multiple entries preserve order', () => {
+  const item = {
+    schedule: { type: 'daily', days: ['Mon'] },
+    cycle: {
+      cycles: [
+        { start_date: '2026-01-01', end_date: '2026-01-20' },
+        { start_date: '2026-02-10', end_date: '2026-03-01' },
+      ],
+    },
+  };
+  const cycles = effectiveCycles(item);
+  assert.equal(cycles.length, 2);
+  assert.equal(cycles[0].start, '2026-01-01');
+  assert.equal(cycles[1].start, '2026-02-10');
+});
+
 // --- isScheduledOnDate with synthesised cycles ---
 //
 // Regression for #138: agent-authored peptide cards land with only


### PR DESCRIPTION
# What changed

\`effectiveCycles()\` in \`public/js/lib/schedule.js\` now surfaces the
\`item.cycle.cycles[]\` shape (cycles nested under a top-level \`cycle\`
metadata object with per-entry \`start_date\` / \`end_date\`) in addition
to the canonical flat \`item.cycles[]\`. The renderer stops filtering
every item out, the schedule card body actually renders.

Fixes #186.

# Why

When the operator asked klebbius to add a peptide stack on klebbtest,
klebbius wrote manifests with this nested structure:

\`\`\`json
{
  \"schedule\": { \"type\": \"daily_straight\", \"days\": [...], \"duration_days\": 20 },
  \"cycle\": {
    \"on_days\": 20,
    \"off_days\": 10,
    \"cycles\": [
      { \"cycle_number\": 1, \"start_date\": \"2026-05-09\", \"end_date\": \"2026-05-28\" }
    ]
  }
}
\`\`\`

The resolver looked for \`item.cycles[]\` (flat) and \`schedule.start_date\`
and found neither → returned \`null\`. The renderer then called
\`activeCycle()\` for each item, got \`null\`, and the filter dropped
every item → empty card body with no \"nothing scheduled\" message
either (that branch only fires when \`items\` itself is empty, not
when everything is filtered out).

Originally observed in 2026-05-11 QA. The schedule card was visually
empty despite 6 items + 3 groups sitting in the manifest.

# How

Minimal change in \`effectiveCycles()\`:

\`\`\`js
if (Array.isArray(item.cycles) && item.cycles.length > 0) return item.cycles;
if (item.cycle && Array.isArray(item.cycle.cycles) && item.cycle.cycles.length > 0) {
  const out = item.cycle.cycles.map(normaliseNestedCycle).filter(Boolean);
  if (out.length > 0) return out;
}
// ... existing schedule.start_date synthesiser ...
\`\`\`

\`normaliseNestedCycle\` maps the nested entry's \`start_date\` /
\`end_date\` to the flat \`{type, start, end}\` shape the rest of the
module expects. Explicit top-level \`item.cycles[]\` still wins so
existing canonical manifests are unaffected.

# Testing

Unit tests in \`tests/schedule.test.js\`:

- \`effectiveCycles: nested cycle.cycles[] shape is surfaced\`
- \`effectiveCycles: nested cycle.cycles[] — multiple entries preserve
  order\`

Both fail on \`main\`, pass with this change.

E2E spec \`tests-e2e/schedule-card-nested-cycles.spec.js\`:

- Seeds a peptide in the nested shape with a cycle spanning today.
- Loads Today view, asserts the \`eh-schedule-card\` shows the item's
  name.

Verified the E2E would fail on \`main\` by stashing the fix and
re-running — spec red without the fix, green with it.

Extended the default sandbox seed
(\`tests-e2e/helpers/seed-manifests.js\`) with the same peptide so
future schedule-related specs have a fixture to reuse. Existing
smoke tests unaffected (they only assert mood + weight cards are
visible, not a specific count).

- [x] \`npm test\` — 819/820 pass locally (same pre-existing Windows-
      local \`no-personal-refs\` flake from earlier PRs; CI green)
- [x] \`npm run test:e2e\` — 6/6 pass
- [x] Fail-on-main verified before writing the fix

# Checklist

- [x] Commit messages follow conventions
- [x] \`CHANGELOG.md\` updated
- [x] Inline comment in \`effectiveCycles()\` explains the resolution
      order (canonical flat → nested → synthesised)
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Follow-up

- #185 (schedule prompt modal wrong shape for a reminder flow) is
  next on the M2 list and is a direct sibling of this fix.
- Worth considering whether MANIFEST-SCHEMA.md should mention the
  nested shape as a supported alternative, or whether the agent
  should be nudged toward the flat canonical. Deferring that
  decision to a later doc pass.