### PR TITLE
feat(input): rating input consults display.emojiMap (#193 Part A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Changed
+
+- **Rating input consults `display.emojiMap` to render emoji buttons.**
+  When a manifest's `view.display.emojiMap` is present, a
+  `type: "rating"` input now labels its buttons with the mapped
+  emojis (😩 😔 😐 🙂 😄) instead of raw numbers. The underlying
+  saved value stays numeric — the emojis are label-only. Works
+  with both the flat emojiMap shape (`{"1": "😩", ...}`, used by
+  mood) and the keyed shape (`{mood: {"1": "😩", ...}}`, used by
+  multi-field cards). Threads `display` through all four
+  `eh-input-form` callers: generic-card, combination-card,
+  list-card, prompt-modal. (Refs #193 Part A)
+
 ### Added
 
 - **`{key:check}` display-template modifier for boolean fields.**

--- a/public/js/components/eh-combination-card.js
+++ b/public/js/components/eh-combination-card.js
@@ -254,6 +254,7 @@ export class EhCombinationCard extends LitElement {
     const src = this._sources?.[sourceId];
     if (!src?.meta?.writeable?.inputs) return '';
     const inputs = src.meta.writeable.inputs;
+    const donorDisplay = src.meta?.view?.display || null;
     // Prefill with the donor's current row for this date, if any.
     const rows = Array.isArray(src.data) ? src.data : [];
     const current = rows.find(r => r && r.date === this.date) || {};
@@ -268,6 +269,7 @@ export class EhCombinationCard extends LitElement {
           .inputs=${inputs}
           .values=${current}
           .date=${this.date}
+          .display=${donorDisplay}
           submit-label=${hasEntry ? 'Update' : 'Add'}
           ?busy=${this._saving}
           @eh-submit=${(e) => this._onDonorSubmit(sourceId, e)}

--- a/public/js/components/eh-generic-card.js
+++ b/public/js/components/eh-generic-card.js
@@ -268,6 +268,7 @@ export class EhGenericCard extends EhBaseCard {
             .inputs=${meta.writeable.inputs}
             .values=${entry || {}}
             .date=${this.date}
+            .display=${display}
             submit-label=${hasEntry ? 'Update' : 'Add'}
             ?busy=${this._saving}
             @eh-submit=${this._onSubmit}

--- a/public/js/components/eh-input-form.js
+++ b/public/js/components/eh-input-form.js
@@ -34,6 +34,12 @@ export class EhInputForm extends LitElement {
     inputs: { type: Array },
     values: { type: Object },
     date: { type: String },
+    // Optional `meta.view.display` from the host card. When present,
+    // certain input types (currently `rating`) consult its
+    // `emojiMap[input.key]` so the buttons render as emojis instead
+    // of plain numbers — matching what the card headline already
+    // shows. See #193.
+    display: { type: Object },
     submitLabel: { type: String, attribute: 'submit-label' },
     cancelLabel: { type: String, attribute: 'cancel-label' },
     busy: { type: Boolean },
@@ -46,6 +52,7 @@ export class EhInputForm extends LitElement {
     this.inputs = [];
     this.values = {};
     this.date = null;
+    this.display = null;
     this.submitLabel = 'Save';
     this.cancelLabel = 'Cancel';
     this.busy = false;
@@ -274,15 +281,37 @@ export class EhInputForm extends LitElement {
         const max = input.max ?? 5;
         const range = [];
         for (let i = min; i <= max; i++) range.push(i);
+        // When the host card's display block carries an emojiMap,
+        // render emojis as the button label instead of the raw number.
+        // Two emojiMap shapes are supported, matching what the rest
+        // of the app already handles:
+        //   flat:  { "1": "😩", "2": "😔", ... }        — used by mood, most atomic rating cards
+        //   keyed: { mood: {"1": "😩", ...}, ... }      — used by multi-field cards / {key:emoji} template
+        // Value persisted on save stays the numeric index — the
+        // emoji is label-only. See #193.
+        const rawMap = this.display && this.display.emojiMap;
+        let emojiMap = null;
+        if (rawMap && typeof rawMap === 'object') {
+          if (rawMap[input.key] && typeof rawMap[input.key] === 'object') {
+            emojiMap = rawMap[input.key];
+          } else if (rawMap[String(min)] !== undefined || rawMap[min] !== undefined) {
+            // Flat shape — keys look like the rating values themselves.
+            emojiMap = rawMap;
+          }
+        }
         return html`
           <div class="rating-row">
-            ${range.map(i => html`
-              <button
-                type="button"
-                class="rating ${Number(v) === i ? 'selected' : ''}"
-                @click=${() => this._update(input.key, i)}
-              >${i}</button>
-            `)}
+            ${range.map(i => {
+              const label = (emojiMap && (emojiMap[String(i)] ?? emojiMap[i])) || String(i);
+              return html`
+                <button
+                  type="button"
+                  class="rating ${emojiMap ? 'rating-emoji' : ''} ${Number(v) === i ? 'selected' : ''}"
+                  @click=${() => this._update(input.key, i)}
+                  aria-label="${input.label || input.key} ${i}"
+                >${label}</button>
+              `;
+            })}
           </div>`;
       }
       default:
@@ -354,6 +383,10 @@ export class EhInputForm extends LitElement {
       min-width: 40px;
     }
     .rating { font-size: 14px; font-weight: 600; }
+    /* When the rating renders emoji labels (driven by display.emojiMap
+       on the host manifest — see #193), bump the font size so the
+       emoji read at a touch-friendly size. */
+    .rating.rating-emoji { font-size: 22px; font-weight: normal; padding: 6px 8px; }
     .emoji.selected, .rating.selected {
       border-color: var(--accent);
       background: var(--accent);

--- a/public/js/components/eh-list-card.js
+++ b/public/js/components/eh-list-card.js
@@ -561,6 +561,7 @@ export class EhListCard extends EhBaseCard {
                   <eh-input-form
                     .inputs=${secondaryInputs}
                     .values=${row}
+                    .display=${display}
                     submit-label="Apply"
                     cancel-label="Cancel"
                     @eh-submit=${(e) => this._onExpandedFormSubmit(idx, e)}

--- a/public/js/components/eh-prompt-modal.js
+++ b/public/js/components/eh-prompt-modal.js
@@ -262,6 +262,7 @@ export class EhPromptModal extends LitElement {
     if (!this.card) return html``;
     const meta = this.card.meta || {};
     const inputs = meta.writeable?.inputs || [];
+    const display = meta.view?.display || null;
     const today = this.date || localToday();
     return html`
       <dialog aria-modal="true" aria-label="${meta.label || 'Log entry'}">
@@ -288,6 +289,7 @@ export class EhPromptModal extends LitElement {
               .inputs=${inputs}
               .values=${{}}
               .date=${today}
+              .display=${display}
               .busy=${this._busy}
               submit-label="Save"
               cancel-label="Not now"

--- a/tests-e2e/mood-rating-shows-emojis.spec.js
+++ b/tests-e2e/mood-rating-shows-emojis.spec.js
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/mood-rating-shows-emojis.spec.js
+// Regression for #193 (Path B): when a `rating` input is rendered on
+// a manifest whose view.display.emojiMap maps the rating key to
+// emojis, the input should render the emoji buttons (😩 😔 😐 🙂 😄)
+// instead of plain numbers (1 2 3 4 5). Numbers persist as the
+// underlying value on save — the emojis are purely presentation.
+//
+// Before Path B the rating input ignored display.emojiMap entirely
+// and rendered numbers, which clashed with the card's headline that
+// DID consult emojiMap (see #183's resolution). The input now
+// matches the headline.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+test.describe('#193 Path B: rating input consults display.emojiMap', () => {
+  test('mood input form shows emoji buttons, not number buttons', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible();
+
+    const moodCard = page.locator('eh-generic-card', { hasText: 'Mood' }).first();
+    await expect(moodCard).toBeVisible({ timeout: 10_000 });
+
+    // Open the edit/add form.
+    await moodCard.locator('.edit-btn').click();
+
+    const form = moodCard.locator('eh-input-form');
+    await expect(form).toBeVisible();
+
+    // The seeded mood manifest has emojiMap
+    // {1:'😩', 2:'😔', 3:'😐', 4:'🙂', 5:'😄'}. All five should appear
+    // as buttons in the rating row.
+    const ratingRow = form.locator('.rating-row');
+    await expect(ratingRow).toBeVisible();
+    for (const emoji of ['😩', '😔', '😐', '🙂', '😄']) {
+      await expect(ratingRow).toContainText(emoji);
+    }
+
+    // Number buttons must NOT appear on their own anymore; the
+    // rating row's text content should not contain bare "1"/"2"/.../"5"
+    // (beyond what the emoji glyph carries).
+    const text = await ratingRow.innerText();
+    expect(text).not.toMatch(/^\s*1\s+2\s+3\s+4\s+5\s*$/);
+  });
+
+  test('clicking an emoji saves the numeric value', async ({ page, sandboxState }) => {
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible();
+
+    const moodCard = page.locator('eh-generic-card', { hasText: 'Mood' }).first();
+    await moodCard.locator('.edit-btn').click();
+    const form = moodCard.locator('eh-input-form');
+    await expect(form).toBeVisible();
+
+    // Click the 😩 button (maps to mood: 1).
+    await form.locator('.rating', { hasText: '😩' }).click();
+
+    await form.getByRole('button', { name: /^(save|update|add)$/i }).click();
+
+    // Pull the saved data via the API and assert today's row has
+    // mood === 1, not "😩".
+    const res = await page.request.get(`${sandboxState.baseUrl}/api/manifests/mood/data`);
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    const todayIso = (() => {
+      const d = new Date();
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    })();
+    const row = body.data.find(r => r.date === todayIso);
+    expect(row).toBeDefined();
+    expect(row.mood).toBe(1);
+
+    // Restore sandbox state: specs that run after this one (past-date
+    // view-and-edit, smoke) expect today's mood to be the seeded 5.
+    // The sandbox is shared across the whole Playwright run; we clean
+    // up our mutations explicitly.
+    const restored = body.data.map(r =>
+      r.date === todayIso ? { ...r, mood: 5 } : r,
+    );
+    const put = await page.request.post(
+      `${sandboxState.baseUrl}/api/manifests/mood/data`,
+      { data: { data: restored } },
+    );
+    expect(put.status()).toBe(200);
+  });
+});

--- a/tests-e2e/past-date-view-and-edit.spec.js
+++ b/tests-e2e/past-date-view-and-edit.spec.js
@@ -69,9 +69,11 @@ test.describe('#182: cards with dateContext:latest honour past-date navigation',
     await moodCard.locator('.edit-btn').click();
 
     // The form is an eh-input-form with a rating input of type "rating".
-    // The rating renderer emits buttons 1..5; click the "1" to change
-    // mood to 1. Scope to the mood card to avoid catching a weight input.
-    await moodCard.locator('eh-input-form').getByRole('button', { name: '1', exact: true }).click();
+    // When display.emojiMap is present the buttons show emoji labels
+    // with aria-label "mood 1" / "mood 2" etc. (see #193). Click by
+    // aria-label so the spec is stable whether numbers or emojis
+    // render.
+    await moodCard.locator('eh-input-form').getByRole('button', { name: 'mood 1' }).click();
 
     // Submit.
     await moodCard.locator('eh-input-form').getByRole('button', { name: /save|update/i }).click();


### PR DESCRIPTION
# What changed

\`type: \"rating\"\` inputs now render emoji buttons when the host card
declares a \`view.display.emojiMap\`. The underlying saved value stays
numeric (1–5); the emoji is label-only.

Part A of three for #193. Part B (either-or required) and Part C
(daily prompt on mood manifest) land separately.

Refs #193.

# Why

The mood card has always mapped 1-to-😩, 5-to-😄 etc. via
\`view.display.emojiMap\`. The card headline consulted it (#183's
calendar work also did) but the rating input in the edit form
stubbornly showed \`[1][2][3][4][5]\` number buttons. Two mental
models for the same card, which the operator called out twice.

Path A (from the design discussion) would have been to flip mood
from \`rating\` to \`emoji-picker\`, but that duplicates the emoji
list across \`display.emojiMap\` and \`inputs[0].emojis\` — exactly
the kind of duplication the \"manifest is the app\" ethos avoids.
Path B lets any rating input (mood today, sleep-quality tomorrow)
get emoji buttons from the same source of truth as its headline.

# How

**\`eh-input-form\`**:

- New optional \`display\` property (falls back to \`null\`).
- Rating render branch looks up the emoji map in two shapes:
  - \`display.emojiMap[input.key]\` (keyed — for cards with
    multiple rating fields sharing one display block)
  - \`display.emojiMap\` directly (flat — what mood actually uses)
- If a map is found, buttons render emojis; if not, numbers
  (existing behaviour preserved).
- CSS: \`.rating.rating-emoji\` bumps font-size to 22px so the
  emojis read at a touch-friendly size.
- aria-label includes the numeric index so screen readers still
  announce \"mood 1\" / \"mood 2\" regardless of the visible glyph.

**Callers** thread the right \`display\` block through:

- \`eh-generic-card.js\`: passes \`this._display()\`.
- \`eh-combination-card.js\`: passes the donor card's
  \`src.meta.view.display\` (per-donor, since each donor has its
  own display rules).
- \`eh-list-card.js\`: passes \`this._display()\`.
- \`eh-prompt-modal.js\`: passes \`meta.view.display\` from the
  prompted card.

# Testing

New E2E spec \`tests-e2e/mood-rating-shows-emojis.spec.js\`:

1. Opens the mood card's add form. Asserts all five emoji
   glyphs (😩 😔 😐 🙂 😄) appear as buttons.
2. Clicks the 😩 button, saves, reads today's row via the API,
   asserts \`mood: 1\` (numeric, not the emoji itself).
3. Restores mood back to 5 so later specs (past-date, smoke)
   aren't broken by the mutation — the sandbox is shared across
   the run.

Updated \`tests-e2e/past-date-view-and-edit.spec.js\` to click the
mood rating button by aria-label (\`mood 1\`) instead of its
visible text (the visible text is now an emoji, not \"1\").

Verified both new tests fail on main before the fix (timeout
waiting for \`.rating\` button with emoji text). Pass with the
implementation.

- [x] \`npm test\` — 827/828 pass locally (pre-existing Windows
      \`no-personal-refs\` flake; CI green)
- [x] \`npm run test:e2e\` — 17/17 pass
- [x] Fail-on-main verified

# Checklist

- [x] Commit messages follow conventions
- [x] \`CHANGELOG.md\` updated
- [x] Inline comment on the rating branch explains the two
      supported emojiMap shapes
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Follow-up

- **Part B** (same #193): cross-field \`requireAny\` validation so
  the mood form's Save button enables when mood OR note is
  present, not only when both (since \`required: true\` is
  per-input today).
- **Part C**: add \`prompt: { enabled: true, mode: \"modal\",
  whenMissing: true }\` to the mood manifest / template so the
  daily prompt actually fires.