### PR TITLE
feat(deploy): auto-deploy demo.klebb.app on every main merge

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+name: Deploy demo.klebb.app
+
+# Fires when "Build and publish container" finishes successfully on
+# main, so the new image is guaranteed to be on GHCR before we try
+# to pull. Manual dispatch is also allowed for re-runs.
+on:
+  workflow_run:
+    workflows: ['Build and publish container']
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-demo
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: SSH to host and run klebb-demo-deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Configure SSH
+        env:
+          DEMO_SSH_KEY: ${{ secrets.DEMO_SSH_KEY }}
+          DEMO_SSH_HOST_KEY: ${{ secrets.DEMO_SSH_HOST_KEY }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$DEMO_SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          printf '%s\n' "$DEMO_SSH_HOST_KEY" > ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Trigger deploy on host
+        env:
+          DEMO_SSH_HOST: ${{ secrets.DEMO_SSH_HOST }}
+        run: |
+          ssh -i ~/.ssh/id_ed25519 \
+              -o IdentitiesOnly=yes \
+              -o BatchMode=yes \
+              "root@${DEMO_SSH_HOST}" \
+              true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Added
+
+- **`demo.klebb.app` now auto-deploys on every push to `main`.** A
+  new `.github/workflows/deploy-demo.yml` workflow fires when the
+  existing publish workflow finishes successfully, SSHes to the
+  demo host, and runs `klebb-demo-deploy` (which does
+  `docker compose pull && up -d` and re-seeds fixtures). The deploy
+  key is locked on the host with a forced-command + `restrict` so
+  the SSH session can only run that one script. See
+  `docs/DEMO.md` for the full picture and key-rotation steps.
+  Fixes #284.
+
 ### Fixed
 
 - **Schedule card week-dot ring now follows the day being viewed.**

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -170,9 +170,17 @@ The cron fires at the top of every hour. Watch
 
 ## 7. Updating to a new release
 
+If `compose.yml` pins to a moving tag like `:main` (the default for
+`demo.klebb.app`), every push to the project's `main` branch is
+already auto-deployed by the `Deploy demo.klebb.app` GitHub Actions
+workflow. There is nothing to do.
+
+If `compose.yml` pins to a fixed version (e.g. `:2.1.2`), bump the
+tag and redeploy by hand:
+
 ```bash
 cd /opt/klebb-demo
-# Pin to the new tag in compose.yml first, e.g. ghcr.io/aristocles/klebb:2.1.3
+# Edit compose.yml to ghcr.io/aristocles/klebb:<new-tag>
 docker compose pull
 docker compose up -d
 # Re-seed; new fixtures may have landed
@@ -183,6 +191,41 @@ docker exec --user root \
 
 Image tag must match the compose file. `latest` is also published but
 explicit version pinning is recommended for visibility.
+
+### How the auto-deploy works (for `demo.klebb.app` only)
+
+1. PR merges to `main`.
+2. `.github/workflows/publish.yml` builds and pushes
+   `ghcr.io/aristocles/klebb:main` (and `:sha-<short>`).
+3. `.github/workflows/deploy-demo.yml` fires on completion of (2),
+   SSHes to the demo host, and the host's forced-command runs
+   `/usr/local/bin/klebb-demo-deploy`.
+4. That script does `docker compose pull && up -d`, waits for the
+   container to be healthy, then runs `reset-demo.js` so any new
+   fixtures land immediately.
+
+The deploy key is constrained on the host with a `command="..."`
+forced-command and `restrict` flags in `~/.ssh/authorized_keys`, so
+even if the GitHub secret leaked, the worst it could do is run that
+one script. To rotate the key:
+
+```bash
+# On the dev box
+ssh-keygen -t ed25519 -N "" -C "klebb-demo-deploy@actions" -f /tmp/klebb_demo_deploy_new
+
+# On the host: replace the line in ~/.ssh/authorized_keys
+ssh -i ~/.ssh/id_ed25519.klebb root@178.105.170.10 \
+  "sed -i '/klebb-demo-deploy@actions/d' ~/.ssh/authorized_keys; \
+   echo 'command=\"/usr/local/bin/klebb-demo-deploy\",restrict $(cat /tmp/klebb_demo_deploy_new.pub)' >> ~/.ssh/authorized_keys"
+
+# Update the GitHub secret
+gh secret set DEMO_SSH_KEY --body "$(cat /tmp/klebb_demo_deploy_new)" --repo Aristocles/klebb
+```
+
+A full forensic of the auto-deploy lives in `/var/log/syslog` (sshd
+auth lines + the script's stdout, prefixed `[deploy]`). To take it
+offline temporarily, comment out the line in `authorized_keys`; the
+workflow will fail noisily.
 
 ## Troubleshooting
 


### PR DESCRIPTION
# What changed

Wires actual auto-deploy for \`demo.klebb.app\`. A new workflow
\`.github/workflows/deploy-demo.yml\` fires when the existing publish
workflow finishes successfully on \`main\`, SSHes to the demo host,
and runs \`/usr/local/bin/klebb-demo-deploy\` (which does
\`docker compose pull && up -d\` and re-seeds fixtures). The compose
file on the host is pinned to \`ghcr.io/aristocles/klebb:main\` so
each deploy picks up the latest digest.

# Why

Fixes #284. The previous understanding that the demo box auto-deployed
on package publish was wrong: nothing on the host was watching GHCR.
A merge to \`main\` published the image but the running container kept
serving the old digest until somebody SSHed in.

# How

- New workflow with a \`workflow_run\` trigger on completion of
  \`Build and publish container\`. Runs only on a successful build,
  on \`main\`, and is also \`workflow_dispatch\`-able for re-runs.
- A \`concurrency\` group prevents two back-to-back merges racing.
- The runner gets two GitHub secrets (\`DEMO_SSH_KEY\` plus a
  pinned \`DEMO_SSH_HOST_KEY\` for known_hosts) and connects to the
  host configured in \`DEMO_SSH_HOST\`.
- On the host, the deploy public key is installed in root's
  \`authorized_keys\` with \`command="/usr/local/bin/klebb-demo-deploy"\`
  plus the \`restrict\` flag (= \`no-pty\`, \`no-port-forwarding\`,
  \`no-agent-forwarding\`, \`no-X11-forwarding\`, \`no-user-rc\`). So the
  worst this key can ever do is run that one script.
- The script itself: pull, \`up -d\`, poll for healthy, run
  \`reset-demo.js\`. All output streams back to the workflow run for
  a single source of truth on what happened.
- \`docs/DEMO.md\` gets a section explaining the new flow and a key
  rotation runbook.

# Testing

- [x] Manually invoked the deploy script on the host via SSH using
      the new key; observed the forced-command override (the SSH
      session ignores its requested command and runs the deploy
      script).
- [x] Confirmed the running container is on \`:main\` and serving
      the schedule-card fix that just merged.
- [ ] End-to-end verification: this PR's own merge will trigger the
      workflow. If it goes red, the issue describes the exact
      contract for what the deploy must do; iterate.

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [x] Docs updated (\`docs/DEMO.md\` gets the new auto-deploy
      section)
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens (the private key sits in
      \`secrets.DEMO_SSH_KEY\`, never in source)

# Breaking changes

None for users. For operators of any other Klebb demo deployments:
the workflow is keyed on \`Aristocles/klebb\`'s GHCR registry and
the operator's host. A fork running its own demo would need its
own equivalent workflow + secrets; nothing here forces that on
anyone.