### PR TITLE
test(e2e): lock in combination-card layout switching (#190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Added
+
+- **E2E regression coverage for combination-card layout switching.**
+  A recovery-overview combination card in the default sandbox seed
+  (with HRV + Resting HR donors and per-day data anchored to today),
+  plus a spec that PATCHes its `layout` through rings and back to
+  stack and asserts the stack still renders donor values on reload.
+  Locks in the #190 behaviour; if a future change ever regresses the
+  render-after-switch path, CI will catch it. (Refs #190)
+
 ### Fixed
 
 - **Input forms and modals no longer overflow horizontally.** Form

--- a/tests-e2e/cc-layout-switch-renders.spec.js
+++ b/tests-e2e/cc-layout-switch-renders.spec.js
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/cc-layout-switch-renders.spec.js
+// Regression for #190: after a combination-card layout is switched
+// (e.g. rings -> stack via klebbius or a direct manifest PATCH), the
+// reloaded view must show the stack content, not an empty card.
+//
+// The sandbox seed starts recovery-overview in stack layout and
+// declares two donors (hrv, resting-heart-rate) with per-day data
+// anchored to today. This spec asserts the stack body actually shows
+// the primary donor's value. Then it PATCHes the manifest to rings
+// and back, reloads, and asserts the stack still renders correctly.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+test.describe('#190: combination-card stack renders after layout switch', () => {
+  test('seeded stack layout shows donor values on load', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible();
+
+    const cc = page.locator('eh-combination-card').first();
+    await expect(cc).toBeVisible({ timeout: 10_000 });
+    await expect(cc).toContainText('Recovery Overview');
+    // HRV is the primary donor; today's seeded value is 55ms.
+    await expect(cc).toContainText('55');
+  });
+
+  test('stack renders correctly after rings round trip', async ({ page, sandboxState }) => {
+    // Flip to rings, then back to stack, via the canonical PATCH path.
+    const toRings = await page.request.patch(
+      `${sandboxState.baseUrl}/api/manifests/recovery-overview`,
+      {
+        data: { meta: { view: { layout: 'rings' } } },
+      },
+    );
+    expect(toRings.status()).toBe(200);
+
+    const toStack = await page.request.patch(
+      `${sandboxState.baseUrl}/api/manifests/recovery-overview`,
+      {
+        data: { meta: { view: { layout: 'stack' } } },
+      },
+    );
+    expect(toStack.status()).toBe(200);
+
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible();
+
+    const cc = page.locator('eh-combination-card').first();
+    await expect(cc).toBeVisible({ timeout: 10_000 });
+    await expect(cc).toContainText('Recovery Overview');
+    // HRV primary donor value should still resolve against today's row.
+    await expect(cc).toContainText('55');
+  });
+});

--- a/tests-e2e/helpers/seed-manifests.js
+++ b/tests-e2e/helpers/seed-manifests.js
@@ -162,14 +162,95 @@ function discoveredMetrics() {
   };
 }
 
+// Minimal HRV + Resting HR atomic pair for the recovery-overview
+// combination card to compose. Plain numeric rows anchored to today.
+function hrv(today) {
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'hrv',
+      label: 'HRV',
+      emoji: '💓',
+      order: 540,
+      category: 'recovery',
+      view: {
+        enabled: true,
+        component: 'generic-card',
+        dateContext: 'latest',
+        display: { template: '{ms:round(0)} ms' },
+      },
+      writeable: { fromWebapp: false },
+    },
+    description: 'HRV atomic card for E2E recovery-overview fixture.',
+    data: [
+      { date: shiftDays(today, -2), ms: 48 },
+      { date: shiftDays(today, -1), ms: 52 },
+      { date: today,                ms: 55 },
+    ],
+  };
+}
+
+function restingHr(today) {
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'resting-heart-rate',
+      label: 'Resting HR',
+      emoji: '❤️',
+      order: 545,
+      category: 'recovery',
+      view: {
+        enabled: true,
+        component: 'generic-card',
+        dateContext: 'latest',
+        display: { template: '{bpm} bpm' },
+      },
+      writeable: { fromWebapp: false },
+    },
+    description: 'Resting HR atomic card for E2E recovery-overview fixture.',
+    data: [
+      { date: shiftDays(today, -2), bpm: 68 },
+      { date: shiftDays(today, -1), bpm: 66 },
+      { date: today,                bpm: 65 },
+    ],
+  };
+}
+
+function recoveryOverview(layout) {
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'recovery-overview',
+      label: 'Recovery Overview',
+      emoji: '🔋',
+      order: 530,
+      category: 'recovery',
+      view: {
+        enabled: true,
+        component: 'combination-card',
+        layout,
+        combines: [
+          { sourceId: 'hrv',                role: 'primary',   label: 'HRV',        unit: 'ms' },
+          { sourceId: 'resting-heart-rate', role: 'secondary', label: 'Resting HR', unit: 'bpm' },
+        ],
+      },
+    },
+    description: 'Recovery Overview combination card for E2E layout-switch coverage.',
+    data: [],
+  };
+}
+
 function seedManifests() {
   const today = todayISO();
   return {
     'weight.json': weight(today),
     'mood.json': mood(today),
     'peptides.json': peptides(today),
+    'hrv.json': hrv(today),
+    'resting-heart-rate.json': restingHr(today),
+    'recovery-overview.json': recoveryOverview('stack'),
     'auto-export/discovered.json': discoveredMetrics(),
   };
 }
 
-module.exports = { seedManifests, todayISO, shiftDays };
+module.exports = { seedManifests, todayISO, shiftDays, recoveryOverview };

--- a/tests-e2e/smoke.spec.js
+++ b/tests-e2e/smoke.spec.js
@@ -16,9 +16,9 @@ test.describe('smoke', () => {
 
     await expect(page.locator('eh-date-view')).toBeVisible({ timeout: 10_000 });
 
-    const genericCards = page.locator('eh-generic-card');
-    await expect(genericCards).toHaveCount(2, { timeout: 10_000 });
-
+    // Core seed includes at least Weight + Mood + HRV + Resting HR as
+    // generic-cards; additional fixtures can be layered in by other
+    // specs without this assertion getting brittle.
     await expect(page.locator('eh-generic-card', { hasText: 'Weight' })).toBeVisible();
     await expect(page.locator('eh-generic-card', { hasText: 'Mood' })).toBeVisible();
   });


### PR DESCRIPTION
# What changed

Adds E2E regression coverage for combination-card layout switching.
Two specs in \`tests-e2e/cc-layout-switch-renders.spec.js\`:

1. Seeded stack-layout \`recovery-overview\` renders the primary
   donor's value on first load.
2. Round-trip \`PATCH\` rings → stack produces a card that still
   shows the primary donor's value after reload.

Default sandbox seed (\`tests-e2e/helpers/seed-manifests.js\`) now
includes the recovery-overview fixture with HRV + Resting HR donors
anchored to today.

Adjusts \`tests-e2e/smoke.spec.js\` to stop asserting an exact
generic-card count — the core seed now has more generic cards
(needed for the CC's donors). Specific card visibility checks
remain.

Closes #190 as covered-by-test rather than bug-fixed.

# Why

#190 reported: \"CC stack renders empty after klebbius switches
layout rings → stack\". Tried to reproduce against current \`main\`
via PATCH-based layout switching; the card renders correctly in
every case I could construct. Likely explanations:

- The bug was a transient stale-cache interaction with #182's
  \`dateContext: \"latest\"\` resolution bug, which is fixed.
- Or it only reproduced with klebbius-authored manifests that had
  leftover rings-specific fields (colour, goalDaily) on
  \`combines[]\` entries, which #209 + surrounding chat-tool
  hardening may have cleaned up.

Either way, shipping regression coverage now means if a future
change ever reintroduces the empty-stack path, CI fails immediately.
The specs pass on current \`main\` without any product code change —
they document the working behaviour, not a fix.

# How

No product code change. Just:

- \`tests-e2e/helpers/seed-manifests.js\`: new \`hrv()\`, \`restingHr()\`,
  \`recoveryOverview(layout)\` fixtures + the seed object picks them up.
- \`tests-e2e/cc-layout-switch-renders.spec.js\`: two specs.
- \`tests-e2e/smoke.spec.js\`: card-count assertion loosened.

# Testing

- [x] \`npm run test:e2e\` — 11/11 pass (was 9, now +2 from the new
      spec)
- [x] \`npm test\` — 821/822 pass locally (pre-existing Windows
      flake; CI green)
- [x] Specs pass against current \`main\` without any product code
      change (verified — this is documented regression coverage,
      not a bug fix)

# Checklist

- [x] Commit messages follow conventions
- [x] \`CHANGELOG.md\` updated (under \`Added\` rather than \`Fixed\`,
      since nothing changed behaviourally)
- [x] No docs changes required (no behaviour change)
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Follow-up

- #185 (schedule prompt modal wrong shape) and #189 (water prompt
  input UX) are the remaining M2 items.
- If the \"empty stack after layout switch\" symptom ever resurfaces
  in live QA, reopen #190 with a fresh reproduction — the locked-in
  coverage should make root-cause analysis easier.