### PR TITLE
feat(demo): add KLEBB_DEMO public-demo mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Added
+
+- **`KLEBB_DEMO=1` runs the server as a public no-credentials demo.**
+  Login swaps the passkey prompt for an "Enter the demo" button that
+  mints a session for a shared `demo` user; all passkey/invite/setup
+  routes return `410`; chat short-circuits with a canned reply (no
+  outbound HTTP); voice endpoints return `503`; card hiding is locked
+  in both the manifest PATCH and settings UI endpoints; the app shell
+  shows a banner pointing visitors at `klebb.app` for self-hosting.
+  Fixes #270.
+
 ### Changed
 
 - **App header now uses the Klebb dog mark instead of the placeholder

--- a/README.md
+++ b/README.md
@@ -298,9 +298,32 @@ Optional feature flags:
 | `CHAT_AGENT_NAME`, `CHAT_AGENT_EMOJI` | Chat widget branding |
 | `FISH_AUDIO_API_KEY`, `FISH_AUDIO_DEFAULT_VOICE` | Voice chat |
 | `HEALTH_INSTANCE_NAME`, `HEALTH_RP_NAME` | UI branding |
+| `KLEBB_DEMO` | Set to `1` to run as a public no-credentials demo (see below) |
 
 See [`config/env.js`](config/env.js) for the complete list with
 defaults.
+
+### Running as a public demo
+
+`KLEBB_DEMO=1` flips the server into a public-demo mode used to host
+read-anyone instances at e.g. `demo.klebb.app`:
+
+- The login page replaces the passkey prompt with a single
+  "Enter the demo" button that mints a session for a shared `demo`
+  user.
+- All passkey, invite, and setup-wizard routes return `410 Gone`.
+- `POST /api/chat` short-circuits with a fixed assistant reply
+  explaining there's no AI gateway connected. No outbound HTTP.
+- Voice endpoints (`/api/voice/*`) return `503`.
+- `PATCH /api/manifests/:id` rejects `meta.enabled` mutations and the
+  `/api/settings/cards/:id/(enable|disable)` endpoints return `403`,
+  so visitors can't hide cards.
+- The authenticated app shell shows a dismissible-once banner pointing
+  back to `klebb.app` for self-hosted use.
+
+Pair the flag with a curated dataset under `$HEALTH_HOME/data/` and a
+periodic reset (cron, systemd timer, or container restart) to keep the
+demo predictable.
 
 ## Docs
 

--- a/auth/webauthn.js
+++ b/auth/webauthn.js
@@ -99,9 +99,12 @@ function clearSessionCookie(res) {
 
 // Auth middleware: returns true if request is authenticated (or route is public)
 function isAuthenticated(req) {
+  if (isAgentRequest(req)) return true;
+  // In demo mode, only a real session counts. The bootstrap "no creds yet"
+  // shortcut would otherwise let unauthenticated visitors past the gate.
+  if (ENV.KLEBB_DEMO) return validateSession(getSessionToken(req));
   // If no credentials registered yet, allow everything (setup mode)
   if (!isSetup()) return true;
-  if (isAgentRequest(req)) return true;
   return validateSession(getSessionToken(req));
 }
 
@@ -144,6 +147,33 @@ async function handleAuthRoutes(req, res, pathname) {
     req.on('data', c => body += c);
     req.on('end', () => resolve(body));
   });
+
+  // Demo mode: serve the demo-login route, then 410 every other auth route.
+  // Status still answers (the front end uses it to gate redirects).
+  if (ENV.KLEBB_DEMO) {
+    if (pathname === '/auth/demo-login' && req.method === 'POST') {
+      const token = createSession(ENV.DEMO_USER_ID);
+      setSessionCookie(res, token);
+      return sendJSON(res, { ok: true, label: ENV.DEMO_USER_ID });
+    }
+    if (pathname === '/auth/status') {
+      const authenticated = validateSession(getSessionToken(req));
+      return sendJSON(res, { setup: true, authenticated, demo: true });
+    }
+    if (pathname === '/auth/logout' && req.method === 'POST') {
+      const token = getSessionToken(req);
+      if (token) {
+        const sessions = loadSessions();
+        delete sessions[token];
+        saveSessions(sessions);
+      }
+      clearSessionCookie(res);
+      return sendJSON(res, { ok: true });
+    }
+    if (pathname.startsWith('/auth/')) {
+      return sendJSON(res, { error: 'Disabled in demo mode' }, 410);
+    }
+  }
 
   // GET /auth/status — check if setup + authenticated
   if (pathname === '/auth/status') {

--- a/config/env.js
+++ b/config/env.js
@@ -123,6 +123,21 @@ const HEALTH_AUTO_EXPORT_TOKEN = (process.env.HEALTH_AUTO_EXPORT_TOKEN || '').tr
 // --- Feature flags ---
 const DEBUG_LOG = process.env.HEALTH_DEBUG === '1';
 
+// --- Demo mode ---
+// When KLEBB_DEMO=1, the server runs as a public no-credentials demo:
+//   - The login page shows a single "Enter the demo" button that calls
+//     POST /auth/demo-login and drops the visitor in as user "demo".
+//   - All passkey / invite / setup-wizard routes return 410 Gone.
+//   - POST /api/chat short-circuits with a fixed assistant reply; no
+//     outbound HTTP is made even if a CHAT_ENDPOINT_URL is set.
+//   - All voice (/api/voice/*) endpoints return 503.
+//   - PATCH /api/manifests/:id rejects meta.enabled mutations with 403,
+//     so visitors can't permanently hide demo cards.
+//   - GET /api/instance reports demo:true so the front end can render a
+//     banner and disable affordances that depend on chat / voice.
+const KLEBB_DEMO = process.env.KLEBB_DEMO === '1';
+const DEMO_USER_ID = 'demo';
+
 // --- Health system prompt (used by chat proxy) ---
 //
 // Default prompt is generic and references whatever cards the registry
@@ -493,5 +508,7 @@ module.exports = {
   getSessionSecret,
   HEALTH_AUTO_EXPORT_TOKEN,
   DEBUG_LOG,
+  KLEBB_DEMO,
+  DEMO_USER_ID,
   HEALTH_SYSTEM_PROMPT,
 };

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -32,6 +32,7 @@ class HealthApp extends LitElement {
     _settingsMenuOpen: { state: true },
     _promptQueue: { state: true },
     _buildInfo: { state: true },
+    _demo: { state: true },
   };
 
   constructor() {
@@ -45,6 +46,7 @@ class HealthApp extends LitElement {
     this._settingsMenuOpen = false;
     this._promptQueue = [];
     this._buildInfo = null;
+    this._demo = false;
     document.documentElement.setAttribute('data-theme', this.theme);
     this._handleRoute();
     this._loadInstance();
@@ -86,6 +88,8 @@ class HealthApp extends LitElement {
       if (r.ok) {
         const j = await r.json();
         if (j.name) this._instanceName = j.name;
+        this._demo = !!j.demo;
+        if (this._demo) document.documentElement.setAttribute('data-demo', '1');
       }
     } catch {}
   }
@@ -247,6 +251,23 @@ class HealthApp extends LitElement {
       white-space: nowrap;
       vertical-align: middle;
     }
+    .demo-banner {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      padding: 6px 12px;
+      background: linear-gradient(135deg, #0ea5e9, #6366f1);
+      color: #fff;
+      font-size: 0.8rem;
+      font-weight: 500;
+      letter-spacing: 0.01em;
+      text-align: center;
+    }
+    .demo-banner a {
+      color: #fff;
+      text-decoration: underline;
+    }
     .nav-links {
       display: flex;
       gap: 4px;
@@ -340,6 +361,12 @@ class HealthApp extends LitElement {
       ` : ''}
       ${this.showNav ? html`
         <nav>
+          ${this._demo ? html`
+            <div class="demo-banner" role="status">
+              You're viewing the public Klebb demo. Data resets hourly. Run your own at
+              <a href="https://klebb.app" target="_blank" rel="noopener">klebb.app</a>.
+            </div>
+          ` : ''}
           <div class="nav-main">
             <div class="logo" @click=${this._toggleTheme} style="cursor:pointer" title="Toggle theme">
               <img

--- a/public/js/components/eh-settings-view.js
+++ b/public/js/components/eh-settings-view.js
@@ -24,6 +24,7 @@ export class EhSettingsView extends LitElement {
     _haeStatus: { state: true },
     _haeLastPushExpanded: { state: true },
     _haeCopied: { state: true },
+    _demo: { state: true },
   };
 
   constructor() {
@@ -38,6 +39,7 @@ export class EhSettingsView extends LitElement {
     this._haeStatus = null;
     this._haeLastPushExpanded = false;
     this._haeCopied = false;
+    this._demo = false;
   }
 
   connectedCallback() {
@@ -45,6 +47,16 @@ export class EhSettingsView extends LitElement {
     this._load();
     this._loadHiddenDiscoveries();
     this._loadHaeStatus();
+    this._loadDemoFlag();
+  }
+
+  async _loadDemoFlag() {
+    try {
+      const r = await fetch('/api/instance');
+      if (!r.ok) return;
+      const j = await r.json();
+      this._demo = !!j.demo;
+    } catch {}
   }
 
   async _loadHaeStatus() {
@@ -561,9 +573,14 @@ export class EhSettingsView extends LitElement {
 
       <h2>Cards</h2>
       <div class="lede">
-        Every card is a file in <code>$HEALTH_HOME/data/</code>. Toggle off to
-        hide a card (keeps the data); delete the file to remove it entirely.
-        <a href="https://github.com/Aristocles/klebb/blob/main/docs/CARDS.md" target="_blank" rel="noopener">How to add a card →</a>
+        ${this._demo ? html`
+          Card visibility is locked in the public demo. Run your own instance to
+          toggle, add, or delete cards.
+        ` : html`
+          Every card is a file in <code>$HEALTH_HOME/data/</code>. Toggle off to
+          hide a card (keeps the data); delete the file to remove it entirely.
+          <a href="https://github.com/Aristocles/klebb/blob/main/docs/CARDS.md" target="_blank" rel="noopener">How to add a card →</a>
+        `}
       </div>
 
       ${totalAll > 0 ? html`
@@ -751,9 +768,10 @@ export class EhSettingsView extends LitElement {
           aria-checked="${c.enabled}"
           aria-pressed="${c.enabled}"
           aria-label="${c.enabled ? 'Disable' : 'Enable'} ${c.label || c.id}"
-          ?disabled=${this._busyId === c.id}
-          @click=${() => this._toggle(c)}
-          @keydown=${(e) => this._onToggleKeydown(e, c)}
+          ?disabled=${this._demo || this._busyId === c.id}
+          title="${this._demo ? 'Locked in demo mode' : ''}"
+          @click=${() => { if (!this._demo) this._toggle(c); }}
+          @keydown=${(e) => { if (!this._demo) this._onToggleKeydown(e, c); }}
         ></button>
       </div>
     `;

--- a/public/login.html
+++ b/public/login.html
@@ -115,9 +115,43 @@
       }
     };
 
-    // Auto-trigger on load
-    // Small delay so the page renders first
-    setTimeout(() => window.login(), 500);
+    window.demoLogin = async function() {
+      const btn = document.getElementById('login-btn');
+      const error = document.getElementById('error');
+      error.classList.remove('show');
+      btn.disabled = true;
+      btn.textContent = 'Loading demo...';
+      try {
+        const r = await fetch('/auth/demo-login', { method: 'POST' });
+        const result = await r.json();
+        if (!r.ok || !result.ok) throw new Error(result.error || 'Demo login failed');
+        window.location.href = '/';
+      } catch (e) {
+        error.textContent = e.message || 'Demo login failed';
+        error.classList.add('show');
+        btn.disabled = false;
+        btn.textContent = 'Enter the demo';
+      }
+    };
+
+    // Branch on demo mode: if the server is in demo mode, swap the
+    // passkey CTA for an "Enter the demo" button and skip auto-trigger.
+    (async () => {
+      try {
+        const r = await fetch('/auth/status');
+        const s = await r.json();
+        if (s.demo) {
+          document.getElementById('subtitle').textContent = 'Public demo. No account needed.';
+          document.getElementById('face-id-icon').textContent = '👋';
+          const btn = document.getElementById('login-btn');
+          btn.textContent = 'Enter the demo';
+          btn.setAttribute('onclick', 'demoLogin()');
+          return;
+        }
+      } catch {}
+      // Default: passkey flow, auto-trigger so Face ID prompts immediately.
+      setTimeout(() => window.login(), 500);
+    })();
   </script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -542,16 +542,26 @@ const server = http.createServer(async (req, res) => {
       res.end(JSON.stringify({ error: 'Unauthorized' }));
       return;
     }
-    // Redirect to login page (or setup if no credentials yet)
-    const redirect = isSetup() ? '/login.html' : '/setup.html';
+    // Redirect to login page (or setup if no credentials yet).
+    // Demo mode never shows setup: the login page hosts the "Enter the demo" button.
+    const redirect = (ENV.KLEBB_DEMO || isSetup()) ? '/login.html' : '/setup.html';
     res.writeHead(302, { 'Location': redirect });
     res.end();
     return;
   }
 
-  // If setup is not done, redirect non-setup pages to setup
-  if (!isSetup() && pathname !== '/setup.html' && !isPublicPath(pathname) && !pathname.startsWith('/api/')) {
+  // If setup is not done, redirect non-setup pages to setup. Skipped in demo
+  // mode: the login page handles bootstrap there.
+  if (!ENV.KLEBB_DEMO && !isSetup() && pathname !== '/setup.html' && !isPublicPath(pathname) && !pathname.startsWith('/api/')) {
     res.writeHead(302, { 'Location': '/setup.html' });
+    res.end();
+    return;
+  }
+
+  // Hide /setup.html and /register entirely in demo mode (so curious
+  // visitors don't stumble onto the setup wizard).
+  if (ENV.KLEBB_DEMO && (pathname === '/setup.html' || pathname === '/register')) {
+    res.writeHead(302, { 'Location': '/login.html' });
     res.end();
     return;
   }
@@ -628,6 +638,9 @@ const server = http.createServer(async (req, res) => {
           patch = JSON.parse(body || '{}');
         } catch (e) {
           return sendJSON(res, { error: 'invalid JSON body' }, 400);
+        }
+        if (ENV.KLEBB_DEMO && patch && patch.meta && Object.prototype.hasOwnProperty.call(patch.meta, 'enabled')) {
+          return sendJSON(res, { error: 'demo mode: cards cannot be hidden' }, 403);
         }
         try {
           const result = registry.patchManifest(id, patch);
@@ -766,6 +779,9 @@ const server = http.createServer(async (req, res) => {
 
     // POST /api/settings/cards/:id/enable — set meta.enabled: true
     if (parts[0] === 'settings' && parts[1] === 'cards' && parts.length === 4 && parts[3] === 'enable' && req.method === 'POST') {
+      if (ENV.KLEBB_DEMO) {
+        return sendJSON(res, { error: 'demo mode: cards cannot be hidden' }, 403);
+      }
       try {
         registry.setMasterEnabled(parts[2], true);
         return sendJSON(res, { ok: true, enabled: true });
@@ -776,6 +792,9 @@ const server = http.createServer(async (req, res) => {
 
     // POST /api/settings/cards/:id/disable — set meta.enabled: false
     if (parts[0] === 'settings' && parts[1] === 'cards' && parts.length === 4 && parts[3] === 'disable' && req.method === 'POST') {
+      if (ENV.KLEBB_DEMO) {
+        return sendJSON(res, { error: 'demo mode: cards cannot be hidden' }, 403);
+      }
       try {
         registry.setMasterEnabled(parts[2], false);
         return sendJSON(res, { ok: true, enabled: false });
@@ -803,9 +822,14 @@ const server = http.createServer(async (req, res) => {
 
     // GET /api/chat/status — is a chat endpoint configured? UI affordances
     // that depend on the agent use this to render an enabled/disabled state
-    // without making an actual chat request.
+    // without making an actual chat request. In demo mode the chat endpoint
+    // is "configured" (the canned-reply short-circuit answers it) but
+    // outbound is reported false so voice / tool affordances stay off.
     if (parts[0] === 'chat' && parts[1] === 'status' && parts.length === 2 && req.method === 'GET') {
       res.setHeader('Cache-Control', 'no-store');
+      if (ENV.KLEBB_DEMO) {
+        return sendJSON(res, { configured: true, demo: true });
+      }
       return sendJSON(res, { configured: !!CHAT_ENDPOINT });
     }
 
@@ -1331,6 +1355,10 @@ const server = http.createServer(async (req, res) => {
           if (!Array.isArray(messages) || messages.length === 0) {
             return sendJSON(res, { error: 'messages required' }, 400);
           }
+          if (ENV.KLEBB_DEMO) {
+            const reply = `This is a public demo without an AI gateway connected, so ${ENV.CHAT_AGENT_NAME} can't answer questions or add new cards. You can still log data into the existing cards. Run your own instance (klebb.app) to chat with your own data.`;
+            return sendJSON(res, voiceMode ? { reply, speak: reply } : { reply });
+          }
 
           // Build a compact card list from the live registry, so the agent
           // always knows what cards exist right now without having to call
@@ -1489,7 +1517,14 @@ Original system prompt follows:
           name: ENV.CHAT_AGENT_NAME,
           emoji: ENV.CHAT_AGENT_EMOJI,
         },
+        demo: !!ENV.KLEBB_DEMO,
       });
+    }
+
+    // Voice is disabled in demo mode. Every /api/voice/* path returns 503
+    // before falling through to the real handlers below.
+    if (ENV.KLEBB_DEMO && parts[0] === 'voice') {
+      return sendJSON(res, { error: 'Voice disabled in demo mode', demo: true }, 503);
     }
 
     // GET /api/voice/config — current Fish Audio status (backend tier, credit, voiceId)

--- a/tests/api/issue-270-demo-mode.test.js
+++ b/tests/api/issue-270-demo-mode.test.js
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/api/issue-270-demo-mode.test.js
+//
+// Coverage for #270 KLEBB_DEMO env flag. Each test boots a fresh sandbox
+// in demo mode and asserts the gate behaves as documented in the issue.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { createSandbox, cleanupSandbox, spawnServer, req, sessionCookie } = require('../helpers/sandbox');
+
+const SAMPLE_MANIFEST = {
+  $schema: 'klebb.datafile.v1',
+  meta: { id: 'demo-card', label: 'Demo card', view: { component: 'generic-card' } },
+  data: [{ date: '2026-05-20', value: 1 }],
+};
+
+function withDemoServer(seed = {}) {
+  return async function setup() {
+    const box = createSandbox({ seed: { 'demo-card.json': SAMPLE_MANIFEST, ...seed } });
+    const srv = await spawnServer(box, { KLEBB_DEMO: '1' });
+    return { box, srv, cleanup: async () => { await srv.kill(); cleanupSandbox(box); } };
+  };
+}
+
+describe('KLEBB_DEMO server-side', () => {
+  test('GET /api/instance reports demo:true', async () => {
+    const { srv, cleanup } = await withDemoServer()();
+    try {
+      const r = await req(srv.baseUrl, '/api/instance', { cookie: 'placeholder' });
+      // /api/instance is gated by auth; we need a session. Easier: hit it
+      // through demo-login first.
+      const login = await req(srv.baseUrl, '/auth/demo-login', { method: 'POST' });
+      assert.equal(login.status, 200);
+      const cookie = login.headers['set-cookie'][0].split(';')[0];
+      const inst = await req(srv.baseUrl, '/api/instance', { cookie });
+      assert.equal(inst.status, 200);
+      assert.equal(inst.json.demo, true);
+    } finally { await cleanup(); }
+  });
+
+  test('POST /auth/demo-login mints a session for the demo user', async () => {
+    const { srv, cleanup } = await withDemoServer()();
+    try {
+      const r = await req(srv.baseUrl, '/auth/demo-login', { method: 'POST' });
+      assert.equal(r.status, 200);
+      assert.equal(r.json.label, 'demo');
+      assert.ok(r.headers['set-cookie'], 'demo-login should set a cookie');
+      assert.match(r.headers['set-cookie'][0], /^klebb_session=[a-f0-9]+/);
+    } finally { await cleanup(); }
+  });
+
+  test('passkey + invite + setup routes return 410 in demo mode', async () => {
+    const { srv, cleanup } = await withDemoServer()();
+    try {
+      for (const path of [
+        '/auth/register/options',
+        '/auth/register/verify',
+        '/auth/login/options',
+        '/auth/login/verify',
+        '/auth/register/available',
+      ]) {
+        const r = await req(srv.baseUrl, path, { method: 'POST', body: {} });
+        assert.equal(r.status, 410, `${path} should be 410 Gone`);
+      }
+    } finally { await cleanup(); }
+  });
+
+  test('/setup.html and /register redirect to /login.html in demo mode', async () => {
+    const { srv, cleanup } = await withDemoServer()();
+    try {
+      for (const path of ['/setup.html', '/register']) {
+        const r = await req(srv.baseUrl, path);
+        assert.equal(r.status, 302, `${path} should redirect`);
+        assert.equal(r.headers['location'], '/login.html');
+      }
+    } finally { await cleanup(); }
+  });
+
+  test('unauthenticated requests still get bounced to /login.html', async () => {
+    const { srv, cleanup } = await withDemoServer()();
+    try {
+      const r = await req(srv.baseUrl, '/');
+      assert.equal(r.status, 302);
+      assert.equal(r.headers['location'], '/login.html');
+    } finally { await cleanup(); }
+  });
+
+  test('POST /api/chat returns the canned demo reply, no outbound HTTP', async () => {
+    const { srv, cleanup } = await withDemoServer()();
+    try {
+      const login = await req(srv.baseUrl, '/auth/demo-login', { method: 'POST' });
+      const cookie = login.headers['set-cookie'][0].split(';')[0];
+      const r = await req(srv.baseUrl, '/api/chat', {
+        method: 'POST',
+        cookie,
+        body: { messages: [{ role: 'user', content: 'hello' }] },
+      });
+      assert.equal(r.status, 200);
+      assert.match(r.json.reply, /public demo/i);
+      assert.match(r.json.reply, /klebb\.app/i);
+      assert.equal(typeof r.json.speak, 'undefined', 'text-mode reply should not include speak');
+    } finally { await cleanup(); }
+  });
+
+  test('POST /api/chat in voiceMode returns both reply and speak fields', async () => {
+    const { srv, cleanup } = await withDemoServer()();
+    try {
+      const login = await req(srv.baseUrl, '/auth/demo-login', { method: 'POST' });
+      const cookie = login.headers['set-cookie'][0].split(';')[0];
+      const r = await req(srv.baseUrl, '/api/chat', {
+        method: 'POST',
+        cookie,
+        body: { messages: [{ role: 'user', content: 'hi' }], voiceMode: true },
+      });
+      assert.equal(r.status, 200);
+      assert.equal(typeof r.json.reply, 'string');
+      assert.equal(typeof r.json.speak, 'string');
+      assert.equal(r.json.reply, r.json.speak);
+    } finally { await cleanup(); }
+  });
+
+  test('GET /api/chat/status reports configured:true with demo:true marker', async () => {
+    const { srv, cleanup } = await withDemoServer()();
+    try {
+      const login = await req(srv.baseUrl, '/auth/demo-login', { method: 'POST' });
+      const cookie = login.headers['set-cookie'][0].split(';')[0];
+      const r = await req(srv.baseUrl, '/api/chat/status', { cookie });
+      assert.equal(r.status, 200);
+      assert.equal(r.json.configured, true);
+      assert.equal(r.json.demo, true);
+    } finally { await cleanup(); }
+  });
+
+  test('voice endpoints return 503 in demo mode', async () => {
+    const { srv, cleanup } = await withDemoServer()();
+    try {
+      const login = await req(srv.baseUrl, '/auth/demo-login', { method: 'POST' });
+      const cookie = login.headers['set-cookie'][0].split(';')[0];
+      for (const path of ['/api/voice/config', '/api/voice/tts', '/api/voice/asr']) {
+        const method = path === '/api/voice/config' ? 'GET' : 'POST';
+        const r = await req(srv.baseUrl, path, { method, cookie, body: method === 'POST' ? { text: 'x' } : null });
+        assert.equal(r.status, 503, `${path} should be 503`);
+        assert.equal(r.json.demo, true);
+      }
+    } finally { await cleanup(); }
+  });
+
+  test('PATCH /api/manifests/:id with meta.enabled is rejected with 403', async () => {
+    const { srv, cleanup } = await withDemoServer()();
+    try {
+      const login = await req(srv.baseUrl, '/auth/demo-login', { method: 'POST' });
+      const cookie = login.headers['set-cookie'][0].split(';')[0];
+      const r = await req(srv.baseUrl, '/api/manifests/demo-card', {
+        method: 'PATCH',
+        cookie,
+        body: { meta: { enabled: false } },
+      });
+      assert.equal(r.status, 403);
+      assert.match(r.json.error, /demo mode/i);
+    } finally { await cleanup(); }
+  });
+
+  test('PATCH with non-enabled meta fields is allowed in demo mode', async () => {
+    const { srv, cleanup } = await withDemoServer()();
+    try {
+      const login = await req(srv.baseUrl, '/auth/demo-login', { method: 'POST' });
+      const cookie = login.headers['set-cookie'][0].split(';')[0];
+      const r = await req(srv.baseUrl, '/api/manifests/demo-card', {
+        method: 'PATCH',
+        cookie,
+        body: { meta: { label: 'Renamed in demo' } },
+      });
+      assert.equal(r.status, 200);
+      assert.equal(r.json.ok, true);
+    } finally { await cleanup(); }
+  });
+
+  test('POST /api/settings/cards/:id/disable is rejected with 403 in demo mode', async () => {
+    const { srv, cleanup } = await withDemoServer()();
+    try {
+      const login = await req(srv.baseUrl, '/auth/demo-login', { method: 'POST' });
+      const cookie = login.headers['set-cookie'][0].split(';')[0];
+      const r = await req(srv.baseUrl, '/api/settings/cards/demo-card/disable', {
+        method: 'POST',
+        cookie,
+      });
+      assert.equal(r.status, 403);
+      assert.match(r.json.error, /demo mode/i);
+    } finally { await cleanup(); }
+  });
+
+  test('POST /api/settings/cards/:id/enable is rejected with 403 in demo mode', async () => {
+    const { srv, cleanup } = await withDemoServer()();
+    try {
+      const login = await req(srv.baseUrl, '/auth/demo-login', { method: 'POST' });
+      const cookie = login.headers['set-cookie'][0].split(';')[0];
+      const r = await req(srv.baseUrl, '/api/settings/cards/demo-card/enable', {
+        method: 'POST',
+        cookie,
+      });
+      assert.equal(r.status, 403);
+      assert.match(r.json.error, /demo mode/i);
+    } finally { await cleanup(); }
+  });
+});
+
+describe('KLEBB_DEMO unset (default behaviour)', () => {
+  test('demo-login does not mint a session when flag is off', async () => {
+    const box = createSandbox();
+    const srv = await spawnServer(box);
+    try {
+      const r = await req(srv.baseUrl, '/auth/demo-login', { method: 'POST' });
+      // /auth/demo-login is only mounted when KLEBB_DEMO=1. Without the
+      // flag the request falls through to the static-file router; the
+      // critical guarantee is that no session cookie is issued.
+      assert.ok(!r.headers['set-cookie'], 'demo-login must not set a session cookie when flag is off');
+    } finally {
+      await srv.kill();
+      cleanupSandbox(box);
+    }
+  });
+
+  test('GET /api/instance does not include demo:true flag', async () => {
+    const box = createSandbox();
+    const auth = require('../helpers/sandbox').fakeAuthState();
+    cleanupSandbox(box);
+    const box2 = createSandbox({ credentials: auth.credentials, sessions: auth.sessions });
+    const srv = await spawnServer(box2);
+    try {
+      const r = await req(srv.baseUrl, '/api/instance', { cookie: auth.cookie });
+      assert.equal(r.status, 200);
+      assert.equal(r.json.demo, false);
+    } finally {
+      await srv.kill();
+      cleanupSandbox(box2);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds a server-side `KLEBB_DEMO=1` flag that turns a Klebb instance into a public, no-credentials demo intended for hosting at e.g. `demo.klebb.app`.

## Why

A public demo lets first-time visitors poke at a real instance from the marketing site without needing to clone, configure, or set up a passkey. The whole thing has to be runnable from a single env var so the demo can be deployed as a stock GHCR image plus a curated dataset.

## How

When `KLEBB_DEMO=1`:

- `POST /auth/demo-login` mints a session for a shared `demo` user. `login.html` reads `/auth/status`, sees `demo:true`, and swaps the passkey auto-prompt for an "Enter the demo" button.
- All passkey, invite, and setup-wizard routes return `410 Gone`; `/setup.html` and `/register` redirect to `/login.html`.
- `POST /api/chat` short-circuits with a fixed assistant reply so no outbound HTTP is made. `/api/chat/status` reports `configured:true, demo:true`. Voice endpoints (`/api/voice/*`) return `503`.
- Card hiding is locked at **both** affected endpoints: `PATCH /api/manifests/:id` rejects `meta.enabled` mutations, and `POST /api/settings/cards/:id/(enable|disable)` returns `403`. The settings UI also greys out the toggle and shows a "locked in demo" hint so the lock is visible, not just a 403 in the console.
- The authenticated app shell shows a small banner pointing visitors back to `klebb.app` for self-hosting.
- `GET /api/instance` reports `demo:true` so the front end can detect the mode without parsing env vars.

## Testing

- New `tests/api/issue-270-demo-mode.test.js` — 15 tests covering every gated route, both with and without the flag.
- `npm test` — 941/942 passing. The 1 failure is `tests/no-personal-refs.test.js`, which fails on `main` already (matches in `.claude/`, `BRIEF-FOR-CC.md`, `CLAUDE.md`, and a runtime `data/sessions/webauthn.json` token — all gitignored).

## Test plan

- [ ] `npm test` passes the 15 new tests.
- [ ] Boot with `KLEBB_DEMO=1` → `/login.html` shows "Enter the demo" button; click drops you into the app with the banner visible.
- [ ] Boot without the flag → unchanged behaviour; passkey auto-prompts as before; no banner.
- [ ] In demo mode, settings page shows greyed-out toggles with "Locked in demo mode" tooltip.
- [ ] In demo mode, chat returns the canned reply; no outbound request to the chat gateway.
- [ ] In demo mode, voice mic button reflects unconfigured state.

Closes #270