### PR TITLE
feat(input): writeable.requireAny for either-or required inputs (#193 Part B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Added
+
+- **`writeable.requireAny` for either-or inputs.** A new optional
+  array on `meta.writeable` lists input keys at least one of which
+  must be filled for the Save button to enable. Mood uses it for
+  `["mood", "note"]` so the user can log a feeling, a journal
+  line, or both — without being blocked by a per-input
+  `required: true`. Individual `required` flags still apply for
+  fields that must always be present.
+  (Fixes #193 Part B)
+
 ### Changed
 
 - **Rating input consults `display.emojiMap` to render emoji buttons.**

--- a/MANIFEST-SCHEMA.md
+++ b/MANIFEST-SCHEMA.md
@@ -360,6 +360,7 @@ the calendar.
   "pastAllowed":       true,
   "futureAllowed":     false,
   "maxReadingsPerDay": 1,
+  "requireAny":        ["mood", "note"],
   "inputs": [
     {
       "key":         "kg",
@@ -378,6 +379,13 @@ the calendar.
 `maxReadingsPerDay` defaults to `1` (upsert: the new entry replaces the
 existing entry for that date). Values `>1` append and keep the N most
 recent same-day entries.
+
+`requireAny` is an optional "either-or" list. When present, the edit
+form's Save button stays disabled until at least one of the listed
+keys has a value. Individual inputs' `required: true` flags still
+apply in addition — use `requireAny` instead of per-input `required`
+for the listed keys. Example: mood's `["mood", "note"]` means the
+user can log just a number, just a journal line, or both.
 
 ### Input types
 

--- a/config/env.js
+++ b/config/env.js
@@ -217,6 +217,8 @@ Everything else is optional pass-through. The endpoint is lenient: if the render
 
 **Gotcha — \`meta.view.display\` is an object, never a string.** Use \`"display": {"template": "{bpm} bpm"}\`, NOT \`"display": "{bpm} bpm"\`. The object can carry \`template\`, \`secondary\`, \`emptyHeadline\`, \`emojiMap\`, \`thresholds\`, \`trendArrow\`, \`unit\`, and \`subtitle\`. A bare string won't render anything.
 
+**Either-or required — \`writeable.requireAny\`.** Some cards accept more than one input where at least one must be filled (e.g. mood lets you log a number, a journal line, or both). Set \`requireAny: [\"mood\", \"note\"]\` instead of flagging each input with \`required: true\` — the form enables Save when ANY listed key has a value. Individual \`required: true\` flags still apply in addition, for fields that must ALWAYS be present.
+
 **Gotcha — booleans in a display template.** A bare \`{trained}\` in a template stringifies the value literally, so a row like \`{trained: true, type: "Functional Strength Training"}\` renders \"true · Functional Strength Training\" on the card. That's never what you want. For boolean fields, prefer:
 - \`{trained:check}\` → renders \`✅\` when true, empty string when false/missing. Best default for \"did this thing happen today\" cards (workouts, meditation, journal).
 - \`{trained?Trained:Rest}\` ternary → when you need both branches labelled.
@@ -247,6 +249,7 @@ For a workouts card specifically: use \`"template": "{type}"\` + drop \`dateCont
       "pastAllowed":  false,
       "futureAllowed":false,
       "maxReadingsPerDay": 1,
+      "requireAny": ["mood", "note"],          // optional either-or gate
       "inputs": [ { "key":"...", "label":"...", "type":"...", ... } ]
     },
     "prompt":   { "enabled": false, "mode": "modal", "whenMissing": true }

--- a/public/js/components/eh-combination-card.js
+++ b/public/js/components/eh-combination-card.js
@@ -270,6 +270,7 @@ export class EhCombinationCard extends LitElement {
           .values=${current}
           .date=${this.date}
           .display=${donorDisplay}
+          .requireAny=${src.meta?.writeable?.requireAny || null}
           submit-label=${hasEntry ? 'Update' : 'Add'}
           ?busy=${this._saving}
           @eh-submit=${(e) => this._onDonorSubmit(sourceId, e)}

--- a/public/js/components/eh-generic-card.js
+++ b/public/js/components/eh-generic-card.js
@@ -269,6 +269,7 @@ export class EhGenericCard extends EhBaseCard {
             .values=${entry || {}}
             .date=${this.date}
             .display=${display}
+            .requireAny=${meta.writeable.requireAny || null}
             submit-label=${hasEntry ? 'Update' : 'Add'}
             ?busy=${this._saving}
             @eh-submit=${this._onSubmit}

--- a/public/js/components/eh-input-form.js
+++ b/public/js/components/eh-input-form.js
@@ -38,8 +38,14 @@ export class EhInputForm extends LitElement {
     // certain input types (currently `rating`) consult its
     // `emojiMap[input.key]` so the buttons render as emojis instead
     // of plain numbers — matching what the card headline already
-    // shows. See #193.
+    // shows. See #193 Part A.
     display: { type: Object },
+    // Optional cross-field "either-or" required list. When set (e.g.
+    // ["mood", "note"]) the form validates as "at least one of these
+    // keys has a value". Individual inputs' `required: true` flags
+    // still apply in addition — use requireAny for the listed keys
+    // instead of per-input required. See #193 Part B.
+    requireAny: { type: Array, attribute: 'require-any' },
     submitLabel: { type: String, attribute: 'submit-label' },
     cancelLabel: { type: String, attribute: 'cancel-label' },
     busy: { type: Boolean },
@@ -53,6 +59,7 @@ export class EhInputForm extends LitElement {
     this.values = {};
     this.date = null;
     this.display = null;
+    this.requireAny = null;
     this.submitLabel = 'Save';
     this.cancelLabel = 'Cancel';
     this.busy = false;
@@ -87,6 +94,16 @@ export class EhInputForm extends LitElement {
         const v = this._state[input.key];
         if (v === null || v === undefined || v === '') return false;
       }
+    }
+    // requireAny: at least one of the listed keys must have a value.
+    // Use this for either-or fields like mood's [mood, note] where the
+    // user might log just a feeling, just a journal line, or both.
+    if (Array.isArray(this.requireAny) && this.requireAny.length > 0) {
+      const hasAny = this.requireAny.some(k => {
+        const v = this._state[k];
+        return v !== null && v !== undefined && v !== '';
+      });
+      if (!hasAny) return false;
     }
     return true;
   }

--- a/public/js/components/eh-prompt-modal.js
+++ b/public/js/components/eh-prompt-modal.js
@@ -290,6 +290,7 @@ export class EhPromptModal extends LitElement {
               .values=${{}}
               .date=${today}
               .display=${display}
+              .requireAny=${meta.writeable?.requireAny || null}
               .busy=${this._busy}
               submit-label="Save"
               cancel-label="Not now"

--- a/tests-e2e/helpers/seed-manifests.js
+++ b/tests-e2e/helpers/seed-manifests.js
@@ -86,9 +86,13 @@ function mood(today) {
         pastAllowed: true,
         futureAllowed: false,
         maxReadingsPerDay: 1,
+        // Either mood OR note is required (see #193 Part B). Neither
+        // input carries required: true; the requireAny list gates the
+        // Save button at the form level.
+        requireAny: ['mood', 'note'],
         inputs: [
-          { key: 'mood', type: 'rating', min: 1, max: 5, required: true },
-          { key: 'note', type: 'textarea', required: false },
+          { key: 'mood', type: 'rating', min: 1, max: 5 },
+          { key: 'note', type: 'textarea' },
         ],
       },
     },

--- a/tests-e2e/mood-requireany-either-or.spec.js
+++ b/tests-e2e/mood-requireany-either-or.spec.js
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/mood-requireany-either-or.spec.js
+// Regression for #193 Part B: an edit form for a manifest declaring
+// `writeable.requireAny: ["mood", "note"]` enables the Save button
+// when EITHER field is filled, and stays disabled only when both
+// are empty.
+//
+// Before Part B, mood's rating input was `required: true`, which
+// meant Save stayed disabled until a number was picked — logging
+// just a note wasn't possible. The operator's 2026-05-11 QA
+// feedback: "save enabled when emoji OR text entered (or both),
+// disabled when neither".
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+// The seed switches mood to requireAny: ["mood", "note"] so both
+// halves of the assertion can fire against a live card.
+test.describe('#193 Part B: form requireAny enables save when any listed field is present', () => {
+  test('save disabled when neither mood nor note is present', async ({ page }) => {
+    await page.goto('/');
+    const moodCard = page.locator('eh-generic-card', { hasText: 'Mood' }).first();
+    await expect(moodCard).toBeVisible({ timeout: 10_000 });
+
+    await moodCard.locator('.edit-btn').click();
+    const form = moodCard.locator('eh-input-form');
+    await expect(form).toBeVisible();
+
+    // Clear the prefilled mood + note so neither is present.
+    await form.evaluate(el => {
+      el._state = { ...(el._state || {}), mood: null, note: '' };
+      el.requestUpdate();
+    });
+
+    const save = form.getByRole('button', { name: /^(save|update|add)$/i });
+    await expect(save).toBeDisabled();
+  });
+
+  test('save enabled when only note is filled', async ({ page }) => {
+    await page.goto('/');
+    const moodCard = page.locator('eh-generic-card', { hasText: 'Mood' }).first();
+    await moodCard.locator('.edit-btn').click();
+    const form = moodCard.locator('eh-input-form');
+    await expect(form).toBeVisible();
+
+    // Reset, then type a note — mood stays null.
+    await form.evaluate(el => {
+      el._state = { ...(el._state || {}), mood: null, note: '' };
+      el.requestUpdate();
+    });
+    await form.locator('textarea').fill('felt decent');
+
+    const save = form.getByRole('button', { name: /^(save|update|add)$/i });
+    await expect(save).toBeEnabled();
+  });
+
+  test('save enabled when only mood is picked', async ({ page }) => {
+    await page.goto('/');
+    const moodCard = page.locator('eh-generic-card', { hasText: 'Mood' }).first();
+    await moodCard.locator('.edit-btn').click();
+    const form = moodCard.locator('eh-input-form');
+    await expect(form).toBeVisible();
+
+    await form.evaluate(el => {
+      el._state = { ...(el._state || {}), mood: null, note: '' };
+      el.requestUpdate();
+    });
+    await form.getByRole('button', { name: 'mood 4' }).click();
+
+    const save = form.getByRole('button', { name: /^(save|update|add)$/i });
+    await expect(save).toBeEnabled();
+  });
+});


### PR DESCRIPTION
# What changed

New optional \`meta.writeable.requireAny\` array lists input keys, at
least one of which must have a value for the edit form's Save button
to enable. Individual \`required: true\` flags still apply in addition
— \`requireAny\` is for the fields where EITHER is acceptable.

Part B of three for #193. Part A (emoji-rating) landed as #220. Part
C (daily prompt) is next.

Refs #193.

# Why

The mood card declared \`{key: mood, type: rating, required: true}\`,
which meant the Save button stayed disabled until a mood number was
picked. The operator's 2026-05-11 QA feedback called this out:

> Save enabled when emoji OR text entered (or both), disabled when
> neither.

Per-input \`required\` can't express \"one of these\". The clean shape
is a declarative list at the writeable level that the form reads
and validates against.

Same shape unlocks future cards: a sleep card where you log
quality-rating OR wake-time OR both; a symptoms card where one of
several affected-areas fields is acceptable.

# How

**\`eh-input-form\`** gets a new \`requireAny\` prop. \`_isValid()\`
extends to:

\`\`\`js
if (Array.isArray(this.requireAny) && this.requireAny.length > 0) {
  const hasAny = this.requireAny.some(k => {
    const v = this._state[k];
    return v !== null && v !== undefined && v !== '';
  });
  if (!hasAny) return false;
}
\`\`\`

Individual \`required\` flags are evaluated first; if all pass, the
cross-field guard runs.

Callers that thread the prop:

- \`eh-generic-card\`: \`meta.writeable.requireAny\`.
- \`eh-combination-card\`: \`src.meta.writeable.requireAny\` (per donor).
- \`eh-prompt-modal\`: \`meta.writeable.requireAny\`.

List-card skipped — expanded-row forms have per-row semantics where
cross-field either-or doesn't help.

**Sandbox mood seed** drops \`required: true\` from the two mood
inputs and declares \`requireAny: [\"mood\", \"note\"]\` instead.

# Testing

New E2E spec \`tests-e2e/mood-requireany-either-or.spec.js\`:

1. Save disabled when both mood and note are empty.
2. Save enabled when only note is filled.
3. Save enabled when only mood is picked (via \`mood 4\` aria-label,
   compatible with both number and emoji renderings).

Verified the first test fails on main (Save button enabled even
with both fields empty, because mood's previous \`required: true\`
flag was dropped from the seed and no cross-field guard yet
exists). Passes with the change.

- [x] \`npm test\` — 827/828 pass (same pre-existing Windows flake)
- [x] \`npm run test:e2e\` — 20/20 pass
- [x] Fail-on-main verified

# Checklist

- [x] Commit messages follow conventions
- [x] \`CHANGELOG.md\` updated
- [x] \`MANIFEST-SCHEMA.md\` + system prompt describe the new field
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Follow-up

- **Part C**: add \`prompt: { enabled: true, mode: \"modal\",
  whenMissing: true }\` to the mood manifest (seed + template) so
  the daily modal actually fires when today has no entry.