### PR TITLE
feat(hae): manage Health Auto Export token in Settings UI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,7 +19,7 @@ reports
 
 # Tests are not needed at runtime
 tests
-fixtures
+/fixtures
 
 # Editor cruft. Docs + root .md files are kept in the image so the
 # read_doc chat tool (chat/docs.js allowlist) can serve them at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Changed
+
+- **Health Auto Export token is now managed in the Settings UI.** The
+  HAE panel offers a Generate button when none is configured, and a
+  masked display + Copy + Regenerate when one is. Regenerate prompts
+  an inline warning that the iPhone HAE app must be updated before
+  the next push. Tokens are persisted to `$HEALTH_HOME/config.json`
+  under `cfg.hae.token` (atomic write, `0o600`). The
+  `HEALTH_AUTO_EXPORT_TOKEN` env var is deprecated: on first boot
+  under the new code, an existing env value migrates into
+  `config.json` once and is then ignored, so existing instances
+  upgrade transparently. New endpoints under
+  `/api/health-auto-export/token` (GET / POST / POST `/regenerate` /
+  DELETE) all sit behind the global passkey auth gate. Fixes #278.
+
 ### Added
 
 - **Reports page on the public demo now ships with a full multi-card

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
   bodies and filenames (the underscore form is accepted in filenames
   since `:` is not a legal NTFS character). Fixes #275.
 
+- **Demo fixtures + reset script now ship inside the Docker image.**
+  The Dockerfile carries `/app/demo/` and `/app/scripts/reset-demo.js`,
+  so the demo VPS reset cron can `docker exec klebb-demo node
+  /app/scripts/reset-demo.js` directly: no more `docker cp` step
+  after a `compose pull`. New `docs/DEMO.md` documents the public
+  demo runbook end-to-end (compose, env, nginx vhost, hourly reset
+  cron, image-tag prefix gotcha). The release runbook now
+  explicitly calls out that the publish workflow strips the `v`
+  prefix from git tags, so `v2.1.0` becomes Docker tag `2.1.0`.
+  Fixes #274.
+
 ## [2.1.1] - 2026-05-21
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,13 @@ COPY --chown=klebb:klebb server ./server
 COPY --chown=klebb:klebb templates ./templates
 COPY --chown=klebb:klebb prompts ./prompts
 
+# Demo fixtures + reset script. Needed inside the image so the public
+# demo's hourly reset cron can `docker exec klebb-demo node
+# /app/scripts/reset-demo.js`. Both directories are public-safe; the
+# reset script refuses to run unless KLEBB_DEMO=1 so it can never be
+# invoked against a real instance.
+COPY --chown=klebb:klebb demo ./demo
+
 # Doc files served by the read_doc chat tool. The allowlist in
 # chat/docs.js enumerates exactly these paths; an absent file would
 # surface to the agent as ENOENT.

--- a/chat/docs.js
+++ b/chat/docs.js
@@ -32,6 +32,7 @@ const DOC_INDEX = [
   { path: 'docs/CHAT-AGENT.md',           summary: 'Chat widget + gateway integration; AGENT_API_TOKEN write contract.' },
   { path: 'docs/HEALTH-AUTO-EXPORT.md',   summary: 'iPhone Health Auto Export ingest: catalogue, row shapes, setup.' },
   { path: 'docs/DEPLOY.md',               summary: 'Single-user and multi-user deploy guide; systemd + Docker.' },
+  { path: 'docs/DEMO.md',                 summary: 'Running a public Klebb demo (KLEBB_DEMO=1, hourly reset cron, image-tag gotchas).' },
   { path: 'docs/TESTING.md',              summary: 'Three test layers, bug-fix workflow rubric.' },
   { path: 'docs/VOICE.md',                summary: 'Voice chat (Fish Audio) configuration and usage.' },
   { path: 'docs/CI.md',                   summary: 'GitHub Actions CI overview; what runs and when.' },

--- a/config/env.js
+++ b/config/env.js
@@ -115,10 +115,14 @@ function getSessionSecret() {
 }
 
 // --- Health Auto Export ingest ---
-// When set, enables POST /api/health-auto-export for the iPhone HAE app's
-// webhook. Unset disables the endpoint entirely (returns 501). See
-// docs/HEALTH-AUTO-EXPORT.md for setup.
-const HEALTH_AUTO_EXPORT_TOKEN = (process.env.HEALTH_AUTO_EXPORT_TOKEN || '').trim() || null;
+// The HAE bearer token is no longer read from the env at runtime. It is
+// managed in the Settings UI and persisted to $HEALTH_HOME/config.json
+// under cfg.hae.token. See health-auto-export/token-store.js.
+//
+// HEALTH_AUTO_EXPORT_TOKEN is read once on boot by
+// tokenStore.migrateFromEnvIfNeeded() so existing instances upgrade
+// transparently, and is otherwise ignored. Do not export it from this
+// module: nothing else in the codebase should depend on the env value.
 
 // --- Feature flags ---
 const DEBUG_LOG = process.env.HEALTH_DEBUG === '1';
@@ -506,7 +510,6 @@ module.exports = {
   WEBAUTHN_RP_ID,
   WEBAUTHN_ORIGIN,
   getSessionSecret,
-  HEALTH_AUTO_EXPORT_TOKEN,
   DEBUG_LOG,
   KLEBB_DEMO,
   DEMO_USER_ID,

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -1,0 +1,208 @@
+# DEMO.md: running a public Klebb demo
+
+This document covers standing up a public, no-credentials demo of
+Klebb (e.g. `demo.klebb.app`) using the official Docker image.
+
+A demo instance behaves differently from a normal Klebb deployment:
+
+- **No passkey login.** A single shared `demo` session is minted on
+  the press of a button.
+- **No invite, no setup, no settings persistence.** All write
+  endpoints that would mutate auth, branding, or chat config return
+  410 Gone.
+- **Chat is a canned reply.** No outbound HTTP to any LLM gateway.
+- **Card-hide is locked.** Visitors can't permanently hide cards.
+- **An hourly reset rolls the dataset forward.** A cron job re-runs
+  `scripts/reset-demo.js` against the bind-mounted data directory so
+  the dashboard always looks like it was updated this week.
+
+The demo mode is gated by a single env var: `KLEBB_DEMO=1`. A normal
+production instance never sets this; the safety wiring inside
+`scripts/reset-demo.js` refuses to run unless `KLEBB_DEMO=1` is set,
+so the reset cron can't accidentally fire against a real instance.
+
+## Prerequisites
+
+- A Linux VPS with Docker Engine + the compose plugin.
+- nginx + certbot in front of the container for TLS.
+- A DNS record pointing at the host.
+
+## 1. Compose file
+
+Create `/opt/klebb-demo/compose.yml`:
+
+```yaml
+services:
+  klebb-demo:
+    image: ghcr.io/aristocles/klebb:2.1.2
+    container_name: klebb-demo
+    restart: unless-stopped
+    ports:
+      - '127.0.0.1:18081:10002'
+    env_file: .env
+    volumes:
+      - ./data:/data
+```
+
+Note: GHCR tags have no `v` prefix. The publish workflow uses
+`docker/metadata-action` with `type=semver,pattern={{version}}`, which
+strips the `v` from the git tag before pushing. So git tag `v2.1.2`
+becomes Docker tag `2.1.2`.
+
+## 2. Environment file
+
+Create `/opt/klebb-demo/.env` (mode 600):
+
+```ini
+KLEBB_DEMO=1
+SESSION_SECRET=<long random hex string>
+HEALTH_RP_ID=demo.klebb.app
+HEALTH_RP_NAME=Klebb demo
+HEALTH_ORIGIN=https://demo.klebb.app
+```
+
+Generate a fresh `SESSION_SECRET` with `openssl rand -hex 32`.
+
+The container defaults `HEALTH_HOME=/data` and `PORT=10002` already,
+so you don't need to set those.
+
+## 3. nginx vhost
+
+Create `/etc/nginx/sites-available/demo.klebb.app` (assumes you
+already have a TLS cert covering the demo hostname; if not, run
+`certbot --nginx --expand -d demo.klebb.app -d <other names>` first):
+
+```nginx
+server {
+    listen 80;
+    server_name demo.klebb.app;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name demo.klebb.app;
+
+    ssl_certificate /etc/letsencrypt/live/<cert-name>/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/<cert-name>/privkey.pem;
+
+    client_max_body_size 32M;
+
+    location / {
+        proxy_pass http://127.0.0.1:18081;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+```
+
+```bash
+ln -s /etc/nginx/sites-available/demo.klebb.app \
+      /etc/nginx/sites-enabled/demo.klebb.app
+nginx -t && systemctl reload nginx
+```
+
+## 4. Boot the container
+
+```bash
+cd /opt/klebb-demo
+docker compose pull
+docker compose up -d
+docker compose logs --tail=50
+```
+
+The first boot will create `./data/` (owned by the in-container
+`klebb` user, uid 1001) and seed an empty welcome card. Visit
+`https://demo.klebb.app/` and click "Enter the demo" to confirm.
+
+## 5. Seed the demo dataset
+
+The image ships `/app/demo/fixtures/` and `/app/scripts/reset-demo.js`,
+so you can seed straight from inside the running container:
+
+```bash
+docker exec --user root \
+  -e KLEBB_DEMO=1 -e HEALTH_HOME=/data \
+  klebb-demo node /app/scripts/reset-demo.js
+```
+
+This wipes any JSON in `/data/data/` and any markdown in
+`/data/reports/`, then copies the curated fixture set over and
+rewrites `__OFFSET_DAYS:N__` placeholders against today.
+
+Verify the dashboard now shows the curated cards plus the Reports
+page entries.
+
+## 6. Hourly reset cron
+
+Create `/usr/local/bin/klebb-demo-reset.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! docker ps --format '{{.Names}}' | grep -q '^klebb-demo$'; then
+  echo "[klebb-demo-reset] container not running; skipping"
+  exit 0
+fi
+
+docker exec --user root \
+  -e KLEBB_DEMO=1 -e HEALTH_HOME=/data \
+  klebb-demo node /app/scripts/reset-demo.js
+```
+
+```bash
+chmod +x /usr/local/bin/klebb-demo-reset.sh
+```
+
+Then `/etc/cron.d/klebb-demo-reset`:
+
+```cron
+0 * * * * root /usr/local/bin/klebb-demo-reset.sh >> /var/log/klebb-demo-reset.log 2>&1
+```
+
+The cron fires at the top of every hour. Watch
+`/var/log/klebb-demo-reset.log` to confirm successful runs.
+
+## 7. Updating to a new release
+
+```bash
+cd /opt/klebb-demo
+# Pin to the new tag in compose.yml first, e.g. ghcr.io/aristocles/klebb:2.1.3
+docker compose pull
+docker compose up -d
+# Re-seed; new fixtures may have landed
+docker exec --user root \
+  -e KLEBB_DEMO=1 -e HEALTH_HOME=/data \
+  klebb-demo node /app/scripts/reset-demo.js
+```
+
+Image tag must match the compose file. `latest` is also published but
+explicit version pinning is recommended for visibility.
+
+## Troubleshooting
+
+| Symptom | First check |
+|---|---|
+| `docker compose pull` returns "unauthorized" | The GHCR package may be private. Flip it to public at `https://github.com/users/<owner>/packages/container/klebb/settings`. The image is meant to be anonymously pullable. |
+| `docker compose pull` returns "tag not found" | Confirm the tag exists at `https://github.com/Aristocles/klebb/pkgs/container/klebb`. Remember the publish workflow strips the `v` prefix: git tag `v2.1.2` → image tag `2.1.2`. |
+| Reset script: "Cannot find module" | The image is older than 2.1.2 and doesn't carry `demo/` or `scripts/reset-demo.js`. Pull a newer tag. |
+| Reset script: "refuses to run without KLEBB_DEMO=1" | The cron is wired correctly; the `.env` for the running container does not have `KLEBB_DEMO=1`. Add it and `docker compose up -d` to recreate. |
+| Visitors see the passkey prompt instead of "Enter the demo" | `KLEBB_DEMO=1` not set in the environment of the running container. Confirm with `docker inspect klebb-demo \| grep -i klebb_demo`. |
+| Cards don't show fresh dates | The hourly cron isn't firing. `tail /var/log/klebb-demo-reset.log` and `systemctl status cron`. |
+
+## What the demo does NOT do
+
+- Issue invites or accept passkey registrations.
+- Persist any visitor input across the next reset cycle.
+- Make outbound HTTP for chat or voice. Chat replies with a canned
+  string; voice routes return 503.
+- Run any of the scheduled tasks that a normal Klebb instance does
+  (no auto-export ingestion, no email, etc.).
+
+If a behaviour you expect from the demo isn't in the above list,
+treat it as a gap and file an issue.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -11,6 +11,9 @@ server. It covers:
 The approach is intentionally lightweight: Node.js + systemd + nginx.
 No Docker, no build step, no CI dependencies.
 
+For a **public, no-credentials demo deployment** (e.g. `demo.klebb.app`),
+see [DEMO.md](DEMO.md).
+
 ---
 
 ## 1. Single-user deploy

--- a/docs/HEALTH-AUTO-EXPORT.md
+++ b/docs/HEALTH-AUTO-EXPORT.md
@@ -76,19 +76,21 @@ combination card if you want them shown together.
 
 ## Setup
 
-### 1. Enable the endpoint
+### 1. Generate a token in Settings
 
-Set `HEALTH_AUTO_EXPORT_TOKEN` in your klebb `.env` to any long random
-string. `openssl rand -hex 32` is a fine source.
+Open Klebb in the browser, go to **Settings**, and find the
+**Health Auto Export** panel. Click **Generate token**. Klebb mints a
+64-char hex secret, persists it to
+`$HEALTH_HOME/config.json` under `cfg.hae.token` (atomic write,
+`0o600`), and reveals it briefly in the panel so you can copy it
+straight to the clipboard.
 
-```
-HEALTH_AUTO_EXPORT_TOKEN=<your-random-hex>
-```
+Without a token the endpoint returns **501**: the feature is off by
+default.
 
-Restart klebb (or `docker compose restart` if you run in Docker).
-
-Without this env var the endpoint returns **501** — the feature is
-off by default.
+You can rotate at any time with the **Regenerate** button. Rotating
+invalidates the previous token immediately, so update the iPhone HAE
+app's Authorization header before the next push.
 
 ### 2. Configure the iPhone app
 
@@ -100,7 +102,7 @@ In Health Auto Export:
 4. **Headers**:
    ```
    Content-Type: application/json
-   Authorization: Bearer <your-HEALTH_AUTO_EXPORT_TOKEN>
+   Authorization: Bearer <token-from-Settings>
    ```
 5. **Metrics**: pick from the table above. Enabling more than you
    subscribe to is harmless — unsubscribed metrics are archived only.
@@ -171,7 +173,7 @@ If nothing shows up:
   Bearer <token>" -H "Content-Type: application/json" -d
   '{"data":{}}'` — expect `200 {"ok":true,"ingested":{}}`.
 - Wrong token → `401`.
-- Missing env var → `501`.
+- No token configured → `501`.
 
 ---
 
@@ -199,7 +201,11 @@ A successful push returns:
 Klebb's Settings view leads with a Health Auto Export panel showing:
 
 - The effective webhook URL (copy to clipboard).
-- Whether `HEALTH_AUTO_EXPORT_TOKEN` is set.
+- The token, with **Generate** when none is configured, or a masked
+  display (`••••<last 4>`) plus **Copy** and **Regenerate** buttons
+  when one is. Regenerate prompts an inline confirmation that warns
+  the iPhone HAE app must be updated before the next push will be
+  accepted.
 - Time and summary of the most recent push, expandable to show the
   full diagnostic (rows per subscriber, unsubscribed metrics seen,
   warnings).
@@ -355,7 +361,7 @@ does nothing does not churn any file.
 
 ```
 POST /api/health-auto-export
-Authorization: Bearer <HEALTH_AUTO_EXPORT_TOKEN>
+Authorization: Bearer <token-from-Settings>
 Content-Type: application/json
 ```
 
@@ -364,8 +370,23 @@ Content-Type: application/json
 | `200 {ok:true, ingested:{...}, availableUnsubscribed:[...]}` | Parsed and dispatched |
 | `200 {ok:true, warning:"..."}` | Parse or dispatch failed but raw was archived; HAE will retry |
 | `401` | Token missing or wrong |
-| `501 {error:"ingest disabled"}` | `HEALTH_AUTO_EXPORT_TOKEN` env var not set |
+| `501 {error:"ingest disabled"}` | No token configured (visit Settings → Health Auto Export) |
 
 Errors after auth passes are swallowed into `200 + warning` on
 purpose: the iPhone app retries aggressively on non-2xx, and we'd
 rather have a raw archive to debug than a spiral.
+
+---
+
+## Upgrading from older Klebb
+
+Older versions used a `HEALTH_AUTO_EXPORT_TOKEN` env var instead of an
+in-app Settings flow. On first boot under the new code:
+
+- If `cfg.hae.token` already exists in `config.json`, nothing changes.
+- If it doesn't exist *and* the env var is set, Klebb copies the env
+  value into `cfg.hae.token` once and logs a deprecation warning. The
+  iPhone app keeps working with the same token.
+- After that, the env var is ignored. You can drop the line from your
+  `.env` / systemd unit / docker-compose `environment` block at your
+  leisure.

--- a/health-auto-export/token-store.js
+++ b/health-auto-export/token-store.js
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// health-auto-export/token-store.js
+//
+// Manages the iPhone Health Auto Export bearer token in
+// $HEALTH_HOME/config.json under cfg.hae.token. Atomic-write at 0o600,
+// matching the auth/invites.js pattern.
+//
+// Schema:
+//   {
+//     "hae": {
+//       "token": "<64 hex chars>",
+//       "lastRegeneratedAt": "2026-05-21T14:02:00.000Z"
+//     }
+//   }
+//
+// One-shot env-var migration: on first boot under this code, if
+// cfg.hae.token is empty and HEALTH_AUTO_EXPORT_TOKEN is set in env,
+// the value is copied into config.json and a deprecation warning is
+// logged. After that, the env var is ignored.
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const PATHS = require('../config/paths');
+
+function _readConfig() {
+  try {
+    const raw = fs.readFileSync(PATHS.CONFIG_PATH, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+function _writeConfig(cfg) {
+  try { fs.mkdirSync(path.dirname(PATHS.CONFIG_PATH), { recursive: true }); } catch {}
+  const tmp = PATHS.CONFIG_PATH + '.tmp';
+  fs.writeFileSync(tmp, JSON.stringify(cfg, null, 2), { mode: 0o600 });
+  fs.renameSync(tmp, PATHS.CONFIG_PATH);
+}
+
+function getToken() {
+  const cfg = _readConfig();
+  const t = cfg && cfg.hae && cfg.hae.token;
+  return (typeof t === 'string' && t.length > 0) ? t : null;
+}
+
+function getLastRegeneratedAt() {
+  const cfg = _readConfig();
+  const v = cfg && cfg.hae && cfg.hae.lastRegeneratedAt;
+  return (typeof v === 'string' && v.length > 0) ? v : null;
+}
+
+function setToken(token) {
+  const t = String(token || '').trim();
+  if (!t) throw new Error('refusing to set empty token; use clearToken() instead');
+  const cfg = _readConfig();
+  cfg.hae = cfg.hae || {};
+  cfg.hae.token = t;
+  cfg.hae.lastRegeneratedAt = new Date().toISOString();
+  _writeConfig(cfg);
+  return t;
+}
+
+function generateToken() {
+  return setToken(crypto.randomBytes(32).toString('hex'));
+}
+
+function clearToken() {
+  const cfg = _readConfig();
+  if (cfg && cfg.hae) {
+    delete cfg.hae.token;
+    delete cfg.hae.lastRegeneratedAt;
+  }
+  _writeConfig(cfg);
+}
+
+// Idempotent. Safe to run on every boot. Returns true if migration
+// happened, false otherwise.
+function migrateFromEnvIfNeeded() {
+  if (getToken()) return false;
+  const env = (process.env.HEALTH_AUTO_EXPORT_TOKEN || '').trim();
+  if (!env) return false;
+  const cfg = _readConfig();
+  cfg.hae = cfg.hae || {};
+  cfg.hae.token = env;
+  // Mark with a migration timestamp so the UI can distinguish a freshly
+  // generated token from one inherited from the env var.
+  cfg.hae.migratedFromEnvAt = new Date().toISOString();
+  _writeConfig(cfg);
+  console.warn(
+    '[hae] migrated HEALTH_AUTO_EXPORT_TOKEN env var into config.json; '
+    + 'you can remove the env var on next deploy'
+  );
+  return true;
+}
+
+module.exports = {
+  getToken,
+  getLastRegeneratedAt,
+  setToken,
+  generateToken,
+  clearToken,
+  migrateFromEnvIfNeeded,
+};

--- a/public/js/components/eh-settings-view.js
+++ b/public/js/components/eh-settings-view.js
@@ -24,6 +24,14 @@ export class EhSettingsView extends LitElement {
     _haeStatus: { state: true },
     _haeLastPushExpanded: { state: true },
     _haeCopied: { state: true },
+    _haeToken: { state: true },
+    _haeTokenLoaded: { state: true },
+    _haeTokenLastRegeneratedAt: { state: true },
+    _haeTokenReveal: { state: true },
+    _haeTokenCopied: { state: true },
+    _haeTokenBusy: { state: true },
+    _haeRegenConfirm: { state: true },
+    _haeTokenError: { state: true },
     _demo: { state: true },
   };
 
@@ -39,6 +47,14 @@ export class EhSettingsView extends LitElement {
     this._haeStatus = null;
     this._haeLastPushExpanded = false;
     this._haeCopied = false;
+    this._haeToken = null;
+    this._haeTokenLoaded = false;
+    this._haeTokenLastRegeneratedAt = null;
+    this._haeTokenReveal = false;
+    this._haeTokenCopied = false;
+    this._haeTokenBusy = false;
+    this._haeRegenConfirm = false;
+    this._haeTokenError = null;
     this._demo = false;
   }
 
@@ -47,6 +63,7 @@ export class EhSettingsView extends LitElement {
     this._load();
     this._loadHiddenDiscoveries();
     this._loadHaeStatus();
+    this._loadHaeToken();
     this._loadDemoFlag();
   }
 
@@ -69,23 +86,111 @@ export class EhSettingsView extends LitElement {
     }
   }
 
-  async _copyEndpoint() {
-    if (!this._haeStatus?.endpointUrl) return;
+  async _writeClipboard(text) {
     try {
-      await navigator.clipboard.writeText(this._haeStatus.endpointUrl);
-      this._haeCopied = true;
-      setTimeout(() => { this._haeCopied = false; }, 1800);
+      await navigator.clipboard.writeText(text);
     } catch {
-      // Fallback: hidden textarea selection.
       const ta = document.createElement('textarea');
-      ta.value = this._haeStatus.endpointUrl;
+      ta.value = text;
       document.body.appendChild(ta);
       ta.select();
       try { document.execCommand('copy'); } catch {}
       document.body.removeChild(ta);
-      this._haeCopied = true;
-      setTimeout(() => { this._haeCopied = false; }, 1800);
     }
+  }
+
+  async _copyEndpoint() {
+    if (!this._haeStatus?.endpointUrl) return;
+    await this._writeClipboard(this._haeStatus.endpointUrl);
+    this._haeCopied = true;
+    setTimeout(() => { this._haeCopied = false; }, 1800);
+  }
+
+  async _loadHaeToken() {
+    try {
+      const r = await fetch('/api/health-auto-export/token');
+      if (!r.ok) {
+        this._haeToken = null;
+        this._haeTokenLastRegeneratedAt = null;
+        this._haeTokenLoaded = true;
+        return;
+      }
+      const j = await r.json();
+      this._haeToken = j.token || null;
+      this._haeTokenLastRegeneratedAt = j.lastRegeneratedAt || null;
+      this._haeTokenLoaded = true;
+    } catch {
+      this._haeTokenLoaded = true;
+    }
+  }
+
+  async _generateHaeToken() {
+    if (this._haeTokenBusy) return;
+    this._haeTokenBusy = true;
+    this._haeTokenError = null;
+    try {
+      const r = await fetch('/api/health-auto-export/token', { method: 'POST' });
+      if (!r.ok) {
+        this._haeTokenError = await errorFromResponse(r, 'Could not generate token.');
+        return;
+      }
+      const j = await r.json();
+      this._haeToken = j.token;
+      this._haeTokenLastRegeneratedAt = j.lastRegeneratedAt || null;
+      this._haeTokenReveal = true;
+      // Refresh status panel so the green dot updates.
+      this._loadHaeStatus();
+      setTimeout(() => { this._haeTokenReveal = false; }, 8000);
+    } catch (e) {
+      this._haeTokenError = e?.message || 'Could not generate token.';
+    } finally {
+      this._haeTokenBusy = false;
+    }
+  }
+
+  _askRegenerateHae() {
+    this._haeRegenConfirm = true;
+    this._haeTokenError = null;
+  }
+
+  _cancelRegenerateHae() {
+    this._haeRegenConfirm = false;
+  }
+
+  async _confirmRegenerateHae() {
+    if (this._haeTokenBusy) return;
+    this._haeTokenBusy = true;
+    this._haeTokenError = null;
+    try {
+      const r = await fetch('/api/health-auto-export/token/regenerate', { method: 'POST' });
+      if (!r.ok) {
+        this._haeTokenError = await errorFromResponse(r, 'Could not regenerate token.');
+        return;
+      }
+      const j = await r.json();
+      this._haeToken = j.token;
+      this._haeTokenLastRegeneratedAt = j.lastRegeneratedAt || null;
+      this._haeRegenConfirm = false;
+      this._haeTokenReveal = true;
+      setTimeout(() => { this._haeTokenReveal = false; }, 8000);
+    } catch (e) {
+      this._haeTokenError = e?.message || 'Could not regenerate token.';
+    } finally {
+      this._haeTokenBusy = false;
+    }
+  }
+
+  async _copyHaeToken() {
+    if (!this._haeToken) return;
+    await this._writeClipboard(this._haeToken);
+    this._haeTokenCopied = true;
+    setTimeout(() => { this._haeTokenCopied = false; }, 1800);
+  }
+
+  _maskToken(token) {
+    if (!token) return '';
+    const tail = token.slice(-4);
+    return '•'.repeat(28) + tail;
   }
 
   _toggleLastPushDetail() {
@@ -444,6 +549,65 @@ export class EhSettingsView extends LitElement {
       background: var(--bg-input, rgba(0, 0, 0, 0.04));
       border-radius: 4px;
     }
+    .hae-token-empty,
+    .hae-token-value {
+      display: inline-flex;
+      gap: 8px;
+      align-items: center;
+      flex: 1;
+      min-width: 0;
+      flex-wrap: wrap;
+    }
+    .hae-token-meta {
+      font-size: 11px;
+      color: var(--text-muted, var(--text-secondary));
+      flex-basis: 100%;
+    }
+    .hae-token-error {
+      font-size: 11px;
+      color: var(--accent-red, #ff5566);
+      flex-basis: 100%;
+    }
+    .copy-btn.primary {
+      background: var(--accent, #4488ff);
+      color: var(--accent-fg, #fff);
+      border-color: var(--accent, #4488ff);
+    }
+    .copy-btn.primary:hover {
+      filter: brightness(1.05);
+    }
+    .copy-btn.danger {
+      background: var(--accent-amber, #ffaa33);
+      color: #1a1a1a;
+      border-color: var(--accent-amber, #ffaa33);
+    }
+    .copy-btn.danger:hover {
+      filter: brightness(1.05);
+    }
+    .hae-regen-confirm {
+      display: inline-flex;
+      flex: 1;
+      min-width: 0;
+    }
+    .hae-regen-body {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      padding: 10px 12px;
+      border: 1px solid var(--accent-amber, #ffaa33);
+      border-radius: 8px;
+      background: var(--accent-amber-bg, rgba(255, 170, 51, 0.10));
+      flex: 1;
+    }
+    .hae-regen-warning {
+      font-size: 12px;
+      color: var(--text-primary);
+      line-height: 1.4;
+    }
+    .hae-regen-actions {
+      display: inline-flex;
+      gap: 8px;
+    }
     .hae-lastpush {
       display: inline-flex;
       gap: 8px;
@@ -641,13 +805,7 @@ export class EhSettingsView extends LitElement {
         </div>
         <div class="hae-row">
           <span class="hae-label">Token</span>
-          <span class="hae-token ${s.tokenSet ? 'on' : 'off'}">
-            ${s.tokenSet
-              ? html`<span class="dot"></span>Set`
-              : html`<span class="dot"></span>Not set — add
-                  <code>HEALTH_AUTO_EXPORT_TOKEN</code> to your
-                  <code>.env</code>`}
-          </span>
+          ${this._renderHaeTokenRow()}
         </div>
         <div class="hae-row">
           <span class="hae-label">Last push</span>
@@ -669,6 +827,97 @@ export class EhSettingsView extends LitElement {
         ` : ''}
       </div>
     `;
+  }
+
+  _renderHaeTokenRow() {
+    if (!this._haeTokenLoaded) {
+      return html`<span class="muted">Loading…</span>`;
+    }
+
+    if (this._haeRegenConfirm) {
+      return html`
+        <span class="hae-regen-confirm">
+          <span class="hae-regen-body">
+            <span class="hae-regen-warning">
+              ⚠ Regenerating will invalidate the current token. You'll need
+              to update your iPhone Health Auto Export configuration with
+              the new token before the next push will be accepted.
+            </span>
+            <span class="hae-regen-actions">
+              <button
+                class="copy-btn"
+                @click=${this._cancelRegenerateHae}
+                ?disabled=${this._haeTokenBusy}
+              >Cancel</button>
+              <button
+                class="copy-btn danger"
+                @click=${this._confirmRegenerateHae}
+                ?disabled=${this._haeTokenBusy}
+              >Yes, regenerate</button>
+            </span>
+            ${this._haeTokenError ? html`<span class="hae-token-error">${this._haeTokenError}</span>` : ''}
+          </span>
+        </span>
+      `;
+    }
+
+    if (!this._haeToken) {
+      return html`
+        <span class="hae-token-empty">
+          <button
+            class="copy-btn primary"
+            @click=${this._generateHaeToken}
+            ?disabled=${this._haeTokenBusy}
+          >${this._haeTokenBusy ? 'Generating…' : 'Generate token'}</button>
+          <span class="hae-token-meta">
+            Klebb will generate a long random token. Paste it into your
+            iPhone Health Auto Export app's Authorization header.
+          </span>
+          ${this._haeTokenError ? html`<span class="hae-token-error">${this._haeTokenError}</span>` : ''}
+        </span>
+      `;
+    }
+
+    const display = this._haeTokenReveal
+      ? this._haeToken
+      : this._maskToken(this._haeToken);
+
+    return html`
+      <span class="hae-token-value">
+        <code class="endpoint-code">${display}</code>
+        <button
+          class="copy-btn"
+          @click=${this._copyHaeToken}
+          aria-label="Copy token"
+        >${this._haeTokenCopied ? 'Copied ✓' : 'Copy'}</button>
+        <button
+          class="copy-btn"
+          @click=${this._askRegenerateHae}
+          ?disabled=${this._haeTokenBusy}
+        >Regenerate</button>
+        ${this._haeTokenLastRegeneratedAt ? html`
+          <span class="hae-token-meta">
+            Last generated: ${this._formatTimestamp(this._haeTokenLastRegeneratedAt)}
+          </span>
+        ` : ''}
+        ${this._haeTokenError ? html`<span class="hae-token-error">${this._haeTokenError}</span>` : ''}
+      </span>
+    `;
+  }
+
+  _formatTimestamp(iso) {
+    try {
+      const d = new Date(iso);
+      if (Number.isNaN(d.getTime())) return iso;
+      const yr = d.getFullYear();
+      const mo = String(d.getMonth() + 1).padStart(2, '0');
+      const da = String(d.getDate()).padStart(2, '0');
+      const hh = String(d.getHours()).padStart(2, '0');
+      const mm = String(d.getMinutes()).padStart(2, '0');
+      return `${yr}-${mo}-${da} ${hh}:${mm}`;
+    } catch {
+      return iso;
+    }
   }
 
   _renderLastPushSummary(lp) {

--- a/server.js
+++ b/server.js
@@ -21,6 +21,7 @@ const { buildDateContextBlock } = require('./chat/date-context');
 const hae = require('./health-auto-export/ingest');
 const haeDiagnostics = require('./health-auto-export/diagnostics');
 const haeDiscoveries = require('./health-auto-export/discoveries');
+const haeTokenStore = require('./health-auto-export/token-store');
 const { describeCatalogue: describeHaeCatalogue } = require('./health-auto-export/describe');
 const { CATEGORIES: MANIFEST_CATEGORIES } = require('./config/categories');
 const ccSuggestions = require('./meta/cc-suggestions');
@@ -52,6 +53,16 @@ const REPORTS_DIR = PATHS.REPORTS_DIR;
 
 // Ensure writable dirs exist
 PATHS.ensureWritableDirs();
+
+// One-shot migration: if the legacy HEALTH_AUTO_EXPORT_TOKEN env var is
+// set and config.json has no token yet, copy it across so existing
+// instances upgrade transparently. Runs before the HTTP listener so the
+// token store is consistent the moment the server accepts requests.
+try {
+  haeTokenStore.migrateFromEnvIfNeeded();
+} catch (e) {
+  console.warn('[hae] token migration error (continuing):', e.message);
+}
 
 // Configure marked for GFM (tables, etc.)
 marked.setOptions({ gfm: true, breaks: true });
@@ -529,10 +540,11 @@ const server = http.createServer(async (req, res) => {
     if (result !== null) return;
   }
 
-  // The HAE webhook carries its own token (HEALTH_AUTO_EXPORT_TOKEN) and
-  // the handler enforces it. Let the request through the outer auth gate
-  // so the handler can respond with 501/401/200 as appropriate. No session
-  // cookie or AGENT_API_TOKEN is expected from the iPhone app.
+  // The HAE webhook carries its own token (managed in Settings; see
+  // health-auto-export/token-store.js) and the handler enforces it. Let
+  // the request through the outer auth gate so the handler can respond
+  // with 501/401/200 as appropriate. No session cookie or
+  // AGENT_API_TOKEN is expected from the iPhone app.
   const isHaeIngest = pathname === '/api/health-auto-export' && req.method === 'POST';
 
   // Redirect to setup or login if not authenticated
@@ -893,19 +905,20 @@ const server = http.createServer(async (req, res) => {
       return send404(res);
     }
 
-    // POST /api/health-auto-export — iPhone Health Auto Export webhook.
+    // POST /api/health-auto-export: iPhone Health Auto Export webhook.
     //
-    // Auth: Bearer <HEALTH_AUTO_EXPORT_TOKEN>. If the env var is unset, the
-    // endpoint returns 501 (feature off). If the header is wrong or
-    // missing, returns 401. Otherwise the raw payload is archived, parsed,
-    // and upserted into atomic manifests (sleep-hours, steps,
-    // active-minutes, workouts).
+    // Auth: Bearer <token-from-Settings>. If no token has been generated
+    // (cfg.hae.token empty in $HEALTH_HOME/config.json), the endpoint
+    // returns 501 (feature off). If the header is wrong or missing,
+    // returns 401. Otherwise the raw payload is archived, parsed, and
+    // upserted into atomic manifests (sleep-hours, steps, active-minutes,
+    // workouts).
     //
     // Errors that occur AFTER auth passes are swallowed into a 200 with a
     // warning so the iPhone app's retry loop doesn't spiral. The raw
     // payload is always archived, so parse failures are debuggable later.
     if (parts[0] === 'health-auto-export' && parts.length === 1 && req.method === 'POST') {
-      const token = ENV.HEALTH_AUTO_EXPORT_TOKEN;
+      const token = haeTokenStore.getToken();
       if (!token) return sendJSON(res, { error: 'ingest disabled' }, 501);
       const auth = req.headers['authorization'];
       if (!auth || !auth.startsWith('Bearer ') || auth.slice(7).trim() !== token) {
@@ -996,7 +1009,7 @@ const server = http.createServer(async (req, res) => {
     // push snapshot written by the dispatcher.
     if (parts[0] === 'health-auto-export' && parts[1] === 'status'
         && parts.length === 2 && req.method === 'GET') {
-      const token = ENV.HEALTH_AUTO_EXPORT_TOKEN;
+      const token = haeTokenStore.getToken();
       const host = req.headers['host'] || `${HOST}:${PORT}`;
       const scheme = (req.headers['x-forwarded-proto'] || 'http').split(',')[0].trim();
       return sendJSON(res, {
@@ -1004,6 +1017,54 @@ const server = http.createServer(async (req, res) => {
         endpointUrl: `${scheme}://${host}/api/health-auto-export`,
         lastPush: haeDiagnostics.readLastPush(),
       });
+    }
+
+    // GET /api/health-auto-export/token: return the current token (or
+    // null) for the Settings UI to display. Behind the global auth gate
+    // (passkey session required, same as every other /api route except
+    // the ingest webhook itself).
+    if (parts[0] === 'health-auto-export' && parts[1] === 'token'
+        && parts.length === 2 && req.method === 'GET') {
+      return sendJSON(res, {
+        token: haeTokenStore.getToken(),
+        lastRegeneratedAt: haeTokenStore.getLastRegeneratedAt(),
+      });
+    }
+
+    // POST /api/health-auto-export/token: generate a token. Returns 409
+    // if one already exists (use /regenerate to replace).
+    if (parts[0] === 'health-auto-export' && parts[1] === 'token'
+        && parts.length === 2 && req.method === 'POST') {
+      if (haeTokenStore.getToken()) {
+        return sendJSON(res, { error: 'token already set; use /regenerate' }, 409);
+      }
+      const token = haeTokenStore.generateToken();
+      return sendJSON(res, {
+        token,
+        lastRegeneratedAt: haeTokenStore.getLastRegeneratedAt(),
+      });
+    }
+
+    // POST /api/health-auto-export/token/regenerate: replace the
+    // current token with a fresh one. The old token is invalidated
+    // immediately; the iPhone HAE app must be updated before it can
+    // push again.
+    if (parts[0] === 'health-auto-export' && parts[1] === 'token'
+        && parts[2] === 'regenerate' && parts.length === 3
+        && req.method === 'POST') {
+      const token = haeTokenStore.generateToken();
+      return sendJSON(res, {
+        token,
+        lastRegeneratedAt: haeTokenStore.getLastRegeneratedAt(),
+      });
+    }
+
+    // DELETE /api/health-auto-export/token: clear the token. Subsequent
+    // ingest requests return 501 (feature off).
+    if (parts[0] === 'health-auto-export' && parts[1] === 'token'
+        && parts.length === 2 && req.method === 'DELETE') {
+      haeTokenStore.clearToken();
+      return sendJSON(res, { ok: true });
     }
 
     // GET /api/health-auto-export/discoveries — list metrics present in

--- a/tests-e2e/hae-settings.spec.js
+++ b/tests-e2e/hae-settings.spec.js
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/hae-settings.spec.js
+// Walks the operator-facing flow for HAE token management: generate,
+// copy, ingest with the displayed token, regenerate, confirm rotation.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+async function getDisplayedToken(page) {
+  // After Generate / Regenerate the panel briefly reveals the full
+  // token unmasked. Read it from the .endpoint-code element inside the
+  // hae-token-value row (matches eh-settings-view styles).
+  return await page.locator('eh-settings-view .hae-token-value .endpoint-code').innerText();
+}
+
+async function ingestWithToken(request, baseURL, token) {
+  return await request.post(`${baseURL}/api/health-auto-export`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { data: { metrics: [] } },
+  });
+}
+
+test.describe('#278 HAE token Settings flow', () => {
+  test('generate, copy, ingest, regenerate rotates', async ({ page, request, baseURL }) => {
+    // Start clean: clear any token a previous spec may have left behind.
+    await request.delete(`${baseURL}/api/health-auto-export/token`);
+
+    await page.goto('/settings');
+    await expect(page.locator('eh-settings-view')).toBeVisible();
+
+    // State A: Generate button visible, no token displayed yet.
+    const generateBtn = page.locator('eh-settings-view .hae-token-empty button', {
+      hasText: /Generate token/i,
+    });
+    await expect(generateBtn).toBeVisible();
+
+    await generateBtn.click();
+
+    // State C: token revealed; capture it for the ingest assertion.
+    await expect(page.locator('eh-settings-view .hae-token-value')).toBeVisible();
+    const firstToken = await getDisplayedToken(page);
+    expect(firstToken).toMatch(/^[a-f0-9]{64}$/);
+
+    // Token authenticates the ingest webhook.
+    const ingestOk = await ingestWithToken(request, baseURL, firstToken);
+    expect(ingestOk.status()).toBe(200);
+
+    // Click Regenerate; the inline confirm strip should appear.
+    await page.locator('eh-settings-view .hae-token-value button', { hasText: /Regenerate/i }).click();
+    const confirmBtn = page.locator('eh-settings-view .hae-regen-actions button', {
+      hasText: /Yes, regenerate/i,
+    });
+    await expect(confirmBtn).toBeVisible();
+    await confirmBtn.click();
+
+    // New token visible; differs from the first.
+    await expect(page.locator('eh-settings-view .hae-token-value')).toBeVisible();
+    const secondToken = await getDisplayedToken(page);
+    expect(secondToken).toMatch(/^[a-f0-9]{64}$/);
+    expect(secondToken).not.toBe(firstToken);
+
+    // Old token rejected; new token accepted.
+    const ingestOld = await ingestWithToken(request, baseURL, firstToken);
+    expect(ingestOld.status()).toBe(401);
+    const ingestNew = await ingestWithToken(request, baseURL, secondToken);
+    expect(ingestNew.status()).toBe(200);
+
+    // Tidy up so subsequent specs that hit /settings see the no-token
+    // state (and so Cards section, etc., aren't perturbed).
+    await request.delete(`${baseURL}/api/health-auto-export/token`);
+  });
+});

--- a/tests/api/hae-token-api.test.js
+++ b/tests/api/hae-token-api.test.js
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/api/hae-token-api.test.js
+// Regression seed for #278 — HAE token managed via Settings UI rather
+// than HEALTH_AUTO_EXPORT_TOKEN. Covers the four new endpoints + the
+// passkey-auth gate, and confirms a freshly-rotated token immediately
+// authenticates the ingest webhook.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const {
+  createSandbox,
+  cleanupSandbox,
+  spawnServer,
+  req,
+  fakeAuthState,
+} = require('../helpers/sandbox');
+
+const TOKEN_PATH = '/api/health-auto-export/token';
+const REGEN_PATH = '/api/health-auto-export/token/regenerate';
+const INGEST_PATH = '/api/health-auto-export';
+
+describe('#278 HAE token API', () => {
+  let sandbox, server, auth;
+
+  before(async () => {
+    auth = fakeAuthState('e2e-user');
+    sandbox = createSandbox({
+      credentials: auth.credentials,
+      sessions: auth.sessions,
+    });
+    // Note: no HEALTH_AUTO_EXPORT_TOKEN passed. The store starts empty.
+    server = await spawnServer(sandbox, { HEALTH_AUTO_EXPORT_TOKEN: '' });
+  });
+  after(async () => {
+    if (server) await server.kill();
+    if (sandbox) cleanupSandbox(sandbox);
+  });
+
+  test('GET token (auth required) returns null when none set', async () => {
+    const r = await req(server.baseUrl, TOKEN_PATH, { cookie: auth.cookie });
+    assert.equal(r.status, 200);
+    assert.equal(r.json.token, null);
+  });
+
+  test('GET token without session returns 401', async () => {
+    const r = await req(server.baseUrl, TOKEN_PATH);
+    assert.equal(r.status, 401);
+  });
+
+  test('POST token (auth) generates a 64-char hex token', async () => {
+    const r = await req(server.baseUrl, TOKEN_PATH, {
+      method: 'POST', cookie: auth.cookie,
+    });
+    assert.equal(r.status, 200);
+    assert.match(r.json.token, /^[a-f0-9]{64}$/);
+    assert.ok(r.json.lastRegeneratedAt);
+  });
+
+  test('POST token without session returns 401', async () => {
+    const r = await req(server.baseUrl, TOKEN_PATH, { method: 'POST' });
+    assert.equal(r.status, 401);
+  });
+
+  test('POST token a second time returns 409 (already set)', async () => {
+    const r = await req(server.baseUrl, TOKEN_PATH, {
+      method: 'POST', cookie: auth.cookie,
+    });
+    assert.equal(r.status, 409);
+  });
+
+  test('GET token after generate returns the stored value', async () => {
+    const r = await req(server.baseUrl, TOKEN_PATH, { cookie: auth.cookie });
+    assert.equal(r.status, 200);
+    assert.match(r.json.token, /^[a-f0-9]{64}$/);
+  });
+
+  test('persisted under cfg.hae.token in $HEALTH_HOME/config.json', () => {
+    const cfg = JSON.parse(fs.readFileSync(path.join(sandbox, 'config.json'), 'utf8'));
+    assert.match(cfg.hae.token, /^[a-f0-9]{64}$/);
+  });
+
+  test('regenerate (auth) rotates: old token 401s, new token 200s', async () => {
+    const before = await req(server.baseUrl, TOKEN_PATH, { cookie: auth.cookie });
+    const oldToken = before.json.token;
+
+    const rotated = await req(server.baseUrl, REGEN_PATH, {
+      method: 'POST', cookie: auth.cookie,
+    });
+    assert.equal(rotated.status, 200);
+    const newToken = rotated.json.token;
+    assert.notEqual(newToken, oldToken);
+    assert.match(newToken, /^[a-f0-9]{64}$/);
+
+    // Old token no longer authenticates the ingest webhook.
+    const oldIngest = await req(server.baseUrl, INGEST_PATH, {
+      method: 'POST',
+      body: { data: { metrics: [] } },
+      headers: { Authorization: `Bearer ${oldToken}` },
+    });
+    assert.equal(oldIngest.status, 401);
+
+    // New token does.
+    const newIngest = await req(server.baseUrl, INGEST_PATH, {
+      method: 'POST',
+      body: { data: { metrics: [] } },
+      headers: { Authorization: `Bearer ${newToken}` },
+    });
+    assert.equal(newIngest.status, 200);
+  });
+
+  test('regenerate without session returns 401', async () => {
+    const r = await req(server.baseUrl, REGEN_PATH, { method: 'POST' });
+    assert.equal(r.status, 401);
+  });
+
+  test('DELETE token (auth) clears it; ingest then 501s', async () => {
+    const r = await req(server.baseUrl, TOKEN_PATH, {
+      method: 'DELETE', cookie: auth.cookie,
+    });
+    assert.equal(r.status, 200);
+    assert.equal(r.json.ok, true);
+
+    const after = await req(server.baseUrl, TOKEN_PATH, { cookie: auth.cookie });
+    assert.equal(after.json.token, null);
+
+    const ingest = await req(server.baseUrl, INGEST_PATH, {
+      method: 'POST', body: { data: { metrics: [] } },
+    });
+    assert.equal(ingest.status, 501);
+  });
+
+  test('DELETE without session returns 401', async () => {
+    const r = await req(server.baseUrl, TOKEN_PATH, { method: 'DELETE' });
+    assert.equal(r.status, 401);
+  });
+});
+
+describe('#278 HAE env var migration on boot', () => {
+  let sandbox, server, auth;
+  const ENV_TOKEN = 'legacy-env-supplied-token-1234567890abcdef';
+
+  before(async () => {
+    auth = fakeAuthState('e2e-user');
+    sandbox = createSandbox({
+      credentials: auth.credentials,
+      sessions: auth.sessions,
+    });
+    // Spawn with the legacy env var set and config.json empty: the boot
+    // path should migrate the value into config.json.
+    server = await spawnServer(sandbox, { HEALTH_AUTO_EXPORT_TOKEN: ENV_TOKEN });
+  });
+  after(async () => {
+    if (server) await server.kill();
+    if (sandbox) cleanupSandbox(sandbox);
+  });
+
+  test('config.json now contains cfg.hae.token from the env var', () => {
+    const cfg = JSON.parse(fs.readFileSync(path.join(sandbox, 'config.json'), 'utf8'));
+    assert.equal(cfg.hae.token, ENV_TOKEN);
+    assert.ok(cfg.hae.migratedFromEnvAt);
+  });
+
+  test('GET /api/health-auto-export/token returns the migrated value', async () => {
+    const r = await req(server.baseUrl, TOKEN_PATH, { cookie: auth.cookie });
+    assert.equal(r.json.token, ENV_TOKEN);
+  });
+
+  test('ingest still authenticates with the migrated token', async () => {
+    const r = await req(server.baseUrl, INGEST_PATH, {
+      method: 'POST',
+      body: { data: { metrics: [] } },
+      headers: { Authorization: `Bearer ${ENV_TOKEN}` },
+    });
+    assert.equal(r.status, 200);
+  });
+});

--- a/tests/health-auto-export.token-store.test.js
+++ b/tests/health-auto-export.token-store.test.js
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/health-auto-export.token-store.test.js
+// Unit tests for the HAE token store. Drives the module against a
+// temp config.json by setting HEALTH_CONFIG_PATH before require().
+
+const { test, describe, before, beforeEach, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'eh-tokstore-'));
+const CFG = path.join(tmpDir, 'config.json');
+process.env.HEALTH_CONFIG_PATH = CFG;
+process.env.HEALTH_HOME = tmpDir;
+process.env.HEALTH_HOME_WARNED = '1';
+
+const tokenStore = require('../health-auto-export/token-store');
+
+function writeCfg(obj) {
+  fs.writeFileSync(CFG, JSON.stringify(obj, null, 2));
+}
+
+function readCfg() {
+  return JSON.parse(fs.readFileSync(CFG, 'utf8'));
+}
+
+function clearCfg() {
+  try { fs.unlinkSync(CFG); } catch {}
+}
+
+after(() => { try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {} });
+
+describe('getToken', () => {
+  beforeEach(() => clearCfg());
+
+  test('returns null when config.json is missing', () => {
+    assert.equal(tokenStore.getToken(), null);
+  });
+
+  test('returns null when cfg.hae is absent', () => {
+    writeCfg({ auth: {} });
+    assert.equal(tokenStore.getToken(), null);
+  });
+
+  test('returns null when cfg.hae.token is empty', () => {
+    writeCfg({ hae: { token: '' } });
+    assert.equal(tokenStore.getToken(), null);
+  });
+
+  test('returns the stored token', () => {
+    writeCfg({ hae: { token: 'abc123' } });
+    assert.equal(tokenStore.getToken(), 'abc123');
+  });
+});
+
+describe('generateToken', () => {
+  beforeEach(() => clearCfg());
+
+  test('writes a 64-char hex token and returns it', () => {
+    const t = tokenStore.generateToken();
+    assert.match(t, /^[a-f0-9]{64}$/);
+    assert.equal(tokenStore.getToken(), t);
+  });
+
+  test('records lastRegeneratedAt as an ISO timestamp', () => {
+    tokenStore.generateToken();
+    const ts = tokenStore.getLastRegeneratedAt();
+    assert.ok(ts && !Number.isNaN(Date.parse(ts)));
+  });
+
+  test('preserves unrelated config sections', () => {
+    writeCfg({ auth: { invites: [{ code: 'x' }] } });
+    tokenStore.generateToken();
+    const cfg = readCfg();
+    assert.deepEqual(cfg.auth.invites, [{ code: 'x' }]);
+    assert.match(cfg.hae.token, /^[a-f0-9]{64}$/);
+  });
+});
+
+describe('setToken', () => {
+  beforeEach(() => clearCfg());
+
+  test('persists an explicit value', () => {
+    tokenStore.setToken('explicit-value');
+    assert.equal(tokenStore.getToken(), 'explicit-value');
+  });
+
+  test('throws on empty input', () => {
+    assert.throws(() => tokenStore.setToken(''), /empty token/);
+    assert.throws(() => tokenStore.setToken(null), /empty token/);
+  });
+});
+
+describe('clearToken', () => {
+  beforeEach(() => clearCfg());
+
+  test('removes the token from disk', () => {
+    tokenStore.generateToken();
+    assert.ok(tokenStore.getToken());
+    tokenStore.clearToken();
+    assert.equal(tokenStore.getToken(), null);
+  });
+
+  test('is a no-op when nothing is stored', () => {
+    assert.doesNotThrow(() => tokenStore.clearToken());
+    assert.equal(tokenStore.getToken(), null);
+  });
+
+  test('preserves unrelated config sections', () => {
+    writeCfg({ auth: { invites: [{ code: 'y' }] }, hae: { token: 'old' } });
+    tokenStore.clearToken();
+    const cfg = readCfg();
+    assert.deepEqual(cfg.auth.invites, [{ code: 'y' }]);
+    assert.ok(!cfg.hae.token);
+  });
+});
+
+describe('migrateFromEnvIfNeeded', () => {
+  beforeEach(() => clearCfg());
+
+  test('copies env value into config.json when token absent', () => {
+    process.env.HEALTH_AUTO_EXPORT_TOKEN = 'env-side-token';
+    try {
+      const migrated = tokenStore.migrateFromEnvIfNeeded();
+      assert.equal(migrated, true);
+      assert.equal(tokenStore.getToken(), 'env-side-token');
+    } finally {
+      delete process.env.HEALTH_AUTO_EXPORT_TOKEN;
+    }
+  });
+
+  test('no-op when both disk and env have no token', () => {
+    delete process.env.HEALTH_AUTO_EXPORT_TOKEN;
+    const migrated = tokenStore.migrateFromEnvIfNeeded();
+    assert.equal(migrated, false);
+    assert.equal(tokenStore.getToken(), null);
+  });
+
+  test('no-op when disk already has a token (env ignored)', () => {
+    writeCfg({ hae: { token: 'already-on-disk' } });
+    process.env.HEALTH_AUTO_EXPORT_TOKEN = 'env-side-different';
+    try {
+      const migrated = tokenStore.migrateFromEnvIfNeeded();
+      assert.equal(migrated, false);
+      assert.equal(tokenStore.getToken(), 'already-on-disk');
+    } finally {
+      delete process.env.HEALTH_AUTO_EXPORT_TOKEN;
+    }
+  });
+
+  test('idempotent across repeated calls', () => {
+    process.env.HEALTH_AUTO_EXPORT_TOKEN = 'sticky';
+    try {
+      assert.equal(tokenStore.migrateFromEnvIfNeeded(), true);
+      assert.equal(tokenStore.migrateFromEnvIfNeeded(), false);
+      assert.equal(tokenStore.migrateFromEnvIfNeeded(), false);
+      assert.equal(tokenStore.getToken(), 'sticky');
+    } finally {
+      delete process.env.HEALTH_AUTO_EXPORT_TOKEN;
+    }
+  });
+});
+
+describe('atomic write + 0o600 mode', () => {
+  beforeEach(() => clearCfg());
+
+  test('writes config.json with mode 0o600 (POSIX only)',
+    { skip: process.platform === 'win32' ? 'POSIX-only file mode semantics' : false },
+    () => {
+      tokenStore.generateToken();
+      const mode = fs.statSync(CFG).mode & 0o777;
+      assert.equal(mode, 0o600);
+    });
+
+  test('does not leave behind a .tmp file on success', () => {
+    tokenStore.generateToken();
+    assert.ok(!fs.existsSync(CFG + '.tmp'),
+      'tmp file should be renamed away on success');
+  });
+});


### PR DESCRIPTION
## Summary

- HAE bearer token now generated, displayed (masked), copied, and regenerated entirely from the Settings panel.
- Persisted to `$HEALTH_HOME/config.json` under `cfg.hae.token` (atomic write, `0o600`); env var path deprecated and migrated transparently on first boot under this code.
- New auth-gated endpoints under `/api/health-auto-export/token` (GET / POST / POST `/regenerate` / DELETE).

## Why

Enabling or rotating the HAE token previously required SSH + editing `.env` + a container restart, then pasting the value into the iPhone app. For a single-user, file-driven app that flow is heavier than the feature warrants. Moving token management into Settings lets the operator flip HAE on (or rotate the token) in under 30 seconds without leaving the browser.

## How

- **`health-auto-export/token-store.js`** (new): atomic-write store backed by `cfg.hae.token`. `getToken()` / `setToken(t)` / `generateToken()` / `clearToken()` / `migrateFromEnvIfNeeded()`.
- **`server.js`**: requires the store at module top, calls `migrateFromEnvIfNeeded()` synchronously before the listener starts (idempotent), and replaces both the ingest auth check and the status route's env lookup with `tokenStore.getToken()`. Adds the four token-management routes behind the existing passkey auth gate.
- **`config/env.js`**: stops exporting `HEALTH_AUTO_EXPORT_TOKEN`; the env value is now read only by the migration helper. Comment explains the contract.
- **`public/js/components/eh-settings-view.js`**: HAE panel now renders three states (no token / token present / regenerate confirm). Masking shows last 4 chars; the new token is briefly revealed unmasked after generate/regenerate so the operator can copy it without an extra click.
- **Docs + CHANGELOG**: setup section in `docs/HEALTH-AUTO-EXPORT.md` rewritten to lead with the Settings flow; "Upgrading from older Klebb" section explains the migration. CHANGELOG entry under `[Unreleased]` describes the move.

## Testing

- [x] `tests/health-auto-export.token-store.test.js` (new) — 18 unit tests covering get/generate/set/clear, env migration semantics, atomic write + `0o600` mode (POSIX-only test skipped on Windows).
- [x] `tests/api/hae-token-api.test.js` (new) — 14 integration tests across two suites: end-to-end token lifecycle (generate / 409 / GET / regenerate-rotates / DELETE / 401-without-session) and env-var migration on boot (config.json populated, GET returns migrated value, ingest authenticates with migrated token).
- [x] `tests-e2e/hae-settings.spec.js` (new) — Playwright walk: navigate to Settings, click Generate, capture token from `.hae-token-value .endpoint-code`, ingest with token expects 200, regenerate confirm flow, old token 401, new token 200.
- [x] Existing HAE tests (`health-auto-export.{ingest,status-api,replay-integration,discoveries-api}.test.js`, `meta-category.test.js`) keep passing unchanged: they still pass `HEALTH_AUTO_EXPORT_TOKEN` to `spawnServer`, and the migration helper transparently moves it into `cfg.hae.token` before the listener starts.
- [x] Manual sandbox runs validated: clean boot returns 501; full token flow round-trips (generate / second-POST 409 / regenerate-with-confirm / old-token 401 / new-token 200); env-var migration on boot logs the deprecation warning, populates `cfg.hae.token` and `migratedFromEnvAt`, ingest authenticates with the migrated value.

Fixes #278.