### PR TITLE
feat(demo): flesh out Reports page with bloods, genome, narrative reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Added
+
+- **Reports page on the public demo now ships with a full multi-card
+  set.** Three new manifest fixtures (`blood-panel.json` with eight
+  RCPA-style categories of fasting bloods, `genome-snps.json` with an
+  APOE call plus 30 categorised SNPs across lipid metabolism /
+  methylation / detox / caffeine / sleep / inflammation, and a
+  reports-shaped extension of `peptide-cycle.json`) plus four narrative
+  markdown reports under `demo/fixtures/reports/` (a blood debrief, a
+  genome overview, a quarterly debrief, and a baseline profile). The
+  reset script now seeds `$HEALTH_HOME/reports/` from the markdown
+  fixtures and resolves `__OFFSET_DAYS:N__` placeholders in both file
+  bodies and filenames (the underscore form is accepted in filenames
+  since `:` is not a legal NTFS character). Fixes #275.
+
 ## [2.1.1] - 2026-05-21
 
 ### Added

--- a/demo/fixtures/README.md
+++ b/demo/fixtures/README.md
@@ -1,7 +1,7 @@
 # Demo fixtures
 
 This directory holds the curated dataset shown on the public Klebb
-demo (e.g. `demo.klebb.app`). Every file is a complete, valid
+demo (e.g. `demo.klebb.app`). Every JSON file is a complete, valid
 `klebb.datafile.v1` manifest with a couple of weeks of plausible-but-
 fake history so the dashboard renders trends, calendars, schedules,
 and reports the moment a visitor lands.
@@ -9,6 +9,23 @@ and reports the moment a visitor lands.
 These fixtures are **not** templates. They are full manifests with
 data already populated. Templates live under `templates/` and ship
 empty starter scaffolding for real users.
+
+## Layout
+
+```
+demo/fixtures/
+├── *.json                      # manifest cards, copied to $HEALTH_HOME/data/
+└── reports/
+    └── *.md                    # narrative reports, copied to $HEALTH_HOME/reports/
+```
+
+The cards include both small per-metric fixtures (weight, sleep, mood,
+hydration, steps, etc.) and richer reports-page cards (a fasting blood
+panel, a categorised SNP / genome card, and a peptide cycle that
+exposes adherence). The markdown narrative reports under
+`reports/` show up on the Reports page underneath the manifest-driven
+cards: a blood debrief, a genome overview, a quarterly debrief, and a
+baseline profile.
 
 ## Date placeholders
 
@@ -18,15 +35,25 @@ placeholders that resolve to *today minus N* (or *today plus N* for
 positive numbers) at the moment the reset script runs. So
 `__OFFSET_DAYS:0__` is today, `__OFFSET_DAYS:-7__` is a week ago.
 
+In **filenames** (e.g. `BLOODS-__OFFSET_DAYS_-30__.md`) use the
+underscore form `__OFFSET_DAYS_N__` since `:` is not a legal NTFS
+character. The reset script accepts both forms; it resolves the
+filename placeholder on copy, so the seeded report ends up named
+`BLOODS-2026-04-21.md` (or whatever date 30 days before today
+produces).
+
 Mixing literal ISO dates with placeholders inside the same array is
 not supported. Pick one shape per fixture and stick with it.
 
 ## Resetting
 
-`scripts/reset-demo.js` wipes `$HEALTH_HOME/data/`, copies every file
-from this directory into it, and rewrites every offset placeholder
-against the current date. It refuses to run unless `KLEBB_DEMO=1` is
-set so it can never be invoked against a real instance by accident.
+`scripts/reset-demo.js` wipes `$HEALTH_HOME/data/` and
+`$HEALTH_HOME/reports/`, then copies every JSON manifest from this
+directory into the data dir and every markdown report from
+`reports/` into the reports dir, rewriting every offset placeholder
+against the current date along the way. It refuses to run unless
+`KLEBB_DEMO=1` is set so it can never be invoked against a real
+instance by accident.
 
 ```
 KLEBB_DEMO=1 HEALTH_HOME=/srv/klebb-demo node scripts/reset-demo.js

--- a/demo/fixtures/blood-panel.json
+++ b/demo/fixtures/blood-panel.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "blood-panel",
+    "label": "Blood panel",
+    "emoji": "🩸",
+    "order": 800,
+    "view": {
+      "enabled": true,
+      "component": "list-card",
+      "display": {
+        "primaryField": "label",
+        "secondaryTemplate": "{value} {unit} (ref {refLow}-{refHigh})",
+        "emptyMessage": "No blood panels recorded yet."
+      }
+    },
+    "reports": {
+      "enabled": true,
+      "component": "table-list"
+    },
+    "writeable": { "fromWebapp": false }
+  },
+  "description": "Most recent fasting blood panel. Latest collection __OFFSET_DAYS:-30__. Reference ranges follow Australian RCPA adult ranges; flag indicates out-of-range high (H) or low (L). Categories: Lipids, Liver, Kidneys, Glucose / Insulin, Iron studies, Thyroid, Inflammation.",
+  "data": {
+    "collected": "__OFFSET_DAYS:-30__",
+    "lab": "DemoLabs Pty Ltd",
+    "categories": [
+      {
+        "name": "Lipids",
+        "findings": [
+          { "label": "Total cholesterol", "value": "4.6", "unit": "mmol/L", "refLow": "<5.5", "refHigh": "", "flag": "" },
+          { "label": "HDL", "value": "1.5", "unit": "mmol/L", "refLow": ">1.0", "refHigh": "", "flag": "" },
+          { "label": "LDL (calc)", "value": "2.7", "unit": "mmol/L", "refLow": "<3.5", "refHigh": "", "flag": "" },
+          { "label": "Triglycerides", "value": "0.9", "unit": "mmol/L", "refLow": "<2.0", "refHigh": "", "flag": "" },
+          { "label": "Non-HDL chol.", "value": "3.1", "unit": "mmol/L", "refLow": "<4.0", "refHigh": "", "flag": "" }
+        ]
+      },
+      {
+        "name": "Liver",
+        "findings": [
+          { "label": "ALT", "value": "28", "unit": "U/L", "refLow": "5", "refHigh": "40", "flag": "" },
+          { "label": "AST", "value": "24", "unit": "U/L", "refLow": "10", "refHigh": "35", "flag": "" },
+          { "label": "GGT", "value": "21", "unit": "U/L", "refLow": "5", "refHigh": "55", "flag": "" },
+          { "label": "ALP", "value": "72", "unit": "U/L", "refLow": "30", "refHigh": "110", "flag": "" },
+          { "label": "Bilirubin", "value": "11", "unit": "umol/L", "refLow": "<20", "refHigh": "", "flag": "" }
+        ]
+      },
+      {
+        "name": "Kidneys",
+        "findings": [
+          { "label": "Creatinine", "value": "82", "unit": "umol/L", "refLow": "60", "refHigh": "110", "flag": "" },
+          { "label": "Urea", "value": "5.4", "unit": "mmol/L", "refLow": "2.5", "refHigh": "8.0", "flag": "" },
+          { "label": "eGFR", "value": ">90", "unit": "mL/min", "refLow": ">60", "refHigh": "", "flag": "" },
+          { "label": "Uric acid", "value": "0.34", "unit": "mmol/L", "refLow": "0.20", "refHigh": "0.42", "flag": "" }
+        ]
+      },
+      {
+        "name": "Glucose / Insulin",
+        "findings": [
+          { "label": "Fasting glucose", "value": "5.0", "unit": "mmol/L", "refLow": "3.5", "refHigh": "6.0", "flag": "" },
+          { "label": "HbA1c", "value": "33", "unit": "mmol/mol", "refLow": "<42", "refHigh": "", "flag": "" },
+          { "label": "Fasting insulin", "value": "6.2", "unit": "mIU/L", "refLow": "2.0", "refHigh": "15.0", "flag": "" },
+          { "label": "HOMA-IR (calc)", "value": "1.4", "unit": "", "refLow": "<2.0", "refHigh": "", "flag": "" }
+        ]
+      },
+      {
+        "name": "Iron studies",
+        "findings": [
+          { "label": "Iron", "value": "18", "unit": "umol/L", "refLow": "10", "refHigh": "30", "flag": "" },
+          { "label": "Ferritin", "value": "112", "unit": "ug/L", "refLow": "30", "refHigh": "300", "flag": "" },
+          { "label": "Transferrin", "value": "2.6", "unit": "g/L", "refLow": "2.0", "refHigh": "3.6", "flag": "" },
+          { "label": "Transferrin sat.", "value": "30", "unit": "%", "refLow": "15", "refHigh": "45", "flag": "" }
+        ]
+      },
+      {
+        "name": "Thyroid",
+        "findings": [
+          { "label": "TSH", "value": "1.8", "unit": "mIU/L", "refLow": "0.4", "refHigh": "4.0", "flag": "" },
+          { "label": "Free T4", "value": "14", "unit": "pmol/L", "refLow": "10", "refHigh": "20", "flag": "" },
+          { "label": "Free T3", "value": "4.6", "unit": "pmol/L", "refLow": "3.5", "refHigh": "6.5", "flag": "" }
+        ]
+      },
+      {
+        "name": "Inflammation",
+        "findings": [
+          { "label": "hs-CRP", "value": "0.6", "unit": "mg/L", "refLow": "<1.0", "refHigh": "", "flag": "" },
+          { "label": "Homocysteine", "value": "8.4", "unit": "umol/L", "refLow": "<12", "refHigh": "", "flag": "" }
+        ]
+      },
+      {
+        "name": "Vitamins",
+        "findings": [
+          { "label": "Vitamin D", "value": "92", "unit": "nmol/L", "refLow": "75", "refHigh": "200", "flag": "" },
+          { "label": "Vitamin B12", "value": "385", "unit": "pmol/L", "refLow": "180", "refHigh": "650", "flag": "" },
+          { "label": "Folate (RBC)", "value": "1240", "unit": "nmol/L", "refLow": "700", "refHigh": "1700", "flag": "" }
+        ]
+      }
+    ]
+  }
+}

--- a/demo/fixtures/genome-snps.json
+++ b/demo/fixtures/genome-snps.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "genome-snps",
+    "label": "Genome (SNPs)",
+    "emoji": "🧬",
+    "order": 850,
+    "view": {
+      "enabled": true,
+      "component": "list-card",
+      "display": {
+        "primaryField": "gene",
+        "secondaryTemplate": "{rsid} · {genotype}",
+        "emptyMessage": "No SNPs loaded yet."
+      }
+    },
+    "reports": {
+      "enabled": true,
+      "component": "table-list"
+    },
+    "writeable": { "fromWebapp": false }
+  },
+  "description": "Curated SNP panel from a saliva-based whole-genome service. APOE shown up top; the categorised list flags polymorphisms with reasonable evidence in lipid metabolism, methylation, detoxification, caffeine sensitivity, sleep, and inflammation. Genotypes are illustrative only and do not constitute clinical advice.",
+  "data": {
+    "panel_provider": "DemoGenomics",
+    "collected": "__OFFSET_DAYS:-180__",
+    "apoe": "3/3",
+    "total_snps": 612000,
+    "found_count": 78,
+    "searched_count": 120,
+    "categories": [
+      {
+        "name": "Lipid metabolism",
+        "findings": [
+          { "gene": "APOE", "rsid": "rs429358", "genotype": "T/T", "phenotype": "ε3 — average risk profile" },
+          { "gene": "APOE", "rsid": "rs7412", "genotype": "C/C", "phenotype": "ε3 — average risk profile" },
+          { "gene": "PCSK9", "rsid": "rs11591147", "genotype": "G/G", "phenotype": "Wild-type; no LDL-lowering loss-of-function" },
+          { "gene": "LPA", "rsid": "rs10455872", "genotype": "A/A", "phenotype": "No Lp(a) elevation flag" },
+          { "gene": "LDLR", "rsid": "rs6511720", "genotype": "G/T", "phenotype": "Heterozygous; modest LDL-lowering" },
+          { "gene": "CETP", "rsid": "rs708272", "genotype": "A/G", "phenotype": "Heterozygous; slightly higher HDL tendency" }
+        ]
+      },
+      {
+        "name": "Methylation",
+        "findings": [
+          { "gene": "MTHFR", "rsid": "rs1801133", "genotype": "C/T", "phenotype": "Heterozygous C677T; ~30% reduced enzyme activity" },
+          { "gene": "MTHFR", "rsid": "rs1801131", "genotype": "A/A", "phenotype": "Wild-type A1298C" },
+          { "gene": "MTRR", "rsid": "rs1801394", "genotype": "A/G", "phenotype": "Heterozygous; mildly reduced B12 recycling" },
+          { "gene": "MTR", "rsid": "rs1805087", "genotype": "A/A", "phenotype": "Wild-type" },
+          { "gene": "BHMT", "rsid": "rs3733890", "genotype": "G/A", "phenotype": "Heterozygous; alternate methyl donor pathway intact" },
+          { "gene": "COMT", "rsid": "rs4680", "genotype": "G/A", "phenotype": "Val/Met — balanced dopamine clearance" }
+        ]
+      },
+      {
+        "name": "Detox",
+        "findings": [
+          { "gene": "GSTM1", "rsid": "CNV", "genotype": "Present", "phenotype": "Functional glutathione S-transferase M1" },
+          { "gene": "GSTT1", "rsid": "CNV", "genotype": "Present", "phenotype": "Functional glutathione S-transferase T1" },
+          { "gene": "GSTP1", "rsid": "rs1695", "genotype": "A/G", "phenotype": "Ile/Val — mildly reduced activity" },
+          { "gene": "NAT2", "rsid": "rs1799930", "genotype": "G/G", "phenotype": "Rapid acetylator profile" },
+          { "gene": "SOD2", "rsid": "rs4880", "genotype": "C/T", "phenotype": "Heterozygous; balanced mitochondrial SOD2 activity" },
+          { "gene": "NQO1", "rsid": "rs1800566", "genotype": "C/C", "phenotype": "Wild-type; full quinone reductase activity" }
+        ]
+      },
+      {
+        "name": "Caffeine",
+        "findings": [
+          { "gene": "CYP1A2", "rsid": "rs762551", "genotype": "A/A", "phenotype": "Rapid caffeine metaboliser" },
+          { "gene": "ADORA2A", "rsid": "rs5751876", "genotype": "C/T", "phenotype": "Intermediate caffeine-induced anxiety risk" },
+          { "gene": "AHR", "rsid": "rs2472297", "genotype": "C/T", "phenotype": "Higher CYP1A2 inducibility" }
+        ]
+      },
+      {
+        "name": "Sleep",
+        "findings": [
+          { "gene": "PER3", "rsid": "rs57875989", "genotype": "5/4", "phenotype": "Mixed chronotype tendency" },
+          { "gene": "CLOCK", "rsid": "rs1801260", "genotype": "T/C", "phenotype": "Heterozygous; slight evening preference" },
+          { "gene": "ADA", "rsid": "rs73598374", "genotype": "C/C", "phenotype": "Standard adenosine clearance; typical sleep pressure" },
+          { "gene": "BHLHE41", "rsid": "rs121912617", "genotype": "C/C", "phenotype": "Wild-type; no short-sleep variant" }
+        ]
+      },
+      {
+        "name": "Inflammation",
+        "findings": [
+          { "gene": "IL6", "rsid": "rs1800795", "genotype": "G/C", "phenotype": "Heterozygous; balanced IL-6 expression" },
+          { "gene": "TNF", "rsid": "rs1800629", "genotype": "G/G", "phenotype": "Wild-type TNF-α promoter" },
+          { "gene": "CRP", "rsid": "rs1205", "genotype": "C/T", "phenotype": "Heterozygous; intermediate baseline hs-CRP" },
+          { "gene": "IL1B", "rsid": "rs16944", "genotype": "G/A", "phenotype": "Heterozygous; balanced IL-1β response" },
+          { "gene": "HLA-DQ2.5", "rsid": "DQA1*05/DQB1*02", "genotype": "Absent", "phenotype": "No coeliac-risk haplotype detected" }
+        ]
+      }
+    ]
+  }
+}

--- a/demo/fixtures/peptide-cycle.json
+++ b/demo/fixtures/peptide-cycle.json
@@ -45,7 +45,15 @@
           "on_days": ["Mon", "Wed", "Fri"]
         },
         "cycles": [
-          { "type": "on", "start": "__OFFSET_DAYS:-21__", "end": "__OFFSET_DAYS:21__" }
+          {
+            "type": "on",
+            "status": "active",
+            "cycle_number": 1,
+            "start": "__OFFSET_DAYS:-21__",
+            "end": "__OFFSET_DAYS:21__",
+            "start_date": "__OFFSET_DAYS:-21__",
+            "end_date": "__OFFSET_DAYS:21__"
+          }
         ],
         "doses": [
           { "scheduledDate": "__OFFSET_DAYS:-21__", "takenAt": "__OFFSET_DAYS:-21__T08:14:00" },

--- a/demo/fixtures/reports/BLOODS-__OFFSET_DAYS_-30__.md
+++ b/demo/fixtures/reports/BLOODS-__OFFSET_DAYS_-30__.md
@@ -1,0 +1,60 @@
+# Blood panel review — fasting
+
+**Collected:** __OFFSET_DAYS:-30__
+**Lab:** DemoLabs Pty Ltd
+**Reviewing clinician:** Dr Demo (the operator's GP, illustrative only)
+
+## Summary
+
+Everything sits comfortably inside the Australian RCPA adult reference
+ranges. No red flags, no follow-up bloods required before the next
+quarterly draw. The lipid panel in particular has continued to drift in
+the right direction; HDL is up a notch from last quarter and
+triglycerides are well below the upper guideline.
+
+## Highlights
+
+- **Lipids:** total cholesterol 4.6 mmol/L, HDL 1.5 mmol/L, LDL (calc)
+  2.7 mmol/L, triglycerides 0.9 mmol/L. Non-HDL 3.1 mmol/L. The
+  HDL:total ratio is exactly where we'd want it for someone on a
+  predominantly Mediterranean-style diet plus daily resistance training.
+- **Liver:** ALT 28, AST 24, GGT 21, ALP 72, bilirubin 11. All midband.
+  The slight tick down in GGT compared to last cycle is consistent with
+  reduced alcohol intake over the last six weeks.
+- **Kidneys:** creatinine 82, urea 5.4, eGFR &gt;90, uric acid 0.34.
+  Hydration is adequate; eGFR is reported only as &gt;90 by the lab,
+  which is the standard ceiling.
+- **Glucose / insulin:** fasting glucose 5.0 mmol/L, HbA1c 33 mmol/mol,
+  fasting insulin 6.2 mIU/L, HOMA-IR 1.4. Insulin sensitivity remains
+  excellent.
+- **Iron studies:** iron 18 µmol/L, ferritin 112 µg/L, transferrin 2.6
+  g/L, transferrin saturation 30%. Stable; no need to revisit
+  supplementation.
+- **Thyroid:** TSH 1.8 mIU/L, free T4 14 pmol/L, free T3 4.6 pmol/L.
+  Comfortably euthyroid.
+- **Inflammation:** hs-CRP 0.6 mg/L, homocysteine 8.4 µmol/L. Both low.
+- **Vitamins:** vitamin D 92 nmol/L, B12 385 pmol/L, folate (RBC) 1240
+  nmol/L. Vitamin D is in the comfortable upper-mid range for late
+  Australian autumn.
+
+## What changed since last quarter
+
+- Triglycerides down from 1.1 → 0.9 mmol/L.
+- HDL up from 1.4 → 1.5 mmol/L.
+- HbA1c stable at 33 mmol/mol.
+- Vitamin D up from 78 → 92 nmol/L (consistent with the increased
+  outdoor walking schedule and the daily 5 000 IU D3).
+
+## Recommendations
+
+1. **No pharmacological change.** Continue the current supplement
+   stack as-is.
+2. **Re-test in 12 weeks** to keep the lipid trend visible.
+3. **Optional:** add fasting Apo-B at the next draw for a more direct
+   view of atherogenic-particle burden.
+
+## Notes
+
+This is a synthetic blood panel produced for the public Klebb demo.
+Reference ranges follow standard Australian RCPA adult panels; values
+are illustrative.

--- a/demo/fixtures/reports/DEBRIEF-__OFFSET_DAYS_-7__.md
+++ b/demo/fixtures/reports/DEBRIEF-__OFFSET_DAYS_-7__.md
@@ -1,0 +1,75 @@
+# Quarterly debrief
+
+**Reporting window:** approximately the last 12 weeks
+**Generated:** __OFFSET_DAYS:-7__
+
+## Where we landed
+
+Strong quarter. The dashboard tells a coherent story: weight is stable
+inside the target band, resting heart rate has trended down, sleep is
+consistently above the 7-hour floor, and the daily supplement and
+peptide adherence numbers are both above 85%. Nothing on bloods asks
+for intervention.
+
+## Headline numbers
+
+- **Weight:** drifting around the target line ± 0.6 kg. No directional
+  trend in either direction over the 12-week window.
+- **Resting heart rate:** mid-50s on most mornings, down ~3 bpm on the
+  rolling 30-day median compared to the start of the window.
+- **Sleep:** 7h 20m mean, 1h 50m mean deep, 0h 55m mean REM. Two
+  obvious dips correlated with late-evening alcohol.
+- **Hydration:** 2.4 L/day median. Comfortably above the 2.0 L floor.
+- **Steps:** 9 800/day median, with the weekend average pulling up
+  the weekday baseline.
+- **Active minutes:** 38/day median. Cardiac zone (zone 3 and above)
+  adds up to ~150 minutes weekly — meets WHO guidance, room to push.
+- **Mood:** stable, occasional dips correlate with the same alcohol
+  events that cost sleep.
+
+## Adherence
+
+- **Supplement stack:** ~88% adherence across the four pillars (D3,
+  Mg-glycinate, Omega-3, creatine). The two missed days clustered on a
+  weekend trip away.
+- **BPC-157 cycle:** 9 of 9 scheduled doses taken. Cycle is 21 days
+  in, 21 days remaining.
+
+## What changed
+
+Three deliberate changes in the window worth noting:
+
+1. **Coffee curfew.** Pulled the last coffee of the day forward from
+   ~3pm to before noon. Subjective sleep latency improved (median time
+   to fall asleep dropped from ~22 min to ~12 min).
+2. **Walking volume.** Added a daily 30-minute lunchtime walk. Picks
+   up most of the gain in the step count.
+3. **Resistance training cadence.** Switched from 4× per week to 3×
+   per week with one extra set per session. Time spent in the gym is
+   roughly the same; weekly tonnage is up ~12%.
+
+## Working hypotheses for next quarter
+
+- The HDL bump from 1.4 → 1.5 mmol/L is small but consistent with
+  reduced ultra-processed food intake and steady cardio. Worth
+  re-checking at the next blood draw.
+- The slight downward trend in resting heart rate is consistent with
+  the increased weekly cardiac zone minutes. Push another 30 min/week
+  and re-look.
+- Two alcohol-impacted weekends in 12 weeks is fine for general
+  health, but the sleep and mood data make the cost legible. No
+  formal restriction; the dashboard is doing the nudging.
+
+## Next quarter
+
+- Add fasting Apo-B to the next blood draw.
+- Aim to lift weekly cardiac zone minutes above 200.
+- Continue the BPC-157 cycle to completion, then 4-week off-cycle as
+  planned.
+- Consider adding a CGM 14-day window to look at post-meal glucose
+  shape under the current diet.
+
+## Notes
+
+This is a synthetic quarterly debrief produced for the public Klebb
+demo. The values reflect the demo dataset, not a real person.

--- a/demo/fixtures/reports/GENOME-overview.md
+++ b/demo/fixtures/reports/GENOME-overview.md
@@ -1,0 +1,90 @@
+# Genome — narrative overview
+
+**Saliva collected:** approximately 6 months ago
+**Provider:** DemoGenomics whole-genome service
+**Reviewing clinician:** Dr Demo (illustrative only)
+
+## TL;DR
+
+The genome shows no high-impact pathogenic variants and no monogenic
+disease flags. APOE genotype is **ε3/ε3**, the most common combination
+worldwide and the one associated with average late-life cognitive risk.
+Methylation, detoxification, caffeine, sleep, and inflammation panels
+all sit in the typical range with a couple of mild heterozygous calls
+worth being aware of (notably MTHFR C677T heterozygous).
+
+## What's in the report
+
+The categorised SNP card on the dashboard lists 78 polymorphisms with
+reasonable evidence in six functional categories. Each genotype is
+shown alongside the gene symbol and the SNP's rsID. Treat every line
+as a starting point for conversation with a clinician, not a clinical
+finding on its own.
+
+### Lipid metabolism
+
+The two APOE-defining SNPs (rs429358 and rs7412) read as ε3/ε3, so the
+LDL receptor binding affinity is average. PCSK9 rs11591147 is wild-type
+(no naturally low-LDL phenotype). LPA rs10455872 carries no Lp(a)
+elevation flag. LDLR rs6511720 is heterozygous, which on its own gives
+a modest LDL-lowering effect. CETP rs708272 heterozygous is consistent
+with the slightly higher HDL seen on recent bloods.
+
+Bottom line: nothing that requires aggressive lipid intervention.
+Standard lifestyle measures (diet pattern, weight, training) plus a
+12-weekly lipid panel is sufficient.
+
+### Methylation
+
+MTHFR C677T (rs1801133) is **C/T heterozygous**, which gives roughly
+30% reduced enzyme activity. The A1298C variant is wild-type. Practical
+implications:
+
+- Folate intake should come from real food where possible (leafy
+  greens, legumes) plus the existing methylated B-complex.
+- B12 status is comfortably mid-range on the current panel; recheck
+  annually.
+- Homocysteine is currently 8.4 µmol/L — the heterozygous MTHFR is
+  silent in practice as long as homocysteine stays under ~12.
+
+### Detoxification
+
+GSTM1 and GSTT1 are both present (the more common phase-II conjugation
+enzymes are functional). NAT2 reads as a rapid acetylator profile.
+There's a heterozygous GSTP1 Ile/Val call (rs1695) which mildly reduces
+activity but doesn't change practical recommendations.
+
+### Caffeine
+
+CYP1A2 rs762551 is **A/A — fast metaboliser**. ADORA2A rs5751876 is
+heterozygous, which is consistent with the moderate caffeine-induced
+sleep disruption noted in the daily logs when coffee is taken after
+~2pm. Three espressos a day before lunch is fine; afternoon caffeine
+will continue to bite.
+
+### Sleep
+
+Nothing extreme. PER3 5/4 mixed chronotype, CLOCK rs1801260 heterozygous
+with a slight evening preference, no short-sleeper variants. Continues
+to support an "8 hours in bed" target rather than trying to chase a
+shorter night.
+
+### Inflammation
+
+Balanced expression genotypes for IL6, TNF-α, IL-1β, and CRP. No HLA-DQ2.5
+coeliac-risk haplotype detected. Combined with the consistently low
+hs-CRP on bloods, this is reassuring.
+
+## What this report does NOT cover
+
+- **Pharmacogenomics** beyond the basics. The next iteration will pull
+  in CYP2D6, CYP2C19, and CYP3A4 detail.
+- **HLA typing** beyond the coeliac flag.
+- **Polygenic risk scores.** Single-SNP calls are easy to overinterpret.
+  PRS work is on the deferred list.
+
+## Notes
+
+This is synthetic genomic data produced for the public Klebb demo. It
+is not derived from any real person and must not be used for clinical
+decision-making.

--- a/demo/fixtures/reports/PROFILE-summary.md
+++ b/demo/fixtures/reports/PROFILE-summary.md
@@ -1,0 +1,82 @@
+# Baseline profile
+
+This page is the demo subject's longitudinal profile — the slow-moving
+context that makes the day-to-day dashboard make sense. It is **not**
+the system prompt the chat agent sees; it is a human-readable snapshot
+intended for the operator and any clinician who happens to be looking
+over their shoulder.
+
+## Demographics
+
+- Age band: late 30s
+- Sex: male
+- Height: 178 cm
+- Frame: medium
+- Country: Australia (eastern seaboard)
+- Time zone: Australia/Sydney
+
+## Goals
+
+In rough priority order:
+
+1. **Healthspan over lifespan.** Stay strong, mobile, and cognitively
+   sharp into the 70s and 80s. Body composition and resting heart rate
+   are the leading indicators.
+2. **Stable energy and sleep.** Avoid post-lunch crashes; protect a
+   7–8h sleep floor.
+3. **Predictable bloods.** Lipids, fasting glucose, and inflammation
+   markers in the comfortable middle of reference ranges.
+4. **Cycle-based experimentation.** Use peptides, training programmes,
+   and dietary tweaks as time-boxed experiments tracked against the
+   metrics on the dashboard.
+
+## Training baseline
+
+- Resistance training 3× per week, full-body split.
+- One ~60-minute zone 2 session per week (steady cycling).
+- Daily 30–45 minute lunchtime walk.
+- Mobility work 2× per week, ~15 minutes each.
+
+## Nutrition pattern
+
+- Predominantly Mediterranean-style, with a protein anchor at each
+  meal (~1.6 g/kg/day).
+- Two coffees in the morning, no caffeine after noon.
+- Alcohol: usually 0–2 standard drinks per week; the dashboard shows
+  the costs when this drifts up.
+- Carbohydrate timing: skewed towards the post-training meal.
+
+## Current cycles
+
+- **BPC-157.** Subcutaneous, 0.25 mg three times per week (Mon/Wed/Fri).
+  Six-week protocol; currently 21 days in.
+- **Supplement stack.** Vitamin D3 (5 000 IU), magnesium glycinate (400
+  mg), omega-3 (2 g EPA/DHA), creatine monohydrate (5 g) — all daily.
+
+## Medical context
+
+No chronic conditions, no regular pharmaceutical medications. Standard
+GP follow-up annually. No known drug allergies. Family history is
+unremarkable except for late-life cardiovascular events on the paternal
+side, which informs the bias towards keeping HDL and triglycerides on
+the favourable side.
+
+## Sleep environment
+
+- Bedroom: blackout, ~18°C, white-noise machine.
+- Wind-down: phone in another room from 9pm.
+- Wake: natural alarm-clock-light at 06:30.
+
+## Why this card exists
+
+The dashboard's day-to-day numbers (steps, sleep, heart rate, mood)
+move quickly. This profile sets the context they should be read
+against. If a future change makes one of these numbers look bad, the
+question to ask first is "did the profile change?" — e.g. is there a
+new training programme, a new medication, a different sleep
+environment.
+
+## Notes
+
+This is a synthetic profile produced for the public Klebb demo. It is
+not derived from any real person.

--- a/scripts/reset-demo.js
+++ b/scripts/reset-demo.js
@@ -6,7 +6,7 @@
 // curated dataset from demo/fixtures/. Resolves `__OFFSET_DAYS:N__`
 // placeholders against today so the dashboard always looks current.
 //
-// Refuses to run unless KLEBB_DEMO=1 — never invoke this against a
+// Refuses to run unless KLEBB_DEMO=1: never invoke this against a
 // real instance.
 
 const fs = require('fs');
@@ -15,9 +15,12 @@ const path = require('path');
 const PATHS = require('../config/paths');
 
 const FIXTURES_DIR = path.join(__dirname, '..', 'demo', 'fixtures');
+const REPORTS_FIXTURES_DIR = path.join(FIXTURES_DIR, 'reports');
 
-// Match __OFFSET_DAYS:N__ where N is a signed integer.
-const OFFSET_RE = /__OFFSET_DAYS:(-?\d+)__/g;
+// Match __OFFSET_DAYS:N__ or __OFFSET_DAYS_N__ where N is a signed
+// integer. The underscore form is needed in filenames on Windows since
+// `:` is not a legal NTFS character.
+const OFFSET_RE = /__OFFSET_DAYS[:_](-?\d+)__/g;
 
 function pad(n) { return n.toString().padStart(2, '0'); }
 
@@ -34,6 +37,13 @@ function rewritePlaceholders(text, today = new Date()) {
 function listFixtures(dir = FIXTURES_DIR) {
   return fs.readdirSync(dir)
     .filter(f => f.endsWith('.json'))
+    .map(f => path.join(dir, f));
+}
+
+function listReportFixtures(dir = REPORTS_FIXTURES_DIR) {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir)
+    .filter(f => f.endsWith('.md'))
     .map(f => path.join(dir, f));
 }
 
@@ -70,13 +80,67 @@ function copyFixtures({ dataDir, fixturesDir = FIXTURES_DIR, today = new Date() 
   return written;
 }
 
-function resetDemo({ dataDir = PATHS.DATA_DIR, fixturesDir = FIXTURES_DIR, today = new Date() } = {}) {
+function wipeReportsDir(reportsDir) {
+  if (!fs.existsSync(reportsDir)) {
+    fs.mkdirSync(reportsDir, { recursive: true });
+    return [];
+  }
+  const removed = [];
+  for (const entry of fs.readdirSync(reportsDir)) {
+    const full = path.join(reportsDir, entry);
+    const stat = fs.statSync(full);
+    if (stat.isFile() && entry.endsWith('.md')) {
+      fs.unlinkSync(full);
+      removed.push(entry);
+    }
+  }
+  return removed;
+}
+
+function copyReportFixtures({ reportsDir, fixturesDir = REPORTS_FIXTURES_DIR, today = new Date() } = {}) {
+  fs.mkdirSync(reportsDir, { recursive: true });
+  const written = [];
+  for (const src of listReportFixtures(fixturesDir)) {
+    const raw = fs.readFileSync(src, 'utf8');
+    const resolved = rewritePlaceholders(raw, today);
+    // Resolve the placeholder in the filename too so reports show up as
+    // e.g. BLOODS-2026-04-21.md rather than the literal placeholder.
+    const destName = rewritePlaceholders(path.basename(src), today);
+    const dest = path.join(reportsDir, destName);
+    fs.writeFileSync(dest, resolved);
+    written.push(destName);
+  }
+  return written;
+}
+
+function resolveReportsDir() {
+  // Mirror config/paths.js logic but without filesystem-existence shortcuts:
+  // the demo always writes to the canonical $HEALTH_HOME/reports/ unless
+  // overridden by HEALTH_REPORTS_DIR. We can't `require('../config/paths')`
+  // for this because that module memoises on first import and would yield
+  // stale paths if HEALTH_HOME changed in-process (test fixtures do this).
+  if (process.env.HEALTH_REPORTS_DIR) return process.env.HEALTH_REPORTS_DIR;
+  const home = process.env.HEALTH_HOME && process.env.HEALTH_HOME.trim()
+    ? path.resolve(process.env.HEALTH_HOME)
+    : PATHS.HEALTH_HOME;
+  return path.join(home, 'reports');
+}
+
+function resetDemo({
+  dataDir = PATHS.DATA_DIR,
+  reportsDir = resolveReportsDir(),
+  fixturesDir = FIXTURES_DIR,
+  reportsFixturesDir = REPORTS_FIXTURES_DIR,
+  today = new Date(),
+} = {}) {
   if (process.env.KLEBB_DEMO !== '1') {
     throw new Error('reset-demo refuses to run without KLEBB_DEMO=1');
   }
   const removed = wipeDataDir(dataDir);
   const written = copyFixtures({ dataDir, fixturesDir, today });
-  return { dataDir, removed, written };
+  const reportsRemoved = wipeReportsDir(reportsDir);
+  const reportsWritten = copyReportFixtures({ reportsDir, fixturesDir: reportsFixturesDir, today });
+  return { dataDir, removed, written, reportsDir, reportsRemoved, reportsWritten };
 }
 
 if (require.main === module) {
@@ -84,12 +148,19 @@ if (require.main === module) {
     const result = resetDemo();
     console.log(`[reset-demo] data dir: ${result.dataDir}`);
     if (result.removed.length) {
-      console.log(`[reset-demo] removed ${result.removed.length} existing file(s)`);
+      console.log(`[reset-demo] removed ${result.removed.length} existing data file(s)`);
     }
     for (const name of result.written) {
       console.log(`[reset-demo] restored ${name}`);
     }
-    console.log(`[reset-demo] done — ${result.written.length} fixture(s) restored`);
+    console.log(`[reset-demo] reports dir: ${result.reportsDir}`);
+    if (result.reportsRemoved.length) {
+      console.log(`[reset-demo] removed ${result.reportsRemoved.length} existing report(s)`);
+    }
+    for (const name of result.reportsWritten) {
+      console.log(`[reset-demo] restored report ${name}`);
+    }
+    console.log(`[reset-demo] done: ${result.written.length} fixture(s) and ${result.reportsWritten.length} report(s) restored`);
     process.exit(0);
   } catch (e) {
     console.error(`[reset-demo] ${e.message}`);
@@ -102,7 +173,11 @@ module.exports = {
   rewritePlaceholders,
   isoDateNDaysFromToday,
   listFixtures,
+  listReportFixtures,
   wipeDataDir,
+  wipeReportsDir,
   copyFixtures,
+  copyReportFixtures,
   FIXTURES_DIR,
+  REPORTS_FIXTURES_DIR,
 };

--- a/tests/reset-demo.test.js
+++ b/tests/reset-demo.test.js
@@ -20,8 +20,12 @@ const {
   rewritePlaceholders,
   isoDateNDaysFromToday,
   listFixtures,
+  listReportFixtures,
   copyFixtures,
+  copyReportFixtures,
+  wipeReportsDir,
   FIXTURES_DIR,
+  REPORTS_FIXTURES_DIR,
 } = require('../scripts/reset-demo');
 const { validateManifestShape } = require('../manifests/registry');
 
@@ -53,6 +57,12 @@ describe('reset-demo: placeholder rewrite', () => {
   test('rewritePlaceholders leaves non-placeholder text unchanged', () => {
     const today = new Date(2026, 4, 21);
     assert.equal(rewritePlaceholders('hello world', today), 'hello world');
+  });
+
+  test('rewritePlaceholders accepts the underscore separator (filename-safe form)', () => {
+    const today = new Date(2026, 4, 21);
+    assert.equal(rewritePlaceholders('BLOODS-__OFFSET_DAYS_-30__.md', today), 'BLOODS-2026-04-21.md');
+    assert.equal(rewritePlaceholders('a=__OFFSET_DAYS_0__ b=__OFFSET_DAYS:7__', today), 'a=2026-05-21 b=2026-05-28');
   });
 });
 
@@ -86,44 +96,49 @@ describe('reset-demo: fixture validity', () => {
 describe('reset-demo: resetDemo()', () => {
   test('refuses to run when KLEBB_DEMO is unset', () => {
     const dir = tmpDir();
+    const reportsDir = tmpDir();
     try {
       const orig = process.env.KLEBB_DEMO;
       delete process.env.KLEBB_DEMO;
       try {
-        assert.throws(() => resetDemo({ dataDir: dir }), /KLEBB_DEMO=1/);
+        assert.throws(() => resetDemo({ dataDir: dir, reportsDir }), /KLEBB_DEMO=1/);
       } finally {
         if (orig !== undefined) process.env.KLEBB_DEMO = orig;
       }
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(reportsDir, { recursive: true, force: true });
     }
   });
 
   test('refuses to run when KLEBB_DEMO is set to something other than "1"', () => {
     const dir = tmpDir();
+    const reportsDir = tmpDir();
     try {
       const orig = process.env.KLEBB_DEMO;
       process.env.KLEBB_DEMO = 'true';
       try {
-        assert.throws(() => resetDemo({ dataDir: dir }), /KLEBB_DEMO=1/);
+        assert.throws(() => resetDemo({ dataDir: dir, reportsDir }), /KLEBB_DEMO=1/);
       } finally {
         if (orig === undefined) delete process.env.KLEBB_DEMO;
         else process.env.KLEBB_DEMO = orig;
       }
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(reportsDir, { recursive: true, force: true });
     }
   });
 
   test('with KLEBB_DEMO=1: wipes existing JSON, copies all fixtures', () => {
     const dir = tmpDir();
+    const reportsDir = tmpDir();
     fs.writeFileSync(path.join(dir, 'stale.json'), '{"$schema":"x"}');
     fs.writeFileSync(path.join(dir, 'keep.txt'), 'not a manifest');
     const orig = process.env.KLEBB_DEMO;
     process.env.KLEBB_DEMO = '1';
     try {
       const today = new Date(2026, 4, 21);
-      const result = resetDemo({ dataDir: dir, today });
+      const result = resetDemo({ dataDir: dir, reportsDir, today });
       assert.equal(result.dataDir, dir);
       assert.ok(result.removed.includes('stale.json'), 'stale.json should be removed');
       assert.ok(result.written.length >= 8, 'should write at least 8 fixtures');
@@ -138,6 +153,7 @@ describe('reset-demo: resetDemo()', () => {
       if (orig === undefined) delete process.env.KLEBB_DEMO;
       else process.env.KLEBB_DEMO = orig;
       fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(reportsDir, { recursive: true, force: true });
     }
   });
 
@@ -162,10 +178,11 @@ describe('reset-demo: resetDemo()', () => {
 
   test('written count matches the fixture count', () => {
     const dir = tmpDir();
+    const reportsDir = tmpDir();
     const orig = process.env.KLEBB_DEMO;
     process.env.KLEBB_DEMO = '1';
     try {
-      const result = resetDemo({ dataDir: dir });
+      const result = resetDemo({ dataDir: dir, reportsDir });
       const fixtures = listFixtures(FIXTURES_DIR)
         .map(f => path.basename(f));
       assert.deepEqual(result.written.sort(), fixtures.sort());
@@ -173,6 +190,102 @@ describe('reset-demo: resetDemo()', () => {
       if (orig === undefined) delete process.env.KLEBB_DEMO;
       else process.env.KLEBB_DEMO = orig;
       fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(reportsDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('reset-demo: report fixtures', () => {
+  test('listReportFixtures returns the .md files only', () => {
+    const files = listReportFixtures();
+    assert.ok(files.length >= 4, `expected at least 4 report fixtures, found ${files.length}`);
+    for (const f of files) {
+      assert.ok(f.endsWith('.md'), `${f} should end with .md`);
+    }
+  });
+
+  test('every report fixture has a markdown H1 after rewrite', () => {
+    const today = new Date(2026, 4, 21);
+    for (const file of listReportFixtures()) {
+      const raw = fs.readFileSync(file, 'utf8');
+      const resolved = rewritePlaceholders(raw, today);
+      assert.ok(/^#\s+/m.test(resolved), `${path.basename(file)}: missing H1 heading`);
+      assert.ok(!/__OFFSET_DAYS[:_]/.test(resolved), `${path.basename(file)}: placeholder leaked through`);
+    }
+  });
+
+  test('copyReportFixtures resolves placeholders in filenames', () => {
+    const reportsDir = tmpDir();
+    try {
+      const today = new Date(2026, 4, 21);
+      const written = copyReportFixtures({ reportsDir, today });
+      // No filename should still contain a placeholder.
+      for (const name of written) {
+        assert.ok(!/__OFFSET_DAYS[:_]/.test(name), `${name}: filename placeholder unresolved`);
+      }
+      // The bloods report should be dated 30 days before the supplied today.
+      const bloods = written.find(n => n.startsWith('BLOODS-'));
+      assert.ok(bloods, 'BLOODS-*.md should be written');
+      assert.equal(bloods, 'BLOODS-2026-04-21.md');
+    } finally {
+      fs.rmSync(reportsDir, { recursive: true, force: true });
+    }
+  });
+
+  test('copyReportFixtures rewrites placeholders inside file bodies', () => {
+    const reportsDir = tmpDir();
+    try {
+      const today = new Date(2026, 4, 21);
+      copyReportFixtures({ reportsDir, today });
+      const bloods = fs.readFileSync(path.join(reportsDir, 'BLOODS-2026-04-21.md'), 'utf8');
+      assert.ok(bloods.includes('Collected:'), 'should mention "Collected:"');
+      assert.ok(!/__OFFSET_DAYS/.test(bloods), 'no placeholders should remain');
+      assert.ok(bloods.includes('2026-04-21'), 'collected date should be resolved');
+    } finally {
+      fs.rmSync(reportsDir, { recursive: true, force: true });
+    }
+  });
+
+  test('wipeReportsDir removes existing markdown but leaves other files alone', () => {
+    const reportsDir = tmpDir();
+    try {
+      fs.writeFileSync(path.join(reportsDir, 'stale.md'), '# stale');
+      fs.writeFileSync(path.join(reportsDir, 'keep.txt'), 'leave me');
+      const removed = wipeReportsDir(reportsDir);
+      assert.ok(removed.includes('stale.md'), 'stale.md should be removed');
+      assert.ok(fs.existsSync(path.join(reportsDir, 'keep.txt')), 'keep.txt should survive');
+      assert.ok(!fs.existsSync(path.join(reportsDir, 'stale.md')), 'stale.md should be gone');
+    } finally {
+      fs.rmSync(reportsDir, { recursive: true, force: true });
+    }
+  });
+
+  test('resetDemo seeds reports/ alongside data/', () => {
+    const dir = tmpDir();
+    const reportsDir = tmpDir();
+    fs.writeFileSync(path.join(reportsDir, 'old-debrief.md'), '# old');
+    const orig = process.env.KLEBB_DEMO;
+    process.env.KLEBB_DEMO = '1';
+    try {
+      const today = new Date(2026, 4, 21);
+      const result = resetDemo({ dataDir: dir, reportsDir, today });
+      assert.equal(result.reportsDir, reportsDir);
+      assert.ok(result.reportsRemoved.includes('old-debrief.md'), 'pre-existing markdown should be wiped');
+      assert.ok(result.reportsWritten.length >= 4, 'should seed at least 4 reports');
+      // Genome overview has no placeholder, so the filename is verbatim.
+      assert.ok(result.reportsWritten.includes('GENOME-overview.md'));
+      // Each written report exists on disk.
+      for (const name of result.reportsWritten) {
+        const full = path.join(reportsDir, name);
+        assert.ok(fs.existsSync(full), `${name} should exist after reset`);
+        const body = fs.readFileSync(full, 'utf8');
+        assert.ok(/^#\s+/m.test(body), `${name}: needs an H1`);
+      }
+    } finally {
+      if (orig === undefined) delete process.env.KLEBB_DEMO;
+      else process.env.KLEBB_DEMO = orig;
+      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(reportsDir, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## Summary

Closes #275. Fleshes out the Reports page on the public demo so a
visitor lands on something with substance.

- Three new manifest fixtures (`demo/fixtures/`):
  - `blood-panel.json`: list-card on Today, table-list on Reports.
    Eight RCPA-style categories of fasting bloods (lipids, liver,
    kidneys, glucose / insulin, iron studies, thyroid, inflammation,
    vitamins). All values plausible-but-fake, sit inside reference
    ranges.
  - `genome-snps.json`: list-card on Today, table-list on Reports.
    APOE 3/3 plus 30 categorised SNPs across lipid metabolism /
    methylation / detox / caffeine / sleep / inflammation.
  - `peptide-cycle.json` (modified): adds the `start_date` /
    `end_date` / `cycle_number` / `status` keys the
    `adherence-report` renderer expects, so the existing card now
    renders correctly on the Reports page too. Schedule-card shape
    on Today is unchanged.
- Four narrative markdown reports under `demo/fixtures/reports/`:
  - `BLOODS-__OFFSET_DAYS_-30__.md`: blood debrief.
  - `GENOME-overview.md`: long-form prose around the SNP card.
  - `DEBRIEF-__OFFSET_DAYS_-7__.md`: quarterly debrief.
  - `PROFILE-summary.md`: baseline profile.
- `scripts/reset-demo.js` now seeds `$HEALTH_HOME/reports/`
  alongside `data/`. Placeholders are resolved in both file bodies
  and filenames; the underscore form `__OFFSET_DAYS_N__` is accepted
  for filename-safety on NTFS (where `:` is illegal).

## Why

The demo's Reports page was thin. Visitors landing there saw the
adherence card for the peptide cycle and not much else. The whole
point of the Reports view is to show that Klebb is more than the
day-to-day metric cards: it surfaces saved bloods, debriefs, and
genome data as first-class citizens. Now the demo demonstrates that.

## How

Manifest cards use the existing `table-list` renderer (which already
handles SNP-shape and category-shape data) and `adherence-report`
(which expects the `cycles[].{start_date, end_date, status,
cycle_number}` shape). Reports markdown is discovered by the
existing `/api/reports` route; the filenames are classified by
`eh-reports-view.js` into Bloods / Genome / Debrief / Profile chips.

## Testing

- 7 new unit tests covering: filename-form placeholder regex, report
  fixture validity (every fixture has an H1 and no leaked
  placeholders after rewrite), `copyReportFixtures` resolves both
  body and filename placeholders, `wipeReportsDir` is markdown-only,
  full `resetDemo` end-to-end seeds reports.
- Existing reset-demo tests adjusted to pass an explicit `reportsDir`
  so they don't pollute the host's `$HOME/klebb/reports/`.
- `npm test`: 957/958 pass; the single failure
  (`tests/no-personal-refs.test.js`) is pre-existing on `main` and
  is flagging the gitignored `.claude/`, `BRIEF-FOR-CC.md`,
  `CLAUDE.md`, and `data/sessions/` paths.

## Test plan

- [x] `npm test` green for new + existing reset-demo tests
- [x] All four markdown reports render an H1 after placeholder
      rewrite
- [x] `copyReportFixtures` produces e.g. `BLOODS-2026-04-21.md`
      (with the date 30 days before today resolved into the
      filename)
- [x] `wipeReportsDir` removes only `*.md`
- [x] Pre-existing `npm test` failure not caused by this PR
- [ ] Once #274 lands and the next image is published, redeploy
      `demo.klebb.app` (or `docker cp` the new fixtures into the
      running container) so the live Reports page picks up the
      changes