### PR TITLE
fix(ui): rename login/setup page titles from vorHealth to Klebb

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -7,7 +7,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>vorHealth - Login</title>
+  <title>Klebb - Login</title>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {

--- a/public/setup.html
+++ b/public/setup.html
@@ -7,7 +7,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>vorHealth - Setup</title>
+  <title>Klebb - Setup</title>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {


### PR DESCRIPTION
## Summary

Update the `<title>` tags on `public/login.html` and `public/setup.html` from `vorHealth - Login` / `vorHealth - Setup` to `Klebb - Login` / `Klebb - Setup`.

## Why

Link-preview crawlers (Signal, iMessage, Slack, etc.) read the `<title>` tag. Sharing https://demo.klebb.app/ surfaced the old name in chat previews.

## How

Two-line change; no logic touched.

## Testing

- [x] `npm test` (unchanged behaviour, pure string change)
- [x] Visual: `<title>` updated on the login page

Doc/string-only change so no new test added.

Fixes #299