### PR TITLE
fix(docker): copy doc files into image so read_doc works

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,9 +21,9 @@ reports
 tests
 fixtures
 
-# Docs + editor cruft
-docs
-*.md
+# Editor cruft. Docs + root .md files are kept in the image so the
+# read_doc chat tool (chat/docs.js allowlist) can serve them at
+# inference time without a network round-trip to GitHub.
 !package.json
 !package-lock.json
 .idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **`read_doc` chat tool returned ENOENT in the Docker image.** The
+  Dockerfile only copied runtime source dirs; the doc files the
+  allowlist enumerates (`README.md`, `MANIFEST-SCHEMA.md`,
+  `CHANGELOG.md`, `CONTRIBUTING*.md`, `SECURITY.md`, `docs/*.md`)
+  were not present at `/app`, so every `read_doc` call from the
+  agent in containerised deployments failed with "no such file or
+  directory". Added explicit COPY directives plus a regression
+  test that diff-checks the allowlist against the Dockerfile.
+  Fixes #248.
 - **Documentation accuracy sweep ahead of public flip.** Three
   doc-only inaccuracies caught by an audit:
   - `docs/CHAT-AGENT.md` referred to the bearer token as

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,14 @@ COPY --chown=klebb:klebb server ./server
 COPY --chown=klebb:klebb templates ./templates
 COPY --chown=klebb:klebb prompts ./prompts
 
+# Doc files served by the read_doc chat tool. The allowlist in
+# chat/docs.js enumerates exactly these paths; an absent file would
+# surface to the agent as ENOENT.
+COPY --chown=klebb:klebb docs ./docs
+COPY --chown=klebb:klebb README.md MANIFEST-SCHEMA.md CHANGELOG.md \
+                        CONTRIBUTING.md CONTRIBUTING-PROMPTS.md CONTRIBUTING-TEMPLATES.md \
+                        SECURITY.md ./
+
 # Data dir — mount a volume here in production. The entrypoint chowns
 # this to the runtime user at container start so bind-mounts owned by
 # the host user Just Work on first boot.

--- a/tests/dockerfile-docs-coverage.test.js
+++ b/tests/dockerfile-docs-coverage.test.js
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/dockerfile-docs-coverage.test.js
+//
+// Regression seed for #248: the read_doc chat tool's allowlist must
+// match the Dockerfile's COPY directives, otherwise containerised
+// deployments serve every read_doc call as ENOENT.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const { DOC_INDEX } = require('../chat/docs');
+
+describe('Dockerfile copies every read_doc allowlist entry', () => {
+  const dockerfileRaw = fs.readFileSync(path.join(REPO_ROOT, 'Dockerfile'), 'utf8');
+  // Collapse backslash-continued lines so a multi-line COPY reads as one line.
+  const dockerfile = dockerfileRaw.replace(/\\\r?\n\s*/g, ' ');
+
+  test('each DOC_INDEX path is named in a COPY directive', () => {
+    const copyLines = dockerfile.split('\n').filter(l => /^\s*COPY\b/.test(l));
+    for (const entry of DOC_INDEX) {
+      const isInSubdir = entry.path.includes('/');
+      const needle = isInSubdir ? entry.path.split('/')[0] : entry.path;
+      const matched = copyLines.some(line => {
+        const re = new RegExp(`(^|\\s|/)${needle.replace('.', '\\.')}(\\s|/|$)`);
+        return re.test(line);
+      });
+      assert.ok(
+        matched,
+        `Dockerfile is missing a COPY directive that would include ${entry.path}`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

PR #247 wired up the `read_doc` chat tool with an allowlist of paths
(`README.md`, `MANIFEST-SCHEMA.md`, `CHANGELOG.md`, `CONTRIBUTING*.md`,
`SECURITY.md`, `docs/*.md`), but the Dockerfile only copies runtime
source dirs. In containerised deployments the agent saw every
`read_doc` call return ENOENT.

## Why

Caught live on klebbtest:

\`\`\`
$ docker exec klebbtest node -e "console.log(require('/app/chat/docs').readDoc('docs/CARDS.md'))"
{ error: 'failed to read docs/CARDS.md: ENOENT: ...' }
\`\`\`

## How

- Added two COPY directives (`docs/`, plus the seven root markdown files
  the allowlist enumerates).
- Added \`tests/dockerfile-docs-coverage.test.js\` which collapses
  backslash-continued COPY lines and asserts every \`DOC_INDEX\` entry
  has a matching directive. Confirmed it fails on main (no Dockerfile
  fix) and passes with the fix.

## Test plan
- [x] \`node --test tests/dockerfile-docs-coverage.test.js\` passes
- [x] Same test fails on \`main\` without the Dockerfile change
- [x] Full \`npm test\` green (one pre-existing failure unrelated)
- [ ] After merge: rebuild klebbtest, confirm a \`read_doc\` call returns content

Fixes #248