### PR TITLE
fix(ui): input forms + prompt modal no longer overflow horizontally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Input forms and modals no longer overflow horizontally.** Form
+  inputs (`<input>`, `<textarea>`, `<select>`) were `width: 100%`
+  without `box-sizing: border-box`, so any padding pushed the
+  computed width past the parent. That caused the inline edit form
+  and the prompt-modal panel to overflow their container by a few
+  pixels and render a rogue horizontal scrollbar at the bottom.
+  Inputs now use `box-sizing: border-box` and the modal panel has
+  an explicit `overflow-x: hidden` as a belt-and-braces guard
+  against oversized platform-native controls (date/time pickers,
+  number spinners). (Fixes #188)
+
 - **Chat embellishment chips persist across page reload and chat
   reopen.** The CC-embellishment chip row attached to a chat reply
   (switch layout, colour-code rings, add goals, etc.) used to vanish

--- a/public/js/components/eh-input-form.js
+++ b/public/js/components/eh-input-form.js
@@ -312,6 +312,11 @@ export class EhInputForm extends LitElement {
     select,
     textarea {
       width: 100%;
+      /* width:100% + padding pushes the computed width past the parent
+         unless we opt into border-box. Without this, inputs overflow
+         the enclosing modal/panel and produce a rogue horizontal
+         scrollbar at the bottom — see #188. */
+      box-sizing: border-box;
       padding: 8px 10px;
       border: 1px solid var(--border);
       border-radius: 6px;

--- a/public/js/components/eh-prompt-modal.js
+++ b/public/js/components/eh-prompt-modal.js
@@ -86,6 +86,12 @@ export class EhPromptModal extends LitElement {
       max-width: 520px;
       max-height: 92vh;
       overflow-y: auto;
+      /* Some platform-native controls (date/time pickers, number
+         spinners) render oversized at default padding and push the
+         panel wider than 100%, producing a rogue horizontal scrollbar.
+         Clip horizontally — inner form fields take the available
+         width via box-sizing:border-box and width:100% below. */
+      overflow-x: hidden;
       background: var(--bg-card, #1a1a1a);
       color: var(--text-primary);
       border-radius: 16px 16px 0 0;
@@ -94,6 +100,12 @@ export class EhPromptModal extends LitElement {
       display: flex;
       flex-direction: column;
       gap: 14px;
+    }
+    .panel * { box-sizing: border-box; }
+    .panel input,
+    .panel textarea,
+    .panel select {
+      max-width: 100%;
     }
     @media (min-width: 640px) {
       .panel {

--- a/tests-e2e/modal-no-horizontal-overflow.spec.js
+++ b/tests-e2e/modal-no-horizontal-overflow.spec.js
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/modal-no-horizontal-overflow.spec.js
+// Regression for #188: dialog/modal surfaces must not show a horizontal
+// scrollbar. Opening a prompt modal or the inline edit form on a card
+// with a full-width input (number, date, text) used to push the panel
+// wider than its max-width, producing a small but visible horizontal
+// scrollbar at the bottom of the modal body.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+// Compare scrollWidth with clientWidth on a given element. If scrollWidth
+// exceeds clientWidth, the element has horizontally-overflowed content
+// and would show a scrollbar. Works for both shadow-DOM and light-DOM
+// roots via the same expression.
+async function horizontalOverflowOf(page, locator) {
+  return locator.evaluate(el => ({
+    scrollWidth: el.scrollWidth,
+    clientWidth: el.clientWidth,
+    overflow: el.scrollWidth > el.clientWidth,
+  }));
+}
+
+test.describe('#188: modal + inline-edit surfaces have no horizontal overflow', () => {
+  test('weight card inline edit form does not overflow', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible();
+
+    const weightCard = page.locator('eh-generic-card', { hasText: 'Weight' }).first();
+    await expect(weightCard).toContainText('kg');
+
+    // Open the edit form by clicking the pencil/+.
+    await weightCard.locator('.edit-btn').click();
+
+    const form = weightCard.locator('eh-input-form');
+    await expect(form).toBeVisible();
+
+    // Probe the form container for horizontal overflow.
+    const probe = await horizontalOverflowOf(page, form);
+    expect(
+      probe.overflow,
+      `eh-input-form overflowed: scrollWidth=${probe.scrollWidth}, clientWidth=${probe.clientWidth}`,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
# What changed

Two small CSS fixes:

- \`eh-input-form.js\`: inputs / textareas / selects get
  \`box-sizing: border-box\` so \`width: 100%\` with padding stays
  inside the parent container.
- \`eh-prompt-modal.js\`: \`.panel\` gets explicit \`overflow-x: hidden\`
  as belt-and-braces against oversized platform-native controls.

Fixes #188.

# Why

Operator-reported bug: every modal (prompt + inline edit) showed a
thin horizontal scrollbar at the bottom with a tiny amount of scroll
room. Classic \`width: 100% + padding\` trap — the computed width
lands slightly past the container.

The inline edit form's inputs had \`width: 100%\`, 8–10px padding, and
1px border, with no \`box-sizing\` declaration. Each input extends
~20px past its parent's \`100%\`, which is just enough to trigger
\`.panel\`'s default \`overflow-x: visible\` behaviour and surface a
scrollbar.

The modal panel itself had \`overflow-y: auto\` without an \`overflow-x\`
declaration, relying on inner content behaving. With the fix in
\`eh-input-form.js\` this second change is belt-and-braces, but worth
having: platform-native controls (date picker, time picker on some
browsers, number spinner) can themselves render oversized, and a
\`.panel\` guard protects future input types without me having to
remember.

# How

Two file edits, both CSS-only.

\`eh-input-form.js\`:

\`\`\`css
input, select, textarea {
  width: 100%;
  box-sizing: border-box;
  padding: 8px 10px;
  ...
}
\`\`\`

\`eh-prompt-modal.js\`:

\`\`\`css
.panel {
  ...
  overflow-y: auto;
  overflow-x: hidden;
  ...
}
.panel * { box-sizing: border-box; }
.panel input, .panel textarea, .panel select { max-width: 100%; }
\`\`\`

The \`.panel *\` catch-all + input max-width are double insurance
inside the modal; cheap and keeps any future input variant safe.

# Testing

New E2E spec \`tests-e2e/modal-no-horizontal-overflow.spec.js\`:

1. Opens Today view.
2. Clicks the Weight card's edit pencil to open the inline form.
3. Probes the form element's \`scrollWidth\` vs \`clientWidth\` via
   \`locator.evaluate\`. Overflow → fail.

Stashed both source changes and reran — spec fails on main
(scrollWidth > clientWidth by ~20px). Reran with fix — spec passes.

- [x] \`npm test\` — 821/822 pass locally (pre-existing Windows
      flake; CI green)
- [x] \`npm run test:e2e\` — 9/9 pass
- [x] Fail-on-main verified before merging

Not yet covered by a spec: the prompt-modal overflow probe. The
inline edit form covers the same class of bug (inputs inside a
constrained container) and the modal CSS fix is defensive; I didn't
want to build a test scaffolding that seeds a manifest with
\`prompt.enabled: true\` just to cover the second surface when the
root cause is the same.

# Checklist

- [x] Commit messages follow conventions
- [x] \`CHANGELOG.md\` updated
- [x] Inline comment in \`.panel\` explains WHY \`overflow-x: hidden\`
      is there
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Follow-up

- #189 (water prompt input UX refinement) is the next M2 item.
- #185 (schedule prompt modal wrong shape for a reminder flow) and
  #190 (CC stack empty after layout-switch) round out M2.