### PR TITLE
feat(settings): alphabetical card list, toggle in place, no scroll jump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Changed
+
+- **Settings card list is alphabetical and toggles in place.** The
+  previous Enabled/Disabled split meant toggling a card reshuffled
+  the list between groups and scrolled the viewport to the top —
+  disorienting when flipping several cards in a row. Cards now sort
+  alphabetically by label in one flat list, the toggle flips state
+  in place via a keyed Lit `repeat`, and the toggle's post-refresh
+  reload runs silently (no "Loading…" flash) so scroll position
+  survives. (Fixes #194)
+
 ### Added
 
 - **E2E regression coverage for combination-card layout switching.**

--- a/public/js/components/eh-settings-view.js
+++ b/public/js/components/eh-settings-view.js
@@ -9,6 +9,7 @@
 // To add a card, drop a valid manifest file into $HEALTH_HOME/data/ — see CARDS.md.
 
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
+import { repeat } from 'https://esm.sh/lit@3/directives/repeat.js';
 import { errorFromResponse } from '../lib/save-error.js';
 
 export class EhSettingsView extends LitElement {
@@ -104,8 +105,12 @@ export class EhSettingsView extends LitElement {
     }
   }
 
-  async _load() {
-    this._loading = true;
+  // Set `silent` when refreshing after a toggle: swapping the card
+  // list into "Loading…" for a moment collapses the page height and
+  // jerks the scroll position (see #194). On a refresh we have card
+  // state already — keep it on screen until the new data lands.
+  async _load({ silent = false } = {}) {
+    if (!silent) this._loading = true;
     this._error = null;
     try {
       const r = await fetch('/api/settings/cards');
@@ -115,7 +120,7 @@ export class EhSettingsView extends LitElement {
     } catch (e) {
       this._error = e.message;
     } finally {
-      this._loading = false;
+      if (!silent) this._loading = false;
     }
   }
 
@@ -126,7 +131,7 @@ export class EhSettingsView extends LitElement {
       const action = card.enabled ? 'disable' : 'enable';
       const r = await fetch(`/api/settings/cards/${encodeURIComponent(card.id)}/${action}`, { method: 'POST' });
       if (!r.ok) throw await errorFromResponse(r);
-      await this._load();
+      await this._load({ silent: true });
     } catch (e) {
       this._error = e.message;
     } finally {
@@ -143,11 +148,18 @@ export class EhSettingsView extends LitElement {
     });
   }
 
-  _groupedCards() {
-    const cards = this._filteredCards();
-    const enabled = cards.filter(c => c.enabled !== false);
-    const disabled = cards.filter(c => c.enabled === false);
-    return { enabled, disabled };
+  // Returns the filtered card list sorted alphabetically by label
+  // (case-insensitive, fallback to id). Enabled/disabled grouping
+  // was removed in #194 — toggling a card used to reshuffle the list
+  // and scroll the page to the top, which was disorienting when
+  // flipping several cards in sequence. One flat list, sorted once,
+  // keyed Lit render below so toggles don't tear down DOM.
+  _sortedCards() {
+    return [...this._filteredCards()].sort((a, b) => {
+      const la = (a.label || a.id || '').toLowerCase();
+      const lb = (b.label || b.id || '').toLowerCase();
+      return la.localeCompare(lb);
+    });
   }
 
   static styles = css`
@@ -520,8 +532,8 @@ export class EhSettingsView extends LitElement {
   render() {
     if (this._loading) return html`<div class="lede">Loading…</div>`;
 
-    const { enabled, disabled } = this._groupedCards();
-    const totalShown = enabled.length + disabled.length;
+    const sorted = this._sortedCards();
+    const totalShown = sorted.length;
     const totalAll = this._cards.length;
 
     return html`
@@ -581,14 +593,7 @@ export class EhSettingsView extends LitElement {
           No cards match "${this._filter}".
         </div>
       ` : html`
-        ${enabled.length > 0 ? html`
-          <div class="group-header">Enabled · ${enabled.length}</div>
-          ${enabled.map(c => this._renderCard(c))}
-        ` : ''}
-        ${disabled.length > 0 ? html`
-          <div class="group-header">Disabled · ${disabled.length}</div>
-          ${disabled.map(c => this._renderCard(c))}
-        ` : ''}
+        ${repeat(sorted, c => c.id, c => this._renderCard(c))}
       `}
 
       ${this._error ? html`<div class="error">${this._error}</div>` : ''}

--- a/tests-e2e/settings-alpha-toggle.spec.js
+++ b/tests-e2e/settings-alpha-toggle.spec.js
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/settings-alpha-toggle.spec.js
+// Regression for #194: Settings page lists cards alphabetically by
+// label (regardless of enabled/disabled state), and toggling a card
+// flips the switch in place without reshuffling the list or jumping
+// to the top of the page.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+test.describe('#194: Settings card list is alphabetical and toggles in place', () => {
+  test('cards render in alphabetical order by label', async ({ page }) => {
+    await page.goto('/settings');
+    await expect(page.locator('eh-settings-view')).toBeVisible();
+
+    // Read the ids shown in each card (the <span class="id"> inside
+    // .card-title). They're declared in the seed with known labels,
+    // so id order maps 1:1 to label order.
+    const ids = await page
+      .locator('eh-settings-view .card .card-title .id')
+      .allInnerTexts();
+
+    // Seeded cards by label (case-insensitive alpha):
+    //   HRV                 (id: hrv)
+    //   Mood                (id: mood)
+    //   Recovery Overview   (id: recovery-overview)
+    //   Resting HR          (id: resting-heart-rate)
+    //   Schedule            (id: peptides)
+    //   Weight              (id: weight)
+    expect(ids).toEqual([
+      'hrv',
+      'mood',
+      'recovery-overview',
+      'resting-heart-rate',
+      'peptides',
+      'weight',
+    ]);
+  });
+
+  test('toggling a card does not reshuffle the list or change scroll position', async ({ page }) => {
+    await page.goto('/settings');
+    await expect(page.locator('eh-settings-view')).toBeVisible();
+
+    // Capture order + scroll before toggling.
+    const beforeTitles = await page.locator('eh-settings-view .card .card-title').allInnerTexts();
+    const weightCard = page.locator('eh-settings-view .card', { hasText: 'Weight' });
+    await expect(weightCard).toBeVisible();
+
+    // Scroll the weight card into view; if the page jumps to top after
+    // toggle, the card will no longer be where we left it.
+    await weightCard.scrollIntoViewIfNeeded();
+    const scrollYBefore = await page.evaluate(() => window.scrollY);
+
+    // Toggle weight off.
+    await weightCard.locator('button.toggle').click();
+
+    // Wait for the button's aria-pressed to settle.
+    await expect(weightCard.locator('button.toggle')).toHaveAttribute('aria-pressed', 'false');
+
+    // Order should be preserved; scroll within a small tolerance.
+    const afterTitles = await page.locator('eh-settings-view .card .card-title').allInnerTexts();
+    expect(afterTitles).toEqual(beforeTitles);
+
+    const scrollYAfter = await page.evaluate(() => window.scrollY);
+    expect(Math.abs(scrollYAfter - scrollYBefore)).toBeLessThan(20);
+
+    // Restore sandbox state so specs that run after this one (smoke
+    // etc.) see Weight enabled again. Global-setup is per-run, not
+    // per-spec.
+    await weightCard.locator('button.toggle').click();
+    await expect(weightCard.locator('button.toggle')).toHaveAttribute('aria-pressed', 'true');
+  });
+});


### PR DESCRIPTION
# What changed

Settings page cards now sort alphabetically by label in one flat
list. Toggling a card flips its state in place via a keyed Lit
\`repeat\`, and the post-toggle refresh runs silently (no
\"Loading…\" flash) so scroll position stays put.

Fixes #194.

# Why

The previous Enabled/Disabled split meant every toggle reshuffled
the list between groups. Combined with \`_load()\` briefly rendering
\"Loading…\" (which collapsed the card grid to a single-line empty
state), the net effect was a scroll-to-top jerk every time the
operator flipped a card. Disorienting when flipping several in a row,
which is exactly what Settings is for.

Reported in 2026-05-11 QA alongside the discovery-card work.

# How

Three layers of fix in \`public/js/components/eh-settings-view.js\`:

1. **\`_sortedCards()\`** replaces \`_groupedCards()\`. Returns one
   flat list sorted by label (case-insensitive, fallback to id).
2. **Keyed Lit \`repeat\`** in the render. Imported from
   \`lit@3/directives/repeat.js\`. Keys each row on \`card.id\` so the
   DOM node survives state changes instead of being torn down.
3. **\`_load({ silent: true })\`** on the post-toggle refresh skips
   the \`_loading = true\` toggle. Cards stay on screen during the
   re-fetch, no layout collapse, no scroll reset.

Removed the \`Enabled · N\` / \`Disabled · N\` group-header markup
entirely. The per-row toggle state is still visible via the
switch's \`aria-pressed\` and the disabled-row CSS class on
\`.card\`.

# Testing

\`tests-e2e/settings-alpha-toggle.spec.js\` covers both halves:

1. Card ids render in alphabetical-by-label order, exactly matching
   the expected sequence given the seed (HRV, Mood, Recovery
   Overview, Resting HR, Schedule, Weight).
2. Toggling the Weight card:
   - Order preserved (no reshuffle).
   - \`window.scrollY\` delta < 20px (no scroll jump).
   - Aria-pressed flips to \"false\".
   - Final step restores the toggle so the shared-sandbox smoke
     spec that runs later still sees Weight enabled.

Verified both tests fail against main before the fix (scroll
delta on main was ~204px, order assertion mismatched).

- [x] \`npm test\` — 821/822 pass locally (pre-existing Windows
      flake; CI green)
- [x] \`npm run test:e2e\` — 13/13 pass
- [x] Fail-on-main verified

# Checklist

- [x] Commit messages follow conventions
- [x] \`CHANGELOG.md\` updated
- [x] Inline comments on \`_sortedCards\` and \`_load({silent})\`
      explain why the previous behaviour caused the scroll jump
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Follow-up

- #193 (Mood input emoji-rating + either-or required + daily
  prompt) is the remaining big M3 item.
- #189 + #185 remain on M2.
- Broader test-isolation concern (shared sandbox across specs)
  flagged in the spec's comment — worth its own issue eventually
  but not blocking here.