### PR TITLE
feat(chat): env-gated forensic logs in agent loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Forensic logging on the chat agent loop.** Setting `HEALTH_DEBUG=1`
+  now emits structured `[chat:<reqId>]` lines on `/api/chat` covering
+  request entry, each agent-loop iteration with gateway latency, each
+  tool dispatch with manifest id and duration, and the final outcome.
+  Off by default; structural facts only (no prompt or reply bodies are
+  logged). Closes the blind spot where a client-side timeout left the
+  journal silent. Fixes #303.
 - **Vocab support on schedule-timeline + adherence-report.** Both
   renderers now read an optional `vocab` block from their view config
   (`trends.vocab` and `reports.vocab` respectively) so a fixture can

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -380,6 +380,14 @@ Mismatch between browser origin and server RP_ID is the #1 cause.
 **Chat widget shows "Chat is not configured."**
 `CHAT_ENDPOINT_URL` or `CHAT_API_KEY` is unset. Set both in the env file and restart.
 
+**Chat times out and the journal is silent.**
+Set `HEALTH_DEBUG=1` and restart. The `/api/chat` path then emits
+structured `[chat:<reqId>]` lines for request entry, each agent-loop
+iteration (with gateway latency), each tool dispatch (with manifest id
+and duration), and the final outcome — visible in `journalctl -u
+klebb@<instance>` or `docker compose logs klebb`. Structural facts
+only; no prompt or reply bodies are logged.
+
 **Voice doesn't work.**
 See [`docs/VOICE.md`](VOICE.md) for Fish Audio configuration and the
 full troubleshooting list.

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const http = require('http');
 const https = require('https');
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 const { marked } = require('marked');
 const { isAuthenticated, isAgentRequest, isPublicPath, handleAuthRoutes, isSetup } = require('./auth/webauthn');
 const PATHS = require('./config/paths');
@@ -34,6 +35,15 @@ const inbox = require('./ingest/pipeline');
 const CHAT_ENDPOINT_URL = ENV.CHAT_ENDPOINT_URL;
 const CHAT_API_KEY = ENV.CHAT_API_KEY;
 const CHAT_MODEL = ENV.CHAT_MODEL;
+const DEBUG_LOG = ENV.DEBUG_LOG;
+
+// Forensic logging for the chat agent loop. Off by default; flip on with
+// HEALTH_DEBUG=1. Emits structural facts only (durations, counts, tool
+// names, manifest ids) so a journal grep can reconstruct a stuck turn
+// without exposing prompt or reply bodies.
+function chatLog(reqId, ...parts) {
+  if (DEBUG_LOG) console.log(`[chat:${reqId}]`, ...parts);
+}
 const CHAT_ENDPOINT = CHAT_ENDPOINT_URL ? (() => {
   const u = new URL(CHAT_ENDPOINT_URL);
   return {
@@ -290,16 +300,20 @@ function callGateway({ messages, tools }) {
 //   3. otherwise, return the assistant's text as the final reply.
 // Caps at MAX_ITERS to keep a misbehaving model from looping forever; if we
 // hit the cap we return the last text we saw (or a fallback).
-async function runAgentLoop({ systemPrompt, userMessages }) {
+async function runAgentLoop({ systemPrompt, userMessages, reqId = '-' }) {
   const MAX_ITERS = 5;
   const messages = [{ role: 'system', content: systemPrompt }, ...userMessages];
   const ctx = { touches: [] };
   let lastAssistantText = '';
   for (let i = 0; i < MAX_ITERS; i++) {
+    const gwStart = Date.now();
     const gw = await callGateway({ messages, tools: TOOL_DEFS });
+    const gwMs = Date.now() - gwStart;
     const choice = gw.choices?.[0];
     const msg = choice?.message || {};
     const finish = choice?.finish_reason;
+    const toolCount = Array.isArray(msg.tool_calls) ? msg.tool_calls.length : 0;
+    chatLog(reqId, `iter=${i} gw=${gwMs}ms finish=${finish || '-'} tools=${toolCount}`);
 
     if (typeof msg.content === 'string' && msg.content.trim()) {
       lastAssistantText = msg.content;
@@ -314,23 +328,35 @@ async function runAgentLoop({ systemPrompt, userMessages }) {
         tool_calls: msg.tool_calls,
       });
       for (const tc of msg.tool_calls) {
+        const name = tc.function?.name || '-';
+        let manifestId = '-';
+        try {
+          const args = JSON.parse(tc.function?.arguments || '{}');
+          manifestId = args.id || args.manifest?.meta?.id || '-';
+        } catch {}
+        const tStart = Date.now();
+        const result = dispatchToolCall(tc, ctx);
+        const tMs = Date.now() - tStart;
+        const ok = !/"error"\s*:/.test(result);
+        chatLog(reqId, `tool ${name} id=${manifestId} took=${tMs}ms ${ok ? 'ok' : 'err'}`);
         messages.push({
           role: 'tool',
           tool_call_id: tc.id,
-          name: tc.function?.name,
-          content: dispatchToolCall(tc, ctx),
+          name,
+          content: result,
         });
       }
       continue;
     }
 
-    return { finalText: msg.content || lastAssistantText || '', cappedOut: false, ctx };
+    return { finalText: msg.content || lastAssistantText || '', cappedOut: false, ctx, iters: i + 1 };
   }
   return {
     finalText: lastAssistantText ||
       "I wasn't able to finish that in one turn — please re-ask or be more specific.",
     cappedOut: true,
     ctx,
+    iters: MAX_ITERS,
   };
 }
 
@@ -1509,9 +1535,14 @@ Original system prompt follows:
             return sendJSON(res, { error: 'Chat endpoint not configured' }, 503);
           }
 
-          runAgentLoop({ systemPrompt, userMessages: messages })
-            .then(({ finalText, ctx }) => {
+          const reqId = crypto.randomBytes(3).toString('hex');
+          const turnStart = Date.now();
+          chatLog(reqId, `start turns=${messages.length} voice=${!!voiceMode}`);
+
+          runAgentLoop({ systemPrompt, userMessages: messages, reqId })
+            .then(({ finalText, ctx, cappedOut, iters }) => {
               const followup = buildFollowup(ctx);
+              chatLog(reqId, `done total=${Date.now() - turnStart}ms iters=${iters} capped=${!!cappedOut}`);
               if (voiceMode) {
                 const parsedReply = extractJsonReply(finalText);
                 if (parsedReply && (parsedReply.speak || parsedReply.display)) {
@@ -1526,6 +1557,7 @@ Original system prompt follows:
             })
             .catch((e) => {
               const msg = e.message || String(e);
+              chatLog(reqId, `err total=${Date.now() - turnStart}ms ${msg.split(':')[0]}`);
               if (msg.startsWith('gateway_timeout')) {
                 console.error('Chat gateway timeout');
                 if (!res.headersSent) sendJSON(res, { error: 'Request timed out' }, 504);

--- a/tests/chat-debug-logs.test.js
+++ b/tests/chat-debug-logs.test.js
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/chat-debug-logs.test.js
+// Coverage for env-gated forensic logging on the chat agent loop (#303).
+// With HEALTH_DEBUG=1 the /api/chat path emits structured [chat:<reqId>]
+// lines: start, per-iter gateway timing, per-tool dispatch, and done.
+// With HEALTH_DEBUG unset, no [chat: lines appear (existing error-only
+// behaviour is preserved).
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('http');
+const { createSandbox, cleanupSandbox, spawnServer, req } = require('./helpers/sandbox');
+
+function startStubGateway() {
+  const responseQueue = [];
+  const server = http.createServer((request, response) => {
+    let body = '';
+    request.on('data', c => { body += c; });
+    request.on('end', () => {
+      const next = responseQueue.shift();
+      if (!next) {
+        response.writeHead(500, { 'Content-Type': 'application/json' });
+        response.end(JSON.stringify({ error: 'stub queue exhausted' }));
+        return;
+      }
+      response.writeHead(200, { 'Content-Type': 'application/json' });
+      response.end(JSON.stringify(next));
+    });
+  });
+  return new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => {
+      const port = server.address().port;
+      resolve({
+        port,
+        close: () => new Promise(r => server.close(r)),
+        pushResponses: (rs) => rs.forEach(r => responseQueue.push(r)),
+      });
+    });
+  });
+}
+
+function toolCallResponse({ name, args, id = 'call_1' }) {
+  return {
+    choices: [{
+      finish_reason: 'tool_calls',
+      message: {
+        role: 'assistant',
+        content: '',
+        tool_calls: [{
+          id,
+          type: 'function',
+          function: { name, arguments: JSON.stringify(args) },
+        }],
+      },
+    }],
+  };
+}
+
+function stopResponse(content) {
+  return {
+    choices: [{ finish_reason: 'stop', message: { role: 'assistant', content } }],
+  };
+}
+
+// Capture both stdout and stderr from a spawned server. Returns a getter
+// that resolves the buffered text, plus a clear() to reset between tests.
+function captureOutput(proc) {
+  let stdout = '';
+  let stderr = '';
+  proc.stdout.on('data', c => { stdout += c.toString(); });
+  proc.stderr.on('data', c => { stderr += c.toString(); });
+  return {
+    stdout: () => stdout,
+    stderr: () => stderr,
+    clear: () => { stdout = ''; stderr = ''; },
+    // Wait briefly for any in-flight log writes to flush before reading.
+    settle: () => new Promise(r => setTimeout(r, 50)),
+  };
+}
+
+describe('chat agent-loop debug logging (HEALTH_DEBUG=1)', () => {
+  let sandbox, server, gateway, capture;
+
+  before(async () => {
+    gateway = await startStubGateway();
+    sandbox = createSandbox();
+    server = await spawnServer(sandbox, {
+      CHAT_ENDPOINT_URL: `http://127.0.0.1:${gateway.port}/v1/chat/completions`,
+      CHAT_API_KEY: 'stub-token',
+      CHAT_MODEL: 'stub-model',
+      HEALTH_DEBUG: '1',
+    });
+    capture = captureOutput(server.proc);
+    capture.clear();
+  });
+  after(async () => {
+    if (server) await server.kill();
+    if (gateway) await gateway.close();
+    cleanupSandbox(sandbox);
+  });
+
+  test('emits start / iter / tool / done lines for a tool-using turn', async () => {
+    const manifest = {
+      $schema: 'klebb.datafile.v1',
+      meta: { id: 'log-test-a', label: 'Log Test A' },
+      data: [],
+    };
+    gateway.pushResponses([
+      toolCallResponse({ name: 'create_manifest', args: { manifest }, id: 'call_log_a' }),
+      stopResponse('Done.'),
+    ]);
+
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'Create Log Test A.' }] },
+    });
+    assert.equal(res.status, 200);
+    await capture.settle();
+
+    const out = capture.stdout();
+    const startMatch = out.match(/\[chat:([0-9a-f]+)\] start turns=1 voice=false/);
+    assert.ok(startMatch, `expected [chat:<id>] start line; got:\n${out}`);
+    const reqId = startMatch[1];
+
+    const iter0 = new RegExp(`\\[chat:${reqId}\\] iter=0 gw=\\d+ms finish=tool_calls tools=1`);
+    assert.match(out, iter0, 'expected iter=0 line with finish=tool_calls tools=1');
+
+    const tool = new RegExp(`\\[chat:${reqId}\\] tool create_manifest id=log-test-a took=\\d+ms ok`);
+    assert.match(out, tool, 'expected tool dispatch line with manifest id and ok');
+
+    const iter1 = new RegExp(`\\[chat:${reqId}\\] iter=1 gw=\\d+ms finish=stop tools=0`);
+    assert.match(out, iter1, 'expected iter=1 line with finish=stop');
+
+    const done = new RegExp(`\\[chat:${reqId}\\] done total=\\d+ms iters=2 capped=false`);
+    assert.match(out, done, 'expected done line with iters=2 capped=false');
+  });
+
+  test('does not log message bodies, prompts, or tool args', async () => {
+    capture.clear();
+    const secret = 'SECRET_PROMPT_TOKEN_X9Q';
+    const manifest = {
+      $schema: 'klebb.datafile.v1',
+      meta: { id: 'log-test-b', label: 'Log Test B' },
+      data: [{ note: secret }],
+    };
+    gateway.pushResponses([
+      toolCallResponse({ name: 'create_manifest', args: { manifest }, id: 'call_log_b' }),
+      stopResponse('Done with ' + secret),
+    ]);
+
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: secret + ' please' }] },
+    });
+    assert.equal(res.status, 200);
+    await capture.settle();
+
+    const both = capture.stdout() + capture.stderr();
+    assert.ok(!both.includes(secret),
+      `log output must not contain prompt/reply bodies; found ${secret} in:\n${both}`);
+  });
+});
+
+describe('chat agent-loop debug logging (HEALTH_DEBUG unset)', () => {
+  let sandbox, server, gateway, capture;
+
+  before(async () => {
+    gateway = await startStubGateway();
+    sandbox = createSandbox();
+    server = await spawnServer(sandbox, {
+      CHAT_ENDPOINT_URL: `http://127.0.0.1:${gateway.port}/v1/chat/completions`,
+      CHAT_API_KEY: 'stub-token',
+      CHAT_MODEL: 'stub-model',
+      // HEALTH_DEBUG deliberately omitted
+    });
+    capture = captureOutput(server.proc);
+    capture.clear();
+  });
+  after(async () => {
+    if (server) await server.kill();
+    if (gateway) await gateway.close();
+    cleanupSandbox(sandbox);
+  });
+
+  test('emits no [chat: lines on success path', async () => {
+    gateway.pushResponses([stopResponse('Hello.')]);
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'Hi.' }] },
+    });
+    assert.equal(res.status, 200);
+    await capture.settle();
+
+    const both = capture.stdout() + capture.stderr();
+    assert.ok(!/\[chat:/.test(both),
+      `expected no [chat: lines without HEALTH_DEBUG; got:\n${both}`);
+  });
+});


### PR DESCRIPTION
# What changed

The `/api/chat` agent loop is silent on the success path: today only three terminal-failure `console.error` lines exist (`server.js:1530`, `1535`, `1539`). With this change, `HEALTH_DEBUG=1` switches the chat path on for structured `[chat:<reqId>]` logging covering request entry, each agent-loop iteration with gateway latency, each tool dispatch with manifest id and duration, and the final outcome.

# Why

Fixes #303.

The client aborts at 120s (`public/js/components/health-chat.js:920`); the server aborts the upstream at 180s (`server.js:277`). When a turn shows "Request timed out" in the bubble, the server may still be mid-loop and never hit *its* timeout, so `journalctl -u klebb@<instance>` can be completely silent for the failed turn. After this change, that turn produces a clean timeline that distinguishes gateway slowness from a stuck tool dispatch from a `MAX_ITERS` cap.

# How

Single-file change in `server.js` (plus test + docs + changelog):

- Reuses the existing `HEALTH_DEBUG=1` env flag (`config/env.js:128`); no new env var.
- One local helper `chatLog(reqId, ...)` gated on `DEBUG_LOG` keeps the prefix consistent.
- `runAgentLoop` takes an optional `reqId`, logs per-iteration `iter=N gw=Xms finish=... tools=N`, and per-tool `tool <name> id=<manifestId> took=Xms ok|err`. Manifest id is parsed best-effort from the tool args.
- `/api/chat` handler generates a 3-byte hex request id, logs `start turns=N voice=bool`, passes it into the loop, and logs a `done` or `err` line with total ms.
- Structural facts only: durations, counts, tool names, manifest ids. No prompt, no reply, no tool args, no tool results are ever logged.

When `HEALTH_DEBUG` is unset, behaviour is unchanged: only the three existing `console.error` lines fire.

# Testing

- [x] `npm test` passes locally (1015/1016): the one failure is a pre-existing `no-personal-refs.test.js` flag against files outside the public surface, unrelated to this PR and present on `main`.
- [x] New `tests/chat-debug-logs.test.js`: 3 cases asserting (a) the on-path log shape with the flag set, (b) no body leakage when prompts/replies contain a sentinel, (c) zero `[chat:` lines on the success path with the flag unset.
- [x] Confirmed the new test fails on `main` before the implementation lands.
- [ ] Manual QA on a real instance: set `HEALTH_DEBUG=1`, restart, send a tool-using prompt, then grep the journal for `[chat:`. Pending.

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [x] Docs updated (`docs/DEPLOY.md` Troubleshooting section)
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens

# Breaking changes

None. Behaviour is gated entirely on `HEALTH_DEBUG=1`; existing instances see no change unless they opt in.
