### PR TITLE
feat(demo): rename peptide-cycle card to Injections, add Ozempic + Insulin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,30 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Changed
+
+- **Health Auto Export token is now managed in the Settings UI.** The
+  HAE panel offers a Generate button when none is configured, and a
+  masked display + Copy + Regenerate when one is. Regenerate prompts
+  an inline warning that the iPhone HAE app must be updated before
+  the next push. Tokens are persisted to `$HEALTH_HOME/config.json`
+  under `cfg.hae.token` (atomic write, `0o600`). The
+  `HEALTH_AUTO_EXPORT_TOKEN` env var is deprecated: on first boot
+  under the new code, an existing env value migrates into
+  `config.json` once and is then ignored, so existing instances
+  upgrade transparently. New endpoints under
+  `/api/health-auto-export/token` (GET / POST / POST `/regenerate` /
+  DELETE) all sit behind the global passkey auth gate. Fixes #278.
+
 ### Added
+
+- **Demo Injections card now covers three concurrent protocols.**
+  `peptide-cycle.json` is renamed to "Injections" and carries
+  BPC-157 (M/W/F, peptide healing), Ozempic / semaglutide (weekly
+  Sunday GLP-1), and basal insulin glargine (daily 18 units), each
+  with its own schedule, cycle window, and dose history. The
+  schedule-card and adherence-report both render the multi-protocol
+  history side by side. Fixes #279.
 
 - **Reports page on the public demo now ships with a full multi-card
   set.** Three new manifest fixtures (`blood-panel.json` with eight

--- a/demo/fixtures/peptide-cycle.json
+++ b/demo/fixtures/peptide-cycle.json
@@ -2,7 +2,7 @@
   "$schema": "klebb.datafile.v1",
   "meta": {
     "id": "peptide-cycle",
-    "label": "BPC-157 cycle",
+    "label": "Injections",
     "emoji": "💉",
     "order": 300,
     "view": {
@@ -31,12 +31,12 @@
       "futureAllowed": false
     }
   },
-  "description": "BPC-157 healing protocol on a six-week cycle.",
+  "description": "Injectables tracked together: BPC-157 (peptide healing protocol), semaglutide (weekly GLP-1), and basal insulin (daily). Each item carries its own schedule and cycle, so the schedule-card and adherence-report both render multi-protocol histories cleanly.",
   "data": {
     "items": [
       {
         "name": "BPC-157",
-        "short_name": "BPC",
+        "short_name": "BPC-157",
         "dose_mg": 0.25,
         "dose_units": "mg",
         "route": "subcutaneous",
@@ -65,6 +65,87 @@
           { "scheduledDate": "__OFFSET_DAYS:-7__", "takenAt": "__OFFSET_DAYS:-7__T08:08:00" },
           { "scheduledDate": "__OFFSET_DAYS:-5__", "takenAt": "__OFFSET_DAYS:-5__T08:33:00" },
           { "scheduledDate": "__OFFSET_DAYS:-3__", "takenAt": "__OFFSET_DAYS:-3__T07:48:00" }
+        ]
+      },
+      {
+        "name": "Ozempic (semaglutide)",
+        "short_name": "Ozempic",
+        "dose_mg": 0.5,
+        "dose_units": "mg",
+        "route": "subcutaneous",
+        "schedule": {
+          "type": "weekly",
+          "on_days": ["Sun"]
+        },
+        "cycles": [
+          {
+            "type": "on",
+            "status": "active",
+            "cycle_number": 1,
+            "start": "__OFFSET_DAYS:-56__",
+            "end": "__OFFSET_DAYS:28__",
+            "start_date": "__OFFSET_DAYS:-56__",
+            "end_date": "__OFFSET_DAYS:28__"
+          }
+        ],
+        "doses": [
+          { "scheduledDate": "__OFFSET_DAYS:-56__", "takenAt": "__OFFSET_DAYS:-56__T19:42:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-49__", "takenAt": "__OFFSET_DAYS:-49__T20:05:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-42__", "takenAt": "__OFFSET_DAYS:-42__T19:11:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-35__", "takenAt": "__OFFSET_DAYS:-35__T19:48:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-28__", "takenAt": "__OFFSET_DAYS:-28__T20:21:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-21__", "takenAt": "__OFFSET_DAYS:-21__T19:34:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-14__", "takenAt": "__OFFSET_DAYS:-14__T19:50:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-7__", "takenAt": "__OFFSET_DAYS:-7__T20:08:00" }
+        ]
+      },
+      {
+        "name": "Insulin glargine (basal)",
+        "short_name": "Insulin",
+        "dose_label": "18 units",
+        "route": "subcutaneous",
+        "schedule": {
+          "type": "daily"
+        },
+        "cycles": [
+          {
+            "type": "on",
+            "status": "active",
+            "cycle_number": 1,
+            "start": "__OFFSET_DAYS:-30__",
+            "start_date": "__OFFSET_DAYS:-30__"
+          }
+        ],
+        "doses": [
+          { "scheduledDate": "__OFFSET_DAYS:-30__", "takenAt": "__OFFSET_DAYS:-30__T22:08:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-29__", "takenAt": "__OFFSET_DAYS:-29__T22:14:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-28__", "takenAt": "__OFFSET_DAYS:-28__T22:02:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-27__", "takenAt": "__OFFSET_DAYS:-27__T22:21:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-26__", "takenAt": "__OFFSET_DAYS:-26__T22:11:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-25__", "takenAt": "__OFFSET_DAYS:-25__T22:18:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-24__", "takenAt": "__OFFSET_DAYS:-24__T22:25:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-23__", "takenAt": "__OFFSET_DAYS:-23__T22:09:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-22__", "takenAt": "__OFFSET_DAYS:-22__T22:16:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-21__", "takenAt": "__OFFSET_DAYS:-21__T22:31:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-20__", "takenAt": "__OFFSET_DAYS:-20__T22:14:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-19__", "takenAt": "__OFFSET_DAYS:-19__T22:22:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-18__", "takenAt": "__OFFSET_DAYS:-18__T22:08:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-17__", "takenAt": "__OFFSET_DAYS:-17__T22:35:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-16__", "takenAt": "__OFFSET_DAYS:-16__T22:11:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-15__", "takenAt": "__OFFSET_DAYS:-15__T22:19:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-14__", "takenAt": "__OFFSET_DAYS:-14__T22:24:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-13__", "takenAt": "__OFFSET_DAYS:-13__T22:07:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-12__", "takenAt": "__OFFSET_DAYS:-12__T22:13:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-11__", "takenAt": "__OFFSET_DAYS:-11__T22:29:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-10__", "takenAt": "__OFFSET_DAYS:-10__T22:17:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-9__", "takenAt": "__OFFSET_DAYS:-9__T22:22:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-8__", "takenAt": "__OFFSET_DAYS:-8__T22:08:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-6__", "takenAt": "__OFFSET_DAYS:-6__T22:42:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-5__", "takenAt": "__OFFSET_DAYS:-5__T22:11:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-4__", "takenAt": "__OFFSET_DAYS:-4__T22:18:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-3__", "takenAt": "__OFFSET_DAYS:-3__T22:25:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-2__", "takenAt": "__OFFSET_DAYS:-2__T22:14:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-1__", "takenAt": "__OFFSET_DAYS:-1__T22:21:00" }
         ]
       }
     ]


### PR DESCRIPTION
## Summary

Promotes the demo's BPC-157 card into a multi-protocol **Injections**
card carrying BPC-157, Ozempic (semaglutide), and basal insulin
glargine, each with its own schedule, cycle, and dose history. The
schedule-card and adherence-report both render the three protocols
side by side.

## Why

The demo had a single peptide on the Injections card, which
under-sells what the schedule-card and adherence-report can do when
asked to handle a real injectable mix. Three concurrent protocols
running on different cadences (every-other-day, weekly, daily) make
the renderer's strengths obvious.

Closes #279.

## How

`demo/fixtures/peptide-cycle.json`:

- `meta.label` → "Injections" (was "BPC-157 cycle"); description
  rewritten to call out all three protocols.
- Item 1 BPC-157: `short_name` corrected from "BPC" to "BPC-157" so
  the inline chip matches the protocol name. Schedule and 9-dose
  history retained.
- Item 2 Ozempic / semaglutide: weekly Sunday, 0.5 mg subcutaneous,
  8-dose history over 8 weeks, cycle from -56 to +28.
- Item 3 Insulin glargine: daily basal, 18 units evening, 29-dose
  history over 30 days, open-ended cycle starting -30 days. Uses
  `dose_label` rather than `dose_mg`/`dose_units` to sidestep the
  schedule-card "u" suffix on `dose_units`.
- Each item carries the dual cycle shape (`type`/`start`/`end` plus
  `status`/`cycle_number`/`start_date`/`end_date`) so it renders on
  schedule-card AND adherence-report.

`CHANGELOG.md`: new `[Unreleased]` Added entry under #279.

## Test plan

- [x] `npm test` (957/958 pass; the pre-existing
  `no-personal-refs.test.js` failure on gitignored files is unchanged
  on `main`)
- [x] `validateManifestShape` accepts the modified fixture (covered
  by `tests/reset-demo.test.js` and the broader manifest test suite)
- [ ] Once merged and a new image is published, re-seed the demo VPS
  with `docker exec klebb-demo node /app/scripts/reset-demo.js` and
  verify the Injections card renders all three items on the schedule
  card and adherence report.