### PR TITLE
docs: fix RECIPES count in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ defaults.
 ## Docs
 
 - [`docs/CARDS.md`](docs/CARDS.md) — How to write and manage cards (user guide)
-- [`docs/RECIPES.md`](docs/RECIPES.md) — 10 copy-pasteable card patterns (cookbook)
+- [`docs/RECIPES.md`](docs/RECIPES.md) — 12 copy-pasteable card patterns (cookbook)
 - [`MANIFEST-SCHEMA.md`](MANIFEST-SCHEMA.md) — Manifest format reference
 - [`docs/CHAT-AGENT.md`](docs/CHAT-AGENT.md) — Chat widget + server-to-server integration
 - [`docs/VOICE.md`](docs/VOICE.md) — Voice chat (Fish Audio) configuration


### PR DESCRIPTION
## What changed
- Updated the README docs index to say `docs/RECIPES.md` has 12 copy-pasteable card patterns.

## Why
- Closes #254.
- `docs/RECIPES.md` currently contains Recipe 1 through Recipe 12, so the README count was stale.

## Verification
Commands run:
```bash
rg "docs/RECIPES.md.*copy-pasteable" -n README.md
rg "^## Recipe [0-9]+" -n docs/RECIPES.md | Measure-Object | Select-Object -ExpandProperty Count
git diff --check
```

`npm test` was not run because this is a docs-only count correction.
