### PR TITLE
fix(schedule-card): track viewed date with week-dot ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Schedule card week-dot ring now follows the day being viewed.**
+  Previously the green halo stayed glued to real calendar today and
+  vanished entirely once the user navigated more than ~7 days from
+  today. The ring now tracks `this.date`, so stepping forward or
+  back any number of days keeps the highlight on the correct
+  letter. The internal CSS class is renamed `today-ring` →
+  `selected-ring`. Fixes #282.
+
 ## [2.1.2] - 2026-05-21
 
 ### Changed

--- a/public/js/components/eh-schedule-card.js
+++ b/public/js/components/eh-schedule-card.js
@@ -7,7 +7,8 @@
 //   - Name + short_name
 //   - Dose label + units
 //   - "Cycle N — Day X of Y" subtitle
-//   - M T W T F S S week dots (filled on scheduled days, ring on today)
+//   - M T W T F S S week dots (filled on scheduled days, ring on the
+//     day currently being viewed)
 //   - Injection checkbox (appends to item.doses[])
 //   - Status chip (Inject / Rest Day / Off Cycle / Loading / Maint)
 //
@@ -25,8 +26,6 @@ const DAY_LETTERS = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
 function iso(d) {
   return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
 }
-
-function todayStr() { return iso(new Date()); }
 
 // Hash a string to a stable hex colour (used when itemColours isn't in meta).
 function autoColour(str) {
@@ -174,10 +173,10 @@ export class EhScheduleCard extends EhBaseCard {
         color: var(--dot-colour, var(--accent));
         background: transparent;
       }
-      .dot.today-ring {
+      .dot.selected-ring {
         box-shadow: 0 0 0 2px var(--bg-card), 0 0 0 3px var(--accent);
       }
-      .dot.active.today-ring {
+      .dot.active.selected-ring {
         background: var(--dot-colour, var(--accent));
         color: white;
       }
@@ -358,16 +357,15 @@ export class EhScheduleCard extends EhBaseCard {
 
   _renderWeekDots(item, colour) {
     const week = weekDatesFor(this.date);
-    const today = todayStr();
     return html`
       <div class="week">
         ${week.map((wd, i) => {
           const status = isScheduledOnDate(item, wd);
           const active = status === 'scheduled';
-          const isToday = wd === today;
+          const isSelected = wd === this.date;
           const classes = ['dot'];
           classes.push(active ? 'active' : 'inactive');
-          if (isToday) classes.push('today-ring');
+          if (isSelected) classes.push('selected-ring');
           return html`<span class="${classes.join(' ')}" style="--dot-colour: ${colour}">${DAY_LETTERS[i]}</span>`;
         })}
       </div>
@@ -379,7 +377,6 @@ export class EhScheduleCard extends EhBaseCard {
     if (items.length === 0) return html`<div class="empty">Nothing scheduled.</div>`;
     // Filter: only render items that have some form of activity (scheduled today OR rest OR in cycle)
     const visible = items.filter(it => activeCycle(it, this.date));
-    const today = todayStr();
     return html`
       <div class="items">
         ${visible.map(item => {

--- a/tests-e2e/schedule-card-selected-day-ring.spec.js
+++ b/tests-e2e/schedule-card-selected-day-ring.spec.js
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/schedule-card-selected-day-ring.spec.js
+// Regression coverage for #282: the highlight ring on the week-dots
+// row in eh-schedule-card must follow the date currently being viewed,
+// not the real calendar today. Before the fix the ring stayed glued to
+// real-today's slot in the visible week and disappeared entirely once
+// the user navigated more than ~7 days from today.
+
+const { test, expect } = require('./helpers/auth-fixture');
+const { todayISO, shiftDays } = require('./helpers/seed-manifests');
+
+const DAY_LETTERS = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
+
+function dayLetterFor(isoDate) {
+  // Mon=0..Sun=6 to match the renderer's Mon-first week.
+  const d = new Date(isoDate + 'T00:00:00');
+  const js = d.getDay();
+  return DAY_LETTERS[js === 0 ? 6 : js - 1];
+}
+
+test.describe('#282: schedule-card week-dots ring follows the viewed date', () => {
+  test('ring tracks the selected day as you step backwards', async ({ page }) => {
+    await page.goto('/');
+    const card = page.locator('eh-schedule-card').first();
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    // Today: ring should be on today's letter.
+    const today = todayISO();
+    const ring = card.locator('.dot.selected-ring');
+    await expect(ring).toHaveCount(1);
+    await expect(ring).toHaveText(dayLetterFor(today));
+
+    // Step back one day; the ring should follow.
+    await page.locator('.arrow-btn[aria-label="previous day"]').click();
+    const yesterday = shiftDays(today, -1);
+    await expect(ring).toHaveText(dayLetterFor(yesterday));
+
+    // Step back two more days (still inside the seeded cycle which
+    // starts today-2 — the card stays visible).
+    await page.locator('.arrow-btn[aria-label="previous day"]').click();
+    const twoDaysAgo = shiftDays(today, -2);
+    await expect(card).toBeVisible();
+    await expect(ring).toHaveText(dayLetterFor(twoDaysAgo));
+    // Exactly one ring at any time.
+    await expect(card.locator('.dot.selected-ring')).toHaveCount(1);
+  });
+
+  test('ring stays present and tracks the selected day going forward', async ({ page }) => {
+    await page.goto('/');
+    const card = page.locator('eh-schedule-card').first();
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    const today = todayISO();
+    const ring = card.locator('.dot.selected-ring');
+    await expect(ring).toHaveText(dayLetterFor(today));
+
+    // Step forward several days. The seeded cycle ends today+17 so the
+    // card is still in-cycle at +5 and the ring must remain visible
+    // and track the viewed date.
+    for (let i = 1; i <= 5; i++) {
+      await page.locator('.arrow-btn[aria-label="next day"]').click();
+      const target = shiftDays(today, i);
+      await expect(card).toBeVisible();
+      await expect(ring).toHaveText(dayLetterFor(target));
+      await expect(card.locator('.dot.selected-ring')).toHaveCount(1);
+    }
+  });
+});


### PR DESCRIPTION
# What changed

The green halo on the M T W T F S S week-dots row inside
\`eh-schedule-card\` now follows the date currently being viewed.
Previously it was hard-coded to real calendar today: navigating the
DateView left the ring stuck on today's letter, and once the user
moved more than ~7 days from today the ring disappeared entirely
because today fell outside the visible week.

# Why

Fixes #282. Reported on demo.klebb.app: the ring stays glued to the
T (Thursday) slot when stepping forward to Friday, and goes missing
once you wander far enough back in time.

# How

\`_renderWeekDots()\` builds the visible week from \`this.date\`
(correct), but applied the highlight class based on
\`wd === todayStr()\`. Switched the predicate to
\`wd === this.date\`. The CSS class is renamed
\`today-ring\` -> \`selected-ring\` to match what it now means;
\`today-ring\` is gone from this renderer entirely. The legacy
\`_legacy-v1/workout-card.js\` still uses its own \`today-ring\`
class internally and is unrelated; left untouched. The unused
\`todayStr()\` helper and one dead \`const today\` in
\`renderCard()\` are also dropped.

# Testing

- [x] \`npm test\` passes locally (same single pre-existing failure
      as main; not introduced by this PR)
- [x] \`npm run test:e2e\` passes on the affected specs
- [x] New e2e regression spec
      \`tests-e2e/schedule-card-selected-day-ring.spec.js\` added.
      Verified it fails on main (selector \`.dot.selected-ring\`
      finds nothing pre-fix) and passes on this branch.
- [x] Manual QA in a local sandbox: ring follows previous-day /
      next-day navigation, stays visible past the 7-day boundary in
      both directions.

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [x] Docs updated if behaviour or schema changed (header comment in
      \`eh-schedule-card.js\` updated)
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens

# Breaking changes

None. CSS class renames are internal to the component's shadow DOM;
no consumer can target them.