### PR TITLE
feat(demo): add curated demo dataset + reset-demo script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,21 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
   shows a banner pointing visitors at `klebb.app` for self-hosting.
   Fixes #270.
 
+- **Curated demo dataset and reset script.** `demo/fixtures/` ships
+  eleven complete `klebb.datafile.v1` manifests (weight, sleep, mood,
+  blood pressure, hydration, steps, daily notes, supplement stack,
+  peptide cycle, active minutes, resting heart rate) populated with a
+  fortnight of plausible-but-fake history so the public demo always
+  shows trends, calendars, schedules, and threshold colour bands the
+  moment a visitor lands. Date fields use `__OFFSET_DAYS:N__`
+  placeholders that resolve to *today minus N* at reset time, so the
+  dataset rolls forward without anyone editing JSON.
+  `scripts/reset-demo.js` wipes `$HEALTH_HOME/data/` and restores the
+  fixture set; it refuses to run unless `KLEBB_DEMO=1` so it can never
+  be invoked against a real instance by accident. Hook it into a cron
+  / systemd timer / docker-compose `restart` policy on the demo host.
+  Fixes #271.
+
 ### Changed
 
 - **App header now uses the Klebb dog mark instead of the placeholder

--- a/demo/fixtures/README.md
+++ b/demo/fixtures/README.md
@@ -1,0 +1,37 @@
+# Demo fixtures
+
+This directory holds the curated dataset shown on the public Klebb
+demo (e.g. `demo.klebb.app`). Every file is a complete, valid
+`klebb.datafile.v1` manifest with a couple of weeks of plausible-but-
+fake history so the dashboard renders trends, calendars, schedules,
+and reports the moment a visitor lands.
+
+These fixtures are **not** templates. They are full manifests with
+data already populated. Templates live under `templates/` and ship
+empty starter scaffolding for real users.
+
+## Date placeholders
+
+`data[].date`, `cycles[].start` / `cycles[].end`, `doses[].scheduledDate`,
+`doses[].takenAt`, and `takenDates[]` use `__OFFSET_DAYS:N__`
+placeholders that resolve to *today minus N* (or *today plus N* for
+positive numbers) at the moment the reset script runs. So
+`__OFFSET_DAYS:0__` is today, `__OFFSET_DAYS:-7__` is a week ago.
+
+Mixing literal ISO dates with placeholders inside the same array is
+not supported. Pick one shape per fixture and stick with it.
+
+## Resetting
+
+`scripts/reset-demo.js` wipes `$HEALTH_HOME/data/`, copies every file
+from this directory into it, and rewrites every offset placeholder
+against the current date. It refuses to run unless `KLEBB_DEMO=1` is
+set so it can never be invoked against a real instance by accident.
+
+```
+KLEBB_DEMO=1 HEALTH_HOME=/srv/klebb-demo node scripts/reset-demo.js
+```
+
+Hook this into a cron / systemd timer / docker-compose `restart`
+policy on the demo host so the dashboard always looks like it was
+updated this week.

--- a/demo/fixtures/active-minutes.json
+++ b/demo/fixtures/active-minutes.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "active-minutes",
+    "label": "Active minutes",
+    "emoji": "⏱️",
+    "order": 525,
+    "ingest": {
+      "source": "hae",
+      "metric": "apple_exercise_time"
+    },
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{minutes}",
+        "unit": "min",
+        "trendArrow": { "field": "minutes" }
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "minutes"
+    },
+    "writeable": { "fromWebapp": false }
+  },
+  "description": "Daily active minutes (Apple Exercise Time).",
+  "data": [
+    { "date": "__OFFSET_DAYS:-13__", "minutes": 18 },
+    { "date": "__OFFSET_DAYS:-12__", "minutes": 42 },
+    { "date": "__OFFSET_DAYS:-11__", "minutes": 12 },
+    { "date": "__OFFSET_DAYS:-10__", "minutes": 55 },
+    { "date": "__OFFSET_DAYS:-9__", "minutes": 35 },
+    { "date": "__OFFSET_DAYS:-8__", "minutes": 38 },
+    { "date": "__OFFSET_DAYS:-7__", "minutes": 60 },
+    { "date": "__OFFSET_DAYS:-6__", "minutes": 22 },
+    { "date": "__OFFSET_DAYS:-5__", "minutes": 33 },
+    { "date": "__OFFSET_DAYS:-4__", "minutes": 48 },
+    { "date": "__OFFSET_DAYS:-3__", "minutes": 30 },
+    { "date": "__OFFSET_DAYS:-2__", "minutes": 52 },
+    { "date": "__OFFSET_DAYS:-1__", "minutes": 41 },
+    { "date": "__OFFSET_DAYS:0__", "minutes": 15 }
+  ]
+}

--- a/demo/fixtures/blood-pressure.json
+++ b/demo/fixtures/blood-pressure.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "blood-pressure",
+    "label": "Blood pressure",
+    "emoji": "🩺",
+    "order": 200,
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{systolic} / {diastolic}",
+        "unit": "mmHg",
+        "thresholds": [
+          { "ifField": "systolic", "max": 120, "colour": "#44ff88", "label": "Optimal" },
+          { "ifField": "systolic", "max": 129, "colour": "#aaff66", "label": "Elevated" },
+          { "ifField": "systolic", "max": 139, "colour": "#ffaa33", "label": "Stage 1" },
+          { "ifField": "systolic", "colour": "#ff4444", "label": "Stage 2" }
+        ]
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "fields": ["systolic", "diastolic"]
+    },
+    "calendar": {
+      "enabled": true,
+      "component": "day-marker",
+      "marker": {
+        "type": "threshold",
+        "field": "systolic",
+        "rules": [
+          { "max": 120, "emoji": "🟢" },
+          { "max": 139, "emoji": "🟡" },
+          { "emoji": "🔴" }
+        ]
+      }
+    },
+    "writeable": {
+      "fromWebapp": true,
+      "maxReadingsPerDay": 3,
+      "inputs": [
+        { "key": "systolic", "type": "number", "required": true, "min": 60, "max": 250 },
+        { "key": "diastolic", "type": "number", "required": true, "min": 40, "max": 160 }
+      ]
+    }
+  },
+  "description": "Morning blood pressure readings.",
+  "data": [
+    { "date": "__OFFSET_DAYS:-12__", "systolic": 124, "diastolic": 79 },
+    { "date": "__OFFSET_DAYS:-10__", "systolic": 126, "diastolic": 80 },
+    { "date": "__OFFSET_DAYS:-8__", "systolic": 121, "diastolic": 78 },
+    { "date": "__OFFSET_DAYS:-6__", "systolic": 119, "diastolic": 76 },
+    { "date": "__OFFSET_DAYS:-4__", "systolic": 117, "diastolic": 75 },
+    { "date": "__OFFSET_DAYS:-2__", "systolic": 118, "diastolic": 74 },
+    { "date": "__OFFSET_DAYS:0__", "systolic": 116, "diastolic": 73 }
+  ]
+}

--- a/demo/fixtures/daily-notes.json
+++ b/demo/fixtures/daily-notes.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "daily-notes",
+    "label": "Daily notes",
+    "emoji": "📝",
+    "order": 410,
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{note|(no notes today)}",
+        "truncate": 200
+      }
+    },
+    "writeable": {
+      "fromWebapp": true,
+      "maxReadingsPerDay": 1,
+      "inputs": [
+        { "key": "note", "type": "textarea", "required": true }
+      ]
+    }
+  },
+  "description": "A single freeform note per day.",
+  "data": [
+    { "date": "__OFFSET_DAYS:-7__", "note": "Started a small lifting program: 3x5 squat, bench, row. Felt awkward but good." },
+    { "date": "__OFFSET_DAYS:-5__", "note": "Cut coffee after midday for two days running. Sleep noticeably deeper." },
+    { "date": "__OFFSET_DAYS:-3__", "note": "Long walk along the river. Took photos. Calmer afternoon than usual." },
+    { "date": "__OFFSET_DAYS:-2__", "note": "Worked through the renderer plan at the pub. Drew it out on a napkin." },
+    { "date": "__OFFSET_DAYS:-1__", "note": "Wrist still a little tight from yesterday's lift. Light day tomorrow." },
+    { "date": "__OFFSET_DAYS:0__", "note": "Prepping a public demo of the dashboard. Curious to see what people poke at first." }
+  ]
+}

--- a/demo/fixtures/hydration.json
+++ b/demo/fixtures/hydration.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "hydration",
+    "label": "Water intake",
+    "emoji": "💧",
+    "order": 420,
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{ml}",
+        "unit": "ml"
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "ml"
+    },
+    "writeable": {
+      "fromWebapp": true,
+      "maxReadingsPerDay": 1,
+      "inputs": [
+        { "key": "ml", "type": "stepper", "step": 250, "min": 0, "max": 10000, "required": true }
+      ]
+    }
+  },
+  "description": "Daily water intake in millilitres.",
+  "data": [
+    { "date": "__OFFSET_DAYS:-13__", "ml": 1750 },
+    { "date": "__OFFSET_DAYS:-12__", "ml": 2000 },
+    { "date": "__OFFSET_DAYS:-11__", "ml": 1500 },
+    { "date": "__OFFSET_DAYS:-10__", "ml": 2250 },
+    { "date": "__OFFSET_DAYS:-9__", "ml": 2500 },
+    { "date": "__OFFSET_DAYS:-8__", "ml": 1750 },
+    { "date": "__OFFSET_DAYS:-7__", "ml": 2000 },
+    { "date": "__OFFSET_DAYS:-6__", "ml": 2250 },
+    { "date": "__OFFSET_DAYS:-5__", "ml": 2500 },
+    { "date": "__OFFSET_DAYS:-4__", "ml": 2750 },
+    { "date": "__OFFSET_DAYS:-3__", "ml": 2000 },
+    { "date": "__OFFSET_DAYS:-2__", "ml": 2250 },
+    { "date": "__OFFSET_DAYS:-1__", "ml": 2500 },
+    { "date": "__OFFSET_DAYS:0__", "ml": 1500 }
+  ]
+}

--- a/demo/fixtures/mood.json
+++ b/demo/fixtures/mood.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "mood",
+    "label": "Mood",
+    "emoji": "🙂",
+    "order": 400,
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{mood:emoji}",
+        "secondary": "{notes|(no notes)}",
+        "emojiMap": {
+          "mood": { "1": "😩", "2": "😴", "3": "😐", "4": "🙂", "5": "😄" }
+        }
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "mood"
+    },
+    "calendar": {
+      "enabled": true,
+      "component": "day-marker",
+      "marker": {
+        "type": "field-emoji",
+        "field": "mood",
+        "emojiMap": { "1": "😩", "2": "😴", "3": "😐", "4": "🙂", "5": "😄" },
+        "fallback": "🙂"
+      }
+    },
+    "writeable": {
+      "fromWebapp": true,
+      "maxReadingsPerDay": 1,
+      "requireAny": ["mood", "notes"],
+      "inputs": [
+        { "key": "mood", "type": "rating", "min": 1, "max": 5 },
+        { "key": "notes", "type": "textarea" }
+      ]
+    }
+  },
+  "description": "Daily mood rating (1-5) with optional notes.",
+  "data": [
+    { "date": "__OFFSET_DAYS:-13__", "mood": 3, "notes": "Long meeting day, foggy by the afternoon." },
+    { "date": "__OFFSET_DAYS:-12__", "mood": 4, "notes": "Good run before work, kept the energy up." },
+    { "date": "__OFFSET_DAYS:-11__", "mood": 4, "notes": "Slept poorly but settled by mid-morning." },
+    { "date": "__OFFSET_DAYS:-10__", "mood": 5, "notes": "Crushed the deep-work block." },
+    { "date": "__OFFSET_DAYS:-9__", "mood": 3, "notes": "Tired, didn't push it." },
+    { "date": "__OFFSET_DAYS:-8__", "mood": 4, "notes": "Shipped a thing I'd been blocked on." },
+    { "date": "__OFFSET_DAYS:-7__", "mood": 5, "notes": "Long walk + sunshine." },
+    { "date": "__OFFSET_DAYS:-6__", "mood": 4 },
+    { "date": "__OFFSET_DAYS:-5__", "mood": 3, "notes": "Stiff lower back, careful with lifting." },
+    { "date": "__OFFSET_DAYS:-4__", "mood": 4 },
+    { "date": "__OFFSET_DAYS:-3__", "mood": 4, "notes": "Solid focus." },
+    { "date": "__OFFSET_DAYS:-2__", "mood": 5, "notes": "Best night's sleep in weeks." },
+    { "date": "__OFFSET_DAYS:-1__", "mood": 4, "notes": "Steady." },
+    { "date": "__OFFSET_DAYS:0__", "mood": 4, "notes": "Easing into the day." }
+  ]
+}

--- a/demo/fixtures/peptide-cycle.json
+++ b/demo/fixtures/peptide-cycle.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "peptide-cycle",
+    "label": "BPC-157 cycle",
+    "emoji": "💉",
+    "order": 300,
+    "view": {
+      "enabled": true,
+      "component": "schedule-card"
+    },
+    "trends": {
+      "enabled": true,
+      "component": "schedule-timeline",
+      "itemsPath": "items"
+    },
+    "reports": {
+      "enabled": true,
+      "component": "adherence-report",
+      "showCompliance": true
+    },
+    "calendar": {
+      "enabled": true,
+      "component": "day-marker",
+      "marker": "💉"
+    },
+    "writeable": {
+      "fromWebapp": true,
+      "pastAllowed": true,
+      "todayAllowed": true,
+      "futureAllowed": false
+    }
+  },
+  "description": "BPC-157 healing protocol on a six-week cycle.",
+  "data": {
+    "items": [
+      {
+        "name": "BPC-157",
+        "short_name": "BPC",
+        "dose_mg": 0.25,
+        "dose_units": "mg",
+        "route": "subcutaneous",
+        "schedule": {
+          "type": "weekly",
+          "on_days": ["Mon", "Wed", "Fri"]
+        },
+        "cycles": [
+          { "type": "on", "start": "__OFFSET_DAYS:-21__", "end": "__OFFSET_DAYS:21__" }
+        ],
+        "doses": [
+          { "scheduledDate": "__OFFSET_DAYS:-21__", "takenAt": "__OFFSET_DAYS:-21__T08:14:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-19__", "takenAt": "__OFFSET_DAYS:-19__T08:02:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-17__", "takenAt": "__OFFSET_DAYS:-17__T08:30:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-14__", "takenAt": "__OFFSET_DAYS:-14__T07:55:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-12__", "takenAt": "__OFFSET_DAYS:-12__T08:11:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-10__", "takenAt": "__OFFSET_DAYS:-10__T08:24:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-7__", "takenAt": "__OFFSET_DAYS:-7__T08:08:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-5__", "takenAt": "__OFFSET_DAYS:-5__T08:33:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-3__", "takenAt": "__OFFSET_DAYS:-3__T07:48:00" }
+        ]
+      }
+    ]
+  }
+}

--- a/demo/fixtures/resting-heart-rate.json
+++ b/demo/fixtures/resting-heart-rate.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "resting-heart-rate",
+    "label": "Resting heart rate",
+    "emoji": "❤️",
+    "order": 210,
+    "ingest": {
+      "source": "hae",
+      "metric": "resting_heart_rate"
+    },
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{bpm}",
+        "unit": "bpm",
+        "trendArrow": { "field": "bpm", "lowerIsBetter": true },
+        "thresholds": [
+          { "ifField": "bpm", "max": 60, "colour": "#44ff88", "label": "Athletic" },
+          { "ifField": "bpm", "max": 70, "colour": "#aaff66", "label": "Healthy" },
+          { "ifField": "bpm", "max": 80, "colour": "#ffaa33", "label": "Average" },
+          { "ifField": "bpm", "colour": "#ff4444", "label": "Elevated" }
+        ]
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "bpm"
+    },
+    "writeable": { "fromWebapp": false }
+  },
+  "description": "Daily resting heart rate from Apple Health.",
+  "data": [
+    { "date": "__OFFSET_DAYS:-13__", "bpm": 64 },
+    { "date": "__OFFSET_DAYS:-12__", "bpm": 63 },
+    { "date": "__OFFSET_DAYS:-11__", "bpm": 65 },
+    { "date": "__OFFSET_DAYS:-10__", "bpm": 62 },
+    { "date": "__OFFSET_DAYS:-9__", "bpm": 64 },
+    { "date": "__OFFSET_DAYS:-8__", "bpm": 63 },
+    { "date": "__OFFSET_DAYS:-7__", "bpm": 61 },
+    { "date": "__OFFSET_DAYS:-6__", "bpm": 62 },
+    { "date": "__OFFSET_DAYS:-5__", "bpm": 60 },
+    { "date": "__OFFSET_DAYS:-4__", "bpm": 60 },
+    { "date": "__OFFSET_DAYS:-3__", "bpm": 59 },
+    { "date": "__OFFSET_DAYS:-2__", "bpm": 60 },
+    { "date": "__OFFSET_DAYS:-1__", "bpm": 58 },
+    { "date": "__OFFSET_DAYS:0__", "bpm": 59 }
+  ]
+}

--- a/demo/fixtures/sleep-hours.json
+++ b/demo/fixtures/sleep-hours.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "sleep-hours",
+    "label": "Sleep",
+    "emoji": "😴",
+    "order": 500,
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{hours:round(1)}",
+        "unit": "hrs",
+        "secondary": "{deep:round(1)|}h deep · {rem:round(1)|}h REM",
+        "trendArrow": { "field": "hours" }
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "hours"
+    }
+  },
+  "description": "Total sleep duration per night with deep / REM breakdown.",
+  "data": [
+    { "date": "__OFFSET_DAYS:-13__", "hours": 6.8, "deep": 1.2, "rem": 1.4 },
+    { "date": "__OFFSET_DAYS:-12__", "hours": 7.2, "deep": 1.4, "rem": 1.6 },
+    { "date": "__OFFSET_DAYS:-11__", "hours": 6.5, "deep": 1.0, "rem": 1.3 },
+    { "date": "__OFFSET_DAYS:-10__", "hours": 7.8, "deep": 1.6, "rem": 1.7 },
+    { "date": "__OFFSET_DAYS:-9__", "hours": 7.1, "deep": 1.3, "rem": 1.5 },
+    { "date": "__OFFSET_DAYS:-8__", "hours": 6.9, "deep": 1.2, "rem": 1.4 },
+    { "date": "__OFFSET_DAYS:-7__", "hours": 8.0, "deep": 1.7, "rem": 1.8 },
+    { "date": "__OFFSET_DAYS:-6__", "hours": 7.4, "deep": 1.4, "rem": 1.6 },
+    { "date": "__OFFSET_DAYS:-5__", "hours": 6.6, "deep": 1.1, "rem": 1.3 },
+    { "date": "__OFFSET_DAYS:-4__", "hours": 7.7, "deep": 1.5, "rem": 1.7 },
+    { "date": "__OFFSET_DAYS:-3__", "hours": 7.3, "deep": 1.4, "rem": 1.6 },
+    { "date": "__OFFSET_DAYS:-2__", "hours": 7.0, "deep": 1.3, "rem": 1.5 },
+    { "date": "__OFFSET_DAYS:-1__", "hours": 7.5, "deep": 1.5, "rem": 1.6 },
+    { "date": "__OFFSET_DAYS:0__", "hours": 7.6, "deep": 1.5, "rem": 1.7 }
+  ]
+}

--- a/demo/fixtures/steps.json
+++ b/demo/fixtures/steps.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "steps",
+    "label": "Steps",
+    "emoji": "👣",
+    "order": 520,
+    "ingest": {
+      "source": "hae",
+      "metric": "step_count"
+    },
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{count}",
+        "unit": "steps",
+        "trendArrow": { "field": "count" }
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "count"
+    },
+    "writeable": { "fromWebapp": false }
+  },
+  "description": "Daily step count.",
+  "data": [
+    { "date": "__OFFSET_DAYS:-13__", "count": 6243 },
+    { "date": "__OFFSET_DAYS:-12__", "count": 9112 },
+    { "date": "__OFFSET_DAYS:-11__", "count": 5478 },
+    { "date": "__OFFSET_DAYS:-10__", "count": 11324 },
+    { "date": "__OFFSET_DAYS:-9__", "count": 7822 },
+    { "date": "__OFFSET_DAYS:-8__", "count": 8945 },
+    { "date": "__OFFSET_DAYS:-7__", "count": 12011 },
+    { "date": "__OFFSET_DAYS:-6__", "count": 6589 },
+    { "date": "__OFFSET_DAYS:-5__", "count": 7341 },
+    { "date": "__OFFSET_DAYS:-4__", "count": 9876 },
+    { "date": "__OFFSET_DAYS:-3__", "count": 8112 },
+    { "date": "__OFFSET_DAYS:-2__", "count": 10567 },
+    { "date": "__OFFSET_DAYS:-1__", "count": 9234 },
+    { "date": "__OFFSET_DAYS:0__", "count": 5012 }
+  ]
+}

--- a/demo/fixtures/supplement-stack.json
+++ b/demo/fixtures/supplement-stack.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "supplement-stack",
+    "label": "Supplement stack",
+    "emoji": "💊",
+    "order": 310,
+    "view": {
+      "enabled": true,
+      "component": "checklist-card"
+    },
+    "reports": {
+      "enabled": true,
+      "component": "adherence-report",
+      "showCompliance": true
+    },
+    "calendar": {
+      "enabled": true,
+      "component": "day-marker",
+      "marker": "💊"
+    },
+    "writeable": {
+      "fromWebapp": true,
+      "pastAllowed": true,
+      "todayAllowed": true,
+      "futureAllowed": false
+    }
+  },
+  "description": "Daily supplement check-off, grouped by time of day.",
+  "data": {
+    "items": [
+      {
+        "name": "Vitamin D3 (5000 IU)",
+        "group": "morning",
+        "takenDates": [
+          "__OFFSET_DAYS:-13__",
+          "__OFFSET_DAYS:-12__",
+          "__OFFSET_DAYS:-10__",
+          "__OFFSET_DAYS:-9__",
+          "__OFFSET_DAYS:-8__",
+          "__OFFSET_DAYS:-7__",
+          "__OFFSET_DAYS:-6__",
+          "__OFFSET_DAYS:-5__",
+          "__OFFSET_DAYS:-4__",
+          "__OFFSET_DAYS:-3__",
+          "__OFFSET_DAYS:-2__",
+          "__OFFSET_DAYS:-1__"
+        ]
+      },
+      {
+        "name": "Magnesium glycinate (400 mg)",
+        "group": "evening",
+        "takenDates": [
+          "__OFFSET_DAYS:-13__",
+          "__OFFSET_DAYS:-12__",
+          "__OFFSET_DAYS:-11__",
+          "__OFFSET_DAYS:-10__",
+          "__OFFSET_DAYS:-9__",
+          "__OFFSET_DAYS:-7__",
+          "__OFFSET_DAYS:-6__",
+          "__OFFSET_DAYS:-5__",
+          "__OFFSET_DAYS:-4__",
+          "__OFFSET_DAYS:-3__",
+          "__OFFSET_DAYS:-2__",
+          "__OFFSET_DAYS:-1__"
+        ]
+      },
+      {
+        "name": "Omega-3 (2 g EPA/DHA)",
+        "group": "morning",
+        "takenDates": [
+          "__OFFSET_DAYS:-13__",
+          "__OFFSET_DAYS:-11__",
+          "__OFFSET_DAYS:-10__",
+          "__OFFSET_DAYS:-8__",
+          "__OFFSET_DAYS:-7__",
+          "__OFFSET_DAYS:-6__",
+          "__OFFSET_DAYS:-4__",
+          "__OFFSET_DAYS:-3__",
+          "__OFFSET_DAYS:-2__",
+          "__OFFSET_DAYS:-1__"
+        ]
+      },
+      {
+        "name": "Creatine monohydrate (5 g)",
+        "group": "morning",
+        "takenDates": [
+          "__OFFSET_DAYS:-13__",
+          "__OFFSET_DAYS:-12__",
+          "__OFFSET_DAYS:-11__",
+          "__OFFSET_DAYS:-10__",
+          "__OFFSET_DAYS:-9__",
+          "__OFFSET_DAYS:-8__",
+          "__OFFSET_DAYS:-7__",
+          "__OFFSET_DAYS:-6__",
+          "__OFFSET_DAYS:-5__",
+          "__OFFSET_DAYS:-4__",
+          "__OFFSET_DAYS:-3__",
+          "__OFFSET_DAYS:-2__",
+          "__OFFSET_DAYS:-1__"
+        ]
+      }
+    ]
+  }
+}

--- a/demo/fixtures/weight.json
+++ b/demo/fixtures/weight.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "weight",
+    "label": "Weight",
+    "emoji": "⚖️",
+    "order": 100,
+    "view": {
+      "enabled": true,
+      "component": "generic-card",
+      "display": {
+        "template": "{kg:round(1)}",
+        "unit": "kg",
+        "trendArrow": { "field": "kg" }
+      }
+    },
+    "trends": {
+      "enabled": true,
+      "component": "line-chart",
+      "field": "kg"
+    },
+    "writeable": {
+      "fromWebapp": true,
+      "maxReadingsPerDay": 1,
+      "inputs": [
+        { "key": "kg", "type": "number", "required": true, "min": 20, "max": 500, "step": 0.1 }
+      ]
+    }
+  },
+  "description": "Body weight logged once per day. New entries replace earlier ones on the same date.",
+  "data": [
+    { "date": "__OFFSET_DAYS:-13__", "kg": 84.6 },
+    { "date": "__OFFSET_DAYS:-12__", "kg": 84.4 },
+    { "date": "__OFFSET_DAYS:-11__", "kg": 84.5 },
+    { "date": "__OFFSET_DAYS:-10__", "kg": 84.2 },
+    { "date": "__OFFSET_DAYS:-9__", "kg": 84.0 },
+    { "date": "__OFFSET_DAYS:-8__", "kg": 83.9 },
+    { "date": "__OFFSET_DAYS:-7__", "kg": 83.7 },
+    { "date": "__OFFSET_DAYS:-6__", "kg": 83.8 },
+    { "date": "__OFFSET_DAYS:-5__", "kg": 83.5 },
+    { "date": "__OFFSET_DAYS:-4__", "kg": 83.3 },
+    { "date": "__OFFSET_DAYS:-3__", "kg": 83.4 },
+    { "date": "__OFFSET_DAYS:-2__", "kg": 83.1 },
+    { "date": "__OFFSET_DAYS:-1__", "kg": 82.9 },
+    { "date": "__OFFSET_DAYS:0__", "kg": 82.8 }
+  ]
+}

--- a/scripts/reset-demo.js
+++ b/scripts/reset-demo.js
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// scripts/reset-demo.js
+//
+// Wipes $HEALTH_HOME/data/ for the public demo and restores the
+// curated dataset from demo/fixtures/. Resolves `__OFFSET_DAYS:N__`
+// placeholders against today so the dashboard always looks current.
+//
+// Refuses to run unless KLEBB_DEMO=1 — never invoke this against a
+// real instance.
+
+const fs = require('fs');
+const path = require('path');
+
+const PATHS = require('../config/paths');
+
+const FIXTURES_DIR = path.join(__dirname, '..', 'demo', 'fixtures');
+
+// Match __OFFSET_DAYS:N__ where N is a signed integer.
+const OFFSET_RE = /__OFFSET_DAYS:(-?\d+)__/g;
+
+function pad(n) { return n.toString().padStart(2, '0'); }
+
+function isoDateNDaysFromToday(offset, today = new Date()) {
+  const d = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  d.setDate(d.getDate() + offset);
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+function rewritePlaceholders(text, today = new Date()) {
+  return text.replace(OFFSET_RE, (_, n) => isoDateNDaysFromToday(parseInt(n, 10), today));
+}
+
+function listFixtures(dir = FIXTURES_DIR) {
+  return fs.readdirSync(dir)
+    .filter(f => f.endsWith('.json'))
+    .map(f => path.join(dir, f));
+}
+
+function wipeDataDir(dataDir) {
+  if (!fs.existsSync(dataDir)) {
+    fs.mkdirSync(dataDir, { recursive: true });
+    return [];
+  }
+  const removed = [];
+  for (const entry of fs.readdirSync(dataDir)) {
+    const full = path.join(dataDir, entry);
+    const stat = fs.statSync(full);
+    if (stat.isFile() && entry.endsWith('.json')) {
+      fs.unlinkSync(full);
+      removed.push(entry);
+    }
+  }
+  return removed;
+}
+
+function copyFixtures({ dataDir, fixturesDir = FIXTURES_DIR, today = new Date() } = {}) {
+  fs.mkdirSync(dataDir, { recursive: true });
+  const written = [];
+  for (const src of listFixtures(fixturesDir)) {
+    const raw = fs.readFileSync(src, 'utf8');
+    const resolved = rewritePlaceholders(raw, today);
+    // Validate the result parses; better to fail loudly than ship a broken
+    // demo dataset to disk.
+    JSON.parse(resolved);
+    const dest = path.join(dataDir, path.basename(src));
+    fs.writeFileSync(dest, resolved);
+    written.push(path.basename(src));
+  }
+  return written;
+}
+
+function resetDemo({ dataDir = PATHS.DATA_DIR, fixturesDir = FIXTURES_DIR, today = new Date() } = {}) {
+  if (process.env.KLEBB_DEMO !== '1') {
+    throw new Error('reset-demo refuses to run without KLEBB_DEMO=1');
+  }
+  const removed = wipeDataDir(dataDir);
+  const written = copyFixtures({ dataDir, fixturesDir, today });
+  return { dataDir, removed, written };
+}
+
+if (require.main === module) {
+  try {
+    const result = resetDemo();
+    console.log(`[reset-demo] data dir: ${result.dataDir}`);
+    if (result.removed.length) {
+      console.log(`[reset-demo] removed ${result.removed.length} existing file(s)`);
+    }
+    for (const name of result.written) {
+      console.log(`[reset-demo] restored ${name}`);
+    }
+    console.log(`[reset-demo] done — ${result.written.length} fixture(s) restored`);
+    process.exit(0);
+  } catch (e) {
+    console.error(`[reset-demo] ${e.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  resetDemo,
+  rewritePlaceholders,
+  isoDateNDaysFromToday,
+  listFixtures,
+  wipeDataDir,
+  copyFixtures,
+  FIXTURES_DIR,
+};

--- a/tests/reset-demo.test.js
+++ b/tests/reset-demo.test.js
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/reset-demo.test.js
+//
+// Coverage for #271. Three guarantees:
+//   1. Every fixture in demo/fixtures/ is a valid klebb.datafile.v1 manifest
+//      after placeholder rewriting.
+//   2. resetDemo() refuses to run unless KLEBB_DEMO=1.
+//   3. resetDemo() wipes the data dir, copies all fixtures, and rewrites
+//      __OFFSET_DAYS:N__ placeholders against the supplied "today".
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  resetDemo,
+  rewritePlaceholders,
+  isoDateNDaysFromToday,
+  listFixtures,
+  copyFixtures,
+  FIXTURES_DIR,
+} = require('../scripts/reset-demo');
+const { validateManifestShape } = require('../manifests/registry');
+
+function tmpDir(prefix = 'klebb-reset-demo-') {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+describe('reset-demo: placeholder rewrite', () => {
+  test('isoDateNDaysFromToday: today + N produces a YYYY-MM-DD string', () => {
+    const today = new Date(2026, 4, 21); // 2026-05-21 local
+    assert.equal(isoDateNDaysFromToday(0, today), '2026-05-21');
+    assert.equal(isoDateNDaysFromToday(-7, today), '2026-05-14');
+    assert.equal(isoDateNDaysFromToday(7, today), '2026-05-28');
+  });
+
+  test('rewritePlaceholders replaces every __OFFSET_DAYS:N__ token', () => {
+    const today = new Date(2026, 4, 21);
+    const input = 'a=__OFFSET_DAYS:0__ b=__OFFSET_DAYS:-7__ c=__OFFSET_DAYS:14__';
+    assert.equal(
+      rewritePlaceholders(input, today),
+      'a=2026-05-21 b=2026-05-14 c=2026-06-04',
+    );
+  });
+
+  test('rewritePlaceholders leaves non-placeholder text unchanged', () => {
+    const today = new Date(2026, 4, 21);
+    assert.equal(rewritePlaceholders('hello world', today), 'hello world');
+  });
+});
+
+describe('reset-demo: fixture validity', () => {
+  test('every fixture parses + validates as klebb.datafile.v1 after rewrite', () => {
+    const today = new Date();
+    const fixtures = listFixtures();
+    assert.ok(fixtures.length >= 8, `expected at least 8 fixtures, found ${fixtures.length}`);
+    for (const file of fixtures) {
+      const raw = fs.readFileSync(file, 'utf8');
+      const resolved = rewritePlaceholders(raw, today);
+      let parsed;
+      try {
+        parsed = JSON.parse(resolved);
+      } catch (e) {
+        assert.fail(`${path.basename(file)}: invalid JSON after rewrite — ${e.message}`);
+      }
+      assert.doesNotThrow(
+        () => validateManifestShape(parsed),
+        `${path.basename(file)}: failed shape validation`,
+      );
+      // Ensure no placeholder leaked through.
+      assert.ok(
+        !/__OFFSET_DAYS:/.test(resolved),
+        `${path.basename(file)}: placeholder not fully resolved`,
+      );
+    }
+  });
+});
+
+describe('reset-demo: resetDemo()', () => {
+  test('refuses to run when KLEBB_DEMO is unset', () => {
+    const dir = tmpDir();
+    try {
+      const orig = process.env.KLEBB_DEMO;
+      delete process.env.KLEBB_DEMO;
+      try {
+        assert.throws(() => resetDemo({ dataDir: dir }), /KLEBB_DEMO=1/);
+      } finally {
+        if (orig !== undefined) process.env.KLEBB_DEMO = orig;
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('refuses to run when KLEBB_DEMO is set to something other than "1"', () => {
+    const dir = tmpDir();
+    try {
+      const orig = process.env.KLEBB_DEMO;
+      process.env.KLEBB_DEMO = 'true';
+      try {
+        assert.throws(() => resetDemo({ dataDir: dir }), /KLEBB_DEMO=1/);
+      } finally {
+        if (orig === undefined) delete process.env.KLEBB_DEMO;
+        else process.env.KLEBB_DEMO = orig;
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('with KLEBB_DEMO=1: wipes existing JSON, copies all fixtures', () => {
+    const dir = tmpDir();
+    fs.writeFileSync(path.join(dir, 'stale.json'), '{"$schema":"x"}');
+    fs.writeFileSync(path.join(dir, 'keep.txt'), 'not a manifest');
+    const orig = process.env.KLEBB_DEMO;
+    process.env.KLEBB_DEMO = '1';
+    try {
+      const today = new Date(2026, 4, 21);
+      const result = resetDemo({ dataDir: dir, today });
+      assert.equal(result.dataDir, dir);
+      assert.ok(result.removed.includes('stale.json'), 'stale.json should be removed');
+      assert.ok(result.written.length >= 8, 'should write at least 8 fixtures');
+      // Non-JSON file is untouched.
+      assert.ok(fs.existsSync(path.join(dir, 'keep.txt')), 'keep.txt should survive');
+      // Every written fixture parses + validates.
+      for (const name of result.written) {
+        const parsed = readJson(path.join(dir, name));
+        assert.doesNotThrow(() => validateManifestShape(parsed), `${name} should validate`);
+      }
+    } finally {
+      if (orig === undefined) delete process.env.KLEBB_DEMO;
+      else process.env.KLEBB_DEMO = orig;
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('rewrites __OFFSET_DAYS:0__ to today', () => {
+    const dir = tmpDir();
+    const orig = process.env.KLEBB_DEMO;
+    process.env.KLEBB_DEMO = '1';
+    try {
+      const today = new Date(2026, 4, 21);
+      const expectedToday = '2026-05-21';
+      copyFixtures({ dataDir: dir, today });
+      // Pick the weight fixture; the last entry uses __OFFSET_DAYS:0__.
+      const w = readJson(path.join(dir, 'weight.json'));
+      const last = w.data[w.data.length - 1];
+      assert.equal(last.date, expectedToday, 'last weight entry should be dated today');
+    } finally {
+      if (orig === undefined) delete process.env.KLEBB_DEMO;
+      else process.env.KLEBB_DEMO = orig;
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('written count matches the fixture count', () => {
+    const dir = tmpDir();
+    const orig = process.env.KLEBB_DEMO;
+    process.env.KLEBB_DEMO = '1';
+    try {
+      const result = resetDemo({ dataDir: dir });
+      const fixtures = listFixtures(FIXTURES_DIR)
+        .map(f => path.basename(f));
+      assert.deepEqual(result.written.sort(), fixtures.sort());
+    } finally {
+      if (orig === undefined) delete process.env.KLEBB_DEMO;
+      else process.env.KLEBB_DEMO = orig;
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Pairs with #270's `KLEBB_DEMO` server flag. Adds the dataset that the
public demo (e.g. `demo.klebb.app`) ships with, plus a reset script
that the demo host can fire on a timer to keep the dashboard looking
like it was updated this week.

- Eleven complete `klebb.datafile.v1` manifests under
  `demo/fixtures/` covering the renderer surface a visitor sees:
  - **`generic-card`** with template + thresholds + trend arrows:
    `weight`, `resting-heart-rate`, `blood-pressure`, `hydration`,
    `steps`, `active-minutes`.
  - **Line-chart trends** on every series above plus `sleep-hours`.
  - **`day-marker` calendar** on `mood`, with a 1-5 scale and
    emoji map.
  - **`checklist-card`** on `supplement-stack` (Vitamin D3,
    magnesium, omega-3, creatine) with `takenDates[]` history.
  - **`schedule-card`** on `peptide-cycle` (BPC-157), weekly
    `on_days: ['Mon','Wed','Fri']`, single 6-week cycle and 9
    completed doses.
  - **Writeable note card** (`daily-notes`).
- All `data[].date` / `cycles[].start` / `cycles[].end` /
  `doses[].scheduledDate` / `doses[].takenAt` / `takenDates[]` use a
  simple `__OFFSET_DAYS:N__` placeholder. Negative N = past, positive
  N = future, 0 = today. Mixing literal ISO dates with placeholders
  in the same array isn't supported; `demo/fixtures/README.md` spells
  that out.
- `scripts/reset-demo.js` wipes `$HEALTH_HOME/data/*.json`, copies
  every fixture into place, and rewrites placeholders against the
  current date. Refuses to run unless `KLEBB_DEMO=1` so it can never
  be invoked against a real instance by accident.

## Why

The KLEBB_DEMO branch (#272) flips the runtime into demo mode but
without curated content the demo just shows an empty add-card prompt.
Manually maintaining 8-12 manifests with rolling dates would be
miserable; the placeholder pattern keeps the dataset declarative and
the reset script keeps the demo evergreen.

## How

- `demo/fixtures/` holds the canonical dataset.
- `scripts/reset-demo.js` exports `resetDemo`, `rewritePlaceholders`,
  `isoDateNDaysFromToday`, `listFixtures`, `wipeDataDir`,
  `copyFixtures`, `FIXTURES_DIR` so the test harness can drive each
  step in isolation. CLI prints a per-file restore log and exits
  0 / 1.
- `tests/reset-demo.test.js`: nine new tests across three describe
  blocks:
  - Placeholder arithmetic (today, today - 7, today + 7).
  - Every fixture parses + validates as `klebb.datafile.v1` after
    rewrite (calls `manifests/registry.validateManifestShape`).
  - Refusal when `KLEBB_DEMO` is unset.
  - Refusal when `KLEBB_DEMO` is set to anything other than `'1'`
    (e.g. `'true'`).
  - Stale `*.json` is wiped, non-JSON survives, fixtures are
    written, every written file validates.
  - `__OFFSET_DAYS:0__` resolves to today end-to-end.
  - Written-file count matches fixture count.

## Testing

- [x] `node --test tests/reset-demo.test.js` — 9/9
- [x] `npm test` — 944/945 (the one failure is the pre-existing
  `tests/no-personal-refs.test.js` from gitignored operator files;
  same failure on `main`)
- [x] Live smoke: `KLEBB_DEMO=1 HEALTH_HOME=$tmp node scripts/reset-demo.js`
  writes 11 fixtures, every one parses + validates.
- [x] Without the flag: exits 1 with `[reset-demo] reset-demo refuses
  to run without KLEBB_DEMO=1`.

Closes #271