### PR TITLE
fix(chat): prefer stepper over number for count-like quick-log inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Changed
 
+- **Chat agent system prompt nudges toward `stepper` for count-like
+  quick-log inputs.** The existing input-types catalogue lists both
+  `number` and `stepper`, but offered no guidance on when to prefer
+  which. The agent would default to `number` for count-like values
+  like glasses of water, producing a bare spinner-arrow input that
+  the operator had to focus and increment with hover-activated
+  arrows. System-prompt guidance now splits the decision by intent:
+  counting → `stepper`, measuring → `number`, with concrete
+  examples. `MANIFEST-SCHEMA.md` gets a matching one-liner.
+  (Fixes #189)
+
 - **Settings card list is alphabetical and toggles in place.** The
   previous Enabled/Disabled split meant toggling a card reshuffled
   the list between groups and scrolled the viewport to the top —

--- a/MANIFEST-SCHEMA.md
+++ b/MANIFEST-SCHEMA.md
@@ -375,7 +375,7 @@ recent same-day entries.
 | type | extra fields |
 |------|--------------|
 | `number` | `min`, `max`, `step`, `placeholder` |
-| `stepper` | `min`, `max`, `step`, `default` (−/+ buttons around a number) |
+| `stepper` | `min`, `max`, `step`, `default` (−/+ buttons around a number — prefer over `number` for count-like quick-log values) |
 | `text` | `maxLength`, `placeholder` |
 | `textarea` | `rows`, `maxLength`, `placeholder` |
 | `select` | `options: [string]` or `[{value,label}]`, `placeholder` |

--- a/config/env.js
+++ b/config/env.js
@@ -272,6 +272,8 @@ Unknown renderer names render as placeholders but the manifest still saves. This
 
 Each input carries \`key\`, \`label\`, \`required\`, \`default\`, \`help\`, plus per-type options (\`min\`/\`max\`/\`step\`/\`placeholder\`/\`options\`/\`emojis\` etc.).
 
+**Picking between \`number\` and \`stepper\`.** Use \`stepper\` (−/+ buttons around a live value) for quick-log counters the user bumps a few at a time: glasses of water, cups of coffee, pushups, supplements taken. Always set a sensible \`step\` (e.g. \`1\` for discrete counts, \`250\` for millilitres, \`0.5\` for half-hours) and a \`min\`/\`max\`. Use \`number\` (free-text numeric entry) for one-shot exact values the user reads off a scale or device: body weight, systolic BP, temperature, sleep hours. The rule of thumb: if the user is COUNTING, use \`stepper\`; if they're MEASURING, use \`number\`. When in doubt, default to \`stepper\` — spinner-arrow number inputs are finicky on mobile.
+
 ### Schedule shapes (meta.schedule or per-item schedule)
 
 - \`{ "type":"daily", "times_per_day":N }\`

--- a/tests-e2e/helpers/seed-manifests.js
+++ b/tests-e2e/helpers/seed-manifests.js
@@ -240,6 +240,47 @@ function recoveryOverview(layout) {
   };
 }
 
+function water(today) {
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'water-intake',
+      label: 'Water',
+      emoji: '💧',
+      order: 250,
+      category: 'lifestyle',
+      view: {
+        enabled: true,
+        component: 'generic-card',
+        dateContext: 'latest',
+        display: { template: '{glasses} glasses' },
+      },
+      writeable: {
+        fromWebapp: true,
+        todayAllowed: true,
+        pastAllowed: true,
+        futureAllowed: false,
+        maxReadingsPerDay: 1,
+        inputs: [
+          {
+            key: 'glasses',
+            type: 'stepper',
+            min: 0,
+            max: 20,
+            step: 1,
+            default: 0,
+            label: 'Glasses of water today',
+            required: true,
+          },
+        ],
+      },
+    },
+    description: 'Daily water intake in glasses. Stepper input — tap +/- to count up.',
+    // No historic data so specs that exercise the add flow start clean.
+    data: [],
+  };
+}
+
 function seedManifests() {
   const today = todayISO();
   return {
@@ -249,6 +290,7 @@ function seedManifests() {
     'hrv.json': hrv(today),
     'resting-heart-rate.json': restingHr(today),
     'recovery-overview.json': recoveryOverview('stack'),
+    'water-intake.json': water(today),
     'auto-export/discovered.json': discoveredMetrics(),
   };
 }

--- a/tests-e2e/settings-alpha-toggle.spec.js
+++ b/tests-e2e/settings-alpha-toggle.spec.js
@@ -26,6 +26,7 @@ test.describe('#194: Settings card list is alphabetical and toggles in place', (
     //   Recovery Overview   (id: recovery-overview)
     //   Resting HR          (id: resting-heart-rate)
     //   Schedule            (id: peptides)
+    //   Water               (id: water-intake)
     //   Weight              (id: weight)
     expect(ids).toEqual([
       'hrv',
@@ -33,6 +34,7 @@ test.describe('#194: Settings card list is alphabetical and toggles in place', (
       'recovery-overview',
       'resting-heart-rate',
       'peptides',
+      'water-intake',
       'weight',
     ]);
   });

--- a/tests-e2e/water-stepper-quick-log.spec.js
+++ b/tests-e2e/water-stepper-quick-log.spec.js
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/water-stepper-quick-log.spec.js
+// Regression for #189: count-like quick-log manifests (water, caffeine
+// cups, etc.) should use `type: "stepper"` so tapping +/- is the
+// primary interaction rather than a bare number input with hover
+// spinners.
+//
+// The canonical `templates/hydration.klebb.json` template has always
+// used a stepper; the system-prompt guidance landed in this PR pushes
+// the chat agent to do the same for future ad-hoc counter cards. This
+// spec exercises the stepper shape end-to-end: open the water card's
+// input form, tap `+` several times, save, assert the count lands
+// correctly on disk.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+test.describe('#189: water card stepper input logs by tap-count', () => {
+  test('tapping + three times then save lands glasses=3 for today', async ({ page, sandboxState }) => {
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible();
+
+    const waterCard = page.locator('eh-generic-card', { hasText: 'Water' }).first();
+    await expect(waterCard).toBeVisible({ timeout: 10_000 });
+
+    // Open the edit form via the add/edit button.
+    await waterCard.locator('.edit-btn').click();
+
+    const form = waterCard.locator('eh-input-form');
+    await expect(form).toBeVisible();
+
+    // Capture whatever the stepper starts at (on Today with no row yet,
+    // the form prefills from the latest available donor value — per
+    // the #182 resolver contract). We care that +1 taps increment
+    // correctly, not the starting value.
+    const stepperValue = form.locator('.stepper-value');
+    const startValue = Number(await stepperValue.inputValue());
+
+    const incButton = form.locator('.stepper-btn', { hasText: '+' });
+    await expect(incButton).toBeVisible();
+    await incButton.click();
+    await incButton.click();
+    await incButton.click();
+
+    const expected = String(startValue + 3);
+    await expect(stepperValue).toHaveValue(expected);
+
+    // Save.
+    await form.getByRole('button', { name: /^(save|update|add)$/i }).click();
+
+    // After save, the card shows today's glasses count.
+    await expect(waterCard).toContainText(`${expected} glasses`, { timeout: 5_000 });
+
+    // Authoritatively verify via the server so we know disk matches.
+    const res = await page.request.get(`${sandboxState.baseUrl}/api/manifests/water-intake/data`);
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    const today = new Date();
+    const todayISO = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+    const todayRow = body.data.find(r => r.date === todayISO);
+    expect(todayRow).toBeDefined();
+    expect(todayRow.glasses).toBe(startValue + 3);
+  });
+});


### PR DESCRIPTION
# What changed

Three things, one PR:

1. **System prompt guidance** (\`config/env.js\`) for the chat agent:
   a new paragraph under \"Input types\" splits the \`number\` vs
   \`stepper\` decision by intent (counting → stepper, measuring →
   number, when in doubt → stepper).
2. **\`MANIFEST-SCHEMA.md\`** gets a matching one-liner on the
   stepper row.
3. **E2E regression spec** that proves the stepper input works
   end-to-end: open the water card's add form, tap \`+\` three
   times, save, assert today's row lands as \`{glasses: 3}\`.

Fixes #189.

# Why

In 2026-05-11 QA the operator observed that the water-intake card
(authored ad hoc by klebbius) used \`type: \"number\"\` — a bare
spinner-arrow input that requires hovering or focusing to increment.
For a daily quick-log of a countable value, that's friction. The
canonical \`templates/hydration.klebb.json\` already ships a stepper;
the miss was klebbius picking \`number\` when creating new cards.

The fix nudges the agent toward the right shape at creation time
rather than patching every custom card after the fact.

# How

No runtime code change. The renderer already has a fully-wired
\`stepper\` input type (eh-input-form.js — −/+ buttons wrapping a
readout). The bug was prompt-layer: the agent didn't know when
to pick it.

Added to \`HEALTH_SYSTEM_PROMPT\`:

> **Picking between \`number\` and \`stepper\`.** Use \`stepper\` (−/+
> buttons around a live value) for quick-log counters the user
> bumps a few at a time: glasses of water, cups of coffee, pushups,
> supplements taken. Always set a sensible \`step\` (e.g. \`1\` for
> discrete counts, \`250\` for millilitres, \`0.5\` for half-hours)
> and a \`min\`/\`max\`. Use \`number\` (free-text numeric entry) for
> one-shot exact values the user reads off a scale or device: body
> weight, systolic BP, temperature, sleep hours. The rule of thumb:
> if the user is COUNTING, use \`stepper\`; if they're MEASURING, use
> \`number\`. When in doubt, default to \`stepper\` — spinner-arrow
> number inputs are finicky on mobile.

# Testing

New E2E spec \`tests-e2e/water-stepper-quick-log.spec.js\`:

- Seeds a water-intake card with \`type: \"stepper\"\`, \`step: 1\`,
  \`min: 0\`, \`max: 20\`, no historic data.
- Opens the add form via the \`➕\` button.
- Taps the \`+\` button three times; asserts the readout reflects
  the starting value + 3.
- Clicks Save / Add.
- Reads the manifest via the server API and asserts today's row
  has \`glasses\` = startValue + 3.

Default sandbox seed now ships the water card so future specs have
the fixture. Settings spec's alphabetical-order assertion updated
to include \`water-intake\` in the list.

- [x] \`npm test\` — 821/822 pass locally (pre-existing Windows
      flake; CI green)
- [x] \`npm run test:e2e\` — 14/14 pass

Note: I did NOT add a test that asserts a fresh klebbius-created
water card picks \`stepper\` over \`number\` — that would require
exercising the chat gateway, which the sandbox deliberately
doesn't speak to. The system-prompt guidance is doc-level behaviour
that lands via model-following-instructions, not runtime logic. The
E2E spec proves the stepper renders + logs correctly; testing that
\"the agent picks stepper\" is out of scope for this harness.

# Checklist

- [x] Commit messages follow conventions
- [x] \`CHANGELOG.md\` updated
- [x] \`MANIFEST-SCHEMA.md\` + system prompt docs aligned
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Follow-up

- #185 (schedule prompt modal reminder-flow shape) needs UX
  direction before starting.
- #193 (mood input emoji rating + either-or required + daily
  prompt) and #195 (manifest-driven starter prompts) are the two
  remaining M3 items.