### PR TITLE
feat(hae): Dismiss all button on unsupported-metrics footer (#218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Changed
+
+- **"Dismiss all" on the HAE discovery card's unsupported-metrics
+  footer.** A single button dismisses every undismissed unsupported
+  metric in one click, avoiding the per-row tedium on instances
+  with 15+ pending metrics. Button sits next to the expand chevron,
+  visible without expanding the list. Per-row dismiss buttons
+  removed to simplify — operators can un-hide from Settings if they
+  want a specific metric back. Fan-out calls the existing
+  per-metric dismiss endpoint in parallel, so no new server
+  surface. (Fixes #218)
+
 ### Added
 
 - **Mood card's daily prompt enabled by default.** The canonical

--- a/public/js/components/eh-hae-discovery-card.js
+++ b/public/js/components/eh-hae-discovery-card.js
@@ -137,6 +137,23 @@ export class EhHaeDiscoveryCard extends LitElement {
     }
   }
 
+  // Fan-out for unsupported metrics. See #218 — on a configured
+  // instance there can be 18+ of these sitting in the footer, and
+  // dismissing them one-by-one is painful.
+  async _dismissAllUnsupported() {
+    const metrics = (this._data?.undismissed?.unsupported || []).map(e => e.metric);
+    if (metrics.length === 0) return;
+    this._busyMetric = '::unsupported';
+    try {
+      await Promise.all(metrics.map(m =>
+        fetch(`/api/health-auto-export/discoveries/${encodeURIComponent(m)}/dismiss`,
+          { method: 'POST' })));
+      for (const m of metrics) this._removeLocally(m);
+    } finally {
+      this._busyMetric = null;
+    }
+  }
+
   _removeLocally(metric) {
     if (!this._data) return;
     const d = this._data;
@@ -258,16 +275,25 @@ export class EhHaeDiscoveryCard extends LitElement {
   _renderUnsupportedFooter(entries) {
     const open = this._unsupportedOpen;
     const n = entries.length;
+    const busy = this._busyMetric === '::unsupported';
     return html`
       <div class="unsupported">
-        <button
-          class="unsupported-toggle"
-          @click=${() => { this._unsupportedOpen = !this._unsupportedOpen; }}
-          aria-expanded=${open}
-        >
-          ${n} more ${n === 1 ? 'metric' : 'metrics'} received but not supported yet
-          <span class="chev">${open ? '▴' : '▾'}</span>
-        </button>
+        <div class="unsupported-header">
+          <button
+            class="unsupported-toggle"
+            @click=${() => { this._unsupportedOpen = !this._unsupportedOpen; }}
+            aria-expanded=${open}
+          >
+            ${n} more ${n === 1 ? 'metric' : 'metrics'} received but not supported yet
+            <span class="chev">${open ? '▴' : '▾'}</span>
+          </button>
+          <button
+            class="btn unsupported-dismiss-all"
+            ?disabled=${busy}
+            @click=${() => this._dismissAllUnsupported()}
+            aria-label="Dismiss all unsupported metrics"
+          >Dismiss all</button>
+        </div>
         ${open ? html`
           <p class="unsupported-hint">
             Klebb doesn't have a catalogue entry for these yet. They're archived
@@ -279,13 +305,6 @@ export class EhHaeDiscoveryCard extends LitElement {
               <li class="row muted-row">
                 <span class="row-label">
                   <span class="metric-key">${e.metric}</span>
-                </span>
-                <span class="row-actions">
-                  <button
-                    class="btn"
-                    ?disabled=${this._busyMetric === e.metric}
-                    @click=${() => this._dismiss(e.metric)}
-                  >Dismiss</button>
                 </span>
               </li>
             `)}
@@ -440,6 +459,23 @@ export class EhHaeDiscoveryCard extends LitElement {
       margin-top: 12px;
       padding-top: 10px;
       border-top: 1px solid var(--border);
+    }
+    /* Toggle + dismiss-all sit on one row so the operator can wipe
+       the whole unsupported list in one click without having to
+       expand it first. See #218. */
+    .unsupported-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    .unsupported-header .unsupported-toggle {
+      flex: 1;
+      text-align: left;
+      justify-content: flex-start;
+    }
+    .unsupported-dismiss-all {
+      flex: 0 0 auto;
     }
     .unsupported-toggle {
       font: inherit;

--- a/tests-e2e/discovery-dismiss-all-unsupported.spec.js
+++ b/tests-e2e/discovery-dismiss-all-unsupported.spec.js
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/discovery-dismiss-all-unsupported.spec.js
+// Regression for #218: the discovery card's unsupported-metrics
+// footer has a "Dismiss all" button that flips every listed metric
+// to dismissed in one click. Per-row Dismiss buttons are removed
+// as part of the simplification — the operator can un-hide from
+// Settings if they want a specific metric back.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+test.describe('#218: discovery card supports dismiss-all for unsupported metrics', () => {
+  test('clicking Dismiss all hides the footer and flips every metric on the server', async ({ page, sandboxState }) => {
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible();
+
+    const card = page.locator('eh-hae-discovery-card').first();
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await expect(card).toContainText(/metric[s]? received but not supported yet/);
+
+    // Click Dismiss all (must be visible without expanding the list
+    // per the #218 design).
+    const dismissAll = card.getByRole('button', { name: /dismiss all/i });
+    await expect(dismissAll).toBeVisible();
+    await dismissAll.click();
+
+    // Footer should disappear when unsupportedCount drops to zero.
+    await expect(card).not.toContainText(/metric[s]? received but not supported yet/, {
+      timeout: 5_000,
+    });
+
+    // Verify the server-side state: every seeded unsupported metric
+    // should now be in the dismissed list.
+    const res = await page.request.get(`${sandboxState.baseUrl}/api/health-auto-export/discoveries`);
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    const dismissedKeys = (body.dismissed || []).map(d => d.metric).sort();
+    expect(dismissedKeys).toEqual([
+      'e2e_unsupported_beta',
+      'e2e_unsupported_gamma',
+      'e2e_unsupported_metric',
+    ]);
+  });
+});

--- a/tests-e2e/helpers/global-setup.js
+++ b/tests-e2e/helpers/global-setup.js
@@ -31,7 +31,14 @@ module.exports = async () => {
     sessions: auth.sessions,
   });
 
-  const server = await spawnServer(sandbox);
+  // Pin the sandbox server's TZ to match the host. Node's default
+  // when TZ is unset is UTC for Intl/Date.toLocaleDateString, which
+  // drifts from the browser's local TZ and trips writeable-card
+  // date-allowance checks when the UTC date is a day behind local.
+  // Intl.DateTimeFormat().resolvedOptions() gives us the host zone
+  // in a portable way (Windows doesn't expose IANA names via TZ).
+  const hostTz = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  const server = await spawnServer(sandbox, { TZ: hostTz });
 
   const state = {
     sandbox,

--- a/tests-e2e/helpers/seed-manifests.js
+++ b/tests-e2e/helpers/seed-manifests.js
@@ -160,9 +160,18 @@ function peptides(today) {
 // rendering path.
 function discoveredMetrics() {
   return {
-    // Not in the HAE catalogue → classified as "unsupported", surfaces
-    // in the discovery card's footer rather than the main list.
+    // Three unsupported metrics. None are in the HAE catalogue, so
+    // they surface in the discovery card's footer. Multiple entries
+    // make the "Dismiss all" spec (see #218) meaningful.
     e2e_unsupported_metric: {
+      firstSeenAt: '2026-05-01T00:00:00.000Z',
+      dismissed: false,
+    },
+    e2e_unsupported_beta: {
+      firstSeenAt: '2026-05-01T00:00:00.000Z',
+      dismissed: false,
+    },
+    e2e_unsupported_gamma: {
       firstSeenAt: '2026-05-01T00:00:00.000Z',
       dismissed: false,
     },

--- a/tests-e2e/mood-daily-prompt.spec.js
+++ b/tests-e2e/mood-daily-prompt.spec.js
@@ -18,9 +18,16 @@ test.describe('#193 Part C: mood daily prompt fires when today has no entry', ()
     // one for today by default — writeable APIs let us drop it).
     const read = await page.request.get(`${sandboxState.baseUrl}/api/manifests/mood/data`);
     const body = await read.json();
+    // Both the browser and the sandbox server use the host timezone
+    // (global-setup passes TZ: Intl.DateTimeFormat().resolvedOptions()
+    // .timeZone into spawnServer), so host-local Date is the common
+    // source of truth.
     const todayIso = (() => {
       const d = new Date();
-      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+      const y = d.getFullYear();
+      const m = String(d.getMonth() + 1).padStart(2, '0');
+      const day = String(d.getDate()).padStart(2, '0');
+      return `${y}-${m}-${day}`;
     })();
     const withoutToday = body.data.filter(r => r.date !== todayIso);
     const put = await page.request.post(


### PR DESCRIPTION
# What changed

The HAE discovery card's \"N more metrics received but not supported
yet\" footer gains a **\"Dismiss all\"** button next to the expand
chevron. Clicking it fans out to the existing per-metric dismiss
endpoint in parallel, wiping every undismissed unsupported metric in
one click. Per-row Dismiss buttons removed as part of the
simplification.

Also pins the E2E sandbox server's TZ to the host's timezone so
writeable-card date checks don't drift from the browser's local
date. Latent bug surfaced while wiring up the mood-daily-prompt
spec.

Fixes #218.

# Why

Operator's 2026-05-12 QA feedback:

> There should be a button for 'dismiss all'. In fact, there doesn't
> need to be a dismiss for each of them. Just the dismiss all.

On a configured instance, 15+ unsupported metrics can sit in the
footer. Dismissing one-by-one is painful and not worth the UX
budget — the operator's already decided they don't want any of
these. Un-hide from Settings remains the rescue hatch for anyone
who changes their mind.

# How

**\`eh-hae-discovery-card.js\`**:

- New \`_dismissAllUnsupported()\` method mirrors the existing
  \`_dismissCategory()\` pattern: collect the current metric keys,
  fan out \`POST /dismiss\` calls in parallel, update local state.
- \`_renderUnsupportedFooter()\` gains a two-button header row (flex
  layout) with the toggle on the left and \"Dismiss all\" on the
  right.
- Per-row Dismiss buttons removed. Expanded list is now purely
  informational — operator sees what's in there but can't
  selectively dismiss.

**Sandbox seed** extends \`discovered.json\` from one unsupported
metric to three so the \"dismiss all\" spec asserts on a meaningful
fan-out.

**TZ fix in \`global-setup.js\`**: the sandbox server's \`ENV.TZ\`
defaulted to UTC but the host / browser use local TZ. On a host
where local date is a day ahead of UTC (AEST etc.), rows seeded
at local-today get flagged as \"future-dated\" by the server's
allowance check. Surfaced in the mood-daily-prompt spec as a 403
on the restore-state call. Now \`global-setup\` passes
\`TZ: Intl.DateTimeFormat().resolvedOptions().timeZone\` into
\`spawnServer\` so all three clocks agree.

# Testing

New E2E spec \`tests-e2e/discovery-dismiss-all-unsupported.spec.js\`:

1. Seeds \`discovered.json\` with three unsupported metrics.
2. Loads Today view.
3. Asserts the footer is visible (renders \"N metrics received
   but not supported yet\").
4. Clicks the Dismiss-all button (which must be visible without
   expanding).
5. Asserts the footer text is gone (footer suppressed when
   unsupportedCount drops to zero).
6. Reads \`/api/health-auto-export/discoveries\` and asserts all
   three seeded metric keys land in the \`dismissed\` list.

Verified fails against main. Passes with the implementation.

- [x] \`npm test\` — 827/828 pass locally (pre-existing Windows
      \`no-personal-refs\` flake; CI green)
- [x] \`npm run test:e2e\` — 22/22 pass (up from 21 with the new
      spec)
- [x] Fail-on-main verified for the new spec
- [x] TZ fix doesn't change any existing spec's behaviour; they
      all still pass

# Checklist

- [x] Commit messages follow conventions
- [x] \`CHANGELOG.md\` updated
- [x] Inline comment on the new header flex layout explains the
      #218 design intent
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Follow-up

Remaining from the 2026-05-12 QA triage:

- #185 — Schedule prompt modal reminder-flow redesign (awaiting
  UX sign-off)
- #216 — Weight/BP \`type:number\` (likely no-action per #189's
  measuring vs counting rule of thumb)
- #217 — \`writeable.prefillFromLatest\` enhancement
- #195 — Manifest-driven starter prompts (biggest remaining item)