### PR TITLE
feat(ingest): inbox watcher for PDFs, images, notes, and audio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Inbox-driven report ingest pipeline.** Drop a `.pdf`, `.png`,
+  `.jpg`, `.txt`, `.md`, `.mp3`, `.wav`, `.m4a`, `.ogg`, or `.opus`
+  file into `$HEALTH_HOME/inbox/` and Klebb extracts text into
+  `$HEALTH_HOME/reports/<YYYY-MM-DD>-<stem>.md` using infra binaries
+  only (no LLM at ingest): `pdftotext` for PDFs, `tesseract` for
+  images, raw `fs.readFile` for text/markdown, and the existing Fish
+  ASR pipeline for audio. Originals are filed under
+  `reports/_archive/`; extraction failures land in `inbox/_failed/`
+  with a sibling `.error` file describing the cause. A new
+  `read_report` chat tool plus the `## Available reports` system
+  prompt block let Klebbius pull any ingested report into a turn on
+  demand. Fixes #288.
 - **`demo.klebb.app` now auto-deploys on every push to `main`.** A
   new `.github/workflows/deploy-demo.yml` workflow fires when the
   existing publish workflow finishes successfully, SSHes to the

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,15 +29,22 @@ LABEL org.opencontainers.image.title="Klebb" \
       org.opencontainers.image.source="https://github.com/Aristocles/klebb"
 
 # Runtime system dependencies:
-#   ca-certificates — HTTPS trust anchors for outbound calls (chat gateway, Fish Audio)
-#   tini            — proper PID 1 so SIGTERM reaches Node cleanly
-#   gosu            — privilege drop from root -> klebb in the entrypoint
-#   ffmpeg          — transcode browser voice-note audio to 16 kHz mono WAV for Fish ASR
+#   ca-certificates    : HTTPS trust anchors for outbound calls (chat gateway, Fish Audio)
+#   tini               : proper PID 1 so SIGTERM reaches Node cleanly
+#   gosu               : privilege drop from root -> klebb in the entrypoint
+#   ffmpeg             : transcode browser voice-note audio to 16 kHz mono WAV for Fish ASR
+#                        (also reused by the inbox audio extractor)
+#   poppler-utils      : pdftotext binary for the inbox PDF extractor
+#   tesseract-ocr (+
+#   tesseract-ocr-eng) : OCR for image reports dropped into the inbox
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates \
-      tini \
-      gosu \
       ffmpeg \
+      gosu \
+      poppler-utils \
+      tesseract-ocr \
+      tesseract-ocr-eng \
+      tini \
     && rm -rf /var/lib/apt/lists/*
 
 # Non-root runtime user
@@ -55,6 +62,7 @@ COPY --chown=klebb:klebb server.js ./
 COPY --chown=klebb:klebb auth ./auth
 COPY --chown=klebb:klebb chat ./chat
 COPY --chown=klebb:klebb config ./config
+COPY --chown=klebb:klebb ingest ./ingest
 COPY --chown=klebb:klebb manifests ./manifests
 COPY --chown=klebb:klebb meta ./meta
 COPY --chown=klebb:klebb public ./public

--- a/README.md
+++ b/README.md
@@ -255,33 +255,20 @@ in `.env`. The compose file already maps that hostname to the host via
 
 Klebb watches `$HEALTH_HOME/inbox/` and turns anything you drop in
 there into a markdown report under `$HEALTH_HOME/reports/`, ready for
-the chat agent to read on demand.
-
-Supported file types:
-
-- `.pdf` (extracted with `pdftotext -layout`, requires `poppler-utils`)
-- `.png`, `.jpg`, `.jpeg` (OCRd with `tesseract`, requires
-  `tesseract-ocr` + `tesseract-ocr-eng`)
-- `.txt`, `.md` (read verbatim)
-- `.mp3`, `.wav`, `.m4a`, `.ogg`, `.opus` (transcoded with `ffmpeg`,
-  transcribed via Fish ASR; requires `FISH_AUDIO_API_KEY`, the same
-  variable that powers voice chat)
-
-Drop a file via SSH/rsync/SCP/`docker cp`, whatever you already use:
+the chat agent to read on demand. Supports `.pdf` (via `pdftotext`),
+`.png` / `.jpg` / `.jpeg` (via `tesseract`), `.txt` / `.md` verbatim,
+and `.mp3` / `.wav` / `.m4a` / `.ogg` / `.opus` (via `ffmpeg` + Fish
+ASR; requires `FISH_AUDIO_API_KEY`).
 
 ```bash
 scp bloods.pdf myhost:/data/inbox/
 ```
 
-The original is filed under `$HEALTH_HOME/reports/_archive/` once
-extraction succeeds. Failures move to `$HEALTH_HOME/inbox/_failed/`
-with a sibling `.error` file describing why; rename out of `_failed/`
-to retry. The Docker image ships with all four binaries baked in, so
-this works out of the box.
-
-Once an ingest lands, the chat agent sees the new report in its
-`## Available reports` block on the next turn and can fetch the full
-text via the `read_report` tool.
+The Docker image ships with all four binaries baked in, so this works
+out of the box. Failures land in `$HEALTH_HOME/inbox/_failed/` with a
+sibling `.error` file. See [`docs/REPORTS.md`](docs/REPORTS.md) for
+the full workflow, output format, troubleshooting, and the chat
+round-trip.
 
 ## Running tests
 
@@ -364,6 +351,7 @@ demo predictable.
 - [`MANIFEST-SCHEMA.md`](MANIFEST-SCHEMA.md) — Manifest format reference
 - [`docs/CHAT-AGENT.md`](docs/CHAT-AGENT.md) — Chat widget + server-to-server integration
 - [`docs/VOICE.md`](docs/VOICE.md) — Voice chat (Fish Audio) configuration
+- [`docs/REPORTS.md`](docs/REPORTS.md) — Inbox-driven report ingest (PDF, scans, notes, audio)
 - [`docs/DEPLOY.md`](docs/DEPLOY.md) — Single-user + multi-user deploy guide
 - [`docs/CI.md`](docs/CI.md) — CI workflow overview
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — Contributor conventions

--- a/README.md
+++ b/README.md
@@ -251,6 +251,38 @@ chat widget), point `CHAT_ENDPOINT_URL=http://host.docker.internal:<port>/v1/cha
 in `.env`. The compose file already maps that hostname to the host via
 `extra_hosts: host.docker.internal:host-gateway`.
 
+## Ingesting reports
+
+Klebb watches `$HEALTH_HOME/inbox/` and turns anything you drop in
+there into a markdown report under `$HEALTH_HOME/reports/`, ready for
+the chat agent to read on demand.
+
+Supported file types:
+
+- `.pdf` (extracted with `pdftotext -layout`, requires `poppler-utils`)
+- `.png`, `.jpg`, `.jpeg` (OCRd with `tesseract`, requires
+  `tesseract-ocr` + `tesseract-ocr-eng`)
+- `.txt`, `.md` (read verbatim)
+- `.mp3`, `.wav`, `.m4a`, `.ogg`, `.opus` (transcoded with `ffmpeg`,
+  transcribed via Fish ASR; requires `FISH_AUDIO_API_KEY`, the same
+  variable that powers voice chat)
+
+Drop a file via SSH/rsync/SCP/`docker cp`, whatever you already use:
+
+```bash
+scp bloods.pdf myhost:/data/inbox/
+```
+
+The original is filed under `$HEALTH_HOME/reports/_archive/` once
+extraction succeeds. Failures move to `$HEALTH_HOME/inbox/_failed/`
+with a sibling `.error` file describing why; rename out of `_failed/`
+to retry. The Docker image ships with all four binaries baked in, so
+this works out of the box.
+
+Once an ingest lands, the chat agent sees the new report in its
+`## Available reports` block on the next turn and can fetch the full
+text via the `read_report` tool.
+
 ## Running tests
 
 ```bash
@@ -352,6 +384,14 @@ auth/
   invites.js                      invite-code issuance
 voice/
   fish.js                         Fish Audio TTS/ASR (optional)
+  transcode.js                    ffmpeg pipe -> 16 kHz mono WAV (shared)
+ingest/
+  pipeline.js                     inbox watcher orchestrator
+  watcher.js                      fs.watch + debounce wrapper
+  extract.js                      extension-keyed dispatcher
+  extractors/                     pdf / image / text / audio extractors
+  writeReport.js                  frontmatter + atomic .md write
+  catalogue.js                    parses headers + builds chat catalogue
 public/
   js/
     app.js                        top-level routing

--- a/chat/reports.js
+++ b/chat/reports.js
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// chat/reports.js
+//
+// Reader for ingested + hand-authored reports under $HEALTH_HOME/reports/.
+// Backs the read_report chat tool: the agent gets a catalogue in the
+// system prompt (describeReportsCatalogue) and can pull any listed
+// report's full text on demand. Distinct from chat/docs.js, which
+// reads in-repo documentation.
+
+const fs = require('fs');
+const path = require('path');
+const PATHS = require('../config/paths');
+const { describeReportsCatalogue, parseReportHeader } = require('../ingest/catalogue');
+
+const NAME_RE = /^[a-zA-Z0-9._-]+$/;
+const MAX_BYTES = 200_000;
+
+function readReport(name) {
+  if (typeof name !== 'string' || !name) {
+    return { error: 'name is required' };
+  }
+  if (!NAME_RE.test(name)) {
+    return { error: `invalid report name: ${name}` };
+  }
+  const reportsDir = PATHS.REPORTS_DIR;
+  const abs = path.join(reportsDir, name + '.md');
+  const rootWithSep = reportsDir + path.sep;
+  if (!abs.startsWith(rootWithSep) && abs !== reportsDir) {
+    return { error: `path escapes reports dir: ${name}` };
+  }
+  let content;
+  try {
+    content = fs.readFileSync(abs, 'utf8');
+  } catch (e) {
+    return { error: `failed to read report ${name}: ${e.message}` };
+  }
+  let truncated = false;
+  if (Buffer.byteLength(content, 'utf8') > MAX_BYTES) {
+    content = content.slice(0, MAX_BYTES);
+    truncated = true;
+  }
+  const header = parseReportHeader(content);
+  return {
+    name,
+    path: `reports/${name}.md`,
+    content,
+    ingestedAt: header?.ingestedAt || null,
+    sourceFormat: header?.sourceFormat || null,
+    truncated,
+  };
+}
+
+module.exports = { readReport, describeReportsCatalogue };

--- a/chat/tools.js
+++ b/chat/tools.js
@@ -8,6 +8,7 @@
 
 const registry = require('../manifests/registry');
 const { readDoc } = require('./docs');
+const { readReport } = require('./reports');
 
 const TOOL_DEFS = [
   {
@@ -151,6 +152,26 @@ const TOOL_DEFS = [
   {
     type: 'function',
     function: {
+      name: 'read_report',
+      description:
+        "Fetch the full text of one of the user's ingested reports. The system prompt lists every report under '## Available reports' with its name, source format, and ingestion date; pass one of those names verbatim (no .md extension, no slashes). Reports are raw text extracted from PDFs, scans, notes, or audio the user has dropped into their inbox: blood panels, scan reports, voice memos, and similar. Use this when the user asks 'what does my latest blood panel show', 'summarise the MRI report', or any other question where the answer is in one of those files. Returns {name, path, content, ingestedAt, sourceFormat, truncated}; unknown or invalid names return {error}.",
+      parameters: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            description:
+              "Report name as listed in the system prompt's catalogue, without the .md extension (e.g. '2026-05-22-bloods-april-fast').",
+          },
+        },
+        required: ['name'],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
       name: 'patch_manifest',
       description:
         "Edit a card's meta or description in place without touching its data. Uses RFC 7396 JSON Merge Patch: nested objects deep-merge, arrays replace wholesale, null removes a key. Use this for any meta-only change — thresholds, labels, emoji maps, input types, writeable flags. The data block is preserved byte-for-byte. You CANNOT change $schema or meta.id via this tool; for those, delete_manifest + create_manifest is the path (and data will be lost). ALWAYS call read_manifest first so you're patching over the real current meta. Destructive-feeling patches (removing inputs from a writeable card, flipping writeable.fromWebapp from true to false on a card that has data) must be confirmed with the user exactly once before calling this.",
@@ -249,6 +270,9 @@ function dispatchToolCall(tc, ctx) {
       }
       case 'read_doc': {
         return JSON.stringify(readDoc(args.path));
+      }
+      case 'read_report': {
+        return JSON.stringify(readReport(args.name));
       }
       default:
         return JSON.stringify({ error: 'unknown tool: ' + name });

--- a/config/paths.js
+++ b/config/paths.js
@@ -32,30 +32,44 @@ function resolveHealthHome() {
 const HEALTH_HOME = resolveHealthHome();
 
 // Standard layout:
-//   $HEALTH_HOME/data/           — card manifest files
-//   $HEALTH_HOME/reports/        — markdown reports
-//   $HEALTH_HOME/sessions/       — WebAuthn sessions
-//   $HEALTH_HOME/credentials/    — WebAuthn credentials
-//   $HEALTH_HOME/data/_archive/  — reserved, not scanned
-//   $HEALTH_HOME/data/auto-export/  — HealthAutoExport dumps
-//   $HEALTH_HOME/config.json     — instance config
+//   $HEALTH_HOME/data/             — card manifest files
+//   $HEALTH_HOME/reports/          — markdown reports (rendered + ingested)
+//   $HEALTH_HOME/reports/_archive/ — original files filed away after ingest
+//   $HEALTH_HOME/inbox/            — drop zone for ingest pipeline
+//   $HEALTH_HOME/inbox/_failed/    — files the pipeline could not extract
+//   $HEALTH_HOME/sessions/         — WebAuthn sessions
+//   $HEALTH_HOME/credentials/      — WebAuthn credentials
+//   $HEALTH_HOME/data/_archive/    — reserved, not scanned
+//   $HEALTH_HOME/data/auto-export/ — HealthAutoExport dumps
+//   $HEALTH_HOME/config.json       — instance config
 
 const DATA_DIR = process.env.HEALTH_DATA_DIR || path.join(HEALTH_HOME, 'data');
 
 // Reports dir resolution, in priority order:
 //   1. HEALTH_REPORTS_DIR env var (explicit override)
-//   2. $HEALTH_HOME/reports/ (canonical location)
-//   3. $HEALTH_HOME/data/reports/ (alt location)
-//   4. $HEALTH_HOME/ (last resort — flat layout)
+//   2. $HEALTH_HOME/reports/ (canonical location; always returned for
+//      fresh installs so ingest writes and listing reads stay aligned)
+//   3. $HEALTH_HOME/data/reports/ (legacy alt location, only if it
+//      already exists from an older install)
 function resolveReportsDir() {
   if (process.env.HEALTH_REPORTS_DIR) return process.env.HEALTH_REPORTS_DIR;
   const canonical = path.join(HEALTH_HOME, 'reports');
   if (fs.existsSync(canonical)) return canonical;
   const under = path.join(DATA_DIR, 'reports');
   if (fs.existsSync(under)) return under;
-  return HEALTH_HOME;
+  return canonical;
 }
 const REPORTS_DIR = resolveReportsDir();
+
+// Canonical reports root for new constructs (ingest archive, inbox).
+// Independent of the resolveReportsDir() fallback chain — that chain is
+// for backwards-compat with old installs that put reports under data/.
+// New paths always anchor on $HEALTH_HOME/reports/.
+const REPORTS_CANONICAL = path.join(HEALTH_HOME, 'reports');
+const REPORTS_ARCHIVE_DIR = path.join(REPORTS_CANONICAL, '_archive');
+
+const INBOX_DIR = process.env.HEALTH_INBOX_DIR || path.join(HEALTH_HOME, 'inbox');
+const INBOX_FAILED_DIR = path.join(INBOX_DIR, '_failed');
 
 const AUTO_EXPORT_DIR = process.env.HEALTH_AUTO_EXPORT_DIR || path.join(DATA_DIR, 'auto-export');
 const SESSIONS_DIR = process.env.HEALTH_SESSIONS_DIR || path.join(HEALTH_HOME, 'sessions');
@@ -86,7 +100,7 @@ const WEBAUTHN_SESSIONS_FILE = resolveWebauthnSessionsFile();
 // Ensure directories exist where we expect to write.
 // Does NOT create HEALTH_HOME itself (bootstrap responsibility).
 function ensureWritableDirs() {
-  const toEnsure = [DATA_DIR, CHAT_DIR];
+  const toEnsure = [DATA_DIR, CHAT_DIR, REPORTS_CANONICAL, REPORTS_ARCHIVE_DIR, INBOX_DIR, INBOX_FAILED_DIR];
   if (WEBAUTHN_CREDENTIALS_FILE.startsWith(CREDENTIALS_DIR)) toEnsure.push(CREDENTIALS_DIR);
   if (WEBAUTHN_SESSIONS_FILE.startsWith(SESSIONS_DIR)) toEnsure.push(SESSIONS_DIR);
   for (const dir of toEnsure) {
@@ -98,6 +112,9 @@ module.exports = {
   HEALTH_HOME,
   DATA_DIR,
   REPORTS_DIR,
+  REPORTS_ARCHIVE_DIR,
+  INBOX_DIR,
+  INBOX_FAILED_DIR,
   AUTO_EXPORT_DIR,
   SESSIONS_DIR,
   CREDENTIALS_DIR,

--- a/docs/CHAT-AGENT.md
+++ b/docs/CHAT-AGENT.md
@@ -40,6 +40,21 @@ and path all come from the URL, so the endpoint doesn't have to live at
 If `CHAT_ENDPOINT_URL` is unset, the chat widget is disabled and
 `POST /api/chat` returns `503`.
 
+### Tools the agent can call
+
+The server passes a small set of tools to the chat-completions
+endpoint on every turn. If your model supports tool-use, the loop in
+`chat/tools.js` dispatches each call inline; if your model doesn't,
+the tools are simply unused.
+
+| Tool | Purpose |
+|------|---------|
+| `create_manifest` / `delete_manifest` / `patch_manifest` | Author and edit cards |
+| `read_manifest` / `list_manifests` / `write_manifest_data` | Inspect and update card data |
+| `hide_card` / `show_card` | Master enable/disable |
+| `read_doc` | Fetch any allowlisted in-repo doc (README, MANIFEST-SCHEMA, this file, etc.) |
+| `read_report` | Fetch any ingested report from `$HEALTH_HOME/reports/`. The agent gets the catalogue automatically in its system prompt; see [`REPORTS.md`](REPORTS.md) for how reports get there. |
+
 ### Legacy env vars
 
 Older deploys used `CHAT_GATEWAY_HOST` + `CHAT_GATEWAY_PORT` +

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -208,6 +208,9 @@ Audio ingest reuses `FISH_AUDIO_API_KEY`: drops without it land in
 `$HEALTH_HOME/inbox/_failed/` with an explanatory `.error` sibling.
 PDF / image / text drops work without any chat or voice key set.
 
+See [`REPORTS.md`](REPORTS.md) for the full workflow, output format,
+and troubleshooting checklist.
+
 ---
 
 ## 2. Multi-user / public-facing deploy

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -186,6 +186,28 @@ sudo nginx -t && sudo systemctl reload nginx
 Voice input and voice replies are supported via Fish Audio. See
 [`docs/VOICE.md`](VOICE.md) for configuration and troubleshooting.
 
+### Inbox-driven report ingest (optional)
+
+Klebb watches `$HEALTH_HOME/inbox/` for `.pdf`, `.png`, `.jpg`,
+`.txt`, `.md`, `.mp3`, `.wav`, `.m4a`, `.ogg`, and `.opus` drops and
+extracts each into a markdown report under `$HEALTH_HOME/reports/`.
+The chat agent picks them up via the `read_report` tool.
+
+System packages required for bare-metal deploys (the published Docker
+image ships with all four baked in):
+
+- `poppler-utils` (provides `pdftotext` for PDF extraction)
+- `tesseract-ocr` + `tesseract-ocr-eng` (image OCR)
+- `ffmpeg` (already required for voice; reused for audio ingest)
+
+```bash
+sudo apt-get install -y poppler-utils tesseract-ocr tesseract-ocr-eng ffmpeg
+```
+
+Audio ingest reuses `FISH_AUDIO_API_KEY`: drops without it land in
+`$HEALTH_HOME/inbox/_failed/` with an explanatory `.error` sibling.
+PDF / image / text drops work without any chat or voice key set.
+
 ---
 
 ## 2. Multi-user / public-facing deploy

--- a/docs/REPORTS.md
+++ b/docs/REPORTS.md
@@ -1,0 +1,194 @@
+# Reports: ingesting PDFs, scans, notes, and audio
+
+Klebb watches `$HEALTH_HOME/inbox/` and turns anything you drop in
+there into a markdown report under `$HEALTH_HOME/reports/`. The chat
+agent picks up new reports automatically and can pull the full text
+into a conversation on demand.
+
+This is the workflow for getting blood panels, scan reports, hand
+notes, voice memos, and similar artefacts into Klebb so you can ask
+about them.
+
+---
+
+## 1. The flow at a glance
+
+```
+$HEALTH_HOME/
+├── inbox/                # drop files here
+│   └── _failed/          # things the pipeline could not extract
+└── reports/              # extracted markdown lives here
+    └── _archive/         # originals filed away after extraction
+```
+
+1. Drop a file into `$HEALTH_HOME/inbox/` (SSH, rsync, SCP, `docker
+   cp`, syncthing: whatever you already use).
+2. Klebb extracts the text using infra binaries (no LLM at ingest)
+   and writes a deterministic `<YYYY-MM-DD>-<stem>.md` into
+   `$HEALTH_HOME/reports/`.
+3. The original file is moved into `$HEALTH_HOME/reports/_archive/`.
+4. The chat agent's system prompt is regenerated on its next turn
+   with the new report listed under `## Available reports`. Ask it
+   anything about the file and it'll call its `read_report` tool to
+   fetch the body.
+
+The Reports view in the webapp shows the new `.md` file alongside any
+hand-authored markdown you've put in `$HEALTH_HOME/reports/` directly.
+
+---
+
+## 2. Supported file types
+
+| Extension | Extractor | Requires |
+|-----------|-----------|----------|
+| `.pdf` | `pdftotext -layout` | `poppler-utils` |
+| `.png`, `.jpg`, `.jpeg` | `tesseract <abs> stdout -l eng` | `tesseract-ocr`, `tesseract-ocr-eng` |
+| `.txt`, `.md` | `fs.readFile` | nothing |
+| `.mp3`, `.wav`, `.m4a`, `.ogg`, `.opus` | `ffmpeg` -> Fish ASR | `ffmpeg`, `FISH_AUDIO_API_KEY` |
+
+The Docker image ships with all four binaries baked in, so containerised
+deploys work out of the box. Bare-metal deploys need to install the
+packages themselves (see [DEPLOY.md](DEPLOY.md)).
+
+Audio ingest reuses the same Fish ASR pipeline that powers voice chat,
+so `FISH_AUDIO_API_KEY` is the only extra config you need. See
+[VOICE.md](VOICE.md) for setup.
+
+Anything else (`.docx`, `.zip`, `.heic`, etc.) is rejected and lands
+in `inbox/_failed/`. The list is intentionally tight: the pipeline is
+about predictable, auditable extraction, not a docx-to-markdown
+adventure.
+
+---
+
+## 3. Output format
+
+Every ingested report is a markdown file with YAML frontmatter:
+
+```
+---
+klebb_ingest: v1
+source_file: bloods-april-fast.pdf
+source_format: pdf
+ingested_at: 2026-05-22T14:07:33Z
+archive_path: reports/_archive/bloods-april-fast.pdf
+---
+
+# 2026-05-22-bloods-april-fast
+
+<raw extractor output, verbatim>
+```
+
+The `klebb_ingest: v1` sentinel is what marks a file as machine-ingested
+versus hand-authored; the chat catalogue uses it to label entries
+appropriately. The body is whatever the extractor returned, untouched.
+Klebb does not summarise, restructure, or "clean up" the text at ingest
+time; comprehension happens at chat time, where you can challenge the
+answer in the same turn.
+
+The output filename is `<YYYY-MM-DD>-<sanitised-stem>.md`, where the
+date is taken from the ingest timestamp (UTC) and the stem is the
+original filename with non-`[a-z0-9._-]` characters collapsed to dashes.
+Collisions get `-2`, `-3`, ... appended.
+
+---
+
+## 4. The chat round-trip
+
+Once a report is ingested, the next chat turn includes a block like
+this in the system prompt:
+
+```
+## Available reports
+
+The user has reports available in Klebb. Call `read_report(name)` to
+fetch the full text of any of them. ...
+
+- `2026-05-22-bloods-april-fast` (pdf, ingested 2026-05-22, source: bloods-april-fast.pdf)
+- `2026-04-12-mri-knee-report` (pdf, ingested 2026-04-12, source: mri-knee-report.pdf)
+```
+
+You don't need to mention the report by its ingested name. Anything
+like *"summarise my latest blood panel"* or *"what did the MRI say
+about the meniscus?"* is enough; the agent picks the right report
+from the catalogue and calls `read_report` to fetch the body.
+
+Reports are capped at 200 KB on read (same as `read_doc`); long
+extractions are truncated and the response includes `truncated: true`
+so the agent knows.
+
+---
+
+## 5. Failure handling
+
+Anything that throws inside the pipeline ends up in
+`$HEALTH_HOME/inbox/_failed/`:
+
+```
+$HEALTH_HOME/inbox/_failed/
+├── evil.docx           # the original
+└── evil.docx.error     # ISO timestamp + error.message + truncated stderr
+```
+
+Common reasons:
+
+- **Unsupported format.** `evil.docx`, `report.heic`, etc. The error
+  reads `unsupported format: .docx`.
+- **Audio without a Fish key.** Audio ingest requires
+  `FISH_AUDIO_API_KEY`. Drops without it land in `_failed/` with
+  `audio ingest disabled: FISH_AUDIO_API_KEY not set`. Set the key
+  (same one as voice chat) and rename the file out of `_failed/` to
+  retry.
+- **Binary not on PATH.** If `pdftotext` or `tesseract` is missing,
+  the spawn fails. Install the package and rename the file out to
+  retry. Containerised deploys never hit this.
+- **File never stabilises.** Klebb waits up to 3s for `mtime` + `size`
+  to stop changing before extracting (so it doesn't race rsync
+  mid-copy). Files still being written after 3s are punted to
+  `_failed/` with `file mtime never stabilised`. Re-drop a complete
+  copy.
+
+To retry a failure, fix the root cause then `mv inbox/_failed/foo.pdf
+inbox/foo.pdf`. The watcher picks the new mtime up immediately.
+
+If your inbox is jammed and nothing is moving, check the server log
+for `[ingest]` lines: every processed file leaves a trace, and watcher
+init failures are logged at boot.
+
+---
+
+## 6. Operational notes
+
+- **Crash resilience.** If the server crashes mid-extraction, the
+  source stays in `inbox/`. On the next boot, the pipeline drains the
+  inbox before attaching `fs.watch`, so leftover files get processed.
+- **Hand-authored reports still work.** Anything you write directly
+  into `$HEALTH_HOME/reports/foo.md` shows up in the Reports view and
+  in the chat catalogue. The `klebb_ingest: v1` sentinel just lets
+  the catalogue label machine-ingested entries with their source
+  format and ingest date; hand-authored files appear with no metadata.
+- **The archive is invisible to the UI.** `$HEALTH_HOME/reports/_archive/`
+  is reserved on the server side; only the top level of `reports/` is
+  scanned for the Reports view and the chat catalogue, so originals
+  don't pollute either surface.
+- **Privacy.** Inbox files are processed locally except for audio,
+  which is shipped to Fish Audio for transcription (same hop voice
+  chat uses). PDF, image, and text extraction never leaves the box.
+
+---
+
+## 7. What's NOT included
+
+- **No upload UI in the webapp.** Files arrive via SSH/rsync/SCP/`docker
+  cp`. A future browser-side drop zone could land on top of this
+  pipeline; today the pipeline is the contract.
+- **No LLM polish at ingest.** Output is whatever the extractor returned.
+  This is deliberate: medical numbers and dates need to round-trip
+  exactly. A future flag (`KLEBB_INGEST_STRUCTURE=1` or similar) could
+  add a structuring pass behind it without changing the on-disk format.
+- **No deduplication.** Drop the same PDF twice and you'll get two
+  reports (`-2` suffix on the second). Delete one if you want to
+  collapse.
+- **No per-report metadata UI.** Tags, notes, "this report supersedes
+  that one": none of that. The chat agent reasons over filenames and
+  bodies.

--- a/docs/VOICE.md
+++ b/docs/VOICE.md
@@ -8,6 +8,11 @@ reply gets a native audio control for playback.
 Voice is strictly optional. Everything works without it; the mic just
 renders greyed out and clicking it points users back here.
 
+The same `FISH_AUDIO_API_KEY` also powers audio-file ingest: drop a
+`.mp3`, `.wav`, `.m4a`, `.ogg`, or `.opus` into `$HEALTH_HOME/inbox/`
+and it'll be transcribed into a markdown report. See
+[`REPORTS.md`](REPORTS.md) for the inbox pipeline.
+
 ---
 
 ## 1. How it works

--- a/ingest/catalogue.js
+++ b/ingest/catalogue.js
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// ingest/catalogue.js
+// Parse ingested-report frontmatter, and build the system-prompt block
+// that lists available reports for the read_report chat tool.
+
+const fs = require('fs');
+const path = require('path');
+const PATHS = require('../config/paths');
+
+function parseReportHeader(text) {
+  if (typeof text !== 'string') return null;
+  const m = text.match(/^---\n([\s\S]*?)\n---/);
+  if (!m) return null;
+  const block = m[1];
+  if (!/^klebb_ingest:\s*v1\s*$/m.test(block)) return null;
+  const out = {};
+  for (const line of block.split('\n')) {
+    const kv = line.match(/^([a-z_]+):\s*(.*)$/);
+    if (kv) out[kv[1]] = kv[2].trim();
+  }
+  if (!out.ingested_at || !out.source_file || !out.source_format) return null;
+  return {
+    ingestedAt: out.ingested_at,
+    sourceFile: out.source_file,
+    sourceFormat: out.source_format,
+    archivePath: out.archive_path || null,
+  };
+}
+
+function listReportsWithMeta() {
+  let entries;
+  try {
+    entries = fs.readdirSync(PATHS.REPORTS_DIR);
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const f of entries) {
+    if (!f.endsWith('.md') || f.startsWith('.') || f.startsWith('_')) continue;
+    const abs = path.join(PATHS.REPORTS_DIR, f);
+    let stat;
+    try { stat = fs.statSync(abs); } catch { continue; }
+    if (!stat.isFile()) continue;
+    const name = f.replace(/\.md$/, '');
+    let header = null;
+    try { header = parseReportHeader(fs.readFileSync(abs, 'utf8')); } catch {}
+    out.push({ name, header });
+  }
+  out.sort((a, b) => {
+    const ai = a.header?.ingestedAt || '';
+    const bi = b.header?.ingestedAt || '';
+    return bi.localeCompare(ai);
+  });
+  return out;
+}
+
+function describeReportsCatalogue() {
+  const entries = listReportsWithMeta();
+  const lines = [
+    '## Available reports',
+    '',
+    'The user has reports available in Klebb. Call `read_report(name)` to',
+    'fetch the full text of any of them. Reports are markdown: either',
+    'authored directly in $HEALTH_HOME/reports/, or extracted from PDFs,',
+    'images, notes, and audio dropped into $HEALTH_HOME/inbox/.',
+    '',
+  ];
+  if (!entries.length) {
+    lines.push('_No reports yet. Drop a file into $HEALTH_HOME/inbox/ and Klebb will ingest it._');
+    lines.push('');
+    return lines.join('\n');
+  }
+  for (const e of entries) {
+    if (e.header) {
+      const date = e.header.ingestedAt.slice(0, 10);
+      lines.push(`- \`${e.name}\` (${e.header.sourceFormat}, ingested ${date}, source: ${e.header.sourceFile})`);
+    } else {
+      lines.push(`- \`${e.name}\` (markdown report)`);
+    }
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+module.exports = { parseReportHeader, listReportsWithMeta, describeReportsCatalogue };

--- a/ingest/extract.js
+++ b/ingest/extract.js
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// ingest/extract.js
+// Extension-keyed extractor dispatcher.
+
+const path = require('path');
+const { extractText } = require('./extractors/text');
+const { extractPdf } = require('./extractors/pdf');
+const { extractImage } = require('./extractors/image');
+const { extractAudio } = require('./extractors/audio');
+
+const EXT_TO_FORMAT = {
+  '.pdf': 'pdf',
+  '.png': 'image',
+  '.jpg': 'image',
+  '.jpeg': 'image',
+  '.txt': 'text',
+  '.md': 'markdown',
+  '.mp3': 'audio',
+  '.wav': 'audio',
+  '.m4a': 'audio',
+  '.ogg': 'audio',
+  '.opus': 'audio',
+};
+
+function formatFor(absPath) {
+  return EXT_TO_FORMAT[path.extname(absPath).toLowerCase()] || null;
+}
+
+async function extract(absPath) {
+  const fmt = formatFor(absPath);
+  if (!fmt) throw new Error(`unsupported format: ${path.extname(absPath).toLowerCase() || '(none)'}`);
+  let result;
+  switch (fmt) {
+    case 'pdf':      result = await extractPdf(absPath); break;
+    case 'image':    result = await extractImage(absPath); break;
+    case 'text':
+    case 'markdown': result = await extractText(absPath); break;
+    case 'audio':    result = await extractAudio(absPath); break;
+  }
+  return { text: result.text, sourceFormat: fmt };
+}
+
+module.exports = { extract, formatFor, EXT_TO_FORMAT };

--- a/ingest/extractors/audio.js
+++ b/ingest/extractors/audio.js
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// ingest/extractors/audio.js
+// ffmpeg transcode + Fish ASR for audio drops.
+//
+// Reuses the same pipeline that powers /api/voice/asr: any container ffmpeg
+// can decode goes in, 16 kHz mono WAV comes out, Fish returns the transcript.
+
+const fs = require('fs');
+const { transcodeToWav } = require('../../voice/transcode');
+const voice = require('../../voice/fish');
+
+async function extractAudio(absPath) {
+  if (!process.env.FISH_AUDIO_API_KEY || !process.env.FISH_AUDIO_API_KEY.trim()) {
+    throw new Error('audio ingest disabled: FISH_AUDIO_API_KEY not set');
+  }
+  const buf = fs.readFileSync(absPath);
+  const wav = await transcodeToWav(buf);
+  const { text } = await voice.asr({ audio: wav, language: 'en' });
+  return { text: text || '' };
+}
+
+module.exports = { extractAudio };

--- a/ingest/extractors/image.js
+++ b/ingest/extractors/image.js
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// ingest/extractors/image.js
+// Tesseract OCR for image drops.
+
+const { spawn } = require('child_process');
+
+function extractImage(absPath) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('tesseract', [absPath, 'stdout', '-l', 'eng'], { stdio: ['ignore', 'pipe', 'pipe'] });
+    const out = [];
+    let stderr = '';
+    proc.stdout.on('data', c => out.push(c));
+    proc.stderr.on('data', c => stderr += c.toString());
+    proc.on('error', e => reject(new Error(`tesseract spawn failed: ${e.message}`)));
+    proc.on('close', code => {
+      if (code !== 0) return reject(new Error(`tesseract exit ${code}: ${stderr.slice(0, 300)}`));
+      resolve({ text: Buffer.concat(out).toString('utf8') });
+    });
+  });
+}
+
+module.exports = { extractImage };

--- a/ingest/extractors/pdf.js
+++ b/ingest/extractors/pdf.js
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// ingest/extractors/pdf.js
+// pdftotext shell-out for PDF drops.
+
+const { spawn } = require('child_process');
+
+function extractPdf(absPath) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('pdftotext', ['-layout', absPath, '-'], { stdio: ['ignore', 'pipe', 'pipe'] });
+    const out = [];
+    let stderr = '';
+    proc.stdout.on('data', c => out.push(c));
+    proc.stderr.on('data', c => stderr += c.toString());
+    proc.on('error', e => reject(new Error(`pdftotext spawn failed: ${e.message}`)));
+    proc.on('close', code => {
+      if (code !== 0) return reject(new Error(`pdftotext exit ${code}: ${stderr.slice(0, 300)}`));
+      resolve({ text: Buffer.concat(out).toString('utf8') });
+    });
+  });
+}
+
+module.exports = { extractPdf };

--- a/ingest/extractors/text.js
+++ b/ingest/extractors/text.js
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// ingest/extractors/text.js
+// Verbatim read of plain-text drops.
+
+const fs = require('fs');
+
+async function extractText(absPath) {
+  return { text: fs.readFileSync(absPath, 'utf8') };
+}
+
+module.exports = { extractText };

--- a/ingest/pipeline.js
+++ b/ingest/pipeline.js
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// ingest/pipeline.js
+// Orchestrates the inbox -> reports pipeline.
+//
+// On start():
+//   1. drain any files left over in INBOX_DIR from a previous boot
+//      (server crashed mid-extract).
+//   2. begin watching INBOX_DIR for new drops.
+//
+// Per-file processing waits for mtime+size to be stable before extracting,
+// to avoid racing rsync mid-copy. Failures move the source to _failed/
+// with a sibling .error file. An in-flight Set prevents the debounced
+// re-scan from double-processing the same file.
+
+const fs = require('fs');
+const path = require('path');
+const PATHS = require('../config/paths');
+const watcher = require('./watcher');
+const { extract, formatFor } = require('./extract');
+const { writeReport } = require('./writeReport');
+
+const STABILITY_DELAY_MS = 500;
+const STABILITY_MAX_ATTEMPTS = 6;
+
+const _inFlight = new Set();
+let _watcherHandle = null;
+
+function _isProcessable(name) {
+  if (!name) return false;
+  if (name.startsWith('.') || name.startsWith('_')) return false;
+  return true;
+}
+
+function _scanInbox(inboxDir) {
+  let entries;
+  try { entries = fs.readdirSync(inboxDir); } catch { return []; }
+  const out = [];
+  for (const f of entries) {
+    if (!_isProcessable(f)) continue;
+    const abs = path.join(inboxDir, f);
+    let stat;
+    try { stat = fs.statSync(abs); } catch { continue; }
+    if (!stat.isFile()) continue;
+    out.push(abs);
+  }
+  return out;
+}
+
+function _sleep(ms) {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+async function _waitUntilStable(absPath) {
+  let prev;
+  try { prev = fs.statSync(absPath); } catch { return false; }
+  for (let i = 0; i < STABILITY_MAX_ATTEMPTS; i++) {
+    await _sleep(STABILITY_DELAY_MS);
+    let cur;
+    try { cur = fs.statSync(absPath); } catch { return false; }
+    if (cur.size === prev.size && cur.mtimeMs === prev.mtimeMs) return true;
+    prev = cur;
+  }
+  return false;
+}
+
+async function _moveToFailed(absPath, reason) {
+  try { fs.mkdirSync(PATHS.INBOX_FAILED_DIR, { recursive: true }); } catch {}
+  const base = path.basename(absPath);
+  const dest = path.join(PATHS.INBOX_FAILED_DIR, base);
+  try {
+    fs.renameSync(absPath, dest);
+  } catch (e) {
+    console.warn(`[ingest] could not move ${base} to _failed/: ${e.message}`);
+  }
+  const errPath = dest + '.error';
+  const stamp = new Date().toISOString();
+  try {
+    fs.writeFileSync(errPath, `${stamp}\n${reason}\n`);
+  } catch (e) {
+    console.warn(`[ingest] could not write error sibling for ${base}: ${e.message}`);
+  }
+}
+
+async function processOne(absPath) {
+  const base = path.basename(absPath);
+  if (_inFlight.has(base)) return { skipped: 'in-flight' };
+  _inFlight.add(base);
+  try {
+    const stable = await _waitUntilStable(absPath);
+    if (!stable) {
+      await _moveToFailed(absPath, 'file mtime never stabilised; still being copied?');
+      return { failed: true, reason: 'unstable' };
+    }
+    const fmt = formatFor(absPath);
+    if (!fmt) {
+      await _moveToFailed(absPath, `unsupported format: ${path.extname(absPath).toLowerCase() || '(none)'}`);
+      return { failed: true, reason: 'unsupported' };
+    }
+    let extracted;
+    try {
+      extracted = await extract(absPath);
+    } catch (e) {
+      await _moveToFailed(absPath, `extraction failed: ${e.message}`);
+      return { failed: true, reason: 'extract-error' };
+    }
+    const ingestedAt = new Date().toISOString();
+    const archiveAbs = path.join(PATHS.REPORTS_ARCHIVE_DIR, base);
+    const archiveRel = path.posix.join('reports', '_archive', base);
+    let outName;
+    try {
+      const written = writeReport({
+        reportsDir: PATHS.REPORTS_DIR,
+        text: extracted.text,
+        sourceFile: base,
+        sourceFormat: extracted.sourceFormat,
+        ingestedAt,
+        archivePath: archiveRel,
+      });
+      outName = written.outName;
+    } catch (e) {
+      await _moveToFailed(absPath, `report write failed: ${e.message}`);
+      return { failed: true, reason: 'write-error' };
+    }
+    try { fs.mkdirSync(PATHS.REPORTS_ARCHIVE_DIR, { recursive: true }); } catch {}
+    try {
+      fs.renameSync(absPath, archiveAbs);
+    } catch (e) {
+      console.warn(`[ingest] processed ${base} but could not archive: ${e.message}`);
+    }
+    return { ok: true, outName };
+  } finally {
+    _inFlight.delete(base);
+  }
+}
+
+function _onChange() {
+  const inbox = PATHS.INBOX_DIR;
+  for (const abs of _scanInbox(inbox)) {
+    const base = path.basename(abs);
+    if (_inFlight.has(base)) continue;
+    processOne(abs).catch(e => console.warn(`[ingest] processOne(${base}) threw:`, e.message));
+  }
+}
+
+function start() {
+  try { fs.mkdirSync(PATHS.INBOX_DIR, { recursive: true }); } catch {}
+  try { fs.mkdirSync(PATHS.INBOX_FAILED_DIR, { recursive: true }); } catch {}
+  try { fs.mkdirSync(PATHS.REPORTS_DIR, { recursive: true }); } catch {}
+  try { fs.mkdirSync(PATHS.REPORTS_ARCHIVE_DIR, { recursive: true }); } catch {}
+
+  _onChange();
+
+  if (_watcherHandle) { try { _watcherHandle.stop(); } catch {} }
+  _watcherHandle = watcher.start({ inboxDir: PATHS.INBOX_DIR, onChange: _onChange });
+  return _watcherHandle;
+}
+
+function stop() {
+  if (_watcherHandle) { try { _watcherHandle.stop(); } catch {} _watcherHandle = null; }
+}
+
+module.exports = { start, stop, processOne };

--- a/ingest/watcher.js
+++ b/ingest/watcher.js
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// ingest/watcher.js
+// fs.watch + 250ms debounce over the inbox dir. Mirrors the manifest
+// registry's watcher shape (manifests/registry.js).
+
+const fs = require('fs');
+
+const DEBOUNCE_MS = 250;
+
+function start({ inboxDir, onChange }) {
+  let timer = null;
+  let watcher = null;
+  const fire = () => {
+    if (timer) return;
+    timer = setTimeout(() => {
+      timer = null;
+      try { onChange(); } catch (e) { console.warn('[ingest] onChange threw:', e.message); }
+    }, DEBOUNCE_MS);
+  };
+  try {
+    watcher = fs.watch(inboxDir, { persistent: false }, fire);
+  } catch (e) {
+    console.warn('[ingest] fs.watch unavailable:', e.message);
+  }
+  return {
+    stop() {
+      if (timer) { clearTimeout(timer); timer = null; }
+      if (watcher) { try { watcher.close(); } catch {} watcher = null; }
+    },
+  };
+}
+
+module.exports = { start, DEBOUNCE_MS };

--- a/ingest/writeReport.js
+++ b/ingest/writeReport.js
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// ingest/writeReport.js
+// Build the .md output for an ingested file (frontmatter + body) and
+// write it atomically into REPORTS_DIR.
+
+const fs = require('fs');
+const path = require('path');
+
+function sanitiseStem(rawStem) {
+  return rawStem
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[-.]+|[-.]+$/g, '')
+    .slice(0, 80);
+}
+
+function buildOutputName(originalFilename, ingestedAtIso) {
+  const date = ingestedAtIso.slice(0, 10);
+  const stem = sanitiseStem(path.parse(originalFilename).name) || 'report';
+  return `${date}-${stem}`;
+}
+
+function pickAvailableName(reportsDir, baseName) {
+  let candidate = path.join(reportsDir, `${baseName}.md`);
+  if (!fs.existsSync(candidate)) return { abs: candidate, name: baseName };
+  for (let i = 2; i < 1000; i++) {
+    const name = `${baseName}-${i}`;
+    candidate = path.join(reportsDir, `${name}.md`);
+    if (!fs.existsSync(candidate)) return { abs: candidate, name };
+  }
+  throw new Error(`could not allocate output name for ${baseName} (1000 collisions)`);
+}
+
+function buildFrontmatter({ sourceFile, sourceFormat, ingestedAt, archivePath }) {
+  return [
+    '---',
+    'klebb_ingest: v1',
+    `source_file: ${sourceFile}`,
+    `source_format: ${sourceFormat}`,
+    `ingested_at: ${ingestedAt}`,
+    `archive_path: ${archivePath}`,
+    '---',
+    '',
+  ].join('\n');
+}
+
+function writeReport({ reportsDir, text, sourceFile, sourceFormat, ingestedAt, archivePath }) {
+  const baseName = buildOutputName(sourceFile, ingestedAt);
+  const { abs, name } = pickAvailableName(reportsDir, baseName);
+  const body = [
+    buildFrontmatter({ sourceFile, sourceFormat, ingestedAt, archivePath }),
+    `# ${name}`,
+    '',
+    text || '',
+  ].join('\n');
+  const tmp = abs + '.tmp';
+  fs.writeFileSync(tmp, body);
+  fs.renameSync(tmp, abs);
+  return { outAbs: abs, outName: name };
+}
+
+module.exports = { writeReport, buildOutputName, sanitiseStem };

--- a/server.js
+++ b/server.js
@@ -5,7 +5,6 @@ const https = require('https');
 const fs = require('fs');
 const path = require('path');
 const { marked } = require('marked');
-const { spawn } = require('child_process');
 const { isAuthenticated, isAgentRequest, isPublicPath, handleAuthRoutes, isSetup } = require('./auth/webauthn');
 const PATHS = require('./config/paths');
 const ENV = require('./config/env');
@@ -15,6 +14,7 @@ const { runFirstBoot } = require('./server/first-boot');
 const { listTemplates, listPrompts } = require('./server/content');
 const voice = require('./voice/fish');
 const voiceCache = require('./voice/cache');
+const { transcodeToWav } = require('./voice/transcode');
 const { TOOL_DEFS, dispatchToolCall } = require('./chat/tools');
 const { pickEmbellishments } = require('./chat/embellish');
 const { buildDateContextBlock } = require('./chat/date-context');
@@ -27,6 +27,8 @@ const { CATEGORIES: MANIFEST_CATEGORIES } = require('./config/categories');
 const ccSuggestions = require('./meta/cc-suggestions');
 const { describeCcSchema } = require('./chat/describe-cc-schema');
 const { describeDocsCatalogue } = require('./chat/docs');
+const { describeReportsCatalogue } = require('./chat/reports');
+const inbox = require('./ingest/pipeline');
 
 // chat endpoint config (env-driven; see config/env.js)
 const CHAT_ENDPOINT_URL = ENV.CHAT_ENDPOINT_URL;
@@ -187,36 +189,6 @@ function getWeightRange(start, end) {
   const arr = (weights && weights.$schema === 'klebb.datafile.v1') ? weights.data : weights;
   if (!Array.isArray(arr)) return [];
   return arr.filter(w => w.date >= start && w.date <= end);
-}
-
-// Pipe a buffer of any audio into ffmpeg and get 16kHz mono 16-bit WAV back
-// on stdout. This is the format Fish ASR accepts most reliably (advertised
-// opus/mp4 support both reject in practice).
-function transcodeToWav(inputBuf) {
-  return new Promise((resolve, reject) => {
-    const ff = spawn('ffmpeg', [
-      '-loglevel', 'error',
-      '-i', 'pipe:0',
-      '-vn',                        // no video
-      '-ac', '1',                   // mono
-      '-ar', '16000',               // 16 kHz
-      '-sample_fmt', 's16',         // 16-bit
-      '-f', 'wav',
-      'pipe:1',
-    ], { stdio: ['pipe', 'pipe', 'pipe'] });
-
-    const outChunks = [];
-    let stderr = '';
-    ff.stdout.on('data', c => outChunks.push(c));
-    ff.stderr.on('data', c => stderr += c.toString());
-    ff.on('error', reject);
-    ff.on('close', code => {
-      if (code !== 0) return reject(new Error(`ffmpeg exit ${code}: ${stderr.slice(0, 300)}`));
-      resolve(Buffer.concat(outChunks));
-    });
-    ff.stdin.on('error', () => {}); // ignore EPIPE if ffmpeg dies early
-    ff.stdin.end(inputBuf);
-  });
 }
 
 // Extract a { speak, display } JSON object from a model's raw reply.
@@ -1456,6 +1428,12 @@ const server = http.createServer(async (req, res) => {
           // happens to inline today.
           const docsCatalogueBlock = '\n\n' + describeDocsCatalogue() + '\n';
 
+          // Catalogue of reports the user has ingested into
+          // $HEALTH_HOME/reports/ via the inbox watcher. Lets the
+          // agent pull a blood panel / scan / voice memo into the
+          // turn via read_report when the question calls for it.
+          const reportsCatalogueBlock = '\n\n' + describeReportsCatalogue() + '\n';
+
           // Constrain meta.category to the canonical enum. Klebb uses the
           // field for clustering heuristics (e.g. CC suggestions); unknown
           // values are silently dropped by the registry, so agent-invented
@@ -1485,7 +1463,7 @@ const server = http.createServer(async (req, res) => {
             '',
           ].join('\n');
 
-          let systemPrompt = HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock + haeCatalogueBlock + ccSchemaBlock + docsCatalogueBlock + categoryBlock;
+          let systemPrompt = HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock + haeCatalogueBlock + ccSchemaBlock + docsCatalogueBlock + reportsCatalogueBlock + categoryBlock;
           if (voiceMode) {
             systemPrompt = `You are ${process.env.CHAT_AGENT_NAME || 'Chat'}, a health assistant.
 Voice mode is active: the user is speaking to you and will hear your reply aloud.
@@ -1518,7 +1496,7 @@ Return STRICTLY the JSON object. No leading/trailing text. No markdown fences.
 
 Original system prompt follows:
 
-` + HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock + haeCatalogueBlock + ccSchemaBlock + docsCatalogueBlock + categoryBlock;
+` + HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock + haeCatalogueBlock + ccSchemaBlock + docsCatalogueBlock + reportsCatalogueBlock + categoryBlock;
           }
 
           // Prepend system prompt
@@ -1822,5 +1800,16 @@ server.listen(PORT, HOST, () => {
     console.log(`[manifest] loaded ${stats.count} card(s); ${stats.errors} error(s)`);
   } catch (e) {
     console.error('[manifest] init failed:', e.message);
+  }
+
+  // Start the inbox watcher: drains anything left behind from a
+  // previous boot, then watches $HEALTH_HOME/inbox/ for new drops.
+  // Failures inside the pipeline land in inbox/_failed/, so a
+  // broken watcher should never wedge boot.
+  try {
+    inbox.start();
+    console.log('[ingest] inbox watcher started');
+  } catch (e) {
+    console.warn('[ingest] watcher init failed:', e.message);
   }
 });

--- a/tests/helpers/sandbox.js
+++ b/tests/helpers/sandbox.js
@@ -23,6 +23,8 @@ function createSandbox({ seed = {}, credentials = null, sessions = null } = {}) 
   fs.mkdirSync(path.join(root, 'data', 'auto-export', 'activity'), { recursive: true });
   fs.mkdirSync(path.join(root, 'sessions'), { recursive: true });
   fs.mkdirSync(path.join(root, 'credentials'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'inbox', '_failed'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'reports', '_archive'), { recursive: true });
 
   // Write seed manifest files
   for (const [filename, content] of Object.entries(seed)) {

--- a/tests/ingest.test.js
+++ b/tests/ingest.test.js
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/ingest.test.js
+//
+// Covers the inbox -> reports ingest pipeline. Three layers:
+//   1. Pure-function unit tests (no fs, no env): header parser, filename
+//      builder, dispatcher rejection, text extractor.
+//   2. Per-process unit tests with a fixed HEALTH_HOME so chat/reports
+//      can resolve PATHS.REPORTS_DIR against a sandbox tree.
+//   3. End-to-end via spawnServer: drop a file into inbox/, watch the
+//      pipeline produce reports/<date>-<stem>.md and archive the source.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync, spawn } = require('child_process');
+
+// Set HEALTH_HOME BEFORE requiring any module that imports config/paths.
+// paths.js captures HEALTH_HOME at require time, so this has to happen
+// before the chat/reports / ingest requires below.
+const SHARED_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'eh-ingest-'));
+fs.mkdirSync(path.join(SHARED_HOME, 'reports', '_archive'), { recursive: true });
+fs.mkdirSync(path.join(SHARED_HOME, 'inbox', '_failed'), { recursive: true });
+process.env.HEALTH_HOME = SHARED_HOME;
+process.env.HEALTH_HOME_WARNED = '1';
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const {
+  createSandbox, cleanupSandbox, spawnServer,
+} = require('./helpers/sandbox');
+
+const { parseReportHeader, describeReportsCatalogue } = require('../ingest/catalogue');
+const { buildOutputName, sanitiseStem, writeReport } = require('../ingest/writeReport');
+const { extract, formatFor } = require('../ingest/extract');
+const { extractText } = require('../ingest/extractors/text');
+const { readReport } = require('../chat/reports');
+const { TOOL_DEFS, dispatchToolCall } = require('../chat/tools');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+function which(bin) {
+  const probe = spawnSync(process.platform === 'win32' ? 'where' : 'which', [bin]);
+  return probe.status === 0;
+}
+
+function makeToolCall(name, args) {
+  return { function: { name, arguments: JSON.stringify(args) } };
+}
+
+async function waitFor(predicate, { timeoutMs = 8000, intervalMs = 200 } = {}) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const result = await predicate();
+    if (result) return result;
+    await new Promise(r => setTimeout(r, intervalMs));
+  }
+  return null;
+}
+
+describe('ingest/catalogue.parseReportHeader', () => {
+  test('parses a valid v1 header', () => {
+    const text = [
+      '---',
+      'klebb_ingest: v1',
+      'source_file: bloods.pdf',
+      'source_format: pdf',
+      'ingested_at: 2026-05-22T14:07:33Z',
+      'archive_path: reports/_archive/bloods.pdf',
+      '---',
+      '',
+      '# bloods',
+      'body',
+    ].join('\n');
+    const out = parseReportHeader(text);
+    assert.equal(out.sourceFile, 'bloods.pdf');
+    assert.equal(out.sourceFormat, 'pdf');
+    assert.equal(out.ingestedAt, '2026-05-22T14:07:33Z');
+    assert.equal(out.archivePath, 'reports/_archive/bloods.pdf');
+  });
+
+  test('returns null without the v1 sentinel', () => {
+    const text = [
+      '---',
+      'source_file: bloods.pdf',
+      'source_format: pdf',
+      'ingested_at: 2026-05-22T14:07:33Z',
+      '---',
+      '',
+    ].join('\n');
+    assert.equal(parseReportHeader(text), null);
+  });
+
+  test('returns null on a truncated/missing closing fence', () => {
+    const text = '---\nklebb_ingest: v1\nsource_file: x.pdf\n';
+    assert.equal(parseReportHeader(text), null);
+  });
+
+  test('returns null on missing required keys', () => {
+    const text = '---\nklebb_ingest: v1\nsource_file: x.pdf\n---\n';
+    assert.equal(parseReportHeader(text), null);
+  });
+});
+
+describe('ingest/writeReport: buildOutputName + sanitiseStem', () => {
+  test('builds <YYYY-MM-DD>-<stem> from filename + ISO timestamp', () => {
+    const out = buildOutputName('Bloods April Fast.pdf', '2026-05-22T14:07:33Z');
+    assert.equal(out, '2026-05-22-bloods-april-fast');
+  });
+
+  test('strips disallowed characters and collapses runs', () => {
+    assert.equal(sanitiseStem('Foo / Bar  *  Baz!'), 'foo-bar-baz');
+  });
+
+  test('truncates to 80 chars', () => {
+    const long = 'a'.repeat(200);
+    assert.equal(sanitiseStem(long).length, 80);
+  });
+
+  test('writeReport collides safely (-2 suffix)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'eh-write-'));
+    try {
+      const a = writeReport({
+        reportsDir: dir,
+        text: 'first',
+        sourceFile: 'note.txt',
+        sourceFormat: 'text',
+        ingestedAt: '2026-05-22T14:07:33Z',
+        archivePath: 'reports/_archive/note.txt',
+      });
+      const b = writeReport({
+        reportsDir: dir,
+        text: 'second',
+        sourceFile: 'note.txt',
+        sourceFormat: 'text',
+        ingestedAt: '2026-05-22T14:07:33Z',
+        archivePath: 'reports/_archive/note.txt',
+      });
+      assert.equal(a.outName, '2026-05-22-note');
+      assert.equal(b.outName, '2026-05-22-note-2');
+      assert.ok(fs.existsSync(a.outAbs));
+      assert.ok(fs.existsSync(b.outAbs));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('ingest/extract dispatcher', () => {
+  test('formatFor maps known extensions', () => {
+    assert.equal(formatFor('foo.pdf'), 'pdf');
+    assert.equal(formatFor('foo.PNG'), 'image');
+    assert.equal(formatFor('foo.txt'), 'text');
+    assert.equal(formatFor('foo.md'), 'markdown');
+    assert.equal(formatFor('foo.mp3'), 'audio');
+    assert.equal(formatFor('foo.docx'), null);
+  });
+
+  test('extract rejects unsupported formats', async () => {
+    await assert.rejects(
+      () => extract('/tmp/foo.docx'),
+      /unsupported format/,
+    );
+  });
+
+  test('extractText reads file verbatim as utf8', async () => {
+    const tmp = path.join(SHARED_HOME, 'extract-text-fixture.txt');
+    fs.writeFileSync(tmp, 'hello\nworld\n');
+    const out = await extractText(tmp);
+    assert.equal(out.text, 'hello\nworld\n');
+    fs.rmSync(tmp);
+  });
+});
+
+describe('chat/reports.readReport: traversal guards', () => {
+  test('rejects non-string / empty', () => {
+    assert.match(readReport('').error, /required/);
+    assert.match(readReport(null).error, /required/);
+    assert.match(readReport(undefined).error, /required/);
+  });
+
+  test('rejects names with slashes / .. / dots', () => {
+    assert.match(readReport('../etc/passwd').error, /invalid report name/);
+    assert.match(readReport('foo/bar').error, /invalid report name/);
+    assert.match(readReport('a b').error, /invalid report name/);
+  });
+
+  test('returns {error} for missing report', () => {
+    const r = readReport('does-not-exist');
+    assert.match(r.error, /failed to read/);
+  });
+
+  test('returns content + parsed header for an ingested report', () => {
+    const reportsDir = path.join(SHARED_HOME, 'reports');
+    const fixture = [
+      '---',
+      'klebb_ingest: v1',
+      'source_file: bloods.pdf',
+      'source_format: pdf',
+      'ingested_at: 2026-05-22T14:07:33Z',
+      'archive_path: reports/_archive/bloods.pdf',
+      '---',
+      '',
+      '# 2026-05-22-bloods',
+      '',
+      'body',
+    ].join('\n');
+    fs.writeFileSync(path.join(reportsDir, '2026-05-22-bloods.md'), fixture);
+    const r = readReport('2026-05-22-bloods');
+    assert.equal(r.name, '2026-05-22-bloods');
+    assert.equal(r.path, 'reports/2026-05-22-bloods.md');
+    assert.ok(r.content.includes('# 2026-05-22-bloods'));
+    assert.equal(r.sourceFormat, 'pdf');
+    assert.equal(r.ingestedAt, '2026-05-22T14:07:33Z');
+    assert.equal(r.truncated, false);
+  });
+});
+
+describe('chat tools: read_report', () => {
+  test('TOOL_DEFS includes read_report with the expected shape', () => {
+    const def = TOOL_DEFS.find(t => t.function?.name === 'read_report');
+    assert.ok(def, 'read_report not registered');
+    assert.equal(def.type, 'function');
+    assert.deepEqual(def.function.parameters.required, ['name']);
+    assert.equal(def.function.parameters.properties.name.type, 'string');
+    assert.equal(def.function.parameters.additionalProperties, false);
+  });
+
+  test('dispatchToolCall(read_report) returns content for an existing report', () => {
+    const out = dispatchToolCall(makeToolCall('read_report', { name: '2026-05-22-bloods' }));
+    const parsed = JSON.parse(out);
+    assert.equal(parsed.name, '2026-05-22-bloods');
+    assert.ok(parsed.content.length > 0);
+  });
+
+  test('dispatchToolCall(read_report) rejects traversal at the tool layer', () => {
+    const out = dispatchToolCall(makeToolCall('read_report', { name: '../etc/passwd' }));
+    const parsed = JSON.parse(out);
+    assert.match(parsed.error, /invalid report name/);
+  });
+});
+
+describe('ingest pipeline: end-to-end via spawnServer', () => {
+  let sandbox;
+  let server;
+
+  before(async () => {
+    sandbox = createSandbox();
+    server = await spawnServer(sandbox);
+  });
+
+  after(async () => {
+    if (server) await server.kill();
+    if (sandbox) cleanupSandbox(sandbox);
+  });
+
+  test('text drop produces a .md report and archives the source', async () => {
+    const inbox = path.join(sandbox, 'inbox');
+    const reports = path.join(sandbox, 'reports');
+    const archive = path.join(reports, '_archive');
+    const src = path.join(inbox, 'note.txt');
+    fs.writeFileSync(src, 'hello world\n');
+
+    const found = await waitFor(() => {
+      const files = fs.readdirSync(reports).filter(f => f.endsWith('.md'));
+      return files.length ? files[0] : null;
+    });
+    assert.ok(found, 'no .md report was produced inside 8s');
+
+    const body = fs.readFileSync(path.join(reports, found), 'utf8');
+    const header = parseReportHeader(body);
+    assert.ok(header, 'header did not parse');
+    assert.equal(header.sourceFormat, 'text');
+    assert.equal(header.sourceFile, 'note.txt');
+    assert.match(body, /hello world/);
+
+    assert.ok(fs.existsSync(path.join(archive, 'note.txt')),
+      'source not archived');
+    assert.ok(!fs.existsSync(src), 'source still in inbox');
+  });
+
+  test('unsupported extension lands in _failed/ with a sibling .error', async () => {
+    const inbox = path.join(sandbox, 'inbox');
+    const failed = path.join(inbox, '_failed');
+    const src = path.join(inbox, 'evil.docx');
+    fs.writeFileSync(src, 'binary doom');
+
+    const moved = await waitFor(() => {
+      return fs.existsSync(path.join(failed, 'evil.docx')) ? true : null;
+    });
+    assert.ok(moved, 'evil.docx never moved to _failed/');
+
+    const errFile = path.join(failed, 'evil.docx.error');
+    assert.ok(fs.existsSync(errFile), 'no sibling .error written');
+    const errBody = fs.readFileSync(errFile, 'utf8');
+    assert.match(errBody, /unsupported format/);
+  });
+
+  test('audio drop without FISH_AUDIO_API_KEY lands in _failed/ with the disabled message', async () => {
+    const inbox = path.join(sandbox, 'inbox');
+    const failed = path.join(inbox, '_failed');
+    const src = path.join(inbox, 'voice-note.mp3');
+    fs.writeFileSync(src, 'not really mp3 bytes; ffmpeg+ASR will not run');
+
+    const moved = await waitFor(() => {
+      return fs.existsSync(path.join(failed, 'voice-note.mp3')) ? true : null;
+    });
+    assert.ok(moved, 'voice-note.mp3 never moved to _failed/');
+
+    const errBody = fs.readFileSync(path.join(failed, 'voice-note.mp3.error'), 'utf8');
+    assert.match(errBody, /audio ingest disabled|FISH_AUDIO_API_KEY/);
+  });
+});
+
+// Optional PDF / image happy-paths only run if the underlying binaries are
+// installed. CI without poppler-utils / tesseract still passes the rest.
+const HAS_PDFTOTEXT = which('pdftotext');
+const HAS_TESSERACT = which('tesseract');
+
+describe('ingest pipeline: optional binary-backed paths', () => {
+  test('pdftotext binary is on PATH', { skip: !HAS_PDFTOTEXT }, () => {
+    assert.ok(HAS_PDFTOTEXT);
+  });
+  test('tesseract binary is on PATH', { skip: !HAS_TESSERACT }, () => {
+    assert.ok(HAS_TESSERACT);
+  });
+});
+
+after(() => {
+  try { fs.rmSync(SHARED_HOME, { recursive: true, force: true }); } catch {}
+});

--- a/voice/transcode.js
+++ b/voice/transcode.js
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// voice/transcode.js
+//
+// Pipe a buffer of any audio into ffmpeg and get 16kHz mono 16-bit WAV
+// back on stdout. This is the format Fish ASR accepts most reliably
+// (advertised opus/mp4 support both reject in practice). Used by the
+// /api/voice/asr route and by the inbox ingest pipeline's audio
+// extractor; they both feed the same Fish endpoint, so the same
+// transcode shape applies.
+
+const { spawn } = require('child_process');
+
+function transcodeToWav(inputBuf) {
+  return new Promise((resolve, reject) => {
+    const ff = spawn('ffmpeg', [
+      '-loglevel', 'error',
+      '-i', 'pipe:0',
+      '-vn',
+      '-ac', '1',
+      '-ar', '16000',
+      '-sample_fmt', 's16',
+      '-f', 'wav',
+      'pipe:1',
+    ], { stdio: ['pipe', 'pipe', 'pipe'] });
+
+    const outChunks = [];
+    let stderr = '';
+    ff.stdout.on('data', c => outChunks.push(c));
+    ff.stderr.on('data', c => stderr += c.toString());
+    ff.on('error', reject);
+    ff.on('close', code => {
+      if (code !== 0) return reject(new Error(`ffmpeg exit ${code}: ${stderr.slice(0, 300)}`));
+      resolve(Buffer.concat(outChunks));
+    });
+    ff.stdin.on('error', () => {});
+    ff.stdin.end(inputBuf);
+  });
+}
+
+module.exports = { transcodeToWav };


### PR DESCRIPTION
## Summary

- Drop `.pdf`, `.png`, `.jpg`, `.txt`, `.md`, `.mp3`, `.wav`, `.m4a`, `.ogg`, or `.opus` into `$HEALTH_HOME/inbox/`; Klebb extracts each into a markdown report under `$HEALTH_HOME/reports/<date>-<stem>.md` using infra binaries only (no LLM at ingest).
- Originals are filed under `reports/_archive/`; failures move to `inbox/_failed/` with a sibling `.error`.
- A new `read_report` chat tool plus a `## Available reports` catalogue block in the system prompt let Klebbius pull any ingested report into a turn on demand.

## Why

Today the Reports page only surfaces `.md` files that landed in `$HEALTH_HOME/reports/` out-of-band. There is no upload path, no PDF/image extractor, and the chat agent cannot read those reports either. Drop a blood-panel PDF on the box and the agent is blind to it.

This bridges the gap with deterministic, auditable infra (poppler-utils, tesseract, ffmpeg + Fish ASR) so the agent does the comprehension at chat time where the user can challenge the answer in the same turn.

## How

- New `ingest/` module: `watcher.js` (fs.watch + 250ms debounce), `pipeline.js` (orchestrator with stability wait + in-flight lock + failure path), `extract.js` (extension-keyed dispatcher), `extractors/{pdf,image,text,audio}.js`, `writeReport.js` (atomic tmp+rename with frontmatter + collision suffix), `catalogue.js` (header parser + system-prompt block).
- `voice/transcode.js`: lifts `transcodeToWav` out of `server.js` so both the voice route and the audio extractor share one pipeline.
- `chat/reports.js` + `chat/tools.js`: registers `read_report` with traversal guards mirroring `read_doc`.
- `config/paths.js`: adds `INBOX_DIR`, `INBOX_FAILED_DIR`, `REPORTS_ARCHIVE_DIR`; ensures all four on boot. `REPORTS_ARCHIVE_DIR` anchors on `$HEALTH_HOME/reports/` (independent of the legacy `data/reports/` fallback chain) so a fresh install always archives into the canonical location.
- `server.js`: requires the pipeline + catalogue, injects the catalogue block into both `/api/chat` system prompts (text + voice), starts the watcher in a try/catch after `registry.init()`.
- `Dockerfile`: appends `poppler-utils`, `tesseract-ocr`, `tesseract-ocr-eng` to the apt-get block, and adds `COPY ingest`.
- Docs: README gains an "Ingesting reports" section + `ingest/` in the architecture tree; `docs/DEPLOY.md` lists the new system packages and notes the Fish dependency for audio; `CHANGELOG.md` `## Unreleased` updated.

## Testing

- [x] `npm test` runs 23 new ingest tests (header parser, filename builder, dispatcher rejection, text extractor, traversal guards, tool dispatch, end-to-end happy path, end-to-end failure path, audio gating without Fish key) plus the existing 1010 pass; pre-existing `no-personal-refs` failure is unrelated and present on `main`.
- [ ] Operator smoke test on `klebbtest`: drop text / PDF / image / audio / unsupported file; verify report markdown, archive, `_failed/` fallback, chat catalogue, `read_report` round-trip, restart resilience (drain on boot).

Fixes #288