### PR TITLE
fix(reports): table-list adapts to lab-shape findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Reports → Blood panel no longer shows `?` for every row.** The
+  generic `table-list` renderer was hardcoded for the SNP finding
+  shape (`gene` / `rsid` / `genotype`), so any card with a
+  lab-result-shaped finding (`label` / `value` / `unit`) rendered the
+  left column as `?` and dropped the unit on the right. The renderer
+  now sniffs the finding shape per-row and uses `label` + `value
+  unit` for lab data while keeping the existing SNP layout intact.
+  The SNP-specific `APOE: ? · ?/? SNPs found` summary line is also
+  hidden on cards that don't carry SNP metadata. Fixes #290.
+
 - **Demo runbook now pins the reset/deploy `docker exec` calls to a
   named timezone.** `scripts/reset-demo.js` anchors fixture dates to
   the container's local calendar day; the image has no `TZ` baked in

--- a/public/js/components/eh-table-list.js
+++ b/public/js/components/eh-table-list.js
@@ -1,10 +1,29 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
-// eh-table-list.js — generic table renderer. Reports view uses this for SNPs.
+// eh-table-list.js — generic table renderer. Reports view uses this for
+// categorised, two-column rowsets. Two finding shapes are auto-detected
+// per-row:
+//   - SNP shape:   { gene, rsid, genotype }       → "GENE  GENOTYPE"
+//   - Lab shape:   { label, value, unit, ... }    → "LABEL  VALUE UNIT"
+// Other shapes fall back to the first two non-meta scalar fields. The
+// summary line is SNP-specific (APOE / count) and only renders when
+// `apoe` or `found_count` is present.
 
 import { html, css } from 'https://esm.sh/lit@3';
 import { EhBaseCard } from './eh-base-card.js';
 import { registerRenderer } from '../renderer-registry.js';
+
+function findingKey(f) {
+  return f.gene ?? f.rsid ?? f.label ?? f.name ?? '?';
+}
+
+function findingValue(f) {
+  if (f.genotype !== undefined && f.genotype !== '') return f.genotype;
+  if (f.value !== undefined && f.value !== '') {
+    return f.unit ? `${f.value} ${f.unit}` : String(f.value);
+  }
+  return '—';
+}
 
 export class EhTableList extends EhBaseCard {
   static styles = [
@@ -34,18 +53,20 @@ export class EhTableList extends EhBaseCard {
   renderCard() {
     const d = this.data;
     if (!d) return html`<div>No data.</div>`;
-    // SNP-like shape: { apoe, total_snps, found_count, categories: [...] }
     if (d.categories && typeof d === 'object') {
+      const hasSnpSummary = d.apoe || d.found_count != null || d.searched_count != null;
       return html`
-        <div class="summary">
-          APOE: <strong>${d.apoe || '?'}</strong> · ${d.found_count ?? '?'} / ${d.searched_count ?? '?'} SNPs found
-        </div>
+        ${hasSnpSummary ? html`
+          <div class="summary">
+            APOE: <strong>${d.apoe || '?'}</strong> · ${d.found_count ?? '?'} / ${d.searched_count ?? '?'} SNPs found
+          </div>
+        ` : ''}
         <div class="kv-grid">
           ${Array.isArray(d.categories) ? d.categories.slice(0, 8).map(cat => html`
             <div class="cat-header">${cat.name || cat.category || '—'}</div>
             ${Array.isArray(cat.findings) ? cat.findings.slice(0, 6).map(f => html`
-              <span class="kv-key">${f.gene || f.rsid || '?'}</span>
-              <span class="kv-val">${f.genotype || f.value || '—'}</span>
+              <span class="kv-key">${findingKey(f)}</span>
+              <span class="kv-val">${findingValue(f)}</span>
             `) : ''}
           `) : ''}
         </div>

--- a/tests-e2e/table-list-lab-shape.spec.js
+++ b/tests-e2e/table-list-lab-shape.spec.js
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/table-list-lab-shape.spec.js
+// Regression for #290: eh-table-list must adapt to lab-shaped findings
+// (label / value / unit / refLow / refHigh / flag), not just SNP-shaped
+// findings (gene / rsid / genotype). Until #290 lands, the blood panel
+// renders every row's left column as `?` and tops the card with a
+// nonsense `APOE: ? · ?/? SNPs found` summary.
+//
+// The spec POSTs a minimal blood-panel manifest into the live sandbox,
+// navigates to Reports, and asserts the rendered card uses the labels
+// (not `?`) and shows `value unit` on the right. The sibling SNP shape
+// is also re-asserted so the auto-detect doesn't regress the existing
+// genome card.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+const BLOOD_ID = 'blood-panel-e2e';
+const SNPS_ID = 'genome-snps-e2e';
+
+function bloodPanelManifest() {
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: BLOOD_ID,
+      label: 'Blood panel',
+      emoji: '🩸',
+      order: 800,
+      view: {
+        enabled: true,
+        component: 'list-card',
+        display: { primaryField: 'label', emptyMessage: 'No blood panels recorded yet.' },
+      },
+      reports: { enabled: true, component: 'table-list' },
+      writeable: { fromWebapp: false },
+    },
+    description: 'Lab-shaped fixture for the table-list regression.',
+    data: {
+      collected: '2026-04-21',
+      lab: 'DemoLabs Pty Ltd',
+      categories: [
+        {
+          name: 'Lipids',
+          findings: [
+            { label: 'Total cholesterol', value: '4.6', unit: 'mmol/L',
+              refLow: '<5.5', refHigh: '', flag: '' },
+            { label: 'HDL', value: '1.5', unit: 'mmol/L',
+              refLow: '>1.0', refHigh: '', flag: '' },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+function snpsManifest() {
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: SNPS_ID,
+      label: 'Genome (SNPs)',
+      emoji: '🧬',
+      order: 850,
+      view: {
+        enabled: true,
+        component: 'list-card',
+        display: { primaryField: 'gene', emptyMessage: 'No SNPs loaded yet.' },
+      },
+      reports: { enabled: true, component: 'table-list' },
+      writeable: { fromWebapp: false },
+    },
+    description: 'SNP-shaped sibling fixture — must keep rendering correctly.',
+    data: {
+      apoe: '3/3',
+      found_count: 78,
+      searched_count: 120,
+      categories: [
+        {
+          name: 'Lipid metabolism',
+          findings: [
+            { gene: 'APOE', rsid: 'rs429358', genotype: 'T/T' },
+            { gene: 'PCSK9', rsid: 'rs11591147', genotype: 'G/G' },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+async function seedManifest(request, baseUrl, manifest) {
+  // Best-effort delete first in case a prior run left the card behind.
+  await request.delete(`${baseUrl}/api/manifests/${manifest.meta.id}`).catch(() => {});
+  const r = await request.post(`${baseUrl}/api/manifests`, { data: manifest });
+  expect([201, 409]).toContain(r.status());
+}
+
+async function deleteManifest(request, baseUrl, id) {
+  await request.delete(`${baseUrl}/api/manifests/${id}`).catch(() => {});
+}
+
+test.describe('#290: table-list adapts to lab-shape findings', () => {
+  test('blood-panel rows show labels + value with unit (not "?")', async ({ page, sandboxState }) => {
+    await seedManifest(page.request, sandboxState.baseUrl, bloodPanelManifest());
+
+    await page.goto('/reports');
+    await expect(page.locator('eh-reports-view')).toBeVisible({ timeout: 10_000 });
+
+    // Scope to the blood-panel card via the wrap's data-card-id, then
+    // dive into its eh-table-list. This avoids matching the SNP card
+    // when both happen to be loaded.
+    const card = page.locator(
+      `eh-view-renderer [data-card-id="${BLOOD_ID}"] eh-table-list`,
+    );
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    // The actual lab labels should appear, not the SNP-fallback `?`.
+    await expect(card).toContainText('Total cholesterol');
+    await expect(card).toContainText('HDL');
+
+    // Value with unit on the right column.
+    await expect(card).toContainText('4.6 mmol/L');
+    await expect(card).toContainText('1.5 mmol/L');
+
+    // The SNP-style summary line must NOT appear on a lab card.
+    await expect(card).not.toContainText('SNPs found');
+
+    await deleteManifest(page.request, sandboxState.baseUrl, BLOOD_ID);
+  });
+
+  test('SNP card still renders genes + APOE summary', async ({ page, sandboxState }) => {
+    await seedManifest(page.request, sandboxState.baseUrl, snpsManifest());
+
+    await page.goto('/reports');
+    await expect(page.locator('eh-reports-view')).toBeVisible({ timeout: 10_000 });
+
+    const card = page.locator(
+      `eh-view-renderer [data-card-id="${SNPS_ID}"] eh-table-list`,
+    );
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    await expect(card).toContainText('APOE');
+    await expect(card).toContainText('PCSK9');
+    await expect(card).toContainText('SNPs found');
+
+    await deleteManifest(page.request, sandboxState.baseUrl, SNPS_ID);
+  });
+});


### PR DESCRIPTION
# What changed

`eh-table-list` no longer hardcodes the SNP finding shape. It now
sniffs each finding per-row and renders lab-shaped rows
(`label` / `value` / `unit`) correctly, while keeping the existing
SNP layout for cards that use `gene` / `rsid` / `genotype`. The
`APOE: ? · ?/? SNPs found` summary line is also gated behind the
presence of SNP metadata, so cards without it get a clean header.

# Why

The public demo at `demo.klebb.app` was rendering the Blood panel
card with every row's left column as `?` and a meaningless
`APOE: ? · ? / ? SNPs found` summary on top. Cause: `eh-table-list`
was originally written for the genome SNPs card and assumed
`finding.gene` / `finding.rsid` / `finding.genotype` accessors. The
blood-panel manifest (`demo/fixtures/blood-panel.json`) reuses the
same `component: "table-list"` but with `finding.label` /
`finding.value` / `finding.unit`, so every row's accessors fell
through to the `?` fallback.

Fixes #290.

# How

- Per-row sniff: pick `finding.gene ?? rsid ?? label ?? name` for the
  left column; pick `genotype` for SNPs or `value unit` for labs for
  the right column.
- The SNP-style summary line is only emitted when `apoe`,
  `found_count`, or `searched_count` is present on the data block.
- No fixture changes. No schema changes. No new dependencies. The
  documented `meta.reports.columns` contract stays unimplemented (out
  of scope for this fix).

# Testing

- [x] `npm test` passes locally (the two pre-existing failures —
      `no-personal-refs` reading gitignored local files, and the
      `chat-starter-prompts` random-sample flake — reproduce on
      `main` and are not related to this change).
- [x] `npm run test:e2e` passes locally (added 2 new tests, all 39
      pass when the new spec is included; the chat-starter-prompts
      flake is pre-existing).
- [x] New regression test at `tests-e2e/table-list-lab-shape.spec.js`
      that POSTs both shapes through `/api/manifests` and asserts
      the rendered DOM. **Verified to fail on `main` with the exact
      `?` symptom**, then pass with the fix applied.
- [x] Manual QA: ran the e2e harness, navigated to `/reports`, the
      seeded blood-panel card now shows `Total cholesterol  4.6 mmol/L`
      etc. and no SNP summary; the seeded SNP card still shows
      `APOE  T/T` and the `78 / 120 SNPs found` summary.

# Checklist

- [x] Commit message follows `CONTRIBUTING.md` conventions
- [x] `CHANGELOG.md` updated under `## Unreleased`
- [x] No docs change needed (the documented `table-list` config
      shape in `MANIFEST-SCHEMA.md` was already correct; this PR
      brings the renderer closer to it without yet implementing
      `columns`)
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed