### PR TITLE
feat(input): writeable.prefillFromLatest seeds add form from prior row (#217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Added
+
+- **`writeable.prefillFromLatest` pre-fills the add form with the
+  most recent prior entry.** Optional boolean on `meta.writeable`,
+  default off. When true, opening the `➕` add form on a date with
+  no existing row seeds the inputs from the most recent row dated
+  strictly before that date. The `date` field is dropped from the
+  pre-fill so the form still stamps the viewed date on submit. Weight
+  gets the flag by default in the sandbox seed; operators can add it
+  to any canonically slow-changing measurement (BP, body fat). Cards
+  where yesterday's value isn't a sensible start (daily notes, mood,
+  water counters) should leave it absent. (Fixes #217)
+
 ### Changed
 
 - **"Dismiss all" on the HAE discovery card's unsupported-metrics

--- a/MANIFEST-SCHEMA.md
+++ b/MANIFEST-SCHEMA.md
@@ -387,6 +387,14 @@ apply in addition — use `requireAny` instead of per-input `required`
 for the listed keys. Example: mood's `["mood", "note"]` means the
 user can log just a number, just a journal line, or both.
 
+`prefillFromLatest` (optional boolean, default `false`) seeds the add
+form on a date with no row from the most recent prior entry. Useful
+for slowly-changing measurements like weight and BP, where today's
+value is almost always close to yesterday's. Only fires when opening
+the `➕` add form — `✏️` edit of an existing row always pre-fills
+from that row. The `date` field is dropped from the pre-fill so the
+form still stamps the currently-viewed date on submit.
+
 ### Input types
 
 | type | extra fields |

--- a/config/env.js
+++ b/config/env.js
@@ -219,6 +219,8 @@ Everything else is optional pass-through. The endpoint is lenient: if the render
 
 **Either-or required — \`writeable.requireAny\`.** Some cards accept more than one input where at least one must be filled (e.g. mood lets you log a number, a journal line, or both). Set \`requireAny: [\"mood\", \"note\"]\` instead of flagging each input with \`required: true\` — the form enables Save when ANY listed key has a value. Individual \`required: true\` flags still apply in addition, for fields that must ALWAYS be present.
 
+**Pre-fill with the last entry — \`writeable.prefillFromLatest\`.** Optional boolean (default false). When true, opening the \`➕\` add form on a date with no existing row seeds the inputs from the most recent prior entry — great for weight, BP, body-fat %, and other \"today is almost always close to yesterday\" measurements. The date is dropped so the form still stamps the currently-viewed date. Don't set it on cards where yesterday's value isn't a sensible starting point (daily notes, mood, water-intake counters).
+
 **Gotcha — booleans in a display template.** A bare \`{trained}\` in a template stringifies the value literally, so a row like \`{trained: true, type: "Functional Strength Training"}\` renders \"true · Functional Strength Training\" on the card. That's never what you want. For boolean fields, prefer:
 - \`{trained:check}\` → renders \`✅\` when true, empty string when false/missing. Best default for \"did this thing happen today\" cards (workouts, meditation, journal).
 - \`{trained?Trained:Rest}\` ternary → when you need both branches labelled.

--- a/public/js/components/eh-generic-card.js
+++ b/public/js/components/eh-generic-card.js
@@ -221,11 +221,37 @@ export class EhGenericCard extends EhBaseCard {
     `,
   ];
 
+  // Resolve the most recent prior entry — the last row dated strictly
+  // before `this.date`. Returns null if none exists. Used by the
+  // prefillFromLatest feature (#217).
+  _latestPriorEntry() {
+    const rows = this._entries();
+    if (rows.length === 0) return null;
+    const target = this.date;
+    const candidates = rows.filter(r => r && r.date && (!target || r.date < target));
+    if (candidates.length === 0) return null;
+    candidates.sort((a, b) => String(b.date).localeCompare(String(a.date)));
+    return candidates[0];
+  }
+
   renderCard() {
     const meta = this._m();
     const display = this._display();
     const entry = this._currentEntry();
     const hasEntry = entry !== null;
+    // prefillFromLatest: when opening the add form on a date with no
+    // existing row, seed the inputs from the most recent prior row so
+    // slowly-changing measurements (weight, BP) land close to the
+    // previous value. Date field is dropped so the form still stamps
+    // the current viewed date. See #217.
+    let prefillValues = null;
+    if (!hasEntry && meta?.writeable?.prefillFromLatest === true) {
+      const prior = this._latestPriorEntry();
+      if (prior) {
+        const { date: _dateIgnored, ...rest } = prior;
+        prefillValues = rest;
+      }
+    }
 
     const canWrite = this._canWrite
       && Array.isArray(meta?.writeable?.inputs)
@@ -266,7 +292,7 @@ export class EhGenericCard extends EhBaseCard {
         ${this._editing ? html`
           <eh-input-form
             .inputs=${meta.writeable.inputs}
-            .values=${entry || {}}
+            .values=${entry || prefillValues || {}}
             .date=${this.date}
             .display=${display}
             .requireAny=${meta.writeable.requireAny || null}

--- a/tests-e2e/helpers/seed-manifests.js
+++ b/tests-e2e/helpers/seed-manifests.js
@@ -48,13 +48,22 @@ function weight(today) {
         pastAllowed: true,
         futureAllowed: false,
         maxReadingsPerDay: 1,
+        // Weight varies slowly; pre-fill the add form with the most
+        // recent prior entry so the operator usually needs just a
+        // small tweak. See #217.
+        prefillFromLatest: true,
         inputs: [
           { key: 'kg', type: 'number', required: true, min: 20, max: 500, step: 0.1 },
         ],
       },
     },
     description: 'Body weight log for E2E sandbox.',
+    // Rows at today-4 and today-2 intentionally leave a gap at today-3
+    // so specs that assert "no entry for this date" have a concrete
+    // past date to navigate to where the prefillFromLatest resolver
+    // still has a prior row to work with (today-4).
     data: [
+      { date: shiftDays(today, -4), kg: 81.3 },
       { date: shiftDays(today, -2), kg: 81.2 },
       { date: shiftDays(today, -1), kg: 81.0 },
       { date: today,                kg: 80.9 },

--- a/tests-e2e/prefill-from-latest.spec.js
+++ b/tests-e2e/prefill-from-latest.spec.js
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/prefill-from-latest.spec.js
+// Regression for #217: when a manifest declares
+// `meta.writeable.prefillFromLatest: true`, opening the add form on
+// a date with no existing row pre-fills the inputs with the most
+// recent prior row's values (minus the date). Great for once-daily
+// measurements like weight, where today's value is almost always
+// close to yesterday's.
+//
+// The sandbox's weight seed opts into the flag. Today has no row by
+// default.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+test.describe('#217: writeable.prefillFromLatest pre-fills the add form', () => {
+  test('weight add form on a past date with no row pre-fills from the latest prior entry', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible();
+
+    const weightCard = page.locator('eh-generic-card', { hasText: 'Weight' }).first();
+    // Ensure today's seeded value is visible before navigating —
+    // otherwise the ← click may fire before the page has hydrated.
+    await expect(weightCard).toContainText('80.9');
+
+    // Weight seed has rows at today-4 (81.3), today-2 (81.2), today-1
+    // (81.0), today (80.9). Navigate back 3 days to today-3 — the gap
+    // between today-4 and today-2 — where no row exists.
+    // dateContext:"latest" still applies, but #182's fix means past-
+    // date navigation uses exact-date lookup, so hasEntry will be
+    // false and prefillFromLatest fires.
+    await page.locator('.arrow-btn[aria-label="previous day"]').click();
+    await page.locator('.arrow-btn[aria-label="previous day"]').click();
+    await page.locator('.arrow-btn[aria-label="previous day"]').click();
+
+    // Card on today-3 has no entry — empty state.
+    await expect(weightCard).toContainText(/no entry|empty/i);
+
+    // Open the add form. With prefillFromLatest, the input should
+    // show today-4's value (81.3) — the most recent row dated
+    // strictly before today-3.
+    await weightCard.locator('.edit-btn').click();
+    const form = weightCard.locator('eh-input-form');
+    await expect(form).toBeVisible();
+
+    const input = form.locator('input[type="number"]');
+    await expect(input).toHaveValue('81.3');
+  });
+
+});


### PR DESCRIPTION
# What changed

New opt-in manifest flag \`meta.writeable.prefillFromLatest\`. When
\`true\` and the operator opens the \`➕\` add form on a date with no
existing row, \`eh-generic-card\` pre-fills the inputs from the most
recent row dated strictly before the viewed date. The row's \`date\`
field is dropped from the pre-fill so the form still stamps the
currently-viewed date on submit.

Fixes #217.

# Why

Operator request from 2026-05-12 live QA:

> on the Weight card. Could we have an extra option in the manifest
> which when enabled (disabled by default or disabled when not
> defined) shows the last captured data when adding new data. So
> if I had put 80 as my weight 3 days ago, then yesterday I put 81.
> Then today, when adding todays weight, the card shows 81 already
> (the last entry) which I can modify and save for today. This
> feature would be useful for other cards too like BP.

Slowly-changing measurements benefit heavily. It's wrong for
counters that reset daily (water glasses, caffeine cups) and for
journal-style cards (daily notes, mood), so the flag is opt-in.

# How

\`eh-generic-card\` gets a new \`_latestPriorEntry()\` helper that
filters by \`r.date < this.date\` and sorts descending. Only called
from \`renderCard()\` and only when \`!hasEntry && prefillFromLatest\`,
so the overhead is zero for cards without the flag.

The \`values\` prop passed to \`eh-input-form\` falls through three
levels: current entry (edit path) → prefillValues (add path with
flag) → \`{}\` (empty default).

\`MANIFEST-SCHEMA.md\` + system-prompt guidance in \`config/env.js\`
describe the flag and call out cards where it's a good idea vs
cards where it isn't.

# Testing

**\`tests-e2e/prefill-from-latest.spec.js\`**:

1. Loads Today view, asserts weight card is visible with today's
   seeded value (80.9).
2. Clicks the prev-day arrow three times to land on today-3 — an
   intentional gap in the seed between today-4 and today-2.
3. Asserts the card shows \"No entry\" on today-3.
4. Opens the add form via \`.edit-btn\`.
5. Asserts the number input pre-fills with \`81.3\` — the today-4
   row's value, which is the most recent row dated strictly before
   today-3.

Fails on main (input is empty when the flag is consulted by code
that doesn't exist yet). Passes with this change.

**Weight seed** now has four rows (today-4, today-2, today-1, today)
with the today-3 gap by design. Any other spec that asserts on
weight's card visibility (smoke, modal-overflow, etc.) still passes
because the headline logic is unchanged.

- [x] \`npm test\` — 827/828 pass locally (pre-existing Windows
      \`no-personal-refs\` flake; CI green)
- [x] \`npm run test:e2e\` — 23/23 pass
- [x] Fail-on-main verified

# Checklist

- [x] Commit messages follow conventions
- [x] \`CHANGELOG.md\` updated
- [x] \`MANIFEST-SCHEMA.md\` + system prompt describe the new flag
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Deployment note

The operator can flip on the flag for weight + BP on klebbtest
after merging:

\`\`\`text
ask klebbius: \"add writeable.prefillFromLatest: true to the weight
card and the blood pressure card\"
\`\`\`

Existing data is unaffected; only new add-form opens will see the
pre-fill.

# Follow-up

Remaining from 2026-05-12 QA triage:

- #195 — Manifest-driven starter prompts (biggest remaining item)
- #216 — Weight/BP \`type:number\` (likely no-action, needs a
  decision)
- #185 — Schedule prompt reminder-flow redesign (awaiting UX
  sign-off)