### PR TITLE
fix: drop LICENSE preamble so detector recognises AGPL-3.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,3 @@
-Klebb: a file-driven personal health dashboard.
-Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as published
-by the Free Software Foundation, version 3.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Affero General Public License for more details.
-
-You should have received a copy of the GNU Affero General Public License
-along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-See AUTHORS.md for the list of contributors.
-
-----------------------------------------------------------------------
-
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,16 @@
+Klebb: a file-driven personal health dashboard.
+Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+See AUTHORS.md for the list of contributors.

--- a/README.md
+++ b/README.md
@@ -389,7 +389,8 @@ issue for those.
 ## License
 
 GNU Affero General Public License v3.0 (AGPL-3.0-only).
-See [`LICENSE`](LICENSE) for the full text and
-[`AUTHORS.md`](AUTHORS.md) for the list of contributors.
+See [`LICENSE`](LICENSE) for the full text, [`NOTICE`](NOTICE) for
+the project copyright, and [`AUTHORS.md`](AUTHORS.md) for the list
+of contributors.
 
 Copyright (C) 2026 Aristocles &lt;https://github.com/Aristocles&gt;.


### PR DESCRIPTION
## Summary

- LICENSE is now verbatim FSF AGPL v3 text (no Klebb-specific prefix).
- Project copyright + summary moved into a new \`NOTICE\` file.
- README licence section now links to both LICENSE and NOTICE.

## Why

GitHub's licence detector matches \`LICENSE\` byte-for-byte against the
canonical FSF text. Our 17-line custom prefix made it fall back to
\"Other\" in the sidebar pill and in the \`gh repo view --json licenseInfo\`
output. Detector should now correctly identify AGPL-3.0.

## Testing

- After merge: \`gh repo view Aristocles/klebb --json licenseInfo\`
  should return \`{ key: 'agpl-3.0', name: 'GNU Affero General Public License v3.0' }\`.
- README rendering on GitHub: licence section still mentions both files.

Fixes #263.