### PR TITLE
feat(mood): enable daily prompt modal (#193 Part C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Mood card's daily prompt enabled by default.** The canonical
+  mood template (`templates/mood.klebb.json`) now carries
+  `prompt: { enabled: true, mode: "modal", whenMissing: true }` so
+  the daily modal fires on first load when today has no entry. The
+  modal's input form picks up `display.emojiMap` + `requireAny`
+  from the card, so the combined experience from parts A/B/C is:
+  five emoji buttons, an optional note textarea, Save enabled when
+  either or both are filled. (Fixes #193 Part C; closes #193)
+
 - **`writeable.requireAny` for either-or inputs.** A new optional
   array on `meta.writeable` lists input keys at least one of which
   must be filled for the Save button to enable. Mood uses it for

--- a/templates/mood.klebb.json
+++ b/templates/mood.klebb.json
@@ -38,12 +38,18 @@
         "fallback": "🙂"
       }
     },
+    "prompt": {
+      "enabled": true,
+      "mode": "modal",
+      "whenMissing": true
+    },
     "writeable": {
       "fromWebapp": true,
       "maxReadingsPerDay": 1,
+      "requireAny": ["mood", "notes"],
       "inputs": [
-        { "key": "mood", "type": "rating", "min": 1, "max": 5, "required": true },
-        { "key": "notes", "type": "textarea", "required": false }
+        { "key": "mood", "type": "rating", "min": 1, "max": 5 },
+        { "key": "notes", "type": "textarea" }
       ]
     }
   },

--- a/tests-e2e/helpers/seed-manifests.js
+++ b/tests-e2e/helpers/seed-manifests.js
@@ -80,6 +80,9 @@ function mood(today) {
           emojiMap: { 1: '😩', 2: '😔', 3: '😐', 4: '🙂', 5: '😄' },
         },
       },
+      // Daily mood prompt: fires once a day on first load if today has
+      // no entry. See #193 Part C.
+      prompt: { enabled: true, mode: 'modal', whenMissing: true },
       writeable: {
         fromWebapp: true,
         todayAllowed: true,

--- a/tests-e2e/mood-daily-prompt.spec.js
+++ b/tests-e2e/mood-daily-prompt.spec.js
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/mood-daily-prompt.spec.js
+// Regression for #193 Part C: the mood card declares
+// `prompt.enabled: true` in its template/seed, so on a day with no
+// mood entry the modal fires on first page load. The modal's input
+// form inherits display.emojiMap + writeable.requireAny from the
+// card (parts A + B), so the combined experience is:
+//   - 5 emoji buttons for the rating,
+//   - an optional note textarea,
+//   - Save enabled when either or both are filled.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+test.describe('#193 Part C: mood daily prompt fires when today has no entry', () => {
+  test('prompt modal opens on load if no mood entry for today', async ({ page, sandboxState }) => {
+    // Clear today's mood row so the prompt triggers (the seed includes
+    // one for today by default — writeable APIs let us drop it).
+    const read = await page.request.get(`${sandboxState.baseUrl}/api/manifests/mood/data`);
+    const body = await read.json();
+    const todayIso = (() => {
+      const d = new Date();
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    })();
+    const withoutToday = body.data.filter(r => r.date !== todayIso);
+    const put = await page.request.post(
+      `${sandboxState.baseUrl}/api/manifests/mood/data`,
+      { data: { data: withoutToday } },
+    );
+    expect(put.status()).toBe(200);
+
+    await page.goto('/');
+
+    // The modal should appear for the Mood card.
+    const modal = page.locator('eh-prompt-modal dialog');
+    await expect(modal).toBeVisible({ timeout: 10_000 });
+
+    // Heading text carries the card label.
+    await expect(modal).toContainText(/mood/i);
+
+    // The modal's input form should pick up the emojiMap + requireAny
+    // from the card's meta — five emoji buttons rendered.
+    const form = modal.locator('eh-input-form');
+    await expect(form).toBeVisible();
+    for (const emoji of ['😩', '😔', '😐', '🙂', '😄']) {
+      await expect(form).toContainText(emoji);
+    }
+
+    // Restore sandbox state so the modal doesn't fire for later specs.
+    const restored = [...withoutToday, { date: todayIso, mood: 5 }];
+    const restore = await page.request.post(
+      `${sandboxState.baseUrl}/api/manifests/mood/data`,
+      { data: { data: restored } },
+    );
+    expect(restore.status()).toBe(200);
+  });
+});


### PR DESCRIPTION
# What changed

Mood template + sandbox seed now declare:

\`\`\`json
\"prompt\": { \"enabled\": true, \"mode\": \"modal\", \"whenMissing\": true }
\`\`\`

…so the daily modal fires on first load when today has no entry.
Template also adopts Parts A/B's \`requireAny\` shape (drops per-input
\`required: true\`, adds \`requireAny: [\"mood\", \"notes\"]\`).

Fixes #193 Part C. **Closes #193** — A (emoji-rating), B (requireAny),
C (daily prompt) all landed.

# Why

Part A made the mood input show emojis. Part B made \"mood or notes or
both\" a valid submission. Part C turns the daily modal on by default
so the user actually gets prompted to log — without it, the nicer
input form only appears if they click the \`+\` icon themselves.

Operator's 2026-05-11 QA note described the combined shape as:
\"modal fires once a day on first load, offers 5 emojis + an
optional notes box, Save enabled if mood OR notes (or both)\".
That's the full mood flow now.

# How

No runtime code changes — the prompt-queue + prompt-modal plumbing
has existed since #180. This PR is purely manifest-level:

- \`templates/mood.klebb.json\`: adds \`meta.prompt\` block; switches
  \`writeable\` to \`requireAny: [\"mood\", \"notes\"]\` + drops per-input
  \`required: true\`.
- \`tests-e2e/helpers/seed-manifests.js\`: mirrors the same change on
  the sandbox mood seed so the E2E spec exercises it.

# Testing

New E2E spec \`tests-e2e/mood-daily-prompt.spec.js\`:

1. Clear today's mood row via the API (the default seed puts one
   there, which would suppress the prompt).
2. Load the app.
3. Assert \`eh-prompt-modal dialog\` becomes visible within 10s.
4. Assert all five emoji buttons (😩 😔 😐 🙂 😄) render in the
   form — proving Part A's emoji-map wiring reaches the modal's
   input-form via \`eh-prompt-modal\`'s \`display\` prop.
5. Restore today's row so later specs don't trip the prompt.

Fails against main (no \`prompt.enabled\`, modal never fires).
Passes with the seed + template change.

- [x] \`npm test\` — 827/828 pass locally (pre-existing Windows
      \`no-personal-refs\` flake; CI green)
- [x] \`npm run test:e2e\` — 21/21 pass
- [x] Fail-on-main verified

# Checklist

- [x] Commit messages follow conventions
- [x] \`CHANGELOG.md\` updated
- [x] Template + sandbox seed aligned
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Deployment note for klebbtest

The existing klebbtest mood manifest still has the old shape
(per-input \`required: true\`, no \`prompt\`). After this merge, the
operator can:

- Ask klebbius to \"update the mood card: add prompt.enabled true,
  switch to requireAny\", OR
- Delete the existing mood manifest and ask klebbius to re-create
  it from the canonical template.

Either way, existing data rows are preserved via \`write_manifest_data\`
+ \`patch_manifest\`.

# Follow-up

Remaining open issues from the 2026-05-12 QA triage:

- #185 — Schedule prompt modal reminder-flow redesign (awaiting UX
  sign-off)
- #216 — Weight/BP still on \`type:number\` (likely no-action;
  measuring cards are correctly on \`number\` per #189's rule of thumb)
- #217 — \`writeable.prefillFromLatest\` enhancement
- #218 — \"Dismiss all\" for unsupported HAE metrics
- #195 — Manifest-driven starter prompts (\`chat.starterPrompts\` +
  \`kind\` tag) — biggest remaining item