### PR TITLE
feat(chat): add 4 starter prompts + voice on starter-prompt send

### DIFF
--- a/prompts/bp-home-monitoring.md
+++ b/prompts/bp-home-monitoring.md
@@ -1,0 +1,38 @@
+---
+title: Home blood-pressure monitoring
+summary: Twice-daily BP and heart-rate logging with a rolling weekly average and an optional antihypertensive checklist.
+tags: [blood-pressure, cardiovascular, monitoring, daily]
+---
+
+Please set up a dashboard for monitoring blood pressure at home.
+Propose the manifests first and confirm with me before creating.
+
+1. **Blood pressure card** — twice-daily entry (morning and evening)
+   capturing:
+   - Systolic (mmHg)
+   - Diastolic (mmHg)
+   - Heart rate (bpm)
+   - Which arm (left / right)
+   - Which session (morning / evening)
+   - Optional notes (e.g. "post-coffee", "after walk")
+
+   Use whichever renderer best supports two readings per day. If the
+   shape doesn't fit cleanly, fall back to one entry per reading and
+   tag the session.
+
+2. **Weekly average trend** — derived chart showing the 7-day rolling
+   average of systolic and diastolic side by side. This is the number
+   that actually matters; single readings are noisy.
+
+3. **Antihypertensive checklist (optional)** — only create this if
+   I tell you I'm on BP medication. Ask me first. If yes, ask which
+   meds, dose, and frequency, and build it as a daily checklist-card.
+
+Before creating anything, ask me:
+- Whether I'm on any antihypertensive medication
+- My target BP range if my GP has given me one (so we can later add
+  a threshold marker; not required for the initial build)
+- Preferred units; default to mmHg
+
+Don't add a "salt intake" card or any lifestyle sidekick. Keep this
+to the measurement loop.

--- a/prompts/cycle-tracking.md
+++ b/prompts/cycle-tracking.md
@@ -1,0 +1,41 @@
+---
+title: Menstrual cycle and fertility tracking
+summary: Period log, daily symptom tracking, and optional BBT and ovulation-test cards for cycle awareness or fertility planning.
+tags: [cycle, menstrual, fertility, women-health]
+---
+
+I'd like a dashboard for tracking my menstrual cycle. Two core
+cards, with two optional ones depending on how much detail I want.
+Propose all manifests before creating; confirm with me.
+
+1. **Period card** — daily log during a period only (skip days where
+   there's no flow). Capture:
+   - Flow rating (none, spotting, light, medium, heavy)
+   - Optional notes (clots, cramping severity, anything notable)
+
+   The card should make it visually obvious when a period started
+   and ended (calendar marker per day with flow makes sense).
+
+2. **Daily symptoms card** — daily entry across the whole cycle, not
+   just during a period. Capture:
+   - Cramps (1-5 or none)
+   - Mood (1-5)
+   - Breast tenderness (yes / no)
+   - Optional freeform notes
+
+3. **Basal body temperature (optional)** — only create if I say I'm
+   tracking BBT. Ask me first. Daily morning temperature, line-chart
+   trend, with units I specify (C or F).
+
+4. **Ovulation test log (optional)** — only create if I say I'm
+   using ovulation tests. Ask me first. Per-test entry with line
+   intensity (negative, faint, positive, peak) and the cycle day.
+
+Before creating, ask me:
+- Whether I want BBT tracking
+- Whether I want ovulation-test logging
+- Typical cycle length if I know it (informational; doesn't change
+  the cards, but helps if you suggest anything later)
+
+Don't create a "fertility window predictor" or any derived
+prediction card. The data goes in; conclusions are mine to draw.

--- a/prompts/fodmap-elimination.md
+++ b/prompts/fodmap-elimination.md
@@ -1,0 +1,46 @@
+---
+title: FODMAP elimination and reintroduction
+summary: Time-boxed gut-health protocol with a daily food log, daily symptom rating, and a reintroduction-challenge log.
+tags: [gut, fodmap, elimination, diet, protocol]
+---
+
+I'm starting a low-FODMAP elimination phase and need a dashboard for
+the protocol. This is time-boxed: typical elimination lasts 2-6
+weeks, then a structured reintroduction phase tests one food group
+at a time. Three cards, all created up front so I can use them
+through both phases. Propose manifests first; confirm before creating.
+
+1. **Daily food log** — one entry per day, freeform textarea. I'll
+   note what I ate at each meal (breakfast / lunch / dinner / snacks)
+   in plain prose. Use a generic-card with a textarea; don't try to
+   structure meals into separate fields.
+
+2. **Daily symptom rating** — daily entry capturing:
+   - Bloating (1-5)
+   - Abdominal pain (1-5)
+   - Stool quality (Bristol stool scale 1-7, or a simpler
+     normal/loose/hard scale if Bristol feels too clinical: ask me
+     which I want)
+   - Optional notes (e.g. "after lunch", "woke up uncomfortable")
+
+3. **Reintroduction challenge log** — entry per challenge, not
+   daily. Capture:
+   - Food being challenged (e.g. onion, wheat, lactose)
+   - Dose (small / medium / large, or specific quantity)
+   - Day of challenge (1, 2, or 3)
+   - Symptom score (1-5) for that day
+   - Verdict so far (tolerated / borderline / reaction)
+
+   Most reintroductions run a 3-day challenge per food, so design
+   the card to handle multiple entries per challenge.
+
+Before creating, ask me:
+- My elimination start date
+- Planned elimination duration (default to 4 weeks if I'm unsure)
+- Whether I want Bristol stool scale or a simpler scale on the
+  symptom card
+
+Don't add a "weight" card or any sidekick that isn't part of the
+protocol. After creating, remind me that the elimination cards stay
+useful through reintroduction; only the challenge card is new in
+the second phase.

--- a/prompts/migraine-log.md
+++ b/prompts/migraine-log.md
@@ -1,0 +1,38 @@
+---
+title: Migraine and headache log
+summary: Episode tracker for migraines and headaches with severity, duration, triggers, and abortive medication taken.
+tags: [migraine, headache, episodic, neurology]
+---
+
+I'd like to set up a dashboard for tracking migraine and headache
+episodes. Two cards, with a third optional one. Ask me follow-ups
+before creating; propose the manifests first and let me confirm.
+
+1. **Episode card** — one entry per headache episode (not daily; some
+   days will have none, some will have more than one). Capture:
+   - Severity 1-10
+   - Duration (in hours, or "ongoing" if not yet resolved)
+   - Location (left, right, bilateral, behind-eye, occipital, other)
+   - Trigger checklist (sleep, food, stress, screens, weather,
+     hormonal, dehydration, alcohol, other). Multi-select.
+   - Abortive medication taken (free-text; I'll write what I took)
+   - Optional notes
+
+   Use whichever renderer fits best for an entry-per-event log; this
+   is not a daily ratings card.
+
+2. **Monthly frequency trend** — derived view that counts episodes
+   per month so I can see whether things are getting better or worse.
+   Line-chart or bar-chart, your call.
+
+3. **Preventative medication checklist (optional)** — only create if
+   I tell you I'm on a daily preventative. Ask me first whether I
+   want this card and what meds are on it.
+
+For the abortives field, ask me whether I'd rather have a fixed
+checklist of meds I commonly take, or keep it free-text. Default to
+free-text if I'm unsure: it's more flexible for early tracking.
+
+Don't create extra cards beyond these. No "wellness score", no
+"hydration tracker", no sidekick mood card. The point is episode
+discipline, not a kitchen sink.

--- a/public/js/components/health-chat.js
+++ b/public/js/components/health-chat.js
@@ -597,6 +597,9 @@ class HealthChat extends LitElement {
     this._expanded = localStorage.getItem('klebb-chat-expanded') === '1';
     this._saveTimer = null;
     this._starterChips = null;
+    // One-shot voice arming: set when a starter prompt is pasted in,
+    // consumed (and disarmed) by the next _sendText.
+    this._voiceArmed = false;
     this._checkVoiceAvailability();
     this._checkChatConfigured();
     this._loadInstance();
@@ -709,6 +712,7 @@ class HealthChat extends LitElement {
     this._audioCache.clear();
     this._messages = [];
     this._playingMsgId = null;
+    this._voiceArmed = false;
     if (this._saveTimer) { clearTimeout(this._saveTimer); this._saveTimer = null; }
     try {
       await fetch('/api/chat/history', { method: 'DELETE', cache: 'no-store' });
@@ -844,6 +848,7 @@ class HealthChat extends LitElement {
       // prior conversation into them bleeds stale context into the reply.
       this._clearHistory();
       this._input = text;
+      this._voiceArmed = true;
       if (!this._open) this._toggle();
       this.updateComplete.then(() => {
         const input = this.shadowRoot?.querySelector('.chat-input');
@@ -913,18 +918,33 @@ class HealthChat extends LitElement {
     this._loading = true;
     this._scrollToBottom();
     const chatMessages = this._messages.filter(m => m.role !== 'error');
+    // Consume the one-shot voice arming. A starter prompt paste sets
+    // _voiceArmed; the next send routes through voice mode if Fish
+    // Audio is configured. Disarm immediately so a follow-up send is
+    // text-only.
+    const useVoice = this._voiceArmed && this._voiceAvailable;
+    this._voiceArmed = false;
+    if (useVoice) primeSharedAudio();
     try {
       // Single request, generous timeout. Earlier two-phase retry was meant
       // for stale TCP sockets after visibility-change; in practice it caused
       // confusing "Gateway unavailable" errors on slow (tool-using) replies.
-      const data = await this._fetchChat(chatMessages, false, 120000);
+      const data = await this._fetchChat(chatMessages, useVoice, 120000);
       if (data.error) this._pushError(data.error);
       else {
         const extra = data.followup ? {
           followupText: data.followup.text,
           embellishments: Array.isArray(data.followup.embellishments) ? data.followup.embellishments : [],
         } : {};
-        this._addMsg('assistant', data.reply, extra);
+        if (useVoice) {
+          const speakText = data.speak || data.reply;
+          const displayText = data.reply || data.display || data.speak || '';
+          const msgId = this._addMsg('assistant', displayText, { ...extra, speakText });
+          this._scrollToBottom();
+          await this._generateAndAutoplay(msgId, speakText);
+        } else {
+          this._addMsg('assistant', data.reply, extra);
+        }
       }
     } catch (e) {
       this._pushError(e.name === 'AbortError' ? 'Request timed out' : 'Failed to connect');


### PR DESCRIPTION
## Summary

- Adds four new starter prompts to `prompts/`: `migraine-log`, `bp-home-monitoring`, `cycle-tracking`, `fodmap-elimination`. The gallery, `/api/prompts`, and the welcome card discover them automatically (no server changes).
- Adds one-shot voice arming in `health-chat.js`: when a starter prompt is pasted via `klebb-paste-into-chat`, the very next `_sendText` routes through voice mode if Fish Audio is configured, then disarms.

## Why

The existing 7 prompts skewed toward weight-loss, supplements, and general training. Episodic conditions (migraine), cardiovascular monitoring (BP), women's health (cycle), and gut protocols (FODMAP) had no coverage.

For voice: `_handleRecordedBlob` already speaks responses when the user taps the mic, but the gallery's "Load into chat" path went through `_sendText` which always sent `voiceMode: false`. So even with Fish Audio configured, starter prompts produced text-only replies.

## How

- **Prompts**: each follows `CONTRIBUTING-PROMPTS.md` (frontmatter + agent-directed body, asks user follow-ups, requires confirmation before creating). No brand names, no dosing recommendations.
- **Voice arming**: a `_voiceArmed` instance flag, set to `true` in `_onPasteIntoChat`, consumed and immediately cleared in `_sendText`. If `_voiceAvailable && _voiceArmed` is true, the send goes out with `voiceMode: true`, the response's `speak` field is captured into `speakText`, and `_generateAndAutoplay` is called (mirroring the mic flow). Otherwise the existing text path runs unchanged. Cleared in `_clearHistory` for safety.

## Edge cases

- Voice not configured: send is plain text, no banner, no notice.
- User edits or deletes the pasted text before sending: voice still plays once. Acceptable; we'd rather over-trigger than thread "did the user keep the paste?" detection through the input.
- Follow-up sends after the first one: text-only unless the user taps the mic.

## Testing

- [x] `npm test` — all relevant tests pass. The only failing test (`tests/no-personal-refs.test.js`) fails identically on `main` (pre-existing, hits in gitignored files).
- [x] Manual verification of the gallery showing the four new prompts with correct title, summary, tags.
- [ ] Manual verification of voice playback against a `data/` with Fish Audio + chat gateway env vars set: load a starter prompt, send, expect audio to auto-play once; follow-up send is text-only.
- [ ] Manual verification with Fish Audio disabled: starter prompt sends as text, no errors.

Closes #258
Closes #310