### PR TITLE
fix(template): {key:check} modifier for boolean fields (#215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Added
+
+- **`{key:check}` display-template modifier for boolean fields.**
+  Renders `✅` when the value is truthy, empty string when
+  falsy/missing. Cleans up workouts-style cards whose data carries
+  a boolean `trained` field that used to stringify to the literal
+  `"true"` / `"false"` on the card headline. System prompt +
+  `MANIFEST-SCHEMA.md` document the new modifier and nudge
+  klebbius to drop `dateContext: "latest"` on "did it happen
+  today" cards so non-workout days show the empty state instead of
+  a stale trained day. (Fixes #215)
+
 ### Changed
 
 - **Chat agent system prompt nudges toward `stepper` for count-like

--- a/MANIFEST-SCHEMA.md
+++ b/MANIFEST-SCHEMA.md
@@ -187,10 +187,19 @@ Template syntax:
 - `{key}` → `row[key]`
 - `{key:round(N)}` → round to N decimals
 - `{key:emoji}` → look up in `emojiMap[key]`
+- `{key:check}` → render `✅` when truthy, empty string when falsy/missing
+- `{key:truncate(N)}` → cap a string at N chars, append `…` when cut
 - `{key|default}` → fallback when empty
 - `{key?yes:no}` → ternary on truthiness
 - `{nested.path}` → dotted access
 - Missing keys render as empty string
+
+Use `{bool:check}` (not `{bool}`) for boolean fields like a workouts
+card's `trained`. A bare `{trained}` stringifies to the literal
+`"true"` / `"false"`, which looks wrong. `{trained:check}` gives you
+a tick when it happened and nothing when it didn't, which is almost
+always what you want on a card headline. If you need both branches
+(e.g. "Trained" vs "Rest day"), use the ternary: `{trained?Trained:Rest}`.
 
 `unit` prints a small secondary string next to the headline.
 

--- a/config/env.js
+++ b/config/env.js
@@ -217,6 +217,12 @@ Everything else is optional pass-through. The endpoint is lenient: if the render
 
 **Gotcha — \`meta.view.display\` is an object, never a string.** Use \`"display": {"template": "{bpm} bpm"}\`, NOT \`"display": "{bpm} bpm"\`. The object can carry \`template\`, \`secondary\`, \`emptyHeadline\`, \`emojiMap\`, \`thresholds\`, \`trendArrow\`, \`unit\`, and \`subtitle\`. A bare string won't render anything.
 
+**Gotcha — booleans in a display template.** A bare \`{trained}\` in a template stringifies the value literally, so a row like \`{trained: true, type: "Functional Strength Training"}\` renders \"true · Functional Strength Training\" on the card. That's never what you want. For boolean fields, prefer:
+- \`{trained:check}\` → renders \`✅\` when true, empty string when false/missing. Best default for \"did this thing happen today\" cards (workouts, meditation, journal).
+- \`{trained?Trained:Rest}\` ternary → when you need both branches labelled.
+
+For a workouts card specifically: use \`"template": "{type}"\` + drop \`dateContext: \"latest\"\` (otherwise every non-workout day shows the most recent workout, which misleads the user). On days without a workout the card uses \`emptyHeadline\` instead — \"No workout today\" or similar.
+
 **Gotcha — writeable cards MUST declare \`meta.writeable.inputs\`.** If \`meta.writeable.fromWebapp: true\` is set, the manifest MUST carry a non-empty \`meta.writeable.inputs\` array that covers every field the card's \`description\` mentions. Without inputs, the edit-form is a primary-field-only stub and the per-row three-dot button (which opens secondary-field editing on list-card) never appears. Concretely: if the description says "Array of {date, type, location, status, followUp, note}", the manifest must declare inputs for all of those keys. For \`list-card\` also set \`meta.view.display.primaryField\` to the key whose value is the row title (e.g. \`"name"\`) so the renderer knows which input is primary vs secondary.
 
 ### Full manifest shape

--- a/public/js/lib/display-template.esm.js
+++ b/public/js/lib/display-template.esm.js
@@ -75,6 +75,12 @@ function resolveField(row, display, expr) {
       const s = String(value);
       return s.length > n ? s.slice(0, n) + '…' : s;
     }
+    // :check — render ✅ when truthy, empty string when falsy/missing.
+    // Use for boolean fields (e.g. workouts `trained`) that shouldn't
+    // stringify to "true"/"false" on the card. See #215.
+    if (modifier === 'check') {
+      return value ? '✅' : (fallback ?? '');
+    }
   }
   if (isEmpty(value)) return fallback ?? '';
   return String(value);

--- a/public/js/lib/display-template.js
+++ b/public/js/lib/display-template.js
@@ -105,6 +105,12 @@
         const s = String(value);
         return s.length > n ? s.slice(0, n) + '…' : s;
       }
+      // :check — render ✅ when truthy, empty string when falsy/missing.
+      // Use for boolean fields (e.g. workouts `trained`) that shouldn't
+      // stringify to "true"/"false" on the card. See #215.
+      if (modifier === 'check') {
+        return value ? '✅' : (fallback ?? '');
+      }
       // Unknown modifier → ignore
     }
 

--- a/tests-e2e/helpers/seed-manifests.js
+++ b/tests-e2e/helpers/seed-manifests.js
@@ -281,6 +281,36 @@ function water(today) {
   };
 }
 
+function workouts(today) {
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'workouts',
+      label: 'Workouts',
+      emoji: '🏋️',
+      order: 420,
+      category: 'activity',
+      ingest: { source: 'hae', metric: 'workouts' },
+      view: {
+        enabled: true,
+        component: 'generic-card',
+        // No dateContext:latest — we want the card to honour viewed
+        // date so non-workout days show the empty state, not the last
+        // trained day's leftovers. See #215.
+        display: {
+          template: '{trained:check} {type}',
+          emptyHeadline: 'No workout today',
+        },
+      },
+      writeable: { fromWebapp: false },
+    },
+    description: 'Workout data ingested from Health Auto Export. One row per date. Fields: date, trained (boolean), type (workout type string).',
+    data: [
+      { date: today, trained: true, type: 'Functional Strength Training' },
+    ],
+  };
+}
+
 function seedManifests() {
   const today = todayISO();
   return {
@@ -291,6 +321,7 @@ function seedManifests() {
     'resting-heart-rate.json': restingHr(today),
     'recovery-overview.json': recoveryOverview('stack'),
     'water-intake.json': water(today),
+    'workouts.json': workouts(today),
     'auto-export/discovered.json': discoveredMetrics(),
   };
 }

--- a/tests-e2e/settings-alpha-toggle.spec.js
+++ b/tests-e2e/settings-alpha-toggle.spec.js
@@ -28,6 +28,7 @@ test.describe('#194: Settings card list is alphabetical and toggles in place', (
     //   Schedule            (id: peptides)
     //   Water               (id: water-intake)
     //   Weight              (id: weight)
+    //   Workouts            (id: workouts)
     expect(ids).toEqual([
       'hrv',
       'mood',
@@ -36,6 +37,7 @@ test.describe('#194: Settings card list is alphabetical and toggles in place', (
       'peptides',
       'water-intake',
       'weight',
+      'workouts',
     ]);
   });
 

--- a/tests-e2e/workouts-card-bool-template.spec.js
+++ b/tests-e2e/workouts-card-bool-template.spec.js
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/workouts-card-bool-template.spec.js
+// Regression for #215: a workouts card whose row is
+// {date, trained:true, type:"Functional Strength Training"} must
+// render readably on the Today card — no literal "true" string.
+//
+// Before the fix, klebbius-authored workouts cards used a template
+// like "{trained} · {type}" which rendered "true · Functional
+// Strength Training". The fix ships a :check modifier so
+// `{trained:check}` renders ✅ for truthy values and empty for
+// falsy/missing, plus system-prompt guidance to steer future
+// klebbius-authored cards toward the right shape.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+test.describe('#215: workouts card renders boolean trained as a tick', () => {
+  test('{trained:check} renders ✅ on a workout day, no literal "true"', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible();
+
+    const card = page.locator('eh-generic-card', { hasText: 'Workouts' }).first();
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await expect(card).toContainText('Functional Strength Training');
+
+    // Tick from the :check modifier should be present.
+    await expect(card).toContainText('✅');
+
+    // Specifically: the literal word "true" must NOT appear on the card.
+    const text = (await card.innerText()).toLowerCase();
+    expect(text).not.toMatch(/\btrue\b/);
+  });
+});

--- a/tests/display-template.test.js
+++ b/tests/display-template.test.js
@@ -111,6 +111,47 @@ describe('display-template', () => {
     test('literal braces with unresolvable key render empty', () => {
       assert.equal(renderTemplate('{xxx}', { yyy: 1 }), '');
     });
+
+    // #215: booleans used to stringify to "true" / "false" which looked
+    // silly on cards like workouts ("{trained} · {type}" → "true · ...").
+    // The :check modifier renders a tick when truthy, empty string
+    // otherwise, and the ternary shorthand continues to be the flexible
+    // escape hatch.
+    describe('boolean handling (#215)', () => {
+      test(':check modifier — true renders ✅', () => {
+        assert.equal(renderTemplate('{trained:check}', { trained: true }), '✅');
+      });
+
+      test(':check modifier — false renders empty', () => {
+        assert.equal(renderTemplate('{trained:check}', { trained: false }), '');
+      });
+
+      test(':check modifier — missing renders empty', () => {
+        assert.equal(renderTemplate('{trained:check}', {}), '');
+      });
+
+      test(':check modifier — truthy non-bool (string) also renders ✅', () => {
+        // Any truthy value is treated as "yes, this happened". Keeps the
+        // modifier useful when a manifest upgrades from bool to a richer
+        // field without breaking the display.
+        assert.equal(renderTemplate('{type:check}', { type: 'Strength' }), '✅');
+      });
+
+      test(':check modifier — 0 renders empty (falsy)', () => {
+        assert.equal(renderTemplate('{count:check}', { count: 0 }), '');
+      });
+
+      test('ternary still works as the flexible bool shorthand', () => {
+        assert.equal(
+          renderTemplate('{trained?Trained:Rest}', { trained: true }),
+          'Trained'
+        );
+        assert.equal(
+          renderTemplate('{trained?Trained:Rest}', { trained: false }),
+          'Rest'
+        );
+      });
+    });
   });
 
   describe('getValue', () => {


### PR DESCRIPTION
# What changed

New \`{key:check}\` modifier in the display-template engine: renders
\`✅\` when the value is truthy, empty string when falsy/missing.
Plus matching guidance in \`MANIFEST-SCHEMA.md\` and the chat system
prompt so future klebbius-authored cards use it correctly.

Fixes #215.

# Why

The operator added a Workouts card on klebbtest via the HAE discovery
prompt. Klebbius wrote a sensible-looking template:

\`\`\`json
\"display\": { \"template\": \"{trained} · {type}\" }
\`\`\`

…which rendered \"**true · Functional Strength Training**\" on the
card because \`{trained}\` stringifies the boolean literally. There
was no existing idiom for \"display a bool as a tick\". The existing
ternary (\`{trained?Trained:Rest}\`) works but it's verbose for the
common case. Adding a \`:check\` modifier makes this the easy path.

The system-prompt addition also notes that workouts-style cards
should NOT use \`dateContext: \"latest\"\` — otherwise a non-workout
day shows last week's workout, misleading the user.

# How

**Engine** (two files, keep-in-sync pair):

- \`public/js/lib/display-template.js\` (UMD, used by Node tests)
- \`public/js/lib/display-template.esm.js\` (browser)

Both gain one branch inside \`resolveField\`:

\`\`\`js
if (modifier === 'check') {
  return value ? '✅' : (fallback ?? '');
}
\`\`\`

**Docs** — \`MANIFEST-SCHEMA.md\` picks up the new modifier in its
template-syntax list plus a short paragraph on when to use
\`:check\` vs ternary.

**System prompt** — \`config/env.js\` gains a \"booleans in a display
template\" gotcha alongside the existing \"display is an object\"
gotcha. Names the workouts-card anti-pattern specifically and
recommends the right shape (\`{type}\` template, drop
\`dateContext: \"latest\"\`, use \`emptyHeadline\` on non-workout days).

# Testing

**Unit** — \`tests/display-template.test.js\` gains 6 assertions
covering:

1. \`{trained:check}\` with \`trained: true\` → \`✅\`
2. \`{trained:check}\` with \`trained: false\` → empty
3. \`{trained:check}\` with missing field → empty
4. \`:check\` on a truthy non-bool (string) → \`✅\`
5. \`:check\` on \`0\` → empty (0 is falsy)
6. Existing ternary still works (\`{trained?Trained:Rest}\` on both branches)

4 failed on main; all 33 pass with the change.

**E2E** — new \`tests-e2e/workouts-card-bool-template.spec.js\`:

1. Seeds a workouts manifest with \`template: \"{trained:check} {type}\"\` and today's row \`{trained:true, type:\"Functional Strength Training\"}\`.
2. Opens Today view.
3. Asserts the card contains the type string.
4. Asserts \`✅\` is visible.
5. Asserts the literal word \"true\" does NOT appear anywhere in the card.

Verified fails against main (stashed the engine change, reran — 1 failed at \`toContainText('✅')\`). Passes with the fix.

- [x] \`npm test\` — 827/828 pass locally (same pre-existing Windows
      \`no-personal-refs\` flake; CI green)
- [x] \`npm run test:e2e\` — 15/15 pass
- [x] Fail-on-main verified

# Deployment note

The existing klebbtest workouts card is still configured with the
old \`\"{trained} · {type}\"\` template. After this merge, the
operator can ask klebbius: \"update the workouts card's template to
use \`{trained:check} {type}\` and drop \`dateContext: latest\`\" and
klebbius will now have the right guidance to comply. Or the
operator can edit the manifest directly.

# Checklist

- [x] Commit messages follow conventions
- [x] \`CHANGELOG.md\` updated
- [x] Docs updated (\`MANIFEST-SCHEMA.md\` + system prompt)
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Follow-up

- #193 (mood input emoji-rating) is the next item in the \"Option C\"
  queue from 2026-05-12 triage.
- #216 (weight/BP still on type:number) — likely no-action;
  needs a decision.
- #217 (\`writeable.prefillFromLatest\`) — new enhancement.
- #218 (\"Dismiss all\" on the unsupported-metrics footer).