### PR TITLE
fix(template): :emoji modifier accepts flat emojiMap shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`{key:emoji}` template modifier accepts the flat `emojiMap`
+  shape.** The calendar marker (#183) and rating input (#193 Part A)
+  both honour both `emojiMap` shapes — flat (`{"1": "😩", ...}`) and
+  keyed (`{field: {"1": "😩", ...}}`). The `:emoji` template
+  modifier only accepted the keyed shape, so a mood card template
+  like `{mood:emoji}` against a flat emojiMap fell through to the
+  raw number. The modifier now tries the keyed lookup first, then
+  the flat lookup — one source of truth across all three consumers
+  of `display.emojiMap`.
+
 ### Changed
 
 - **Chat starter chips are manifest-driven.** The previously-hardcoded

--- a/public/js/lib/display-template.esm.js
+++ b/public/js/lib/display-template.esm.js
@@ -22,9 +22,20 @@ export function getValue(row, keyPath) {
 
 export function lookupEmoji(display, key, value) {
   if (!display || !display.emojiMap) return null;
-  const map = display.emojiMap[key];
-  if (!map) return null;
-  return map[String(value)] ?? map[value] ?? null;
+  // Keyed shape: emojiMap[field][value] — used by multi-field cards
+  // and the canonical mood template.
+  const keyed = display.emojiMap[key];
+  if (keyed && typeof keyed === 'object' && !Array.isArray(keyed)) {
+    const hit = keyed[String(value)] ?? keyed[value];
+    if (hit) return hit;
+  }
+  // Flat shape: emojiMap[value] — used by mood on klebbtest and any
+  // manifest where a single emoji map drives the card headline, the
+  // calendar marker (#183), and the rating input (#193 Part A). One
+  // source of truth across all three consumers.
+  const flat = display.emojiMap[String(value)] ?? display.emojiMap[value];
+  if (flat && typeof flat === 'string') return flat;
+  return null;
 }
 
 export function applyRound(value, digits) {

--- a/public/js/lib/display-template.js
+++ b/public/js/lib/display-template.js
@@ -34,9 +34,21 @@
 
   function lookupEmoji(display, key, value) {
     if (!display || !display.emojiMap) return null;
-    const map = display.emojiMap[key];
-    if (!map) return null;
-    return map[String(value)] ?? map[value] ?? null;
+    // Keyed shape: emojiMap[field][value] — used by multi-field cards
+    // and the canonical mood template.
+    const keyed = display.emojiMap[key];
+    if (keyed && typeof keyed === 'object' && !Array.isArray(keyed)) {
+      const hit = keyed[String(value)] ?? keyed[value];
+      if (hit) return hit;
+    }
+    // Flat shape: emojiMap[value] — used by mood on klebbtest and any
+    // manifest where a single emoji map drives both the card
+    // headline and the calendar marker (#183). The calendar marker
+    // and rating input already accept both shapes; this lets the
+    // template modifier do the same so there's one source of truth.
+    const flat = display.emojiMap[String(value)] ?? display.emojiMap[value];
+    if (flat && typeof flat === 'string') return flat;
+    return null;
   }
 
   function applyRound(value, digits) {

--- a/tests-e2e/helpers/seed-manifests.js
+++ b/tests-e2e/helpers/seed-manifests.js
@@ -91,7 +91,11 @@ function mood(today) {
         component: 'generic-card',
         dateContext: 'latest',
         display: {
-          template: '{mood}',
+          // {mood:emoji} resolves via display.emojiMap (flat shape).
+          // The optional {note} appears as a sub-line when a note
+          // is logged alongside the mood.
+          template: '{mood:emoji}',
+          secondary: '{note}',
           emojiMap: { 1: '😩', 2: '😔', 3: '😐', 4: '🙂', 5: '😄' },
         },
       },

--- a/tests-e2e/mood-headline-emoji-and-note.spec.js
+++ b/tests-e2e/mood-headline-emoji-and-note.spec.js
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/mood-headline-emoji-and-note.spec.js
+// Regression coverage for the mood headline rendering:
+//   1. {mood:emoji} resolves against display.emojiMap in its flat
+//      shape ({"1":"😩",...}) — same as the calendar marker (#183)
+//      and rating input (#193 Part A). Before this fix, :emoji
+//      required the keyed shape (emojiMap[field][value]), so mood
+//      cards using a flat map showed the raw number on save.
+//   2. {note} appears as a secondary sub-line when a note is logged.
+//
+// Seed mood data puts today at mood=5 + note="great"; the card
+// headline should show 😄 and the secondary line should show
+// "great".
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+test.describe('mood card headline — emoji + note', () => {
+  test('headline shows emoji (not number) and secondary shows the note', async ({ page, sandboxState }) => {
+    // Seed today's mood row with a note so both render surfaces have
+    // something to show. The sandbox default seed has mood=5 but no
+    // note.
+    const todayIso = (() => {
+      const d = new Date();
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    })();
+    const read = await page.request.get(`${sandboxState.baseUrl}/api/manifests/mood/data`);
+    const body = await read.json();
+    const originalRows = body.data;
+    const withoutToday = originalRows.filter(r => r.date !== todayIso);
+    const seeded = [...withoutToday, { date: todayIso, mood: 5, note: 'great day at work' }];
+    await page.request.post(`${sandboxState.baseUrl}/api/manifests/mood/data`, {
+      data: { data: seeded },
+    });
+
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible();
+
+    // Dismiss the daily prompt if it fires (today has an entry now, so
+    // it shouldn't — but be defensive).
+    const promptModal = page.locator('eh-prompt-modal dialog');
+    await promptModal.waitFor({ state: 'visible', timeout: 2000 }).catch(() => {});
+    if (await promptModal.isVisible().catch(() => false)) {
+      await promptModal.locator('button[aria-label="Dismiss"]').click();
+    }
+
+    const moodCard = page.locator('eh-generic-card', { hasText: 'Mood' }).first();
+    await expect(moodCard).toBeVisible({ timeout: 10_000 });
+
+    // Headline should be the emoji, not "5".
+    await expect(moodCard).toContainText('😄');
+
+    // Secondary line should carry the note.
+    await expect(moodCard).toContainText('great day at work');
+
+    // Specifically: the literal digit "5" should NOT appear in the
+    // card's rendered body text (outside the aria-label on an edit
+    // button, which is not part of innerText).
+    const bodyText = await moodCard.innerText();
+    expect(bodyText).not.toMatch(/\b5\b/);
+
+    // Restore so later specs see the default seed.
+    await page.request.post(`${sandboxState.baseUrl}/api/manifests/mood/data`, {
+      data: { data: originalRows },
+    });
+  });
+});

--- a/tests-e2e/past-date-view-and-edit.spec.js
+++ b/tests-e2e/past-date-view-and-edit.spec.js
@@ -24,12 +24,14 @@ test.describe('#182: cards with dateContext:latest honour past-date navigation',
     await expect(page.locator('eh-date-view')).toBeVisible();
 
     const moodCard = page.locator('eh-generic-card', { hasText: 'Mood' }).first();
-    // Wait for TODAY's value to appear before clicking — avoids a race
-    // where the click fires before the app hydrates this.date.
-    await expect(moodCard).toContainText('5');
+    // Mood card headline uses {mood:emoji} with the flat emojiMap,
+    // so today (seeded mood=5) shows 😄 and yesterday (mood=4) shows
+    // 🙂. Wait for the current (today's) value to paint before
+    // navigating to avoid racing the app's _today hydration.
+    await expect(moodCard).toContainText('😄');
 
     await page.locator('.arrow-btn[aria-label="previous day"]').click();
-    await expect(moodCard).toContainText('4');
+    await expect(moodCard).toContainText('🙂');
   });
 
   test('weight card on two days ago shows that date\'s value', async ({ page }) => {
@@ -50,14 +52,13 @@ test.describe('#182: cards with dateContext:latest honour past-date navigation',
     await expect(page.locator('eh-date-view')).toBeVisible();
 
     const moodCard = page.locator('eh-generic-card', { hasText: 'Mood' }).first();
-    // Wait for the mood card to render TODAY's value before navigating.
-    // Without this, on slower runners the click fires before _today is
-    // hydrated and the date shift lands on an unexpected day.
-    await expect(moodCard).toContainText('5');
+    // Mood headline is {mood:emoji}; today's seeded row (mood=5)
+    // renders 😄. Wait for it to paint before navigating.
+    await expect(moodCard).toContainText('😄');
 
-    // Go to yesterday.
+    // Go to yesterday (mood=4 → 🙂).
     await page.locator('.arrow-btn[aria-label="previous day"]').click();
-    await expect(moodCard).toContainText('4');
+    await expect(moodCard).toContainText('🙂');
 
     // Capture the POST the card sends so we can assert what it asked
     // the server to write, independently of what lands on disk.
@@ -84,8 +85,8 @@ test.describe('#182: cards with dateContext:latest honour past-date navigation',
     expect(sentByDate[yesterday]).toBe(1);
     expect(sentByDate[today]).toBe(5);
 
-    // Wait for the card to reflect the new value.
-    await expect(moodCard).toContainText('1', { timeout: 5000 });
+    // Wait for the card to reflect the new value — mood=1 → 😩.
+    await expect(moodCard).toContainText('😩', { timeout: 5000 });
 
     // Verify the manifest via the server (authoritative read — avoids
     // any filesystem-buffering surprises with the direct file read).

--- a/tests/display-template.test.js
+++ b/tests/display-template.test.js
@@ -68,6 +68,38 @@ describe('display-template', () => {
       assert.equal(renderTemplate('{mood:emoji}', { mood: 4 }), '4');
     });
 
+    // Mood-style manifests declare a flat emojiMap
+    // ({"1": "😩", ...}) rather than a field-keyed one. The calendar
+    // marker and rating input already honour both shapes; the
+    // template :emoji modifier should too, so a single source of
+    // truth (display.emojiMap) drives the card headline, the
+    // calendar markers, and the rating input buttons.
+    test('emoji modifier — flat emojiMap shape is also supported', () => {
+      const display = {
+        emojiMap: { '1': '😩', '2': '😔', '3': '😐', '4': '🙂', '5': '😄' },
+      };
+      assert.equal(renderTemplate('{mood:emoji}', { mood: 4 }, display), '🙂');
+      assert.equal(renderTemplate('{mood:emoji}', { mood: 1 }, display), '😩');
+      assert.equal(renderTemplate('{mood:emoji}', { mood: 5 }, display), '😄');
+    });
+
+    test('emoji modifier — keyed shape still wins over flat when both resolve', () => {
+      // If a card has BOTH a keyed entry for its field AND flat
+      // top-level entries, the keyed one takes precedence.
+      const display = {
+        emojiMap: {
+          '1': 'WRONG-FLAT',
+          mood: { '1': '😩' },
+        },
+      };
+      assert.equal(renderTemplate('{mood:emoji}', { mood: 1 }, display), '😩');
+    });
+
+    test('emoji modifier — flat shape falls back to raw value on miss', () => {
+      const display = { emojiMap: { '1': '😩' } };
+      assert.equal(renderTemplate('{mood:emoji}', { mood: 99 }, display), '99');
+    });
+
     test('dotted-path access', () => {
       assert.equal(
         renderTemplate('{sleep.deepMinutes}', { sleep: { deepMinutes: 85 } }),


### PR DESCRIPTION
# What changed

\`lookupEmoji\` in \`display-template.{js,esm.js}\` now falls through
to the flat \`emojiMap\` shape (\`{\"1\": \"😩\", ...}\`) when the
keyed shape (\`{field: {\"1\": \"😩\", ...}}\`) doesn't resolve. The
calendar marker (#183) and rating input (#193 Part A) already
honour both shapes; the template modifier now matches.

# Why

Operator flagged on klebbtest 2026-05-14:

> I'm able to select the Mood using the emojis now, but once I save
> it, it shows the number — not the emoji. Also, when I add a note
> and save it it doesn't show the note in the card.

Traced to two things:

1. Klebbtest's mood manifest declares a flat emojiMap —
   \`{\"1\": \"😩\", \"2\": \"😔\", ...}\` — but uses \`template: \"{mood}\"\`
   (no modifier). Even if the template became \`{mood:emoji}\`, the
   old \`lookupEmoji\` only recognised \`emojiMap[field][value]\`, so the
   flat shape fell through to the raw number. This PR fixes the code
   side so the existing manifest shape works once the operator
   updates the template.

2. Klebbtest's mood template doesn't reference \`{note}\` at all.
   Note is saving correctly (verified via the raw manifest file —
   rows like \`{mood: 5, note: \"yes\"}\`), just not displayed.
   This is purely a manifest-shape issue; the fix is to ask klebbius
   to update the template, not a code change. Called out in the
   deployment note below.

# How

\`lookupEmoji\`:

\`\`\`js
// Keyed shape first (existing behaviour preserved).
const keyed = display.emojiMap[key];
if (keyed && typeof keyed === 'object' && !Array.isArray(keyed)) {
  const hit = keyed[String(value)] ?? keyed[value];
  if (hit) return hit;
}
// Flat shape fallback — matches what the calendar marker + rating
// input already do.
const flat = display.emojiMap[String(value)] ?? display.emojiMap[value];
if (flat && typeof flat === 'string') return flat;
return null;
\`\`\`

Both \`display-template.js\` (UMD, for Node tests) and
\`display-template.esm.js\` (browser) updated together.

Mood seed template changed to \`{mood:emoji}\` + \`secondary: \"{note}\"\`
so the fix is exercised by E2E.

# Testing

**Unit** (\`tests/display-template.test.js\`): 4 new assertions

- Flat emojiMap resolves correctly (3 values covered).
- Keyed takes precedence when both keyed + flat resolve.
- Flat shape falls back to raw value on unmapped value.

Verified: the flat-shape test fails against main (returns \"4\"
instead of \"🙂\"); passes with the change.

**E2E** (\`tests-e2e/mood-headline-emoji-and-note.spec.js\`):

1. Seeds today's mood row with \`mood: 5, note: \"great day at work\"\`.
2. Loads Today; asserts mood card's headline contains 😄.
3. Asserts the secondary line carries \"great day at work\".
4. Asserts the literal digit \"5\" is absent from the card's text.

Verified fails against main (🙂/😄 not rendered; raw number shown
instead); passes with the change.

Past-date specs updated to match the new headline rendering
(emoji glyphs instead of \"5\"/\"4\").

- [x] \`npm test\` — 842/843 pass locally (pre-existing Windows
      \`no-personal-refs\` flake; CI green)
- [x] \`npm run test:e2e\` — 26/26 pass
- [x] Fail-on-main verified for both the unit + E2E tests

# Checklist

- [x] Commit messages follow conventions
- [x] \`CHANGELOG.md\` updated
- [x] Inline comment on the new flat fallback cross-references
      the three consumers
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Deployment note for klebbtest

After merge + redeploy, the mood card headline will still show
\"5\" until the template changes. The existing template is \`{mood}\`
(no modifier). Ask klebbius after deploy:

> update the mood card's template to \`{mood:emoji}\`, add a
> secondary template \`{note}\`, and set writeable.requireAny to
> [\"mood\", \"note\"] while you're in there

That single patch adopts all three outstanding improvements (emoji
headline, note display, either-or required). Existing data is
untouched.

# Follow-up

None directly. The only remaining open issue is #185 (schedule
reminder modal), still awaiting UX sign-off.