### PR TITLE
feat(docker): ship demo fixtures + reset-demo.js inside the image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,7 +19,7 @@ reports
 
 # Tests are not needed at runtime
 tests
-fixtures
+/fixtures
 
 # Editor cruft. Docs + root .md files are kept in the image so the
 # read_doc chat tool (chat/docs.js allowlist) can serve them at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
   bodies and filenames (the underscore form is accepted in filenames
   since `:` is not a legal NTFS character). Fixes #275.
 
+- **Demo fixtures + reset script now ship inside the Docker image.**
+  The Dockerfile carries `/app/demo/` and `/app/scripts/reset-demo.js`,
+  so the demo VPS reset cron can `docker exec klebb-demo node
+  /app/scripts/reset-demo.js` directly: no more `docker cp` step
+  after a `compose pull`. New `docs/DEMO.md` documents the public
+  demo runbook end-to-end (compose, env, nginx vhost, hourly reset
+  cron, image-tag prefix gotcha). The release runbook now
+  explicitly calls out that the publish workflow strips the `v`
+  prefix from git tags, so `v2.1.0` becomes Docker tag `2.1.0`.
+  Fixes #274.
+
 ## [2.1.1] - 2026-05-21
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,13 @@ COPY --chown=klebb:klebb server ./server
 COPY --chown=klebb:klebb templates ./templates
 COPY --chown=klebb:klebb prompts ./prompts
 
+# Demo fixtures + reset script. Needed inside the image so the public
+# demo's hourly reset cron can `docker exec klebb-demo node
+# /app/scripts/reset-demo.js`. Both directories are public-safe; the
+# reset script refuses to run unless KLEBB_DEMO=1 so it can never be
+# invoked against a real instance.
+COPY --chown=klebb:klebb demo ./demo
+
 # Doc files served by the read_doc chat tool. The allowlist in
 # chat/docs.js enumerates exactly these paths; an absent file would
 # surface to the agent as ENOENT.

--- a/chat/docs.js
+++ b/chat/docs.js
@@ -32,6 +32,7 @@ const DOC_INDEX = [
   { path: 'docs/CHAT-AGENT.md',           summary: 'Chat widget + gateway integration; AGENT_API_TOKEN write contract.' },
   { path: 'docs/HEALTH-AUTO-EXPORT.md',   summary: 'iPhone Health Auto Export ingest: catalogue, row shapes, setup.' },
   { path: 'docs/DEPLOY.md',               summary: 'Single-user and multi-user deploy guide; systemd + Docker.' },
+  { path: 'docs/DEMO.md',                 summary: 'Running a public Klebb demo (KLEBB_DEMO=1, hourly reset cron, image-tag gotchas).' },
   { path: 'docs/TESTING.md',              summary: 'Three test layers, bug-fix workflow rubric.' },
   { path: 'docs/VOICE.md',                summary: 'Voice chat (Fish Audio) configuration and usage.' },
   { path: 'docs/CI.md',                   summary: 'GitHub Actions CI overview; what runs and when.' },

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -1,0 +1,208 @@
+# DEMO.md: running a public Klebb demo
+
+This document covers standing up a public, no-credentials demo of
+Klebb (e.g. `demo.klebb.app`) using the official Docker image.
+
+A demo instance behaves differently from a normal Klebb deployment:
+
+- **No passkey login.** A single shared `demo` session is minted on
+  the press of a button.
+- **No invite, no setup, no settings persistence.** All write
+  endpoints that would mutate auth, branding, or chat config return
+  410 Gone.
+- **Chat is a canned reply.** No outbound HTTP to any LLM gateway.
+- **Card-hide is locked.** Visitors can't permanently hide cards.
+- **An hourly reset rolls the dataset forward.** A cron job re-runs
+  `scripts/reset-demo.js` against the bind-mounted data directory so
+  the dashboard always looks like it was updated this week.
+
+The demo mode is gated by a single env var: `KLEBB_DEMO=1`. A normal
+production instance never sets this; the safety wiring inside
+`scripts/reset-demo.js` refuses to run unless `KLEBB_DEMO=1` is set,
+so the reset cron can't accidentally fire against a real instance.
+
+## Prerequisites
+
+- A Linux VPS with Docker Engine + the compose plugin.
+- nginx + certbot in front of the container for TLS.
+- A DNS record pointing at the host.
+
+## 1. Compose file
+
+Create `/opt/klebb-demo/compose.yml`:
+
+```yaml
+services:
+  klebb-demo:
+    image: ghcr.io/aristocles/klebb:2.1.2
+    container_name: klebb-demo
+    restart: unless-stopped
+    ports:
+      - '127.0.0.1:18081:10002'
+    env_file: .env
+    volumes:
+      - ./data:/data
+```
+
+Note: GHCR tags have no `v` prefix. The publish workflow uses
+`docker/metadata-action` with `type=semver,pattern={{version}}`, which
+strips the `v` from the git tag before pushing. So git tag `v2.1.2`
+becomes Docker tag `2.1.2`.
+
+## 2. Environment file
+
+Create `/opt/klebb-demo/.env` (mode 600):
+
+```ini
+KLEBB_DEMO=1
+SESSION_SECRET=<long random hex string>
+HEALTH_RP_ID=demo.klebb.app
+HEALTH_RP_NAME=Klebb demo
+HEALTH_ORIGIN=https://demo.klebb.app
+```
+
+Generate a fresh `SESSION_SECRET` with `openssl rand -hex 32`.
+
+The container defaults `HEALTH_HOME=/data` and `PORT=10002` already,
+so you don't need to set those.
+
+## 3. nginx vhost
+
+Create `/etc/nginx/sites-available/demo.klebb.app` (assumes you
+already have a TLS cert covering the demo hostname; if not, run
+`certbot --nginx --expand -d demo.klebb.app -d <other names>` first):
+
+```nginx
+server {
+    listen 80;
+    server_name demo.klebb.app;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name demo.klebb.app;
+
+    ssl_certificate /etc/letsencrypt/live/<cert-name>/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/<cert-name>/privkey.pem;
+
+    client_max_body_size 32M;
+
+    location / {
+        proxy_pass http://127.0.0.1:18081;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+```
+
+```bash
+ln -s /etc/nginx/sites-available/demo.klebb.app \
+      /etc/nginx/sites-enabled/demo.klebb.app
+nginx -t && systemctl reload nginx
+```
+
+## 4. Boot the container
+
+```bash
+cd /opt/klebb-demo
+docker compose pull
+docker compose up -d
+docker compose logs --tail=50
+```
+
+The first boot will create `./data/` (owned by the in-container
+`klebb` user, uid 1001) and seed an empty welcome card. Visit
+`https://demo.klebb.app/` and click "Enter the demo" to confirm.
+
+## 5. Seed the demo dataset
+
+The image ships `/app/demo/fixtures/` and `/app/scripts/reset-demo.js`,
+so you can seed straight from inside the running container:
+
+```bash
+docker exec --user root \
+  -e KLEBB_DEMO=1 -e HEALTH_HOME=/data \
+  klebb-demo node /app/scripts/reset-demo.js
+```
+
+This wipes any JSON in `/data/data/` and any markdown in
+`/data/reports/`, then copies the curated fixture set over and
+rewrites `__OFFSET_DAYS:N__` placeholders against today.
+
+Verify the dashboard now shows the curated cards plus the Reports
+page entries.
+
+## 6. Hourly reset cron
+
+Create `/usr/local/bin/klebb-demo-reset.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! docker ps --format '{{.Names}}' | grep -q '^klebb-demo$'; then
+  echo "[klebb-demo-reset] container not running; skipping"
+  exit 0
+fi
+
+docker exec --user root \
+  -e KLEBB_DEMO=1 -e HEALTH_HOME=/data \
+  klebb-demo node /app/scripts/reset-demo.js
+```
+
+```bash
+chmod +x /usr/local/bin/klebb-demo-reset.sh
+```
+
+Then `/etc/cron.d/klebb-demo-reset`:
+
+```cron
+0 * * * * root /usr/local/bin/klebb-demo-reset.sh >> /var/log/klebb-demo-reset.log 2>&1
+```
+
+The cron fires at the top of every hour. Watch
+`/var/log/klebb-demo-reset.log` to confirm successful runs.
+
+## 7. Updating to a new release
+
+```bash
+cd /opt/klebb-demo
+# Pin to the new tag in compose.yml first, e.g. ghcr.io/aristocles/klebb:2.1.3
+docker compose pull
+docker compose up -d
+# Re-seed; new fixtures may have landed
+docker exec --user root \
+  -e KLEBB_DEMO=1 -e HEALTH_HOME=/data \
+  klebb-demo node /app/scripts/reset-demo.js
+```
+
+Image tag must match the compose file. `latest` is also published but
+explicit version pinning is recommended for visibility.
+
+## Troubleshooting
+
+| Symptom | First check |
+|---|---|
+| `docker compose pull` returns "unauthorized" | The GHCR package may be private. Flip it to public at `https://github.com/users/<owner>/packages/container/klebb/settings`. The image is meant to be anonymously pullable. |
+| `docker compose pull` returns "tag not found" | Confirm the tag exists at `https://github.com/Aristocles/klebb/pkgs/container/klebb`. Remember the publish workflow strips the `v` prefix: git tag `v2.1.2` → image tag `2.1.2`. |
+| Reset script: "Cannot find module" | The image is older than 2.1.2 and doesn't carry `demo/` or `scripts/reset-demo.js`. Pull a newer tag. |
+| Reset script: "refuses to run without KLEBB_DEMO=1" | The cron is wired correctly; the `.env` for the running container does not have `KLEBB_DEMO=1`. Add it and `docker compose up -d` to recreate. |
+| Visitors see the passkey prompt instead of "Enter the demo" | `KLEBB_DEMO=1` not set in the environment of the running container. Confirm with `docker inspect klebb-demo \| grep -i klebb_demo`. |
+| Cards don't show fresh dates | The hourly cron isn't firing. `tail /var/log/klebb-demo-reset.log` and `systemctl status cron`. |
+
+## What the demo does NOT do
+
+- Issue invites or accept passkey registrations.
+- Persist any visitor input across the next reset cycle.
+- Make outbound HTTP for chat or voice. Chat replies with a canned
+  string; voice routes return 503.
+- Run any of the scheduled tasks that a normal Klebb instance does
+  (no auto-export ingestion, no email, etc.).
+
+If a behaviour you expect from the demo isn't in the above list,
+treat it as a gap and file an issue.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -11,6 +11,9 @@ server. It covers:
 The approach is intentionally lightweight: Node.js + systemd + nginx.
 No Docker, no build step, no CI dependencies.
 
+For a **public, no-credentials demo deployment** (e.g. `demo.klebb.app`),
+see [DEMO.md](DEMO.md).
+
 ---
 
 ## 1. Single-user deploy


### PR DESCRIPTION
## Summary

Closes #274. Two related changes so the public demo can be operated as
"pull image, run, exec reset" without a `docker cp` step.

- **Dockerfile**: COPY `demo/` into `/app/demo/` (`scripts/` was already
  copied, so `scripts/reset-demo.js` already lived in the image — only
  the fixture set was missing).
- **`.dockerignore`**: was excluding `fixtures` at every depth, which
  would have caught `demo/fixtures/` along with the top-level `fixtures/`
  it was meant to exclude. Narrowed to `/fixtures` so it only excludes
  the top-level dir.
- **`docs/DEMO.md`** (new): documents the public-demo deployment
  end-to-end: compose file, env, nginx vhost, hourly reset cron, and
  the image-tag-prefix gotcha (publish workflow strips the leading `v`
  from git tags, so `v2.1.0` lands as Docker tag `2.1.0`). Wired
  into the `chat/docs.js` allowlist so the chat agent can read it.
- **`.claude/commands/release.md`** (gitignored, local-only): release
  runbook now explicitly calls out the tag-prefix behaviour and the
  `VERSION=2.1.0` (no `v`) shape for the smoke-test pull. Bonus: an
  extra smoke step that confirms the image carries `/app/demo/` and
  `/app/scripts/reset-demo.js`.

## Why

When the demo VPS was first stood up against the v2.1.1 image, the
Dockerfile didn't carry the demo fixtures or the reset script. We
worked around it with `docker cp`, but the workaround would have
broken the next release cycle: `docker compose pull && docker
compose up -d` recreates the container without the copied-in files.

## How

`scripts/reset-demo.js` is unchanged here. It's already in the image
because line 61 of the Dockerfile already copies the whole `scripts/`
dir. The only addition is the new `COPY demo ./demo` directive plus
the `.dockerignore` narrowing.

The reset script's safety wiring (`KLEBB_DEMO=1` env-gate) means
including these in every image is safe: a normal production instance
that doesn't set `KLEBB_DEMO=1` cannot accidentally invoke the reset.

## Testing

- `npm test`: 957/958 pass, same single pre-existing failure as `main`
  (`tests/no-personal-refs.test.js` flagging gitignored `.claude/` and
  `data/sessions/` files).
- Local Docker build smoke not run because Docker Desktop wasn't
  running on the dev box; CI builds the image on every PR via the test
  workflow's Docker build step.

## Test plan

- [ ] CI green (test + e2e)
- [ ] CI Docker build dry-run succeeds (it builds the image as part
      of the test workflow)
- [ ] After the next release, confirm the published image carries
      `/app/demo/fixtures/` and `/app/scripts/reset-demo.js`:
      `docker run --rm ghcr.io/aristocles/klebb:<version> ls /app/demo/fixtures /app/scripts/reset-demo.js`
- [ ] Demo VPS can run `docker compose pull && docker compose up -d`
      followed by `docker exec klebb-demo node /app/scripts/reset-demo.js`
      with no `docker cp` step