### PR TITLE
fix(chat): persist embellishment chips across reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Chat embellishment chips persist across page reload and chat
+  reopen.** The CC-embellishment chip row attached to a chat reply
+  (switch layout, colour-code rings, add goals, etc.) used to vanish
+  after a reload. Server-side the `PUT /api/chat/history` filter kept
+  only `{id, role, content}`; client-side `_flushHistory()` sent only
+  those fields anyway. Both ends now round-trip the `embellishments`
+  array and `followupText` string when an assistant message carries
+  them. Shape is shallow-validated server-side: label + prompt must
+  be strings, or the entry is dropped. (Fixes #191)
+
 - **Discovery card renders a footer-only surface when only unsupported
   metrics remain.** Once every catalogue-supported HAE metric has a
   subscriber (the steady state on a configured instance), the

--- a/public/js/components/health-chat.js
+++ b/public/js/components/health-chat.js
@@ -628,6 +628,19 @@ class HealthChat extends LitElement {
     } catch {}
   }
 
+  // Optional fields that ride alongside {id, role, content} when the
+  // message carries a CC-embellishment chip row (see #191).
+  _persistExtras(m) {
+    const out = {};
+    if (typeof m.followupText === 'string' && m.followupText) {
+      out.followupText = m.followupText;
+    }
+    if (Array.isArray(m.embellishments) && m.embellishments.length) {
+      out.embellishments = m.embellishments;
+    }
+    return out;
+  }
+
   _saveHistory() {
     if (this._saveTimer) clearTimeout(this._saveTimer);
     this._saveTimer = setTimeout(() => this._flushHistory(), 500);
@@ -637,7 +650,7 @@ class HealthChat extends LitElement {
     this._saveTimer = null;
     const keep = this._messages
       .filter(m => (m.role === 'user' || m.role === 'assistant') && !m.voiceUnconfiguredNotice)
-      .map(m => ({ id: m.id, role: m.role, content: m.content }))
+      .map(m => ({ id: m.id, role: m.role, content: m.content, ...this._persistExtras(m) }))
       .slice(-200);
     try {
       await fetch('/api/chat/history', {

--- a/server.js
+++ b/server.js
@@ -1274,11 +1274,29 @@ const server = http.createServer(async (req, res) => {
             .filter(m => m && typeof m === 'object'
               && (m.role === 'user' || m.role === 'assistant')
               && typeof m.content === 'string')
-            .map(m => ({
-              id: typeof m.id === 'string' ? m.id : `m${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-              role: m.role,
-              content: m.content,
-            }))
+            .map(m => {
+              const out = {
+                id: typeof m.id === 'string' ? m.id : `m${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+                role: m.role,
+                content: m.content,
+              };
+              // Preserve the embellishment chip payload that CC-create/edit
+              // replies carry, so it survives a page reload or chat reopen
+              // (see #191). Only shallow-validate shape; labels/prompts are
+              // strings the client will show and send back.
+              if (typeof m.followupText === 'string' && m.followupText) {
+                out.followupText = m.followupText;
+              }
+              if (Array.isArray(m.embellishments) && m.embellishments.length) {
+                out.embellishments = m.embellishments
+                  .filter(e => e && typeof e === 'object'
+                    && typeof e.label === 'string'
+                    && typeof e.prompt === 'string')
+                  .map(e => ({ label: e.label, prompt: e.prompt }));
+                if (out.embellishments.length === 0) delete out.embellishments;
+              }
+              return out;
+            })
             .slice(-200);
           try {
             fs.mkdirSync(PATHS.CHAT_DIR, { recursive: true });

--- a/tests-e2e/chat-embellishment-chips-persist.spec.js
+++ b/tests-e2e/chat-embellishment-chips-persist.spec.js
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/chat-embellishment-chips-persist.spec.js
+// Regression for #191: the CC-embellishment chip row attached to an
+// assistant reply must survive a page reload / chat-widget reopen.
+//
+// Exercises the full round trip: post a history through the server's
+// PUT filter, reload the page, open the widget, assert the chips
+// render. Before the fix, the server PUT filter stripped every field
+// outside {id, role, content}, so the chips were lost even if the
+// client had sent them.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+function historyWithChips() {
+  return {
+    messages: [
+      { id: 'm1', role: 'user', content: 'switch recovery-overview to rings' },
+      {
+        id: 'm2',
+        role: 'assistant',
+        content: 'Done! Recovery Overview is now in rings layout.',
+        followupText: 'Anything else?',
+        embellishments: [
+          { label: 'Colour-code the rings', prompt: 'colour-code rings on recovery-overview' },
+          { label: 'Switch to stack', prompt: 'switch recovery-overview to stack layout' },
+        ],
+      },
+    ],
+  };
+}
+
+test.describe('#191: chat embellishment chips persist across reload', () => {
+  test('chips round-trip through server PUT and render after reload', async ({ page, sandboxState }) => {
+    // Post the history through the real /api/chat/history endpoint so
+    // the server-side PUT filter runs. This is the surface that used
+    // to drop the embellishments fields.
+    const put = await page.request.put(`${sandboxState.baseUrl}/api/chat/history`, {
+      data: historyWithChips(),
+    });
+    expect(put.status()).toBe(200);
+
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible();
+    await page.getByRole('button', { name: /open chat/i }).click();
+
+    await expect(page.getByText('Colour-code the rings', { exact: true }))
+      .toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Switch to stack', { exact: true }))
+      .toBeVisible();
+
+    // Reload to prove the persistence sticks across a fresh load.
+    await page.reload();
+    await expect(page.locator('eh-date-view')).toBeVisible();
+    await page.getByRole('button', { name: /open chat/i }).click();
+    await expect(page.getByText('Colour-code the rings', { exact: true }))
+      .toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Switch to stack', { exact: true }))
+      .toBeVisible();
+  });
+});

--- a/tests/api/chat-history-preserves-embellishments.test.js
+++ b/tests/api/chat-history-preserves-embellishments.test.js
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/api/chat-history-preserves-embellishments.test.js
+// Regression for #191: PUT /api/chat/history must round-trip the
+// `embellishments` array and `followupText` string so the CC-
+// embellishment chip row (attached to an assistant reply when a
+// combination-card is created or modified) survives a page reload /
+// chat-widget reopen.
+//
+// Before the fix, the server filter dropped every field other than
+// {id, role, content} on PUT, so the chips were lost even if the
+// client had sent them.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const {
+  createSandbox,
+  cleanupSandbox,
+  spawnServer,
+  req,
+  fakeAuthState,
+} = require('../helpers/sandbox');
+
+describe('M2/#191: chat history round-trips embellishments + followupText', () => {
+  let sandbox, server, auth;
+
+  before(async () => {
+    auth = fakeAuthState('e2e-user');
+    sandbox = createSandbox({
+      credentials: auth.credentials,
+      sessions: auth.sessions,
+    });
+    server = await spawnServer(sandbox);
+  });
+
+  after(async () => {
+    if (server) await server.kill();
+    cleanupSandbox(sandbox);
+  });
+
+  test('PUT then GET preserves embellishments + followupText', async () => {
+    const put = await req(server.baseUrl, '/api/chat/history', {
+      method: 'PUT',
+      cookie: auth.cookie,
+      body: {
+        messages: [
+          { id: 'm1', role: 'user', content: 'switch recovery-overview to rings' },
+          {
+            id: 'm2',
+            role: 'assistant',
+            content: 'Done! Recovery Overview is now in rings layout.',
+            followupText: 'Want to keep going?',
+            embellishments: [
+              { label: 'Colour-code the rings', prompt: 'colour-code the rings on recovery-overview' },
+              { label: 'Switch back to stack', prompt: 'switch recovery-overview back to stack layout' },
+            ],
+          },
+        ],
+      },
+    });
+    assert.equal(put.status, 200, `PUT failed: ${put.body}`);
+
+    const get = await req(server.baseUrl, '/api/chat/history', {
+      cookie: auth.cookie,
+    });
+    assert.equal(get.status, 200);
+    const msgs = get.json.messages;
+    assert.equal(msgs.length, 2);
+
+    const assistant = msgs.find(m => m.id === 'm2');
+    assert.ok(assistant, 'assistant message present');
+    assert.equal(assistant.followupText, 'Want to keep going?');
+    assert.ok(Array.isArray(assistant.embellishments), 'embellishments present');
+    assert.equal(assistant.embellishments.length, 2);
+    assert.equal(assistant.embellishments[0].label, 'Colour-code the rings');
+    assert.equal(assistant.embellishments[0].prompt,
+      'colour-code the rings on recovery-overview');
+  });
+
+  test('PUT with no embellishments fields still round-trips user messages', async () => {
+    const put = await req(server.baseUrl, '/api/chat/history', {
+      method: 'PUT',
+      cookie: auth.cookie,
+      body: {
+        messages: [
+          { id: 'u1', role: 'user', content: 'hi' },
+          { id: 'a1', role: 'assistant', content: 'hello' },
+        ],
+      },
+    });
+    assert.equal(put.status, 200);
+    const get = await req(server.baseUrl, '/api/chat/history', {
+      cookie: auth.cookie,
+    });
+    assert.equal(get.json.messages.length, 2);
+    // Absent fields should NOT be forced into the persisted payload
+    // (keeps the file tidy and older clients happy).
+    const assistant = get.json.messages.find(m => m.id === 'a1');
+    assert.ok(!('embellishments' in assistant) || assistant.embellishments === undefined);
+  });
+});


### PR DESCRIPTION
# What changed

Both sides of the chat-history round trip (server PUT filter + client
serialiser) now preserve the \`embellishments\` array and
\`followupText\` string when an assistant message carries them. The
chip row attached to CC-create/edit replies survives a page reload
and a chat-widget close/reopen.

Fixes #191.

# Why

The embellishment chip row is the point of the CC post-create flow:
after klebbius confirms a combination-card change, the reply carries
chips like \"Colour-code the rings\", \"Switch to stack\", \"Promote a
donor to primary\", etc. Users who don't click immediately should be
able to come back to them. Instead, reloading or reopening the
widget made them vanish:

- Server \`PUT /api/chat/history\` filter at \`server.js:1277\` mapped
  each message to \`{id, role, content}\` only.
- Client \`_flushHistory()\` at \`health-chat.js:640\` sent only those
  three fields anyway.

Reported in 2026-05-11 QA batch 3 (the original trigger for logging
the chip row bug).

# How

Server side (\`server.js:1273\`): in the PUT filter, keep
\`followupText\` when it's a non-empty string, keep \`embellishments\`
when it's a non-empty array of \`{label, prompt}\` objects (strings,
shallow-validated). Invalid or absent fields are dropped.

Client side (\`public/js/components/health-chat.js\`): added
\`_persistExtras(m)\` helper that returns \`{followupText,
embellishments}\` when the source message has them. Spread into the
\`map()\` in \`_flushHistory\`. \`_loadHistory\` already adopts whatever
comes back, so no change needed there.

Applying an embellishment still clears the chips (existing behaviour
in \`_applyEmbellishment\` — once clicked, the chip is consumed).
Persistence only carries pending (unclicked) chips.

# Testing

**\`tests/api/chat-history-preserves-embellishments.test.js\`** — two
cases:

1. PUT with chips + followupText → GET returns both round-tripped.
2. PUT without those fields → GET returns clean messages with no
   spurious \`embellishments\` key (file stays tidy, older clients
   unaffected).

**\`tests-e2e/chat-embellishment-chips-persist.spec.js\`** — full
round trip:

1. PUT a history payload through \`/api/chat/history\` (the real
   server filter runs).
2. Load the page, open the chat widget, assert both chips visible.
3. Reload. Open widget again. Chips still visible.

**Fail-on-main verification**: stashed both source changes, reran
the E2E spec → 1 failed at chip visibility (timed out waiting 10s),
reran with fix → 1 passed in 1.9s.

- [x] \`npm test\` — 821/822 pass locally (same pre-existing
      \`no-personal-refs\` Windows flake; CI green)
- [x] \`npm run test:e2e\` — 8/8 pass
- [x] Fail-on-main verified for the E2E spec

# Checklist

- [x] Commit messages follow conventions
- [x] \`CHANGELOG.md\` updated
- [x] Inline comments explain why the extra fields matter
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Follow-up

- #190 (CC stack layout empty after klebbius layout-switch) and
  #188 / #189 (modal overflow + water prompt UX) remain on M2.