### PR TITLE
fix(renderer): schedule-card prompt uses checklist instead of free-text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Added
+
+- **`meta.prompt.mode: "checklist"` for schedule-card prompts.** Schedule
+  cards (peptides, medications, supplement stacks) that opt into
+  `meta.prompt.enabled: true` previously rendered the daily reminder as
+  a free-text add-entry form (Item name / Scheduled date / Taken at):
+  the wrong shape for "did you take it?" because the card already knows
+  what's scheduled today. The new `mode: "checklist"` renders one row
+  per item scheduled today, each with a single "Taken" button that
+  stamps `{scheduledDate, takenAt}` into that item's `doses[]` (or
+  `takenDates[]` for plain supplement-stack items). The modal updates
+  in place and auto-closes once every scheduled item is marked.
+  Eligibility is per-item: the prompt fires when at least one item is
+  unmarked. The `medication-schedule`, `injection-protocol`, and
+  `supplement-stack` templates default to checklist mode. Existing
+  `mode: "modal"` (or absent) cards are unaffected.
+
 ### Fixed
 
 - **Edit button on Today with no today-row now targets today, not

--- a/MANIFEST-SCHEMA.md
+++ b/MANIFEST-SCHEMA.md
@@ -89,18 +89,30 @@ or `true` means the card participates according to its per-view config.
 ### Modal prompt (`meta.prompt`)
 
 Opt-in. Makes the card fire a full-screen modal on app load, once per
-day, until the user saves or dismisses. Applies to any card that has
-`meta.writeable.inputs`.
+day, until the user saves or dismisses.
 
 ```json
 "meta": {
   "prompt": {
     "enabled": true,         // required — default false
-    "mode": "modal",         // only mode supported today
+    "mode": "modal",         // "modal" (default) or "checklist"
     "whenMissing": true      // default true; skip if today already logged
   }
 }
 ```
+
+`mode` selects the modal's shape:
+
+| `mode`        | Shape                                                                 | Best for                            | `whenMissing: true` skip rule                                                            |
+|---------------|-----------------------------------------------------------------------|-------------------------------------|------------------------------------------------------------------------------------------|
+| `"modal"`     | Wraps `meta.writeable.inputs` in a single Save form. Default.         | Atomic per-day cards (mood, weight) | Skip if today already has a row in `data` (or any item logged for cards with `items[]`). |
+| `"checklist"` | One row per item scheduled today, each with a single "Taken" button.  | `schedule-card` (peptides, meds)    | Skip only when EVERY item scheduled today already has a `doses[]` entry with `takenAt`.  |
+
+Checklist rows write `{ scheduledDate: today, takenAt: ISO-now }` into
+the matching `item.doses[]` and update in place. The modal auto-closes
+once every scheduled item is marked taken. There is no free-text item
+name input, no editable date, and no time picker — the prompt IS the
+"did you take it just now?" reminder.
 
 Queue semantics: if multiple cards qualify, they render sequentially
 in `meta.order` ascending. Shown-today state is tracked in

--- a/config/env.js
+++ b/config/env.js
@@ -429,7 +429,7 @@ Once \`create_manifest\` succeeds, your reply MUST end with a short offer of opt
 - **Thresholds on the Today headline:** \`meta.view.display.thresholds\` — colour the value green/amber/red against bands (great for BP, glucose, RHR, weight goals).
 - **Reports renderer:** \`meta.reports\` — \`table-list\` for history, \`adherence-report\` for schedules.
 - **Extra inputs:** a notes field, a time-of-day field, a tag/category select.
-- **A daily target or reminder prompt:** \`meta.prompt = {enabled:true, ...}\` if the user wants to be nudged.
+- **A daily target or reminder prompt:** \`meta.prompt = {enabled:true, ...}\` if the user wants to be nudged. For \`schedule-card\` manifests (peptides / meds / supplement stacks) prefer \`meta.prompt = {enabled:true, mode:"checklist"}\` — the modal renders one Taken button per item scheduled that day instead of a free-text input form.
 
 Offer them as a single short sentence or a 2-3 item bullet list, e.g. "Done. Want me to add a trends chart, a daily target, or a calendar marker?" — not a long menu. Never auto-add beyond what was asked.
 

--- a/docs/CARDS.md
+++ b/docs/CARDS.md
@@ -108,7 +108,7 @@ BP, weight, hydration.
 "meta": {
   "prompt": {
     "enabled": true,         // required to opt in; default false
-    "mode": "modal",         // only "modal" is supported today
+    "mode": "modal",         // "modal" (default) or "checklist"
     "whenMissing": true      // default true — skip if today's entry exists
   }
 }
@@ -128,7 +128,7 @@ BP, weight, hydration.
 - Multiple qualifying cards are queued in `meta.order` ascending; the
   user fills or dismisses one at a time until the queue empties.
 
-**Modal UX:**
+**Modal UX (`mode: "modal"`):**
 
 - Full viewport on mobile (bottom-sheet style), centered card on
   desktop (≥ 640px).
@@ -138,8 +138,25 @@ BP, weight, hydration.
 - ✕ in the header dismisses without saving.
 - Escape key also dismisses.
 
-Defaults: `enabled: false`. Opt-in only — no card gets a modal unless
-you explicitly set this.
+**Checklist UX (`mode: "checklist"`):**
+
+For `schedule-card` manifests (peptides, medications, supplement stacks)
+where the daily "did you take it?" question maps to multiple per-item
+ticks, use `mode: "checklist"`. The modal renders one row per item
+scheduled today, each with a single "Taken" button that writes
+`{ scheduledDate, takenAt }` into that item's `doses[]`. Rows update
+in place; the modal auto-closes once every scheduled item is marked.
+
+The eligibility rule is per-item: the prompt fires when at least one
+scheduled item lacks today's dose, and stays out of the queue once
+they're all logged. There is no editable date or time — tapping
+"Taken" stamps `now`. Out-of-band manual entry (logging a dose
+yesterday, or off-schedule) still goes through the schedule-card's
+own renderer; the prompt path only handles the "I just took it"
+reminder.
+
+Defaults: `enabled: false`, `mode: "modal"`. Opt-in only — no card
+gets a modal unless you explicitly set this.
 
 ### `meta.view` — the Today view config
 

--- a/public/js/components/eh-prompt-modal.js
+++ b/public/js/components/eh-prompt-modal.js
@@ -3,10 +3,18 @@
 // eh-prompt-modal.js — Full-screen "log this now" modal.
 //
 // A card with meta.prompt.enabled = true triggers this modal on app load
-// (once per day per card). The modal wraps the card's normal input form
-// (meta.writeable.inputs) inside a native <dialog>, forcing the user to
-// acknowledge. Closing via ✕ or Save marks the card "prompted today"
-// in localStorage; the modal won't appear again until the next day.
+// (once per day per card). The modal renders one of two shapes based on
+// meta.prompt.mode:
+//   - "modal" (default): wraps the card's meta.writeable.inputs in
+//     eh-input-form for a single Save submission.
+//   - "checklist": for schedule-card data where each item has its own
+//     scheduled-today status. Renders one row per item scheduled today
+//     with a single "Taken" button that stamps that item's doses[]
+//     with { scheduledDate, takenAt } and updates in place. Auto-closes
+//     when every scheduled item is marked.
+// Closing via ✕ or Save (or marking the last checklist row) marks the
+// card "prompted today" in localStorage; the modal won't appear again
+// until the next day.
 //
 // See docs/CARDS.md → Modal prompts for user-facing documentation.
 //
@@ -30,6 +38,7 @@
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
 import { localToday } from '../lib/date-util.js';
 import { errorFromResponse } from '../lib/save-error.js';
+import { isScheduledOnDate } from '../lib/schedule.js';
 import './eh-input-form.js';
 
 export class EhPromptModal extends LitElement {
@@ -38,6 +47,8 @@ export class EhPromptModal extends LitElement {
     date: { type: String },
     _error: { state: true },
     _busy: { state: true },
+    _checklistData: { state: true },
+    _pendingItem: { state: true },
   };
 
   constructor() {
@@ -46,6 +57,8 @@ export class EhPromptModal extends LitElement {
     this.date = null;
     this._error = null;
     this._busy = false;
+    this._checklistData = null;
+    this._pendingItem = null;
   }
 
   static styles = css`
@@ -176,6 +189,73 @@ export class EhPromptModal extends LitElement {
       padding: 8px 12px;
       font-size: 13px;
     }
+
+    .checklist {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    .row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 12px;
+      align-items: center;
+      padding: 10px 12px;
+      border-radius: 10px;
+      background: var(--bg-hover, rgba(255, 255, 255, 0.03));
+      border: 1px solid var(--border);
+    }
+    .row.taken { opacity: 0.55; }
+    .row-info { min-width: 0; }
+    .row-name {
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+    .row-meta {
+      font-size: 12px;
+      color: var(--text-secondary);
+      margin-top: 2px;
+    }
+    button.taken-btn {
+      background: var(--accent);
+      color: white;
+      border: none;
+      padding: 6px 14px;
+      border-radius: 8px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+    button.taken-btn:hover { filter: brightness(1.08); }
+    button.taken-btn:disabled { cursor: default; opacity: 0.7; }
+    button.taken-btn.done {
+      background: transparent;
+      color: var(--accent);
+      border: 1px solid var(--accent);
+    }
+    .footer {
+      display: flex;
+      justify-content: flex-end;
+      padding-top: 4px;
+    }
+    button.dismiss-btn {
+      background: transparent;
+      color: var(--text-secondary);
+      border: 1px solid var(--border);
+      padding: 8px 14px;
+      border-radius: 8px;
+      font-size: 13px;
+      cursor: pointer;
+    }
+    button.dismiss-btn:hover { color: var(--text-primary); border-color: var(--text-secondary); }
+    .empty-checklist {
+      color: var(--text-muted, var(--text-secondary));
+      font-size: 13px;
+      text-align: center;
+      padding: 12px 0;
+    }
   `;
 
   firstUpdated() {
@@ -208,6 +288,97 @@ export class EhPromptModal extends LitElement {
       bubbles: true,
       composed: true,
     }));
+  }
+
+  // Checklist mode: derive today's working item list from the card's data
+  // (or from the most recent in-modal write). Items with a schedule/cycle
+  // are filtered through isScheduledOnDate; plain items (supplement-stack
+  // style without a schedule block) are always due.
+  _checklistItems() {
+    const data = this._checklistData || this.card?.data || {};
+    const items = Array.isArray(data.items)
+      ? data.items
+      : Array.isArray(data.current) ? data.current
+      : [];
+    const date = this.date || localToday();
+    return items.filter(item => {
+      if (item.schedule || item.cycle || Array.isArray(item.cycles)) {
+        return isScheduledOnDate(item, date) === 'scheduled';
+      }
+      return true;
+    });
+  }
+
+  _itemUsesDoses(item) {
+    return Array.isArray(item.doses) || !!item.schedule || !!item.cycle || Array.isArray(item.cycles);
+  }
+
+  _isItemTaken(item) {
+    const date = this.date || localToday();
+    if (Array.isArray(item.doses)
+      && item.doses.some(d => d.scheduledDate === date && d.takenAt)) return true;
+    if (Array.isArray(item.takenDates) && item.takenDates.includes(date)) return true;
+    return false;
+  }
+
+  _doseLabel(item) {
+    const parts = [];
+    if (item.dose_label) parts.push(item.dose_label);
+    else if (item.dose_mg != null) parts.push(`${item.dose_mg}mg`);
+    else if (item.dose) parts.push(item.dose);
+    if (item.dose_units) parts.push(`${item.dose_units}u`);
+    if (item.route) parts.push(item.route);
+    return parts.join(' · ');
+  }
+
+  async _markItemTaken(item) {
+    if (this._busy || this._pendingItem) return;
+    if (this._isItemTaken(item)) return;
+    const meta = this.card?.meta || {};
+    const date = this.date || localToday();
+    this._pendingItem = item.id || item.name;
+    this._error = null;
+    try {
+      const current = await fetch(`/api/manifests/${encodeURIComponent(meta.id)}/data`, {
+        credentials: 'same-origin',
+      }).then(r => r.json());
+      const data = current?.data ?? current ?? {};
+      const items = Array.isArray(data.items) ? data.items : [];
+      const matchKey = item.id ? 'id' : 'name';
+      const matchVal = item[matchKey];
+      const useTakenDates = !this._itemUsesDoses(item);
+      const updatedItems = items.map(it => {
+        if (it[matchKey] !== matchVal) return it;
+        if (useTakenDates) {
+          const taken = Array.isArray(it.takenDates) ? [...it.takenDates] : [];
+          if (!taken.includes(date)) taken.push(date);
+          return { ...it, takenDates: taken };
+        }
+        const doses = Array.isArray(it.doses) ? [...it.doses] : [];
+        const idx = doses.findIndex(d => d.scheduledDate === date);
+        const stamped = { scheduledDate: date, takenAt: new Date().toISOString() };
+        if (idx >= 0) doses[idx] = { ...doses[idx], ...stamped };
+        else doses.push(stamped);
+        return { ...it, doses };
+      });
+      const updated = { ...data, items: updatedItems };
+      const r = await fetch(`/api/manifests/${encodeURIComponent(meta.id)}/data`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({ data: updated }),
+      });
+      if (!r.ok) throw await errorFromResponse(r);
+      this._checklistData = updated;
+      // Auto-close once every scheduled item is taken.
+      const remaining = this._checklistItems().some(it => !this._isItemTaken(it));
+      if (!remaining) this._finish('saved', { mode: 'checklist' });
+    } catch (err) {
+      console.warn('[prompt-modal] checklist save failed', err);
+      this._error = err.message || 'Could not save. Try again or dismiss.';
+    } finally {
+      this._pendingItem = null;
+    }
   }
 
   async _onSubmit(e) {
@@ -261,9 +432,8 @@ export class EhPromptModal extends LitElement {
   render() {
     if (!this.card) return html``;
     const meta = this.card.meta || {};
-    const inputs = meta.writeable?.inputs || [];
-    const display = meta.view?.display || null;
     const today = this.date || localToday();
+    const mode = meta.prompt?.mode === 'checklist' ? 'checklist' : 'modal';
     return html`
       <dialog aria-modal="true" aria-label="${meta.label || 'Log entry'}">
         <div class="wrap">
@@ -285,21 +455,71 @@ export class EhPromptModal extends LitElement {
 
             ${this._error ? html`<div class="error" role="alert">${this._error}</div>` : ''}
 
-            <eh-input-form
-              .inputs=${inputs}
-              .values=${{}}
-              .date=${today}
-              .display=${display}
-              .requireAny=${meta.writeable?.requireAny || null}
-              .busy=${this._busy}
-              submit-label="Save"
-              cancel-label="Not now"
-              @eh-submit=${this._onSubmit}
-              @eh-cancel=${this._dismiss}
-            ></eh-input-form>
+            ${mode === 'checklist'
+              ? this._renderChecklist(today)
+              : this._renderModalForm(meta, today)}
           </div>
         </div>
       </dialog>
+    `;
+  }
+
+  _renderModalForm(meta, today) {
+    const inputs = meta.writeable?.inputs || [];
+    const display = meta.view?.display || null;
+    return html`
+      <eh-input-form
+        .inputs=${inputs}
+        .values=${{}}
+        .date=${today}
+        .display=${display}
+        .requireAny=${meta.writeable?.requireAny || null}
+        .busy=${this._busy}
+        submit-label="Save"
+        cancel-label="Not now"
+        @eh-submit=${this._onSubmit}
+        @eh-cancel=${this._dismiss}
+      ></eh-input-form>
+    `;
+  }
+
+  _renderChecklist(today) {
+    const items = this._checklistItems();
+    if (items.length === 0) {
+      return html`
+        <div class="empty-checklist">Nothing scheduled for today.</div>
+        <div class="footer">
+          <button class="dismiss-btn" type="button" @click=${this._dismiss}>Close</button>
+        </div>
+      `;
+    }
+    return html`
+      <div class="checklist" role="list">
+        ${items.map(item => {
+          const taken = this._isItemTaken(item);
+          const pendingKey = item.id || item.name;
+          const pending = this._pendingItem === pendingKey;
+          const meta = this._doseLabel(item);
+          return html`
+            <div class="row ${taken ? 'taken' : ''}" role="listitem">
+              <div class="row-info">
+                <div class="row-name">${item.short_name || item.name}</div>
+                ${meta ? html`<div class="row-meta">${meta}</div>` : ''}
+              </div>
+              <button
+                class="taken-btn ${taken ? 'done' : ''}"
+                type="button"
+                ?disabled=${taken || pending}
+                aria-label="mark ${item.name} taken"
+                @click=${() => this._markItemTaken(item)}
+              >${taken ? '✓ Taken' : pending ? '...' : 'Taken'}</button>
+            </div>
+          `;
+        })}
+      </div>
+      <div class="footer">
+        <button class="dismiss-btn" type="button" @click=${this._dismiss}>Not now</button>
+      </div>
     `;
   }
 }

--- a/public/js/lib/prompt-queue.js
+++ b/public/js/lib/prompt-queue.js
@@ -19,6 +19,7 @@
 //     eh-prompt-modal.
 
 import { localToday } from './date-util.js';
+import { isScheduledOnDate } from './schedule.js';
 
 const STORAGE_PREFIX = 'klebb-prompt-shown-';
 
@@ -57,6 +58,9 @@ export function markShownToday(cardId, date = todayStr(), storage = globalThis.l
 //   at least one item has a taken mark for today. (Some cards have
 //   multiple items; the modal is opt-in so this behaviour is documented
 //   as "shows until ANY item is ticked off".)
+//
+// For checklist-mode prompts the gate is per-item, not any/all-or-nothing
+// — see allScheduledTakenForDate below.
 export function entryExistsForDate(data, date) {
   if (!data) return false;
   if (Array.isArray(data)) {
@@ -80,6 +84,28 @@ export function entryExistsForDate(data, date) {
   return false;
 }
 
+// Eligibility helper for checklist-mode prompts. Returns true when every
+// item scheduled for the given date already has a takenAt dose, i.e. the
+// checklist would render with nothing to tick. The default
+// entryExistsForDate is too eager here — it would suppress the prompt as
+// soon as one of three items was logged.
+export function allScheduledTakenForDate(data, date) {
+  const items = Array.isArray(data?.items)
+    ? data.items
+    : Array.isArray(data?.current) ? data.current
+    : [];
+  let scheduledCount = 0;
+  for (const item of items) {
+    if (isScheduledOnDate(item, date) !== 'scheduled') continue;
+    scheduledCount++;
+    const dosed = Array.isArray(item.doses)
+      && item.doses.some(d => d.scheduledDate === date && d.takenAt);
+    const flagged = Array.isArray(item.takenDates) && item.takenDates.includes(date);
+    if (!dosed && !flagged) return false;
+  }
+  return scheduledCount > 0;
+}
+
 // Build the queue. Pure function separated so tests can run it against
 // a synthetic manifest list without hitting the network.
 export function buildPromptQueue(manifests, {
@@ -97,7 +123,12 @@ export function buildPromptQueue(manifests, {
     if (meta.enabled === false) continue;
     if (wasShownToday(meta.id, date, storage)) continue;
     const whenMissing = prompt.whenMissing !== false; // default true
-    if (whenMissing && entryExistsForDate(card.data, date)) continue;
+    if (whenMissing) {
+      const eligible = prompt.mode === 'checklist'
+        ? !allScheduledTakenForDate(card.data, date)
+        : !entryExistsForDate(card.data, date);
+      if (!eligible) continue;
+    }
     out.push(card);
   }
   // meta.order ascending, stable on id for determinism

--- a/templates/injection-protocol.klebb.json
+++ b/templates/injection-protocol.klebb.json
@@ -32,6 +32,11 @@
       "component": "day-marker",
       "marker": "💉"
     },
+    "prompt": {
+      "enabled": true,
+      "mode": "checklist",
+      "whenMissing": true
+    },
     "writeable": {
       "fromWebapp": true,
       "pastAllowed": true,

--- a/templates/medication-schedule.klebb.json
+++ b/templates/medication-schedule.klebb.json
@@ -33,6 +33,11 @@
       "component": "day-marker",
       "marker": "💊"
     },
+    "prompt": {
+      "enabled": true,
+      "mode": "checklist",
+      "whenMissing": true
+    },
     "writeable": {
       "fromWebapp": true,
       "pastAllowed": true,

--- a/templates/supplement-stack.klebb.json
+++ b/templates/supplement-stack.klebb.json
@@ -27,6 +27,11 @@
       "component": "day-marker",
       "marker": "💊"
     },
+    "prompt": {
+      "enabled": true,
+      "mode": "checklist",
+      "whenMissing": true
+    },
     "writeable": {
       "fromWebapp": true,
       "pastAllowed": true,

--- a/tests-e2e/helpers/seed-manifests.js
+++ b/tests-e2e/helpers/seed-manifests.js
@@ -138,6 +138,11 @@ function peptides(today) {
       order: 200,
       category: 'supplements',
       view: { enabled: true, component: 'schedule-card', dateContext: 'exact-date' },
+      // Schedule cards in production opt into the checklist-mode prompt
+      // (see #185); this seed leaves it off so unrelated specs aren't
+      // impacted. The schedule-checklist-prompt spec patches it on at
+      // runtime.
+      writeable: { fromWebapp: true, todayAllowed: true, pastAllowed: true, futureAllowed: false },
     },
     description: 'Peptide schedule for E2E coverage (nested-cycle shape).',
     data: {

--- a/tests-e2e/schedule-checklist-prompt.spec.js
+++ b/tests-e2e/schedule-checklist-prompt.spec.js
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/schedule-checklist-prompt.spec.js
+// Regression for #185: when a schedule-card manifest declares
+// `meta.prompt.mode: "checklist"`, the daily prompt renders as a list of
+// today's scheduled doses with a single "Taken" button per row. Tapping
+// each Taken button stamps `{scheduledDate, takenAt}` into that item's
+// `doses[]` and updates in place; the modal auto-closes once every
+// scheduled item is marked.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+function todayISO() {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+function shiftDays(iso, delta) {
+  const [y, m, d] = iso.split('-').map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  dt.setUTCDate(dt.getUTCDate() + delta);
+  const yy = dt.getUTCFullYear();
+  const mm = String(dt.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(dt.getUTCDate()).padStart(2, '0');
+  return `${yy}-${mm}-${dd}`;
+}
+
+test.describe('#185: schedule-card checklist-mode prompt', () => {
+  test('renders one row per scheduled item, marks each Taken, auto-closes', async ({ page, sandboxState }) => {
+    const today = todayISO();
+    const baseUrl = sandboxState.baseUrl;
+
+    // Snapshot original manifest so we can restore at end.
+    const original = await (await page.request.get(`${baseUrl}/api/manifests/peptides`)).json();
+
+    // Seed two scheduled-today items with no doses, and turn the prompt
+    // on in checklist mode.
+    const seedData = {
+      items: [
+        {
+          id: 'semax',
+          name: 'Semax',
+          short_name: 'Semax',
+          dose_mg: 1,
+          dose_units: 'mcg',
+          route: 'subQ',
+          schedule: { type: 'daily_straight', duration_days: 20 },
+          cycle: { cycles: [{ cycle_number: 1, start_date: shiftDays(today, -2), end_date: shiftDays(today, 17) }] },
+        },
+        {
+          id: 'selank',
+          name: 'Selank',
+          short_name: 'Selank',
+          dose_mg: 0.5,
+          dose_units: 'mcg',
+          route: 'subQ',
+          schedule: { type: 'daily_straight', duration_days: 20 },
+          cycle: { cycles: [{ cycle_number: 1, start_date: shiftDays(today, -2), end_date: shiftDays(today, 17) }] },
+        },
+      ],
+    };
+    const writeData = await page.request.post(`${baseUrl}/api/manifests/peptides/data`, { data: { data: seedData } });
+    expect(writeData.status()).toBe(200);
+
+    const patch = await page.request.fetch(`${baseUrl}/api/manifests/peptides`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      data: { meta: { prompt: { enabled: true, mode: 'checklist', whenMissing: true } } },
+    });
+    expect(patch.status()).toBe(200);
+
+    // Clear any prior shown-today marker so the prompt is eligible.
+    await page.addInitScript((id) => {
+      const today = (() => {
+        const d = new Date();
+        const y = d.getFullYear();
+        const m = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        return `${y}-${m}-${day}`;
+      })();
+      try { localStorage.removeItem(`klebb-prompt-shown-${id}-${today}`); } catch {}
+    }, 'peptides');
+
+    await page.goto('/');
+
+    const modal = page.locator('eh-prompt-modal dialog');
+    await expect(modal).toBeVisible({ timeout: 10_000 });
+    await expect(modal).toContainText(/schedule|peptide/i);
+
+    // Two rows, two Taken buttons.
+    const rows = modal.locator('.row');
+    await expect(rows).toHaveCount(2);
+    await expect(modal).toContainText('Semax');
+    await expect(modal).toContainText('Selank');
+
+    // No free-text item input, no editable date picker, no time picker.
+    await expect(modal.locator('input[type="text"]')).toHaveCount(0);
+    await expect(modal.locator('input[type="date"]')).toHaveCount(0);
+    await expect(modal.locator('input[type="time"]')).toHaveCount(0);
+
+    // Tap Taken on the first row → row toggles, modal stays open.
+    await rows.nth(0).locator('button.taken-btn').click();
+    await expect(rows.nth(0).locator('button.taken-btn')).toHaveText(/Taken/);
+    await expect(rows.nth(0).locator('button.taken-btn')).toBeDisabled();
+    await expect(modal).toBeVisible();
+
+    // Tap Taken on the second row → auto-close.
+    await rows.nth(1).locator('button.taken-btn').click();
+    await expect(modal).toBeHidden({ timeout: 5_000 });
+
+    // Verify writes landed on disk.
+    const after = await (await page.request.get(`${baseUrl}/api/manifests/peptides/data`)).json();
+    const items = after.data.items;
+    for (const it of items) {
+      const dose = (it.doses || []).find(d => d.scheduledDate === today);
+      expect(dose, `item ${it.name} should have a dose for today`).toBeTruthy();
+      expect(dose.takenAt, `item ${it.name} dose should have takenAt`).toBeTruthy();
+    }
+
+    // Reload — prompt should NOT re-fire (every item already taken,
+    // and the shown-today marker is set anyway).
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('eh-prompt-modal dialog')).toHaveCount(0);
+
+    // Restore the original manifest so unrelated specs remain unaffected.
+    const restoreData = await page.request.post(`${baseUrl}/api/manifests/peptides/data`, {
+      data: { data: original.data },
+    });
+    expect(restoreData.status()).toBe(200);
+    const restoreMeta = await page.request.fetch(`${baseUrl}/api/manifests/peptides`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      data: { meta: { prompt: null } },
+    });
+    expect(restoreMeta.status()).toBe(200);
+  });
+});

--- a/tests/prompt-queue.test.js
+++ b/tests/prompt-queue.test.js
@@ -14,6 +14,7 @@ import assert from 'node:assert/strict';
 import {
   buildPromptQueue,
   entryExistsForDate,
+  allScheduledTakenForDate,
   wasShownToday,
   markShownToday,
   shownTodayKey,
@@ -166,6 +167,120 @@ test('buildPromptQueue: handles empty and null manifests', () => {
   assert.deepEqual(buildPromptQueue([], { storage }), []);
   assert.deepEqual(buildPromptQueue(null, { storage }), []);
   assert.deepEqual(buildPromptQueue(undefined, { storage }), []);
+});
+
+// --- checklist-mode (#185) ---
+
+const SCHEDULE_DATA = (taken) => ({
+  items: [
+    {
+      id: 'a',
+      name: 'A',
+      schedule: { type: 'daily' },
+      doses: taken.a ? [{ scheduledDate: '2026-04-23', takenAt: '2026-04-23T08:00' }] : [],
+    },
+    {
+      id: 'b',
+      name: 'B',
+      schedule: { type: 'daily' },
+      doses: taken.b ? [{ scheduledDate: '2026-04-23', takenAt: '2026-04-23T08:01' }] : [],
+    },
+    {
+      id: 'c',
+      name: 'C',
+      schedule: { type: 'daily' },
+      doses: taken.c ? [{ scheduledDate: '2026-04-23', takenAt: '2026-04-23T08:02' }] : [],
+    },
+  ],
+});
+
+test('allScheduledTakenForDate: NONE taken → false', () => {
+  assert.equal(allScheduledTakenForDate(SCHEDULE_DATA({}), '2026-04-23'), false);
+});
+
+test('allScheduledTakenForDate: SOME taken → false', () => {
+  assert.equal(allScheduledTakenForDate(SCHEDULE_DATA({ a: true }), '2026-04-23'), false);
+  assert.equal(allScheduledTakenForDate(SCHEDULE_DATA({ a: true, b: true }), '2026-04-23'), false);
+});
+
+test('allScheduledTakenForDate: ALL taken → true', () => {
+  assert.equal(
+    allScheduledTakenForDate(SCHEDULE_DATA({ a: true, b: true, c: true }), '2026-04-23'),
+    true,
+  );
+});
+
+test('allScheduledTakenForDate: nothing scheduled today → false (no prompt to suppress)', () => {
+  // schedule.type omitted is the same as no schedule → not 'scheduled'
+  // for items with explicit schedule blocks, so use a weekly Mon-only
+  // schedule and a Tuesday date.
+  const data = {
+    items: [
+      { id: 'a', name: 'A', schedule: { type: 'weekly', on_days: ['Mon'] } },
+    ],
+  };
+  // 2026-04-23 is a Thursday — item A is not scheduled, so the
+  // checklist would render empty. Treat that as "no prompt warranted"
+  // (false), matching the same falsy answer entryExistsForDate returns
+  // when the data is empty.
+  assert.equal(allScheduledTakenForDate(data, '2026-04-23'), false);
+});
+
+test('allScheduledTakenForDate: takenDates shape (supplement-stack) ALL taken', () => {
+  const data = {
+    items: [
+      { id: 'a', name: 'B12', takenDates: ['2026-04-23'] },
+      { id: 'b', name: 'D3',  takenDates: ['2026-04-23'] },
+    ],
+  };
+  assert.equal(allScheduledTakenForDate(data, '2026-04-23'), true);
+});
+
+test('allScheduledTakenForDate: takenDates shape SOME taken → false', () => {
+  const data = {
+    items: [
+      { id: 'a', name: 'B12', takenDates: ['2026-04-23'] },
+      { id: 'b', name: 'D3',  takenDates: [] },
+    ],
+  };
+  assert.equal(allScheduledTakenForDate(data, '2026-04-23'), false);
+});
+
+test('buildPromptQueue: checklist mode skips when ALL items taken', () => {
+  const storage = makeStorage();
+  const manifests = [
+    {
+      meta: { id: 'peptides', prompt: { enabled: true, mode: 'checklist' } },
+      data: SCHEDULE_DATA({ a: true, b: true, c: true }),
+    },
+  ];
+  const q = buildPromptQueue(manifests, { date: '2026-04-23', storage });
+  assert.deepEqual(q, []);
+});
+
+test('buildPromptQueue: checklist mode includes card when SOME items unmarked', () => {
+  const storage = makeStorage();
+  const manifests = [
+    {
+      meta: { id: 'peptides', prompt: { enabled: true, mode: 'checklist' } },
+      data: SCHEDULE_DATA({ a: true }),
+    },
+  ];
+  const q = buildPromptQueue(manifests, { date: '2026-04-23', storage });
+  assert.equal(q.length, 1);
+  assert.equal(q[0].meta.id, 'peptides');
+});
+
+test('buildPromptQueue: checklist mode includes card when NONE taken', () => {
+  const storage = makeStorage();
+  const manifests = [
+    {
+      meta: { id: 'peptides', prompt: { enabled: true, mode: 'checklist' } },
+      data: SCHEDULE_DATA({}),
+    },
+  ];
+  const q = buildPromptQueue(manifests, { date: '2026-04-23', storage });
+  assert.equal(q.length, 1);
 });
 
 test('buildPromptQueue: defends against malformed manifest entries', () => {


### PR DESCRIPTION
# What changed

Schedule cards (peptides / medications / supplement stacks) that opt into the daily prompt previously rendered a free-text Item name + editable date + time-picker form on app open. The card already knows what's scheduled today, so the form was the wrong shape: the operator wants one tap to mean "I took it just now."

Adds `meta.prompt.mode: "checklist"` as a first-class prompt shape alongside the existing `"modal"`. When set, the modal renders one row per item that `isScheduledOnDate` flags as scheduled today, each with a single Taken button that stamps `{scheduledDate, takenAt}` into the item's `doses[]` (or `takenDates[]` for plain supplement items). Rows update in place; the modal auto-closes once every scheduled item is marked. The card's normal renderer + add-form for off-schedule entries is untouched.

Eligibility for checklist-mode prompts is per-item: a new `allScheduledTakenForDate` helper in `prompt-queue.js` suppresses the prompt only when EVERY today-scheduled item already has a logged dose. Default `mode: "modal"` (or absent) keeps existing behaviour.

`medication-schedule`, `injection-protocol`, and `supplement-stack` templates now ship with `prompt: { enabled: true, mode: "checklist", whenMissing: true }` enabled by default. The chat agent's system prompt suggests the same default when creating schedule-style cards.

# Why

Fixes #185. Observed in 2026-05-11 manual QA: the morning peptide reminder presented three blank fields the operator had to retype values into, when the desired interaction is one tap per item.

# How

- `public/js/components/eh-prompt-modal.js`: branch on `card.meta.prompt.mode` inside `render()`. Approach A from the issue (single component, two render paths). Existing `mode: "modal"` flow untouched.
- `public/js/lib/prompt-queue.js`: new `allScheduledTakenForDate` exported and used by `buildPromptQueue` when `prompt.mode === "checklist"`. Falls back to the existing `entryExistsForDate` for `"modal"` mode.
- `public/js/lib/schedule.js`: no changes — `isScheduledOnDate` reused as-is.
- Schema docs: `MANIFEST-SCHEMA.md` and `docs/CARDS.md` now describe both modes with a per-mode behaviour table.
- Templates updated; the e2e seed leaves the prompt off so unrelated specs stay green and the new spec patches it on at runtime.
- Adds 10 unit tests covering `allScheduledTakenForDate` (NONE / SOME / ALL taken, doses + takenDates shapes) and the checklist-mode branch in `buildPromptQueue`.
- Adds `tests-e2e/schedule-checklist-prompt.spec.js` covering the full happy path: modal opens with two rows, taps mark them in place, modal auto-closes, writes land in `doses[]`, and a reload does not re-fire the prompt.

# Testing

- [x] `npm test` passes locally (851/852; the lone failure is a pre-existing infra-noise hygiene assertion present on main, unrelated to this change).
- [x] `npm run test:e2e` passes locally (28/28).
- [x] New unit + e2e coverage added.
- [x] New e2e spec verified to fail on `main` before the fix lands (asserts `.row` count = 2 against the old form-only modal which has no `.row` elements).
- [x] Manual smoke: ran the sandbox locally, confirmed the modal renders two rows, Taken updates in place, modal closes after the last tap, and a reload no longer fires it.

# Checklist

- [x] Commit message follows CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [x] Docs updated (`MANIFEST-SCHEMA.md`, `docs/CARDS.md`, system prompt)
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens

# Breaking changes

None. `mode` is optional and defaults to `"modal"`; existing manifests without `prompt.mode` continue to render the legacy form. The two production instances run schedule cards without `prompt.mode` set today, so no migration is required to upgrade.