### PR TITLE
chore(release): cut v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-05-21
+
 ### Fixed
 
 - **`read_doc` chat tool returned ENOENT in the Docker image.** The


### PR DESCRIPTION
## Summary

Anchor the existing curated changelog entries (sitting under `## [Unreleased]` since 2.0.0) at `## [2.1.0] - 2026-05-21`.

## Why

The README's Docker section references `ghcr.io/aristocles/klebb:v2.1.0` and `:latest`. There is no matching git tag yet, so a stranger trying to verify the version they're pulling has no anchor.

## Followup after merge

- Tag the merge commit `v2.1.0`
- Push the tag (triggers GHCR publish workflow per `.github/workflows/publish.yml`)
- Create a GitHub Release with notes drawn from the 2.1.0 changelog section

## Testing

- [x] CHANGELOG.md still parses cleanly (Keep a Changelog format)
- [x] No source changes; CI runs are advisory only

Fixes #261