### PR TITLE
feat(chat): add read_doc tool so Klebbius can read shipped docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,20 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Chat agent can read its own docs at inference time.** New
+  `read_doc(path)` function-call tool surfaces every shipped doc
+  (README, MANIFEST-SCHEMA, CHANGELOG, CONTRIBUTING\*, SECURITY,
+  docs/CARDS, docs/RECIPES, docs/CHAT-AGENT, docs/HEALTH-AUTO-EXPORT,
+  docs/DEPLOY, docs/TESTING, docs/VOICE, docs/CI) to the chat agent.
+  Local disk only; the agent always sees the same version of the docs
+  as the running app, so a deployed instance on an older release
+  isn't misled by newer guidance on main. The system prompt now
+  carries an `## Available docs` catalogue listing every callable
+  path with a one-line summary; the agent picks one and calls
+  `read_doc`. Allowlist-gated (no traversal, no symlink escape, no
+  reading of gitignored operator files like CLAUDE.md or
+  BRIEF-FOR-CC.md). See #246.
+
 - **`workouts` rows expose `sessionCount`.** The
   `workouts-merge-per-date` aggregator now emits a `sessionCount`
   field (positive integer) on every merged daily row, equal to the

--- a/chat/docs.js
+++ b/chat/docs.js
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// chat/docs.js
+//
+// Whitelist-gated reader for in-repo documentation. Backs the read_doc
+// chat tool: the agent gets a catalogue of available paths in the
+// system prompt and can pull any of them on demand. Local-disk only;
+// the agent always sees the same version of the docs as the running
+// app, so a deployed instance on an older release won't be misled by
+// newer guidance on main.
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+// Hand-curated allowlist. Every entry is (a) a path relative to the
+// repo root, in POSIX form, and (b) a one-line summary used in the
+// system-prompt catalogue. Add to this list as new docs are added.
+// `.claude/`, BRIEF-FOR-CC.md, CLAUDE.md, data/, credentials/ are NOT
+// listed and cannot be read through this tool, by design.
+const DOC_INDEX = [
+  { path: 'README.md',                    summary: 'Quickstart, architecture overview, env vars, Docker section.' },
+  { path: 'MANIFEST-SCHEMA.md',           summary: 'Full klebb.datafile.v1 reference. The authoritative schema doc.' },
+  { path: 'CHANGELOG.md',                 summary: 'Per-release changelog; useful for "when did X land" questions.' },
+  { path: 'CONTRIBUTING.md',              summary: 'Repo workflow, commit conventions, branch naming.' },
+  { path: 'CONTRIBUTING-PROMPTS.md',      summary: 'Authoring starter prompts for the chat widget.' },
+  { path: 'CONTRIBUTING-TEMPLATES.md',    summary: 'Authoring .klebb.json templates that ship under templates/.' },
+  { path: 'SECURITY.md',                  summary: 'Threat model, reporting, secrets handling.' },
+  { path: 'docs/CARDS.md',                summary: 'Card authoring guide. How to write a manifest end-to-end.' },
+  { path: 'docs/RECIPES.md',              summary: 'Copy-pasteable manifest examples by card type.' },
+  { path: 'docs/CHAT-AGENT.md',           summary: 'Chat widget + gateway integration; AGENT_API_TOKEN write contract.' },
+  { path: 'docs/HEALTH-AUTO-EXPORT.md',   summary: 'iPhone Health Auto Export ingest: catalogue, row shapes, setup.' },
+  { path: 'docs/DEPLOY.md',               summary: 'Single-user and multi-user deploy guide; systemd + Docker.' },
+  { path: 'docs/TESTING.md',              summary: 'Three test layers, bug-fix workflow rubric.' },
+  { path: 'docs/VOICE.md',                summary: 'Voice chat (Fish Audio) configuration and usage.' },
+  { path: 'docs/CI.md',                   summary: 'GitHub Actions CI overview; what runs and when.' },
+];
+
+const ALLOWED_PATHS = new Set(DOC_INDEX.map(d => d.path));
+const MAX_BYTES = 200_000;
+
+function listDocs() {
+  return DOC_INDEX.slice();
+}
+
+// Resolve `relPath` against the repo root, but only after validating
+// that it's an exact entry on the allowlist. This rejects everything
+// the allowlist doesn't explicitly enumerate: traversal sequences,
+// absolute paths, symlinks pointing outside, alternate casings. Also
+// double-checks the resolved path stays inside REPO_ROOT in case a
+// future symlink in the docs/ tree tries to escape.
+function readDoc(relPath) {
+  if (typeof relPath !== 'string' || !relPath) {
+    return { error: 'path is required' };
+  }
+  const normalised = relPath.replace(/\\/g, '/');
+  if (!ALLOWED_PATHS.has(normalised)) {
+    return {
+      error: `unknown doc: ${relPath}. See the system prompt for the list of available paths.`,
+    };
+  }
+  const abs = path.resolve(REPO_ROOT, normalised);
+  const rootWithSep = REPO_ROOT + path.sep;
+  if (!abs.startsWith(rootWithSep) && abs !== REPO_ROOT) {
+    return { error: `path escapes repo root: ${relPath}` };
+  }
+  let content;
+  try {
+    content = fs.readFileSync(abs, 'utf8');
+  } catch (e) {
+    return { error: `failed to read ${relPath}: ${e.message}` };
+  }
+  let truncated = false;
+  if (Buffer.byteLength(content, 'utf8') > MAX_BYTES) {
+    content = content.slice(0, MAX_BYTES);
+    truncated = true;
+  }
+  return { path: normalised, content, truncated };
+}
+
+// Markdown-formatted catalogue for embedding in the chat system
+// prompt. Lists every path on the allowlist with its one-line
+// summary; the agent uses this to pick which doc to fetch.
+function describeDocsCatalogue() {
+  const lines = [
+    '## Available docs',
+    '',
+    'Klebb ships its docs alongside the app. Call `read_doc(path)` to',
+    'fetch the full text of any of the following at inference time.',
+    'You always get the same version as the running app, so use this',
+    'instead of guessing from training data when the user asks about',
+    'schema, renderer contracts, or workflows.',
+    '',
+  ];
+  for (const d of DOC_INDEX) {
+    lines.push(`- \`${d.path}\` — ${d.summary}`);
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+module.exports = {
+  DOC_INDEX,
+  listDocs,
+  readDoc,
+  describeDocsCatalogue,
+};

--- a/chat/tools.js
+++ b/chat/tools.js
@@ -7,6 +7,7 @@
 // safe to do inline inside a chat request.
 
 const registry = require('../manifests/registry');
+const { readDoc } = require('./docs');
 
 const TOOL_DEFS = [
   {
@@ -130,6 +131,26 @@ const TOOL_DEFS = [
   {
     type: 'function',
     function: {
+      name: 'read_doc',
+      description:
+        "Fetch the full text of one of Klebb's shipped documentation files (README, MANIFEST-SCHEMA, docs/*, etc.). The system prompt lists every available path under '## Available docs' with a one-line summary; pass one of those paths verbatim. Use this when the user asks about schema fields, renderer contracts, deploy steps, or any other topic where the docs are authoritative — you'll get the same version the running app shipped with, so you won't be misled by training-data drift or by what's on main. Unknown or non-allowlisted paths return {error}; do not retry with traversal sequences or absolute paths.",
+      parameters: {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            description:
+              "Repo-relative POSIX path of the doc to read, exactly as it appears in the system prompt's catalogue (e.g. 'MANIFEST-SCHEMA.md' or 'docs/CARDS.md').",
+          },
+        },
+        required: ['path'],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
       name: 'patch_manifest',
       description:
         "Edit a card's meta or description in place without touching its data. Uses RFC 7396 JSON Merge Patch: nested objects deep-merge, arrays replace wholesale, null removes a key. Use this for any meta-only change — thresholds, labels, emoji maps, input types, writeable flags. The data block is preserved byte-for-byte. You CANNOT change $schema or meta.id via this tool; for those, delete_manifest + create_manifest is the path (and data will be lost). ALWAYS call read_manifest first so you're patching over the real current meta. Destructive-feeling patches (removing inputs from a writeable card, flipping writeable.fromWebapp from true to false on a card that has data) must be confirmed with the user exactly once before calling this.",
@@ -225,6 +246,9 @@ function dispatchToolCall(tc, ctx) {
         const result = registry.patchManifest(args.id, args.patch);
         recordTouch(ctx, { id: args.id, flow: 'edit' });
         return JSON.stringify({ ok: true, ...result });
+      }
+      case 'read_doc': {
+        return JSON.stringify(readDoc(args.path));
       }
       default:
         return JSON.stringify({ error: 'unknown tool: ' + name });

--- a/config/env.js
+++ b/config/env.js
@@ -159,6 +159,7 @@ You, ${CHAT_AGENT_NAME}, are embedded in the dashboard itself. You act by callin
 - \`read_manifest(id)\` → full card content: meta + description + schema + data. No confirmation. Use before any write so you can see what you're changing and preserve everything else.
 - \`write_manifest_data(id, data)\` → replace the full data block of a card. Full-array rewrite, not a row-level patch — to add/edit/delete one row you first read_manifest, mutate the array in memory, then write it back. Rejected if \`meta.writeable.fromWebapp\` is not \`true\` (ingest-only cards are untouchable; use \`patch_manifest\` to flip the flag first if the user really wants to make the card writeable). Confirm with the user EXACTLY ONCE before a write that removes rows.
 - \`patch_manifest(id, patch)\` → edit meta or description without touching data. RFC 7396 JSON Merge Patch: nested objects deep-merge, ARRAYS REPLACE, \`null\` removes a key. Use for thresholds, labels, emoji maps, input types, writeable flags. Cannot change \`$schema\` or \`meta.id\`. Confirm ONCE before destructive-feeling patches (removing inputs from a writeable card, flipping \`writeable.fromWebapp\` from \`true\` to \`false\` on a card that has data).
+- \`read_doc(path)\` → fetch the full text of a Klebb doc shipped with this app. The "## Available docs" section below lists every callable path with a one-line summary. Reach for this whenever the user asks about schema, renderer contracts, deploy steps, ingest formats, or any other topic where the docs are authoritative — you'll get the same version the running app shipped with, so you won't be misled by training-data drift.
 
 ## When to use which write tool
 
@@ -172,6 +173,7 @@ Choose the smallest-blast-radius tool for the job:
 | "Stop showing this card" / "show it again" | \`hide_card\` / \`show_card\` |
 | "I want a new tracker for X" | \`create_manifest\` |
 | "Throw this card away and start over" (explicit data loss OK) | \`delete_manifest\` then \`create_manifest\` |
+| "How does X work?" / "What fields does Y accept?" / questions about schema, renderers, deploy, ingest | \`read_doc\` |
 
 **Read before write.** Any call to \`write_manifest_data\` or \`patch_manifest\` MUST be preceded by \`read_manifest\` in the same turn. Never blind-write — you'll clobber fields you didn't mean to touch. Arrays in JSON Merge Patch replace wholesale, so if you \`patch_manifest(id, {meta:{writeable:{inputs:[…]}}})\` you must include every input you want to keep, not just the one you're changing.
 

--- a/server.js
+++ b/server.js
@@ -25,6 +25,7 @@ const { describeCatalogue: describeHaeCatalogue } = require('./health-auto-expor
 const { CATEGORIES: MANIFEST_CATEGORIES } = require('./config/categories');
 const ccSuggestions = require('./meta/cc-suggestions');
 const { describeCcSchema } = require('./chat/describe-cc-schema');
+const { describeDocsCatalogue } = require('./chat/docs');
 
 // chat endpoint config (env-driven; see config/env.js)
 const CHAT_ENDPOINT_URL = ENV.CHAT_ENDPOINT_URL;
@@ -1360,6 +1361,12 @@ const server = http.createServer(async (req, res) => {
           // hallucinating view.slots[]/view.sources[] shapes.
           const ccSchemaBlock = '\n\n' + describeCcSchema() + '\n';
 
+          // Catalogue of doc paths the read_doc tool can fetch. Lets
+          // the agent pull MANIFEST-SCHEMA.md / docs/CARDS.md / etc.
+          // on demand instead of relying on whatever the prompt
+          // happens to inline today.
+          const docsCatalogueBlock = '\n\n' + describeDocsCatalogue() + '\n';
+
           // Constrain meta.category to the canonical enum. Klebb uses the
           // field for clustering heuristics (e.g. CC suggestions); unknown
           // values are silently dropped by the registry, so agent-invented
@@ -1389,7 +1396,7 @@ const server = http.createServer(async (req, res) => {
             '',
           ].join('\n');
 
-          let systemPrompt = HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock + haeCatalogueBlock + ccSchemaBlock + categoryBlock;
+          let systemPrompt = HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock + haeCatalogueBlock + ccSchemaBlock + docsCatalogueBlock + categoryBlock;
           if (voiceMode) {
             systemPrompt = `You are ${process.env.CHAT_AGENT_NAME || 'Chat'}, a health assistant.
 Voice mode is active: the user is speaking to you and will hear your reply aloud.
@@ -1422,7 +1429,7 @@ Return STRICTLY the JSON object. No leading/trailing text. No markdown fences.
 
 Original system prompt follows:
 
-` + HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock + haeCatalogueBlock + ccSchemaBlock + categoryBlock;
+` + HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock + haeCatalogueBlock + ccSchemaBlock + docsCatalogueBlock + categoryBlock;
           }
 
           // Prepend system prompt

--- a/tests/chat-prompt-cc-schema.test.js
+++ b/tests/chat-prompt-cc-schema.test.js
@@ -125,4 +125,18 @@ describe('chat proxy injects CC schema into system prompt', () => {
     assert.match(prompt, /view\.slots/);
     assert.match(prompt, /view\.sources/);
   });
+
+  test('system prompt advertises read_doc + the docs catalogue', async () => {
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'hello' }] },
+    });
+    assert.equal(res.status, 200);
+    const prompt = gateway.getLastPrompt();
+    assert.ok(prompt);
+    assert.match(prompt, /## Available docs/);
+    assert.match(prompt, /read_doc/);
+    assert.match(prompt, /MANIFEST-SCHEMA\.md/);
+    assert.match(prompt, /docs\/CARDS\.md/);
+  });
 });

--- a/tests/chat-tools-docs.test.js
+++ b/tests/chat-tools-docs.test.js
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/chat-tools-docs.test.js
+//
+// Covers the read_doc chat tool: TOOL_DEFS membership, the docs
+// module's allowlist + traversal protections, and the system-prompt
+// catalogue block.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const {
+  DOC_INDEX, listDocs, readDoc, describeDocsCatalogue,
+} = require('../chat/docs');
+const { TOOL_DEFS, dispatchToolCall } = require('../chat/tools');
+
+function makeToolCall(name, args) {
+  return { function: { name, arguments: JSON.stringify(args) } };
+}
+
+describe('chat/docs: index integrity', () => {
+  test('every allowlisted doc actually exists on disk', () => {
+    for (const entry of DOC_INDEX) {
+      const abs = path.resolve(REPO_ROOT, entry.path);
+      assert.ok(
+        fs.existsSync(abs),
+        `DOC_INDEX entry ${entry.path} does not exist on disk`,
+      );
+    }
+  });
+
+  test('every entry carries a non-empty summary', () => {
+    for (const entry of DOC_INDEX) {
+      assert.ok(entry.summary && entry.summary.length > 5,
+        `DOC_INDEX entry ${entry.path} missing summary`);
+    }
+  });
+
+  test('listDocs returns a copy, not the live array', () => {
+    const a = listDocs();
+    const b = listDocs();
+    assert.notStrictEqual(a, b);
+    assert.deepEqual(a, b);
+  });
+});
+
+describe('chat/docs.readDoc: success path', () => {
+  test('reads README.md and returns content + path', () => {
+    const res = readDoc('README.md');
+    assert.equal(res.path, 'README.md');
+    assert.ok(typeof res.content === 'string');
+    assert.ok(res.content.length > 0);
+    assert.equal(res.error, undefined);
+  });
+
+  test('reads docs/CARDS.md (subdir path) without traversal', () => {
+    const res = readDoc('docs/CARDS.md');
+    assert.equal(res.path, 'docs/CARDS.md');
+    assert.ok(res.content.length > 0);
+  });
+
+  test('accepts backslash-style paths by normalising to POSIX', () => {
+    const res = readDoc('docs\\CARDS.md');
+    assert.equal(res.path, 'docs/CARDS.md');
+    assert.ok(res.content.length > 0);
+  });
+});
+
+describe('chat/docs.readDoc: rejection path', () => {
+  test('rejects unknown allowlist entries', () => {
+    const res = readDoc('docs/SOMETHING-MADE-UP.md');
+    assert.match(res.error, /unknown doc/);
+  });
+
+  test('rejects relative traversal (../package.json)', () => {
+    const res = readDoc('../package.json');
+    assert.match(res.error, /unknown doc/);
+  });
+
+  test('rejects normalised traversal (docs/../config/env.js)', () => {
+    const res = readDoc('docs/../config/env.js');
+    assert.match(res.error, /unknown doc/);
+  });
+
+  test('rejects absolute paths', () => {
+    const res = readDoc('/etc/passwd');
+    assert.match(res.error, /unknown doc/);
+  });
+
+  test('rejects gitignored hygiene-risk files even if they exist', () => {
+    // CLAUDE.md and BRIEF-FOR-CC.md are gitignored operator-only files;
+    // they must not be reachable through this tool.
+    const a = readDoc('CLAUDE.md');
+    const b = readDoc('BRIEF-FOR-CC.md');
+    assert.match(a.error, /unknown doc/);
+    assert.match(b.error, /unknown doc/);
+  });
+
+  test('rejects empty / non-string input', () => {
+    assert.match(readDoc('').error, /required/);
+    assert.match(readDoc(null).error, /required/);
+    assert.match(readDoc(undefined).error, /required/);
+    assert.match(readDoc(42).error, /required/);
+  });
+});
+
+describe('chat/docs.describeDocsCatalogue', () => {
+  test('emits a markdown catalogue with every allowlisted path', () => {
+    const out = describeDocsCatalogue();
+    assert.match(out, /## Available docs/);
+    assert.match(out, /read_doc/);
+    for (const entry of DOC_INDEX) {
+      assert.ok(out.includes('`' + entry.path + '`'),
+        `catalogue missing ${entry.path}`);
+    }
+  });
+});
+
+describe('chat tools: read_doc', () => {
+  test('TOOL_DEFS includes read_doc with the expected schema shape', () => {
+    const def = TOOL_DEFS.find(t => t.function?.name === 'read_doc');
+    assert.ok(def, 'read_doc not registered');
+    assert.equal(def.type, 'function');
+    assert.deepEqual(def.function.parameters.required, ['path']);
+    assert.equal(def.function.parameters.properties.path.type, 'string');
+    assert.equal(def.function.parameters.additionalProperties, false);
+  });
+
+  test('dispatchToolCall(read_doc) returns stringified content for a real doc', () => {
+    const out = dispatchToolCall(makeToolCall('read_doc', { path: 'README.md' }));
+    const parsed = JSON.parse(out);
+    assert.equal(parsed.path, 'README.md');
+    assert.ok(parsed.content.length > 0);
+  });
+
+  test('dispatchToolCall(read_doc) returns {error} for unknown path', () => {
+    const out = dispatchToolCall(makeToolCall('read_doc', { path: 'docs/nope.md' }));
+    const parsed = JSON.parse(out);
+    assert.match(parsed.error, /unknown doc/);
+  });
+
+  test('dispatchToolCall(read_doc) rejects path traversal at the tool layer too', () => {
+    const out = dispatchToolCall(makeToolCall('read_doc', { path: '../package.json' }));
+    const parsed = JSON.parse(out);
+    assert.match(parsed.error, /unknown doc/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a single `read_doc(path)` function-call tool to the chat agent. Reads from local disk through a hand-curated allowlist of repo-relative paths. The system prompt picks up a generated `## Available docs` block listing every callable path with a one-line summary, so the agent can pick a doc and fetch it on demand instead of relying on whatever the prompt builder happened to inline.

## Why

Two recent incidents showed the cost of static prompts:

- #242: the CC schema block in the prompt elided `accessor`, so the agent authored sleep CCs where every ring resolved the same field.
- #244: the HAE row-shape doc + prompt block drifted from `catalogue.js` until an audit caught it.

Stuffing more text into the prompt scales badly: every doc edit ships in the next deploy, prompt cost grows, and the agent only sees what the prompt builder anticipated.

`read_doc` solves it: local-disk reads guarantee the agent sees the same version of the docs the running app shipped with, so a deployed instance on an older release isn't misled by newer guidance on main. No GitHub fetch, no embeddings, no vector store; the corpus is ~50k tokens of markdown and fits trivially in the gateway's context budget on demand.

## How

- **`chat/docs.js`** — exports `DOC_INDEX`, `listDocs`, `readDoc`, `describeDocsCatalogue`. Allowlist is hand-curated (15 entries today). `readDoc` rejects empty input, anything not on the list, and double-checks the resolved absolute path stays inside the repo root in case a future symlink tries to escape. 200 KiB content cap; backslash paths are normalised to POSIX.
- **`chat/tools.js`** — registers `read_doc` in `TOOL_DEFS` and dispatches it. Mirrors the existing seven manifest tools.
- **`server.js` + `config/env.js`** — appends the catalogue block to the system prompt; `HEALTH_SYSTEM_PROMPT` tool list and the when-to-use matrix both call out `read_doc` so the agent reaches for it on schema / renderer / deploy / ingest questions.
- **Tests** — 16 new tests in `tests/chat-tools-docs.test.js` covering allowlist integrity (every entry exists on disk), success path, traversal rejection (`../`, `docs/../`, absolute, gitignored CLAUDE.md), tool-layer dispatch, and the catalogue's markdown shape. Plus a system-prompt-injection assertion in `tests/chat-prompt-cc-schema.test.js`.

## Out of scope (intentionally)

- No RAG / embeddings.
- No `search_docs(query)` tool. If it becomes necessary later, plain full-text grep is the right next step.
- No GitHub fetch.

## Testing

- [x] `node --test tests/chat-tools-docs.test.js tests/chat-prompt-cc-schema.test.js` (25 pass, 0 fail)
- [x] `npm test` → 924 tests, 1 fail (unchanged from main: pre-existing flag in `no-personal-refs.test.js` against gitignored operator files)
- [x] Hygiene scan clean
- [ ] Manual: ask Klebbius "what fields can I put on a list-card?" and confirm it calls `read_doc("docs/CARDS.md")` instead of guessing

Closes #246