### PR TITLE
fix(renderer): edit button targets viewed date, not the display fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Edit button on Today with no today-row now targets today, not
+  the fallback day.** Cards with `dateContext: "latest"` correctly
+  fall back to the most recent prior row for display when today has
+  no entry. But clicking the edit button used to open the form
+  pre-filled from that prior row — including its date — so saving
+  rewrote the prior day's row instead of creating a new row for
+  today. Operators hit this on mood after logging yesterday: editing
+  "today" silently clobbered yesterday, and both views kept showing
+  the same row. The edit path now looks up the row for the viewed
+  date specifically; when no such row exists, the form opens in
+  add-mode and the save stamps the viewed date. Display behaviour
+  unchanged.
+
 - **`{key:emoji}` template modifier accepts the flat `emojiMap`
   shape.** The calendar marker (#183) and rating input (#193 Part A)
   both honour both `emojiMap` shapes — flat (`{"1": "😩", ...}`) and

--- a/public/js/components/eh-generic-card.js
+++ b/public/js/components/eh-generic-card.js
@@ -234,29 +234,58 @@ export class EhGenericCard extends EhBaseCard {
     return candidates[0];
   }
 
+  // Exact-date entry lookup regardless of dateContext. Used by the
+  // edit flow: a card on Today with dateContext:"latest" can show
+  // yesterday's row as a display fallback, but the EDIT button must
+  // always target today, not the fallback day. Otherwise saving
+  // rewrites the wrong row. See the 2026-05-14 klebbtest report.
+  _entryForExactDate() {
+    const rows = this._entries();
+    if (rows.length === 0) return null;
+    return rows.find(e => e && e.date === this.date) || null;
+  }
+
   renderCard() {
     const meta = this._m();
     const display = this._display();
-    const entry = this._currentEntry();
-    const hasEntry = entry !== null;
+    // Two different resolutions:
+    //   - displayEntry:  what the card headline shows. Honours
+    //     dateContext:"latest" on Today, so a card with no row today
+    //     can still show yesterday's value.
+    //   - editEntry:     what the edit form targets. ALWAYS exact-
+    //     date, so saving writes to the viewed date. When there's
+    //     no exact-date row, we fall through to the add-form path
+    //     (optionally seeded by prefillFromLatest, #217).
+    const displayEntry = this._currentEntry();
+    const editEntry = this._entryForExactDate();
+    const hasEntry = displayEntry !== null;
+    const hasEditEntry = editEntry !== null;
     // prefillFromLatest: when opening the add form on a date with no
     // existing row, seed the inputs from the most recent prior row so
     // slowly-changing measurements (weight, BP) land close to the
     // previous value. Date field is dropped so the form still stamps
     // the current viewed date. See #217.
     let prefillValues = null;
-    if (!hasEntry && meta?.writeable?.prefillFromLatest === true) {
+    if (!hasEditEntry && meta?.writeable?.prefillFromLatest === true) {
       const prior = this._latestPriorEntry();
       if (prior) {
         const { date: _dateIgnored, ...rest } = prior;
         prefillValues = rest;
       }
     }
+    // Back-compat for the variables used further down the render —
+    // `entry` remains the display fallback (drives the headline,
+    // thresholds, trend arrow); the form consumes editEntry.
+    const entry = displayEntry;
 
     const canWrite = this._canWrite
       && Array.isArray(meta?.writeable?.inputs)
       && meta.writeable.inputs.length > 0;
-    const editIcon = hasEntry ? '✏️' : '➕';
+    // Icon + label reflect whether the VIEWED date has an entry,
+    // not the display fallback. Clicking should be "add" on a day
+    // with no row, even when the headline happens to show a
+    // fallback value from a different day.
+    const editIcon = hasEditEntry ? '✏️' : '➕';
 
     const headline = hasEntry
       ? renderTemplate(display.template || '', entry, display)
@@ -285,18 +314,18 @@ export class EhGenericCard extends EhBaseCard {
         ${canWrite ? html`
           <button class="edit-btn"
             @click=${this._openEdit}
-            aria-label="${hasEntry ? 'Edit' : 'Add'} entry"
-            title="${hasEntry ? 'Edit' : 'Add'} entry">${editIcon}</button>
+            aria-label="${hasEditEntry ? 'Edit' : 'Add'} entry"
+            title="${hasEditEntry ? 'Edit' : 'Add'} entry">${editIcon}</button>
         ` : ''}
 
         ${this._editing ? html`
           <eh-input-form
             .inputs=${meta.writeable.inputs}
-            .values=${entry || prefillValues || {}}
+            .values=${editEntry || prefillValues || {}}
             .date=${this.date}
             .display=${display}
             .requireAny=${meta.writeable.requireAny || null}
-            submit-label=${hasEntry ? 'Update' : 'Add'}
+            submit-label=${hasEditEntry ? 'Update' : 'Add'}
             ?busy=${this._saving}
             @eh-submit=${this._onSubmit}
             @eh-cancel=${this._closeEdit}

--- a/tests-e2e/past-date-view-and-edit.spec.js
+++ b/tests-e2e/past-date-view-and-edit.spec.js
@@ -99,5 +99,17 @@ test.describe('#182: cards with dateContext:latest honour past-date navigation',
     expect(byDate[today]).toBe(5);
     expect(byDate[twoDaysAgo]).toBe(3);
     expect(byDate[shiftDays(today, -3)]).toBe(2);
+
+    // Restore yesterday's seeded value so specs that run later in
+    // the same sandbox run (today-edit-with-no-today-row, etc.) see
+    // the original data instead of our mutation.
+    const restored = onServer.data.map(r =>
+      r.date === yesterday ? { ...r, mood: 4 } : r,
+    );
+    const restoreRes = await page.request.post(
+      `${sandboxState.baseUrl}/api/manifests/mood/data`,
+      { data: { data: restored } },
+    );
+    expect(restoreRes.status()).toBe(200);
   });
 });

--- a/tests-e2e/today-edit-with-no-today-row.spec.js
+++ b/tests-e2e/today-edit-with-no-today-row.spec.js
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/today-edit-with-no-today-row.spec.js
+// Regression for a latent bug surfaced on klebbtest 2026-05-14:
+//
+// When a card uses dateContext:"latest" and there's no row for
+// today, the card's display correctly falls back to the latest
+// prior row (per #182's fix). But clicking the edit button on
+// that card used to open the form pre-filled from the prior
+// row — INCLUDING that row's date field — so saving rewrote the
+// PRIOR day's row instead of creating a new row for today.
+//
+// Net effect for the operator: editing "today" on mood (which has
+// yesterday's row displayed as the fallback) silently clobbered
+// yesterday. Both days appeared to change together because today
+// view kept showing yesterday's row as the latest.
+//
+// This spec exercises the full loop end-to-end on the mood card:
+// clear today, navigate to Today, click edit, pick a mood, save,
+// assert today now has a NEW row and yesterday is untouched.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+test.describe('edit on Today with dateContext:latest + no today-row targets today, not the fallback day', () => {
+  test('clearing today, editing, saving — writes a NEW row for today', async ({ page, sandboxState }) => {
+    const todayIso = (() => {
+      const d = new Date();
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    })();
+
+    // Drop today's mood so the Today view falls back to yesterday.
+    const read = await page.request.get(`${sandboxState.baseUrl}/api/manifests/mood/data`);
+    const body = await read.json();
+    const originalRows = body.data;
+    const withoutToday = originalRows.filter(r => r.date !== todayIso);
+    await page.request.post(`${sandboxState.baseUrl}/api/manifests/mood/data`, {
+      data: { data: withoutToday },
+    });
+
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible();
+
+    // Dismiss the daily prompt if it fires.
+    const promptModal = page.locator('eh-prompt-modal dialog');
+    await promptModal.waitFor({ state: 'visible', timeout: 2000 }).catch(() => {});
+    if (await promptModal.isVisible().catch(() => false)) {
+      await promptModal.locator('button[aria-label="Dismiss"]').click();
+      await expect(promptModal).not.toBeVisible();
+    }
+
+    const moodCard = page.locator('eh-generic-card', { hasText: 'Mood' }).first();
+    await expect(moodCard).toBeVisible({ timeout: 10_000 });
+
+    // Open the edit form. The ➕ / ✏️ icon depends on whether the
+    // renderer thinks today has an entry — we don't care which,
+    // just click it.
+    await moodCard.locator('.edit-btn').click();
+    const form = moodCard.locator('eh-input-form');
+    await expect(form).toBeVisible();
+
+    // Pick mood=1 via the aria-label (emoji labels don't have
+    // stable "name: '1'" text).
+    await form.getByRole('button', { name: 'mood 1' }).click();
+
+    // Submit.
+    await form.getByRole('button', { name: /^(save|update|add)$/i }).click();
+
+    // Read back from the server. Assertions:
+    //   - today now has mood = 1
+    //   - yesterday's row is STILL the seed value (4) — not clobbered
+    //   - every other prior row unchanged
+    await expect(async () => {
+      const res = await page.request.get(`${sandboxState.baseUrl}/api/manifests/mood/data`);
+      const j = await res.json();
+      const byDate = Object.fromEntries(j.data.map(r => [r.date, r.mood]));
+      const yesterdayIso = (() => {
+        const d = new Date();
+        d.setDate(d.getDate() - 1);
+        return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+      })();
+      expect(byDate[todayIso], `expected a NEW today row; disk: ${JSON.stringify(j.data.slice(-3))}`).toBe(1);
+      expect(byDate[yesterdayIso], `yesterday must be unchanged; disk: ${JSON.stringify(j.data.slice(-3))}`).toBe(4);
+    }).toPass({ timeout: 5000 });
+
+    // Restore full seed so later specs see the default state.
+    await page.request.post(`${sandboxState.baseUrl}/api/manifests/mood/data`, {
+      data: { data: originalRows },
+    });
+  });
+});


### PR DESCRIPTION
# What changed

Cards with \`dateContext: \"latest\"\` still use the most recent prior
row as a display fallback when the viewed date has no entry (per
#182). But the **edit** flow now resolves independently — by exact
date — so saving writes to the viewed date, not the fallback day's
row. Pencil-vs-plus icon and Update-vs-Add label reflect the
viewed-date state.

# Why

Reported on klebbtest 2026-05-14:

> when I update 14/5/26 mood or note it changes it for 13/5/26 too.
> Then when I change 13/5/26 it changes it for the 14/5/26 too.

Traced by inspecting the on-disk manifest: today (14/5/26) had no
row. Today view correctly fell back to showing yesterday's row
(13/5/26). Clicking edit opened the form with \`values=${entry}\` —
which was the yesterday row, **including its date field**. The
form's submit carried that date through. Server wrote to
13/5/26. Today view then re-resolved \"latest\" back to the
(now-overwritten) 13/5/26 row. Looked like both days changed.

Same class of bug as #181/#182: Today-fallback-display tangled up
with the edit flow. #182 fixed the display; this closes the loop
on the edit side.

# How

\`eh-generic-card\` splits the resolution:

- \`_currentEntry()\` — unchanged. Drives the headline, thresholds,
  trend arrow. Honours \`dateContext:\"latest\"\`.
- \`_entryForExactDate()\` — new. Always returns the row whose date
  exactly matches \`this.date\`, or null. Drives the form's
  \`.values\` prop, the ✏️/➕ icon, and the Update/Add submit label.

When no exact-date row exists, the form opens in add-mode with
either an empty object or the \`prefillFromLatest\` seed (#217).
\`_onSubmit\`'s existing \`if (!entry.date) entry.date = this.date\`
stamps the viewed date on submit, because the pre-filled values
object (from \`prefillFromLatest\`) already strips the date field
and an empty \`{}\` never had one.

Two new \`renderCard\` locals:
- \`displayEntry\` — was \`entry\`, kept for back-compat with the
  headline / threshold / trend computations.
- \`editEntry\` — drives the form.

# Testing

\`tests-e2e/today-edit-with-no-today-row.spec.js\`:

1. Seed weight/mood sandbox as usual (mood seeded today-3..today,
   all with moods 2/3/4/5 and no notes).
2. Clear today's mood row via the API.
3. Load the app; dismiss the daily-prompt modal if it fires.
4. Click the mood card's edit button.
5. Pick \`mood 1\` via aria-label.
6. Submit.
7. Read back via the server:
   - today now has mood=1 (NEW row, not an overwrite of yesterday).
   - yesterday stays at mood=4.

Verified fails on main (yesterday gets overwritten to 1; no new
today row created).

Also extends \`tests-e2e/past-date-view-and-edit.spec.js\` with a
state-restore at the end of the pencil-edit test, so the sandbox's
yesterday row goes back to the seeded mood=4 before later specs
inherit the mutation.

- [x] \`npm test\` — 842/843 pass locally (pre-existing Windows
      \`no-personal-refs\` flake; CI green)
- [x] \`npm run test:e2e\` — 27/27 pass
- [x] Fail-on-main verified

# Checklist

- [x] Commit messages follow conventions
- [x] \`CHANGELOG.md\` updated
- [x] Inline comments on \`_entryForExactDate\` + the render split
      cross-reference the 2026-05-14 klebbtest report and the
      #182 fallback contract so future readers see the two
      concerns together
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Deployment note

Rebuild klebbtest after merge. No data cleanup needed — the bug
wasn't corrupting data, just misdirecting writes. Any rows the
operator thought they were editing for today that actually
clobbered yesterday are gone either way (the clobber already
happened). Going forward, today's edits land on today.