### PR TITLE
feat(data): emit sessionCount on workouts merge-per-date rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **`workouts` rows expose `sessionCount`.** The
+  `workouts-merge-per-date` aggregator now emits a `sessionCount`
+  field (positive integer) on every merged daily row, equal to the
+  number of distinct HAE workout entries for that date. This makes a
+  `goalWeekly` ring with `accessor: "sessionCount"` actually count
+  distinct sessions across the week (e.g. 2 walks + 1 run + 1 cycle =
+  4) regardless of how long each session ran. Existing minimal
+  `{date, trained, type}` rows continue to validate; an HAE re-push
+  backfills `sessionCount`. Catalogue describe block tells the chat
+  assistant about the field and recommends it for per-session weekly
+  rings. See #240.
+
 - **Weekly accumulation rings on `combination-card`.** Ring-segment
   entries now accept `goalWeekly` as an alternative to `goalDaily`. A
   weekly ring fills against the sum of the accessor across all rows in

--- a/health-auto-export/describe.js
+++ b/health-auto-export/describe.js
@@ -113,10 +113,15 @@ function describeCatalogue() {
   lines.push('  land on the same date, additive fields (durationMin, distanceKm,');
   lines.push('  calories, elevationM) are summed; `type` becomes a comma-');
   lines.push('  separated chronological dedup list; `avgHr` is duration-');
-  lines.push('  weighted; `maxHr` is the max; `startTime` is the earliest. So');
-  lines.push('  a richer template like `{trained:check} {type}` headline +');
-  lines.push('  `{durationMin} min · {distanceKm|} km · {calories} cal`');
-  lines.push('  secondary will show daily totals on multi-session days.');
+  lines.push('  weighted; `maxHr` is the max; `startTime` is the earliest;');
+  lines.push('  `sessionCount` is how many distinct sessions HAE delivered for');
+  lines.push('  that day (always >= 1 on a workout day). A richer template like');
+  lines.push('  `{trained:check} {type}` headline + `{durationMin} min ·');
+  lines.push('  {distanceKm|} km · {calories} cal` secondary will show daily');
+  lines.push('  totals on multi-session days. To track distinct activity');
+  lines.push('  sessions per week (e.g. a goalWeekly ring counting walks + runs');
+  lines.push('  + cycles regardless of duration), use `accessor: "sessionCount"`');
+  lines.push('  on a ring-segment that points at the workouts donor.');
   lines.push('');
 
   const keys = Object.keys(catalogue).sort();

--- a/health-auto-export/ingest.js
+++ b/health-auto-export/ingest.js
@@ -156,7 +156,7 @@ function aggregate(rows, strategy) {
         // earliest local start time. See #235 for the full rule table.
         const sorted = [...list].sort((a, b) =>
           String(a.startTime || '').localeCompare(String(b.startTime || '')));
-        const acc = { date };
+        const acc = { date, sessionCount: sorted.length };
         const trained = sorted.some(r => r.trained === true);
         if (trained) acc.trained = true;
 

--- a/tests/health-auto-export.describe.test.js
+++ b/tests/health-auto-export.describe.test.js
@@ -46,6 +46,12 @@ describe('describeCatalogue', () => {
     assert.match(out, /per-day rollup/i);
   });
 
+  test('describes sessionCount + goalWeekly accessor pattern (#240)', () => {
+    const out = describeCatalogue();
+    assert.match(out, /sessionCount/);
+    assert.match(out, /goalWeekly/);
+  });
+
   test('carries display-template guidance for HAE-backed cards', () => {
     const out = describeCatalogue();
     assert.match(out, /round\(N\)/);

--- a/tests/health-auto-export.workouts.test.js
+++ b/tests/health-auto-export.workouts.test.js
@@ -152,7 +152,7 @@ describe('aggregate(workouts-merge-per-date)', () => {
     }], 'workouts-merge-per-date');
     assert.equal(out.length, 1);
     assert.deepEqual(out[0], {
-      date: '2026-05-04', trained: true, type: 'Outdoor Walk',
+      date: '2026-05-04', sessionCount: 1, trained: true, type: 'Outdoor Walk',
       durationMin: 30, distanceKm: 2.5, calories: 200,
       avgHr: 110, maxHr: 130, elevationM: 25, startTime: '09:30',
     });
@@ -252,5 +252,34 @@ describe('aggregate(workouts-merge-per-date)', () => {
     ], 'workouts-merge-per-date');
     assert.equal(out.length, 1);
     assert.equal(out[0].type, 'Outdoor Walk, Functional Strength Training');
+  });
+
+  test('emits sessionCount = 1 for a single-session day', () => {
+    const out = aggregate([
+      { date: '2026-05-04', trained: true, type: 'Outdoor Walk', durationMin: 30 },
+    ], 'workouts-merge-per-date');
+    assert.equal(out[0].sessionCount, 1);
+  });
+
+  test('emits sessionCount equal to the number of merged sessions', () => {
+    const out = aggregate([
+      { date: '2026-05-04', trained: true, type: 'Outdoor Walk', startTime: '07:30' },
+      { date: '2026-05-04', trained: true, type: 'Functional Strength Training', startTime: '11:00' },
+      { date: '2026-05-04', trained: true, type: 'Cycling', startTime: '18:00' },
+    ], 'workouts-merge-per-date');
+    assert.equal(out.length, 1);
+    assert.equal(out[0].sessionCount, 3);
+  });
+
+  test('sessionCount is per-date: separate days get their own count', () => {
+    const out = aggregate([
+      { date: '2026-05-04', trained: true, type: 'Walk', startTime: '08:00' },
+      { date: '2026-05-04', trained: true, type: 'Lift', startTime: '18:00' },
+      { date: '2026-05-05', trained: true, type: 'Walk', startTime: '08:00' },
+    ], 'workouts-merge-per-date');
+    assert.equal(out.length, 2);
+    const byDate = Object.fromEntries(out.map(r => [r.date, r.sessionCount]));
+    assert.equal(byDate['2026-05-04'], 2);
+    assert.equal(byDate['2026-05-05'], 1);
   });
 });


### PR DESCRIPTION
# What changed

The `workouts-merge-per-date` aggregator now emits `sessionCount`
(positive integer) on every merged daily row. It is the number of
distinct HAE workout entries received for that date.

# Why

Fixes #240. With #238 shipped (weekly ring accumulation), the operator
wants a "4 exercise sessions per week" inner ring on Activity Overview
that fills regardless of session duration or type — 2 walks + 1 run +
1 cycle = 4. The merged workouts row had no field that incremented
per session: `trained` is boolean, `type` is a comma-joined string,
duration/calories sum but conflate session count with effort.

# How

One-line addition in `health-auto-export/ingest.js:159`:
`const acc = { date, sessionCount: sorted.length };` — pre-aggregation
HAE has already produced one entry per session, so `sorted.length` is
authoritative.

Catalogue describe block at `health-auto-export/describe.js` updated
to document the field and recommend `accessor: "sessionCount"` for
per-session weekly rings.

# Testing

- [x] `npm test` passes locally (905/906; the one failure is the
      pre-existing `no-personal-refs` hit on `main`, unrelated)
- [x] New unit tests cover: single-session day → 1; three-session day
      → 3; per-date counting (two days with different counts)
- [x] Existing single-row test updated to expect `sessionCount: 1`
- [x] Describe test asserts the agent prompt now mentions
      `sessionCount` and `goalWeekly`
- [ ] Manual QA: re-push HAE on the test instance, confirm Activity
      Overview inner ring with `accessor: "sessionCount"` +
      `goalWeekly: 4` fills correctly across mixed session types

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [x] Docs updated (catalogue describe block)
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens

# Breaking changes

None. The new field is purely additive. Old minimal
`{date, trained, type}` rows continue to validate (single-session
backfill on next HAE push).