### PR TITLE
feat(demo): rings-layout Sleep card + Strength Training fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Demo rings-layout Sleep card and Strength Training schedule
+  card.** The `demo.klebb.app` Sleep fixture is now a self-referencing
+  combination-card with `layout: rings`, surfacing Total / Deep / REM
+  / Light as concentric progress arcs against per-stage daily goals.
+  A new `demo/fixtures/strength-training.json` schedule-card fixture
+  ships ten lifts across a Mon / Wed / Fri split (3 / 3 / 4) with
+  weight, sets, reps and body part on each item. The schedule-card
+  status chip now honours an optional `item.action_label` so the
+  strength card chip reads "Lift" instead of "Inject"; the existing
+  Inject / Spray default is unchanged. Fixes #292.
 - **Inbox-driven report ingest pipeline.** Drop a `.pdf`, `.png`,
   `.jpg`, `.txt`, `.md`, `.mp3`, `.wav`, `.m4a`, `.ogg`, or `.opus`
   file into `$HEALTH_HOME/inbox/` and Klebb extracts text into

--- a/demo/fixtures/sleep-hours.json
+++ b/demo/fixtures/sleep-hours.json
@@ -7,13 +7,46 @@
     "order": 500,
     "view": {
       "enabled": true,
-      "component": "generic-card",
-      "display": {
-        "template": "{hours:round(1)}",
-        "unit": "hrs",
-        "secondary": "{deep:round(1)|}h deep · {rem:round(1)|}h REM",
-        "trendArrow": { "field": "hours" }
-      }
+      "component": "combination-card",
+      "layout": "rings",
+      "combines": [
+        {
+          "sourceId": "sleep-hours",
+          "role": "ring-segment",
+          "label": "Total",
+          "accessor": "hours",
+          "unit": "h",
+          "goalDaily": 8,
+          "colour": "#7aa2ff"
+        },
+        {
+          "sourceId": "sleep-hours",
+          "role": "ring-segment",
+          "label": "Deep",
+          "accessor": "deep",
+          "unit": "h",
+          "goalDaily": 1.5,
+          "colour": "#5b3aa8"
+        },
+        {
+          "sourceId": "sleep-hours",
+          "role": "ring-segment",
+          "label": "REM",
+          "accessor": "rem",
+          "unit": "h",
+          "goalDaily": 1.8,
+          "colour": "#d36bd0"
+        },
+        {
+          "sourceId": "sleep-hours",
+          "role": "ring-segment",
+          "label": "Light",
+          "accessor": "light",
+          "unit": "h",
+          "goalDaily": 4.5,
+          "colour": "#54c7c7"
+        }
+      ]
     },
     "trends": {
       "enabled": true,
@@ -21,21 +54,21 @@
       "field": "hours"
     }
   },
-  "description": "Total sleep duration per night with deep / REM breakdown.",
+  "description": "Total sleep duration per night with deep / REM / light breakdown rendered as concentric progress rings against per-stage daily targets.",
   "data": [
-    { "date": "__OFFSET_DAYS:-13__", "hours": 6.8, "deep": 1.2, "rem": 1.4 },
-    { "date": "__OFFSET_DAYS:-12__", "hours": 7.2, "deep": 1.4, "rem": 1.6 },
-    { "date": "__OFFSET_DAYS:-11__", "hours": 6.5, "deep": 1.0, "rem": 1.3 },
-    { "date": "__OFFSET_DAYS:-10__", "hours": 7.8, "deep": 1.6, "rem": 1.7 },
-    { "date": "__OFFSET_DAYS:-9__", "hours": 7.1, "deep": 1.3, "rem": 1.5 },
-    { "date": "__OFFSET_DAYS:-8__", "hours": 6.9, "deep": 1.2, "rem": 1.4 },
-    { "date": "__OFFSET_DAYS:-7__", "hours": 8.0, "deep": 1.7, "rem": 1.8 },
-    { "date": "__OFFSET_DAYS:-6__", "hours": 7.4, "deep": 1.4, "rem": 1.6 },
-    { "date": "__OFFSET_DAYS:-5__", "hours": 6.6, "deep": 1.1, "rem": 1.3 },
-    { "date": "__OFFSET_DAYS:-4__", "hours": 7.7, "deep": 1.5, "rem": 1.7 },
-    { "date": "__OFFSET_DAYS:-3__", "hours": 7.3, "deep": 1.4, "rem": 1.6 },
-    { "date": "__OFFSET_DAYS:-2__", "hours": 7.0, "deep": 1.3, "rem": 1.5 },
-    { "date": "__OFFSET_DAYS:-1__", "hours": 7.5, "deep": 1.5, "rem": 1.6 },
-    { "date": "__OFFSET_DAYS:0__", "hours": 7.6, "deep": 1.5, "rem": 1.7 }
+    { "date": "__OFFSET_DAYS:-13__", "hours": 6.8, "deep": 1.2, "rem": 1.4, "light": 4.2 },
+    { "date": "__OFFSET_DAYS:-12__", "hours": 7.2, "deep": 1.4, "rem": 1.6, "light": 4.2 },
+    { "date": "__OFFSET_DAYS:-11__", "hours": 6.5, "deep": 1.0, "rem": 1.3, "light": 4.2 },
+    { "date": "__OFFSET_DAYS:-10__", "hours": 7.8, "deep": 1.6, "rem": 1.7, "light": 4.5 },
+    { "date": "__OFFSET_DAYS:-9__", "hours": 7.1, "deep": 1.3, "rem": 1.5, "light": 4.3 },
+    { "date": "__OFFSET_DAYS:-8__", "hours": 6.9, "deep": 1.2, "rem": 1.4, "light": 4.3 },
+    { "date": "__OFFSET_DAYS:-7__", "hours": 8.0, "deep": 1.7, "rem": 1.8, "light": 4.5 },
+    { "date": "__OFFSET_DAYS:-6__", "hours": 7.4, "deep": 1.4, "rem": 1.6, "light": 4.4 },
+    { "date": "__OFFSET_DAYS:-5__", "hours": 6.6, "deep": 1.1, "rem": 1.3, "light": 4.2 },
+    { "date": "__OFFSET_DAYS:-4__", "hours": 7.7, "deep": 1.5, "rem": 1.7, "light": 4.5 },
+    { "date": "__OFFSET_DAYS:-3__", "hours": 7.3, "deep": 1.4, "rem": 1.6, "light": 4.3 },
+    { "date": "__OFFSET_DAYS:-2__", "hours": 7.0, "deep": 1.3, "rem": 1.5, "light": 4.2 },
+    { "date": "__OFFSET_DAYS:-1__", "hours": 7.5, "deep": 1.5, "rem": 1.6, "light": 4.4 },
+    { "date": "__OFFSET_DAYS:0__", "hours": 7.6, "deep": 1.5, "rem": 1.7, "light": 4.4 }
   ]
 }

--- a/demo/fixtures/strength-training.json
+++ b/demo/fixtures/strength-training.json
@@ -1,0 +1,325 @@
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "strength-training",
+    "label": "Strength Training",
+    "emoji": "🏋️",
+    "order": 310,
+    "view": {
+      "enabled": true,
+      "component": "schedule-card"
+    },
+    "trends": {
+      "enabled": true,
+      "component": "schedule-timeline",
+      "itemsPath": "items"
+    },
+    "reports": {
+      "enabled": true,
+      "component": "adherence-report",
+      "showCompliance": true
+    },
+    "calendar": {
+      "enabled": true,
+      "component": "day-marker",
+      "marker": "🏋️"
+    },
+    "writeable": {
+      "fromWebapp": true,
+      "pastAllowed": true,
+      "todayAllowed": true,
+      "futureAllowed": false
+    }
+  },
+  "description": "Three-day push/pull/legs split. Monday and Wednesday hit three lifts each, Friday adds a fourth accessory. Each exercise carries its working-set load in kilos plus the prescribed sets x reps so the schedule-card surfaces the day's plan as a checklist.",
+  "data": {
+    "items": [
+      {
+        "name": "Bench Press",
+        "short_name": "Bench",
+        "body_part": "Chest",
+        "weight_kg": 72.5,
+        "sets": 4,
+        "reps": 8,
+        "dose_label": "72.5 kg · 4×8",
+        "action_label": "Lift",
+        "schedule": {
+          "type": "weekly",
+          "on_days": ["Mon"]
+        },
+        "cycles": [
+          {
+            "type": "on",
+            "status": "active",
+            "cycle_number": 1,
+            "start": "__OFFSET_DAYS:-28__",
+            "start_date": "__OFFSET_DAYS:-28__"
+          }
+        ],
+        "doses": [
+          { "scheduledDate": "__OFFSET_DAYS:-25__", "takenAt": "__OFFSET_DAYS:-25__T07:14:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-18__", "takenAt": "__OFFSET_DAYS:-18__T07:08:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-11__", "takenAt": "__OFFSET_DAYS:-11__T07:22:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-4__",  "takenAt": "__OFFSET_DAYS:-4__T07:11:00" }
+        ]
+      },
+      {
+        "name": "Lat Pull-down",
+        "short_name": "Lat PD",
+        "body_part": "Back",
+        "weight_kg": 60,
+        "sets": 4,
+        "reps": 10,
+        "dose_label": "60 kg · 4×10",
+        "action_label": "Lift",
+        "schedule": {
+          "type": "weekly",
+          "on_days": ["Mon"]
+        },
+        "cycles": [
+          {
+            "type": "on",
+            "status": "active",
+            "cycle_number": 1,
+            "start": "__OFFSET_DAYS:-28__",
+            "start_date": "__OFFSET_DAYS:-28__"
+          }
+        ],
+        "doses": [
+          { "scheduledDate": "__OFFSET_DAYS:-25__", "takenAt": "__OFFSET_DAYS:-25__T07:32:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-18__", "takenAt": "__OFFSET_DAYS:-18__T07:28:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-11__", "takenAt": "__OFFSET_DAYS:-11__T07:41:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-4__",  "takenAt": "__OFFSET_DAYS:-4__T07:33:00" }
+        ]
+      },
+      {
+        "name": "Bicep Curl",
+        "short_name": "Curl",
+        "body_part": "Arms",
+        "weight_kg": 14,
+        "sets": 3,
+        "reps": 12,
+        "dose_label": "14 kg · 3×12",
+        "action_label": "Lift",
+        "schedule": {
+          "type": "weekly",
+          "on_days": ["Mon"]
+        },
+        "cycles": [
+          {
+            "type": "on",
+            "status": "active",
+            "cycle_number": 1,
+            "start": "__OFFSET_DAYS:-28__",
+            "start_date": "__OFFSET_DAYS:-28__"
+          }
+        ],
+        "doses": [
+          { "scheduledDate": "__OFFSET_DAYS:-25__", "takenAt": "__OFFSET_DAYS:-25__T07:48:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-18__", "takenAt": "__OFFSET_DAYS:-18__T07:46:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-11__", "takenAt": "__OFFSET_DAYS:-11__T07:56:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-4__",  "takenAt": "__OFFSET_DAYS:-4__T07:52:00" }
+        ]
+      },
+      {
+        "name": "Back Squat",
+        "short_name": "Squat",
+        "body_part": "Legs",
+        "weight_kg": 95,
+        "sets": 5,
+        "reps": 5,
+        "dose_label": "95 kg · 5×5",
+        "action_label": "Lift",
+        "schedule": {
+          "type": "weekly",
+          "on_days": ["Wed"]
+        },
+        "cycles": [
+          {
+            "type": "on",
+            "status": "active",
+            "cycle_number": 1,
+            "start": "__OFFSET_DAYS:-28__",
+            "start_date": "__OFFSET_DAYS:-28__"
+          }
+        ],
+        "doses": [
+          { "scheduledDate": "__OFFSET_DAYS:-23__", "takenAt": "__OFFSET_DAYS:-23__T07:09:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-16__", "takenAt": "__OFFSET_DAYS:-16__T07:14:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-9__",  "takenAt": "__OFFSET_DAYS:-9__T07:18:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-2__",  "takenAt": "__OFFSET_DAYS:-2__T07:11:00" }
+        ]
+      },
+      {
+        "name": "Romanian Deadlift",
+        "short_name": "RDL",
+        "body_part": "Hamstrings",
+        "weight_kg": 80,
+        "sets": 4,
+        "reps": 8,
+        "dose_label": "80 kg · 4×8",
+        "action_label": "Lift",
+        "schedule": {
+          "type": "weekly",
+          "on_days": ["Wed"]
+        },
+        "cycles": [
+          {
+            "type": "on",
+            "status": "active",
+            "cycle_number": 1,
+            "start": "__OFFSET_DAYS:-28__",
+            "start_date": "__OFFSET_DAYS:-28__"
+          }
+        ],
+        "doses": [
+          { "scheduledDate": "__OFFSET_DAYS:-23__", "takenAt": "__OFFSET_DAYS:-23__T07:28:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-16__", "takenAt": "__OFFSET_DAYS:-16__T07:34:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-9__",  "takenAt": "__OFFSET_DAYS:-9__T07:36:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-2__",  "takenAt": "__OFFSET_DAYS:-2__T07:30:00" }
+        ]
+      },
+      {
+        "name": "Standing Calf Raise",
+        "short_name": "Calves",
+        "body_part": "Calves",
+        "weight_kg": 50,
+        "sets": 4,
+        "reps": 15,
+        "dose_label": "50 kg · 4×15",
+        "action_label": "Lift",
+        "schedule": {
+          "type": "weekly",
+          "on_days": ["Wed"]
+        },
+        "cycles": [
+          {
+            "type": "on",
+            "status": "active",
+            "cycle_number": 1,
+            "start": "__OFFSET_DAYS:-28__",
+            "start_date": "__OFFSET_DAYS:-28__"
+          }
+        ],
+        "doses": [
+          { "scheduledDate": "__OFFSET_DAYS:-23__", "takenAt": "__OFFSET_DAYS:-23__T07:46:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-16__", "takenAt": "__OFFSET_DAYS:-16__T07:51:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-9__",  "takenAt": "__OFFSET_DAYS:-9__T07:53:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-2__",  "takenAt": "__OFFSET_DAYS:-2__T07:47:00" }
+        ]
+      },
+      {
+        "name": "Overhead Press",
+        "short_name": "OHP",
+        "body_part": "Shoulders",
+        "weight_kg": 45,
+        "sets": 4,
+        "reps": 6,
+        "dose_label": "45 kg · 4×6",
+        "action_label": "Lift",
+        "schedule": {
+          "type": "weekly",
+          "on_days": ["Fri"]
+        },
+        "cycles": [
+          {
+            "type": "on",
+            "status": "active",
+            "cycle_number": 1,
+            "start": "__OFFSET_DAYS:-28__",
+            "start_date": "__OFFSET_DAYS:-28__"
+          }
+        ],
+        "doses": [
+          { "scheduledDate": "__OFFSET_DAYS:-21__", "takenAt": "__OFFSET_DAYS:-21__T07:10:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-14__", "takenAt": "__OFFSET_DAYS:-14__T07:14:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-7__",  "takenAt": "__OFFSET_DAYS:-7__T07:08:00" }
+        ]
+      },
+      {
+        "name": "Seated Cable Row",
+        "short_name": "Row",
+        "body_part": "Back",
+        "weight_kg": 65,
+        "sets": 4,
+        "reps": 10,
+        "dose_label": "65 kg · 4×10",
+        "action_label": "Lift",
+        "schedule": {
+          "type": "weekly",
+          "on_days": ["Fri"]
+        },
+        "cycles": [
+          {
+            "type": "on",
+            "status": "active",
+            "cycle_number": 1,
+            "start": "__OFFSET_DAYS:-28__",
+            "start_date": "__OFFSET_DAYS:-28__"
+          }
+        ],
+        "doses": [
+          { "scheduledDate": "__OFFSET_DAYS:-21__", "takenAt": "__OFFSET_DAYS:-21__T07:26:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-14__", "takenAt": "__OFFSET_DAYS:-14__T07:30:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-7__",  "takenAt": "__OFFSET_DAYS:-7__T07:24:00" }
+        ]
+      },
+      {
+        "name": "Tricep Pushdown",
+        "short_name": "Pushdown",
+        "body_part": "Arms",
+        "weight_kg": 32,
+        "sets": 3,
+        "reps": 12,
+        "dose_label": "32 kg · 3×12",
+        "action_label": "Lift",
+        "schedule": {
+          "type": "weekly",
+          "on_days": ["Fri"]
+        },
+        "cycles": [
+          {
+            "type": "on",
+            "status": "active",
+            "cycle_number": 1,
+            "start": "__OFFSET_DAYS:-28__",
+            "start_date": "__OFFSET_DAYS:-28__"
+          }
+        ],
+        "doses": [
+          { "scheduledDate": "__OFFSET_DAYS:-21__", "takenAt": "__OFFSET_DAYS:-21__T07:42:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-14__", "takenAt": "__OFFSET_DAYS:-14__T07:46:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-7__",  "takenAt": "__OFFSET_DAYS:-7__T07:40:00" }
+        ]
+      },
+      {
+        "name": "Dumbbell Fly",
+        "short_name": "DB Fly",
+        "body_part": "Chest",
+        "weight_kg": 16,
+        "sets": 3,
+        "reps": 12,
+        "dose_label": "16 kg · 3×12",
+        "action_label": "Lift",
+        "schedule": {
+          "type": "weekly",
+          "on_days": ["Fri"]
+        },
+        "cycles": [
+          {
+            "type": "on",
+            "status": "active",
+            "cycle_number": 1,
+            "start": "__OFFSET_DAYS:-28__",
+            "start_date": "__OFFSET_DAYS:-28__"
+          }
+        ],
+        "doses": [
+          { "scheduledDate": "__OFFSET_DAYS:-21__", "takenAt": "__OFFSET_DAYS:-21__T07:55:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-14__", "takenAt": "__OFFSET_DAYS:-14__T07:59:00" },
+          { "scheduledDate": "__OFFSET_DAYS:-7__",  "takenAt": "__OFFSET_DAYS:-7__T07:54:00" }
+        ]
+      }
+    ]
+  }
+}

--- a/public/js/components/eh-schedule-card.js
+++ b/public/js/components/eh-schedule-card.js
@@ -290,7 +290,11 @@ export class EhScheduleCard extends EhBaseCard {
 
   _statusChip(item) {
     const status = isScheduledOnDate(item, this.date);
-    if (status === 'scheduled') return { cls: 'inject', text: item.route === 'intranasal' ? 'Spray' : 'Inject' };
+    if (status === 'scheduled') {
+      const text = item.action_label
+        || (item.route === 'intranasal' ? 'Spray' : 'Inject');
+      return { cls: 'inject', text };
+    }
     if (status === 'rest') return { cls: 'rest', text: 'Rest day' };
     if (status === 'off') return { cls: 'off', text: 'Off cycle' };
     return null; // outside all cycles — don't show


### PR DESCRIPTION
## Summary

- Sleep fixture on `demo.klebb.app` becomes a self-referencing
  `combination-card` with `layout: rings`: four concentric arcs for
  Total / Deep / REM / Light against per-stage daily goals (8 / 1.5
  / 1.8 / 4.5 hours), each with its own colour. History rows
  backfilled with a `light` field.
- New `demo/fixtures/strength-training.json` schedule-card fixture:
  ten lifts on a Mon / Wed / Fri split (3 / 3 / 4), each carrying
  `weight_kg`, `sets`, `reps`, `body_part`, plus a precomputed
  `dose_label` for the existing schedule-card subtitle. Cycle and
  `doses[]` backfilled for the past four weeks.
- `eh-schedule-card` status chip now honours an optional
  `item.action_label` so the new card's chip reads "Lift" instead of
  "Inject"; existing Inject / Spray default unchanged.
- `CHANGELOG.md` Unreleased entry.

Fixes #292.

## Why

Two of the more interesting renderer shapes (rings + non-medication
schedule card) weren't represented on the public demo. Visitors now
see them on first load.

## How

- `demo/fixtures/sleep-hours.json` switched renderer; data rows
  gained a `light` field. No new ingest path, no schema change.
- `demo/fixtures/strength-training.json` (new) follows the existing
  injection-protocol shape exactly — `meta.writeable.fromWebapp`
  enabled, schedule-timeline / adherence-report / day-marker hooks
  wired the same as Injections.
- `public/js/components/eh-schedule-card.js` `_statusChip()` reads
  `item.action_label` first, then falls back through the existing
  Inject / Spray logic.

## Testing

- [x] `npm test` — 1012/1013 (one failure on `no-personal-refs`
      pre-exists on `main`; not introduced here).
- [x] JSON validity check on both fixtures with placeholders
      resolved.
- [x] Manual review of fixture against `MANIFEST-SCHEMA.md`
      "Combination cards" + "schedule" sections.
- [ ] Visual confirmation will land on `demo.klebb.app` after the
      deploy-demo workflow runs post-merge.

## Out of scope

- No new renderer.
- No server changes.
- No schema bump.