### PR TITLE
feat(ui): mark fallbackToLatest carry-over entries with dim + Nd ago chip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Added
+
+- **Carry-over visual cue on `fallbackToLatest` cards.** When a
+  `generic-card` with `meta.view.fallbackToLatest: true` displays a
+  prior-day row on Today (because today has no entry yet), the
+  headline now renders dimmed with a dotted underline, and a small
+  `Nd ago` chip appears below any existing secondary line. Built-in
+  and not opt-out: the whole point is to remove uncertainty about
+  whether a value was logged today or carried over from a previous
+  day. The chip clears as soon as a row for today is logged. Past-
+  date navigation is unaffected (the fallback path is Today-only).
+  See #231.
+
 ### Changed
 
 - **`meta.view.dateContext` renamed to `meta.view.fallbackToLatest`

--- a/MANIFEST-SCHEMA.md
+++ b/MANIFEST-SCHEMA.md
@@ -173,7 +173,12 @@ All view configs share the same shape:
                                       //   recent prior row instead of an
                                       //   empty state. The edit button
                                       //   still always targets today.
-                                      //   See #228.
+                                      //   When the fallback is active the
+                                      //   headline renders dimmed + dotted-
+                                      //   underlined with an "Nd ago" chip
+                                      //   so the value is visibly marked
+                                      //   as carry-over (built-in, not
+                                      //   opt-out). See #228, #231.
   "expanded":         false,          // allow click-to-expand
   "display":          { ... },        // template config (generic-card)
   "source":           "other-card-id" // virtual/computed cards only

--- a/docs/CARDS.md
+++ b/docs/CARDS.md
@@ -191,6 +191,10 @@ Fields:
   targets the viewed date regardless of this flag (see #227). The
   legacy `dateContext: "latest"` string is read as
   `fallbackToLatest: true` during the deprecation window — see #228.
+  When the fallback is active, the headline renders dimmed with a
+  dotted underline and a small `Nd ago` chip below the secondary
+  line so the value is visibly marked as a carry-over rather than a
+  fresh entry — built-in, not opt-out. See #231.
 - `slot` (`"top"` | `null`): if `"top"`, the card spans the full row
 - `order` (int): view-specific ordering override; falls back to `meta.order`
 - `display` (object): see the **generic-card** section below

--- a/public/js/components/eh-generic-card.js
+++ b/public/js/components/eh-generic-card.js
@@ -41,6 +41,7 @@ import { renderTemplate, evaluateThresholds, computeTrend } from '../lib/display
 import { registerRenderer } from '../renderer-registry.js';
 import { EhBaseCard, invalidateManifestCache } from './eh-base-card.js';
 import { errorFromResponse } from '../lib/save-error.js';
+import { daysBetweenISO } from '../lib/date-util.js';
 import './eh-input-form.js';
 
 export class EhGenericCard extends EhBaseCard {
@@ -163,6 +164,30 @@ export class EhGenericCard extends EhBaseCard {
         font-weight: 700;
         color: var(--text-primary);
         line-height: 1.2;
+      }
+      /* Carry-over: today has no row but the card opted into
+         fallbackToLatest, so the headline is yesterday's value (or
+         older). Dim the value + dotted-underline it so the user knows
+         the number isn't fresh. Paired with the .gen-carry-chip below.
+         See #231. */
+      .gen-headline.carry-over {
+        opacity: 0.7;
+        text-decoration: underline dotted;
+        text-underline-offset: 4px;
+        text-decoration-color: var(--text-muted, var(--text-secondary));
+      }
+      .gen-carry-chip {
+        display: inline-block;
+        font-size: 10px;
+        font-weight: 600;
+        padding: 2px 8px;
+        border-radius: 10px;
+        background: var(--bg-hover, rgba(255, 255, 255, 0.06));
+        color: var(--text-muted, var(--text-secondary));
+        white-space: nowrap;
+      }
+      .gen-carry-line {
+        margin-top: 6px;
       }
       .gen-unit {
         font-size: 0.9rem;
@@ -299,6 +324,25 @@ export class EhGenericCard extends EhBaseCard {
     // thresholds, trend arrow); the form consumes editEntry.
     const entry = displayEntry;
 
+    // Carry-over: on Today with no exact-date row, but the
+    // fallbackToLatest path resolved a prior row. Surface this so the
+    // user can tell stale-from-prior-day apart from fresh-today. See
+    // #231. The display fallback only triggers on Today, so this
+    // condition is a sufficient detector — past-date navigation never
+    // hits the fallback path in _currentEntry().
+    const isToday = this.dateMode === 'today' || !this.dateMode;
+    const isCarryOver = isToday
+      && hasEntry
+      && !hasEditEntry
+      && entry?.date
+      && entry.date !== this.date;
+    const carryOverDays = isCarryOver
+      ? daysBetweenISO(entry.date, this.date)
+      : null;
+    const carryOverLabel = (carryOverDays != null && carryOverDays > 0)
+      ? `${carryOverDays}d ago`
+      : null;
+
     const canWrite = this._canWrite
       && Array.isArray(meta?.writeable?.inputs)
       && meta.writeable.inputs.length > 0;
@@ -353,7 +397,7 @@ export class EhGenericCard extends EhBaseCard {
           ></eh-input-form>
         ` : hasEntry ? html`
           <div class="gen-row">
-            <span class="gen-headline">${headline}</span>
+            <span class="gen-headline ${isCarryOver ? 'carry-over' : ''}">${headline}</span>
             ${display.unit ? html`<span class="gen-unit">${display.unit}</span>` : ''}
             ${trend ? html`
               <span class="gen-trend ${trend.dir}" title="vs ${trend.prev.date}">
@@ -365,6 +409,10 @@ export class EhGenericCard extends EhBaseCard {
               </span>` : ''}
           </div>
           ${secondary ? html`<div class="gen-secondary">${secondary}</div>` : ''}
+          ${carryOverLabel ? html`
+            <div class="gen-carry-line">
+              <span class="gen-carry-chip" title="Last logged ${entry.date}">${carryOverLabel}</span>
+            </div>` : ''}
         ` : html`
           <div class="gen-empty">${headline}</div>
         `}

--- a/public/js/lib/date-util.js
+++ b/public/js/lib/date-util.js
@@ -15,3 +15,17 @@ export function localDateStr(date) {
 export function localToday() {
   return localDateStr(new Date());
 }
+
+// Whole-day difference between two YYYY-MM-DD ISO date strings (later
+// minus earlier). Anchors at UTC midnight so DST shifts can't add or
+// drop an hour and flip the count. Negative when `later` precedes
+// `earlier`. Returns null if either argument is malformed. See #231.
+export function daysBetweenISO(earlier, later) {
+  if (typeof earlier !== 'string' || typeof later !== 'string') return null;
+  const re = /^(\d{4})-(\d{2})-(\d{2})$/;
+  const a = re.exec(earlier);
+  const b = re.exec(later);
+  if (!a || !b) return null;
+  const ms = Date.UTC(+b[1], +b[2] - 1, +b[3]) - Date.UTC(+a[1], +a[2] - 1, +a[3]);
+  return Math.round(ms / 86_400_000);
+}

--- a/tests-e2e/carry-over-visual-cue.spec.js
+++ b/tests-e2e/carry-over-visual-cue.spec.js
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/carry-over-visual-cue.spec.js
+// Regression for #231: cards with fallbackToLatest:true that resolve
+// to a PRIOR-day row on Today must visually mark the headline as
+// stale (dimmed + dotted underline) and render an `Nd ago` chip
+// below any existing secondary line. Logging today's row clears both
+// signals.
+
+const { test, expect } = require('./helpers/auth-fixture');
+const { todayISO, shiftDays } = require('./helpers/seed-manifests');
+
+// These tests mutate sandbox state (strip today's row, then put it
+// back). Run them in serial so a failed mid-test doesn't leak data
+// into the next one's assertions.
+test.describe.configure({ mode: 'serial' });
+
+test.describe('#231: fallbackToLatest carry-over visual cue', () => {
+  // Mark the mood prompt as already-shown today so it doesn't fire
+  // mid-spec when a sibling test temporarily strips mood. Without this,
+  // a stale prompt modal can intercept clicks meant for the date arrows.
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      const d = new Date();
+      const today = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+      try { localStorage.setItem(`klebb-prompt-shown-mood-${today}`, '1'); } catch {}
+    });
+  });
+
+  test('weight card on Today with no today-row shows dimmed headline + Nd ago chip', async ({ page, sandboxState }) => {
+    const today = todayISO();
+    const baseUrl = sandboxState.baseUrl;
+
+    // Snapshot weight so we can restore.
+    const original = await (await page.request.get(`${baseUrl}/api/manifests/weight/data`)).json();
+
+    // Strip today's row, leave today-1 in place. Weight seed already
+    // has rows at today-4, today-2, today-1, today; remove only today.
+    const without = original.data.filter(r => r.date !== today);
+    const strip = await page.request.post(`${baseUrl}/api/manifests/weight/data`, {
+      data: { data: without },
+    });
+    expect(strip.status()).toBe(200);
+
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible();
+
+    const weightCard = page.locator('eh-generic-card', { hasText: 'Weight' }).first();
+    // The most recent prior row is today-1, so the chip should read 1d ago.
+    await expect(weightCard.locator('.gen-headline.carry-over')).toBeVisible();
+    await expect(weightCard.locator('.gen-carry-chip')).toHaveText('1d ago');
+
+    // Now log a row for today via the API and reload — both signals clear.
+    const restore = await page.request.post(`${baseUrl}/api/manifests/weight/data`, {
+      data: { data: original.data },
+    });
+    expect(restore.status()).toBe(200);
+
+    await page.goto('/');
+    await expect(weightCard).toBeVisible();
+    await expect(weightCard.locator('.gen-headline.carry-over')).toHaveCount(0);
+    await expect(weightCard.locator('.gen-carry-chip')).toHaveCount(0);
+  });
+
+  test('chip stacks below an existing secondary line (mood card)', async ({ page, sandboxState }) => {
+    const today = todayISO();
+    const baseUrl = sandboxState.baseUrl;
+    const original = await (await page.request.get(`${baseUrl}/api/manifests/mood/data`)).json();
+
+    // Make sure today-1 has a note so the secondary line renders.
+    const yesterday = shiftDays(today, -1);
+    const seeded = original.data
+      .filter(r => r.date !== today)
+      .map(r => r.date === yesterday ? { ...r, note: 'felt steady' } : r);
+    const seed = await page.request.post(`${baseUrl}/api/manifests/mood/data`, {
+      data: { data: seeded },
+    });
+    expect(seed.status()).toBe(200);
+
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible();
+
+    const moodCard = page.locator('eh-generic-card', { hasText: 'Mood' }).first();
+    // Carry-over from today-1 → 1d ago.
+    await expect(moodCard.locator('.gen-headline.carry-over')).toBeVisible();
+    await expect(moodCard.locator('.gen-carry-chip')).toHaveText('1d ago');
+    // Secondary line still rendered with the note.
+    await expect(moodCard.locator('.gen-secondary')).toContainText('felt steady');
+    // The chip lives in its own line (.gen-carry-line), not inside the
+    // secondary, so it never replaces the note.
+    await expect(moodCard.locator('.gen-carry-line .gen-carry-chip')).toBeVisible();
+
+    // Restore.
+    const restore = await page.request.post(`${baseUrl}/api/manifests/mood/data`, {
+      data: { data: original.data },
+    });
+    expect(restore.status()).toBe(200);
+  });
+
+  test('non-fallback card (workouts) on a rest day shows neither dimming nor chip', async ({ page, sandboxState }) => {
+    const baseUrl = sandboxState.baseUrl;
+    const today = todayISO();
+    // workouts is HAE-only by default (fromWebapp: false). Temporarily
+    // PATCH it writeable so we can strip today's row via the webapp
+    // path, then restore.
+    const enable = await page.request.fetch(`${baseUrl}/api/manifests/workouts`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      data: { meta: { writeable: { fromWebapp: true, pastAllowed: true, todayAllowed: true, futureAllowed: false } } },
+    });
+    expect(enable.status()).toBe(200);
+
+    const original = await (await page.request.get(`${baseUrl}/api/manifests/workouts/data`)).json();
+    const without = original.data.filter(r => r.date !== today);
+    const strip = await page.request.post(`${baseUrl}/api/manifests/workouts/data`, {
+      data: { data: without },
+    });
+    expect(strip.status()).toBe(200);
+
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible();
+
+    const workoutsCard = page.locator('eh-generic-card', { hasText: 'Workouts' }).first();
+    // Empty state — no fallback to a previous workout, no chip, no dim.
+    await expect(workoutsCard.locator('.gen-headline.carry-over')).toHaveCount(0);
+    await expect(workoutsCard.locator('.gen-carry-chip')).toHaveCount(0);
+    await expect(workoutsCard).toContainText(/no workout today/i);
+
+    const restoreData = await page.request.post(`${baseUrl}/api/manifests/workouts/data`, {
+      data: { data: original.data },
+    });
+    expect(restoreData.status()).toBe(200);
+    const restoreMeta = await page.request.fetch(`${baseUrl}/api/manifests/workouts`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      data: { meta: { writeable: { fromWebapp: false } } },
+    });
+    expect(restoreMeta.status()).toBe(200);
+  });
+
+  test('past-date navigation never shows the chip even on a fallback card', async ({ page, sandboxState }) => {
+    const baseUrl = sandboxState.baseUrl;
+    // Weight seed already has a today-3 gap (rows at today-4 and today-2,
+    // none at today-3). Navigate to today-3 and assert no chip — the
+    // fallback path is Today-only.
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible();
+
+    await page.locator('.arrow-btn[aria-label="previous day"]').click();
+    await page.locator('.arrow-btn[aria-label="previous day"]').click();
+    await page.locator('.arrow-btn[aria-label="previous day"]').click();
+
+    const weightCard = page.locator('eh-generic-card', { hasText: 'Weight' }).first();
+    await expect(weightCard.locator('.gen-carry-chip')).toHaveCount(0);
+    await expect(weightCard.locator('.gen-headline.carry-over')).toHaveCount(0);
+  });
+});

--- a/tests/date-util.test.js
+++ b/tests/date-util.test.js
@@ -9,7 +9,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { localDateStr, localToday } from '../public/js/lib/date-util.js';
+import { localDateStr, localToday, daysBetweenISO } from '../public/js/lib/date-util.js';
 
 test('localDateStr: formats a local Date as YYYY-MM-DD', () => {
   const d = new Date(2026, 3, 25, 7, 0, 0); // 25 April 2026, local
@@ -44,4 +44,54 @@ test('localToday: returns today in local timezone, YYYY-MM-DD format', () => {
   assert.match(result, /^\d{4}-\d{2}-\d{2}$/);
   const now = new Date();
   assert.equal(result, localDateStr(now));
+});
+
+// --- daysBetweenISO (#231) ---
+
+test('daysBetweenISO: same day → 0', () => {
+  assert.equal(daysBetweenISO('2026-05-17', '2026-05-17'), 0);
+});
+
+test('daysBetweenISO: 1d ago / 2d ago / 7d ago', () => {
+  assert.equal(daysBetweenISO('2026-05-16', '2026-05-17'), 1);
+  assert.equal(daysBetweenISO('2026-05-15', '2026-05-17'), 2);
+  assert.equal(daysBetweenISO('2026-05-10', '2026-05-17'), 7);
+});
+
+test('daysBetweenISO: month boundary', () => {
+  assert.equal(daysBetweenISO('2026-04-30', '2026-05-01'), 1);
+  assert.equal(daysBetweenISO('2026-04-25', '2026-05-02'), 7);
+});
+
+test('daysBetweenISO: year boundary', () => {
+  assert.equal(daysBetweenISO('2026-12-31', '2027-01-01'), 1);
+  assert.equal(daysBetweenISO('2026-12-29', '2027-01-03'), 5);
+});
+
+test('daysBetweenISO: leap-year-spanning still rounds clean', () => {
+  // 2024 is a leap year; 2025 is not. The helper should not be fazed
+  // by Feb 29 sitting between two ISO dates a week apart.
+  assert.equal(daysBetweenISO('2024-02-26', '2024-03-04'), 7);
+});
+
+test('daysBetweenISO: DST shoulder dates do not slip an hour and round wrong', () => {
+  // AEST→AEDT in Sydney happens on 2026-10-04 02:00 → 03:00. UTC-anchor
+  // means the helper is unaffected regardless of runner timezone.
+  assert.equal(daysBetweenISO('2026-10-03', '2026-10-04'), 1);
+  assert.equal(daysBetweenISO('2026-10-04', '2026-10-05'), 1);
+  // EDT→EST in New York on 2026-11-01 (the other direction).
+  assert.equal(daysBetweenISO('2026-10-31', '2026-11-01'), 1);
+  assert.equal(daysBetweenISO('2026-11-01', '2026-11-02'), 1);
+});
+
+test('daysBetweenISO: negative when later precedes earlier', () => {
+  assert.equal(daysBetweenISO('2026-05-17', '2026-05-15'), -2);
+});
+
+test('daysBetweenISO: malformed input returns null', () => {
+  assert.equal(daysBetweenISO(null, '2026-05-17'), null);
+  assert.equal(daysBetweenISO('2026-05-17', undefined), null);
+  assert.equal(daysBetweenISO('2026/05/17', '2026-05-17'), null);
+  assert.equal(daysBetweenISO('not a date', '2026-05-17'), null);
+  assert.equal(daysBetweenISO('', ''), null);
 });


### PR DESCRIPTION
# What changed

Cards with \`meta.view.fallbackToLatest: true\` that resolve to a prior-day row on Today previously rendered identically to a fresh-today row, with no signal that the value was carried over. The user could plausibly mistake yesterday's number (or older) for one they entered today.

This PR makes the carry-over case visually obvious. Two reinforcing signals applied together:

1. **Dimmed headline.** \`opacity: 0.7\` + dotted underline on the value.
2. **\`Nd ago\` chip.** Small muted pill on its own line below the secondary content. Phrasing is \`1d ago\`, \`2d ago\`, ..., terse and uniform.

Built-in, not opt-out. Scope is \`generic-card\` only — \`schedule-card\`, \`combination-card\`, and \`list-card\` don't use the fallback path. Past-date navigation is unaffected (the fallback path is Today-only).

# Why

Fixes #231. Surfaced while reviewing post-#228 fallback semantics: the behaviour is genuinely useful (slow-changing measurements like weight don't read as \"No data\" on a morning before logging), but the lack of any cue means a stale value can pass for a fresh one. The fix is a display-only concern; data, write path, and edit flow already do the right thing post-#227.

# How

- The renderer already computes \`displayEntry\` (honours fallback) and \`editEntry\` (always today). The carry-over case is precisely \`displayEntry !== null && editEntry === null\` on Today. No new state needed; just a derived boolean.
- \`public/js/components/eh-generic-card.js\`: derive \`isCarryOver\` + \`carryOverDays\` in \`renderCard()\`. Apply \`.carry-over\` class to the headline. Render \`.gen-carry-line > .gen-carry-chip\` after the secondary slot so it always stacks below any existing secondary content.
- \`public/js/lib/date-util.js\`: new \`daysBetweenISO(earlier, later)\` helper. UTC-anchored so DST shifts can't flip the count. Returns null on malformed input.
- Schema docs: \`MANIFEST-SCHEMA.md\` and \`docs/CARDS.md\` describe the new visual treatment under \`fallbackToLatest\`.
- No agent / system prompt changes — the cue is automatic, the chat agent doesn't need to know about it.

# Testing

- [x] \`npm test\` passes locally (851/853 — pre-existing intermittent \`chat-history-api\` flake on parallel runs and the personal-refs hygiene infra noise are both unrelated; both pass when isolated).
- [x] \`npm run test:e2e\` passes locally (32/32, includes 4 new \`carry-over-visual-cue\` cases).
- [x] New unit tests for \`daysBetweenISO\`: same-day, 1d/2d/7d, month/year/leap-year boundaries, DST shoulder dates, negative direction, malformed input.
- [x] New e2e spec verified to fail on \`main\` before the renderer change lands.
- [x] Manual smoke locally: weight card with today stripped → headline dimmed, dotted underline, \`1d ago\` chip below; logging today → snaps back to canonical full-opacity / no-chip.

# Checklist

- [x] Commit message follows CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [x] Docs updated (\`MANIFEST-SCHEMA.md\`, \`docs/CARDS.md\`)
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens

# Breaking changes

None. The visual treatment only renders when an existing card already opted into \`fallbackToLatest\` (or its legacy alias) AND today has no row. Cards without the flag, and cards with a row for today, render exactly as before.