### PR TITLE
fix(ui): discovery card keeps unsupported-metrics footer reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Discovery card renders a footer-only surface when only unsupported
+  metrics remain.** Once every catalogue-supported HAE metric has a
+  subscriber (the steady state on a configured instance), the
+  discovery card previously suppressed itself whole and took the
+  "received but not supported" footer with it — stranding any
+  pending dismiss actions. The card now renders a compact
+  footer-only layout in that case (no headline, no intro, no
+  category list), keeping the dismiss UI reachable from Today.
+  (Fixes #192)
+
 - **Schedule cards render when the manifest uses the agent-authored
   nested-cycle shape.** Klebbius-written peptide manifests put the
   cycles array at `item.cycle.cycles[]` (nested under a top-level

--- a/public/js/components/eh-hae-discovery-card.js
+++ b/public/js/components/eh-hae-discovery-card.js
@@ -162,19 +162,28 @@ export class EhHaeDiscoveryCard extends LitElement {
 
   render() {
     if (this._loading || !this._data) return html``;
-    const { supportedCount } = this._totalUndismissed();
-    // Suppress the card entirely when there are no catalogue-supported
-    // metrics to surface. The unsupported-metrics footer is informational
-    // only; rendering an accent-bordered card around nothing but that
-    // footer creates visual noise on every Today view. Users who want
-    // to inspect the full received-metric list can reach it via the
-    // Settings panel.
-    if (supportedCount === 0) return html``;
+    const { supportedCount, unsupportedCount } = this._totalUndismissed();
+    // Hide the card entirely only when there's nothing at all to
+    // show. When the operator has subscribers for every supported
+    // metric (steady state after setup) but still has undismissed
+    // unsupported metrics, render a compact footer-only surface so
+    // they retain a path to dismiss those metrics from Today. See
+    // #192 (formerly #170's overcorrection).
+    if (supportedCount === 0 && unsupportedCount === 0) return html``;
 
     const supported = this._data.undismissed.supported || {};
     const unsupported = this._data.undismissed.unsupported || [];
     const categories = Object.keys(supported)
       .sort((a, b) => (CATEGORY_META[a]?.order ?? 999) - (CATEGORY_META[b]?.order ?? 999));
+
+    if (supportedCount === 0) {
+      // Footer-only mode — no headline, no intro, no category list.
+      return html`
+        <div class="card footer-only">
+          ${this._renderUnsupportedFooter(unsupported)}
+        </div>
+      `;
+    }
 
     const headline = supportedCount === 1
       ? 'New Apple Health data spotted'

--- a/tests-e2e/discovery-card-footer-only.spec.js
+++ b/tests-e2e/discovery-card-footer-only.spec.js
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/discovery-card-footer-only.spec.js
+// Regression coverage for #192: when every catalogue-supported HAE
+// metric already has a subscriber (the steady state on a configured
+// instance) but `discovered.json` still carries undismissed
+// unsupported metrics, the discovery card must render a compact
+// footer-only surface so the operator can still dismiss those
+// metrics from Today view.
+//
+// Before the fix, `render()` bailed early on `supportedCount === 0`
+// and the entire card disappeared, stranding the footer dismiss UI.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+test.describe('#192: discovery card surfaces footer-only when only unsupported metrics are pending', () => {
+  test('footer renders on Today view when supportedCount === 0', async ({ page }) => {
+    await page.goto('/');
+
+    const card = page.locator('eh-hae-discovery-card').first();
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    // Footer toggle mentions "metric(s) received but not supported yet"
+    // and surfaces the unsupported-count. Assert that string renders.
+    await expect(card).toContainText(/metric[s]? received but not supported yet/);
+
+    // The seeded unsupported metric key should be reachable once the
+    // footer is expanded. The toggle is a button; click it.
+    await card.getByRole('button', { name: /received but not supported yet/ }).click();
+    await expect(card).toContainText('e2e_unsupported_metric');
+  });
+});

--- a/tests-e2e/helpers/seed-manifests.js
+++ b/tests-e2e/helpers/seed-manifests.js
@@ -145,12 +145,30 @@ function peptides(today) {
   };
 }
 
+// Seed the HAE "discovered metrics" ledger with one unknown metric and
+// no supported ones. This reproduces the operator's steady-state on
+// klebbtest after every catalogue-supported HAE metric has a subscriber
+// — the exact condition that used to suppress the discovery card
+// entirely (#192). Specs can use this to assert the footer-only
+// rendering path.
+function discoveredMetrics() {
+  return {
+    // Not in the HAE catalogue → classified as "unsupported", surfaces
+    // in the discovery card's footer rather than the main list.
+    e2e_unsupported_metric: {
+      firstSeenAt: '2026-05-01T00:00:00.000Z',
+      dismissed: false,
+    },
+  };
+}
+
 function seedManifests() {
   const today = todayISO();
   return {
     'weight.json': weight(today),
     'mood.json': mood(today),
     'peptides.json': peptides(today),
+    'auto-export/discovered.json': discoveredMetrics(),
   };
 }
 


### PR DESCRIPTION
# What changed

\`eh-hae-discovery-card.js\` no longer suppresses the entire card when
\`supportedCount === 0\` if there are undismissed unsupported metrics
pending. It renders a compact footer-only surface in that case.

Fixes #192.

# Why

Issue #170 added a \`supportedCount === 0\` early return to avoid
rendering an accent-bordered card containing nothing but an empty
state + footer. That addressed noise but overshot: once every
catalogue-supported HAE metric has a subscriber (which is the steady
state on any configured instance), the entire card disappears.

If the operator still has undismissed unsupported metrics (vo2_max,
respiratory_rate, etc.) sitting in \`discovered.json\`, they have no
way to dismiss them from Today view. On klebbtest this was 18
unsupported metrics with no accessible dismiss UI — confirmed during
2026-05-11 QA.

# How

One render branch change in \`eh-hae-discovery-card.js\`:

- Bail only when \`supportedCount === 0 && unsupportedCount === 0\`.
- When \`supportedCount === 0 && unsupportedCount > 0\`, return a
  compact shell that just wraps the existing \`_renderUnsupportedFooter\`
  (no headline, no intro, no category list).
- Normal code path unchanged when \`supportedCount > 0\`.

No CSS changes in this PR. The \`.card.footer-only\` class sits on the
wrapper so a future styling pass can shrink the surface if desired,
but the default card shell is already reasonable for this case.

# Testing

New spec \`tests-e2e/discovery-card-footer-only.spec.js\`:

- Loads Today view.
- Asserts \`eh-hae-discovery-card\` is visible.
- Asserts the toggle string (\"N metrics received but not supported
  yet\") renders.
- Expands the footer and asserts the seeded unsupported metric key
  is reachable.

The default E2E seed now writes \`auto-export/discovered.json\` with
one unknown metric (\`e2e_unsupported_metric\`), producing
\`supportedCount=0, unsupportedCount=1\` — the exact condition this PR
fixes.

- [x] Verified the new spec **fails against main** (stashed the fix,
      reran, confirmed 1 failed; restored, confirmed 7 passed).
- [x] \`npm test\` — 819/820 pass locally (same pre-existing Windows-
      local \`no-personal-refs\` flake; CI green)
- [x] \`npm run test:e2e\` — 7/7 pass

# Checklist

- [x] Commit messages follow conventions
- [x] \`CHANGELOG.md\` updated
- [x] Inline comment in \`render()\` explains the three-state guard
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Follow-up

- #191 (CC embellishment chips don't persist across reload) is
  still open and touches the chat-widget surface. Next on M2.
- A future cosmetic pass could give the \`.card.footer-only\` surface
  a tighter layout — out of scope here.