### PR TITLE
Render decimal hours as H:MM on combination + generic cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Hours-as-time display hint.** New optional `format: "hm"` field on
+  `meta.view.combines[]` entries renders the legend value and goal as
+  `H:MM` instead of decimal hours (e.g. `8.17` → `8:10`, `8` → `8:00`).
+  A matching `{key:hm}` modifier in the display-template engine lets
+  atomic generic-cards (e.g. `sleep-hours`) use the same conversion.
+  The on-disk shape is unchanged — manifests still store decimal
+  hours. Fixes #312.
 - **Forensic logging on the chat agent loop.** Setting `HEALTH_DEBUG=1`
   now emits structured `[chat:<reqId>]` lines on `/api/chat` covering
   request entry, each agent-loop iteration with gateway latency, each

--- a/MANIFEST-SCHEMA.md
+++ b/MANIFEST-SCHEMA.md
@@ -218,6 +218,7 @@ Template syntax:
 - `{key:emoji}` → look up in `emojiMap[key]`
 - `{key:check}` → render `✅` when truthy, empty string when falsy/missing
 - `{key:truncate(N)}` → cap a string at N chars, append `…` when cut
+- `{key:hm}` → treat as decimal hours, render as `H:MM` (e.g. `8.17` → `8:10`)
 - `{key|default}` → fallback when empty
 - `{key?yes:no}` → ternary on truthiness
 - `{nested.path}` → dotted access
@@ -607,6 +608,7 @@ An ordered array of source entries. Each entry:
 | `goalDaily` | one of `goalDaily`/`goalWeekly` required for `ring-segment` | Positive finite number. Ring fills `min(value / goalDaily, 1)` against the viewed date's row; overshoot paints a "complete" glow. |
 | `goalWeekly` | one of `goalDaily`/`goalWeekly` required for `ring-segment` | Positive finite number. Ring fills `min(weeklySum / goalWeekly, 1)` summing the accessor across all rows in the Mon-Sun week containing the viewed date. If both goals are set, `goalWeekly` wins. |
 | `colour` | no | CSS colour for a `ring-segment`. Falls back to the renderer's theme palette by ring index. |
+| `format` | no | Display hint. Currently supported: `"hm"` — treat the value as decimal hours and render the legend value and goal as `H:MM` (e.g. `8.17` → `8:10`). Unknown values fall through to the default numeric stringification. |
 
 ### Row resolution
 

--- a/demo/fixtures/sleep-hours.json
+++ b/demo/fixtures/sleep-hours.json
@@ -15,7 +15,7 @@
           "role": "ring-segment",
           "label": "Total",
           "accessor": "hours",
-          "unit": "h",
+          "format": "hm",
           "goalDaily": 8,
           "colour": "#7aa2ff"
         },
@@ -24,7 +24,7 @@
           "role": "ring-segment",
           "label": "Deep",
           "accessor": "deep",
-          "unit": "h",
+          "format": "hm",
           "goalDaily": 1.5,
           "colour": "#5b3aa8"
         },
@@ -33,7 +33,7 @@
           "role": "ring-segment",
           "label": "REM",
           "accessor": "rem",
-          "unit": "h",
+          "format": "hm",
           "goalDaily": 1.8,
           "colour": "#d36bd0"
         },
@@ -42,7 +42,7 @@
           "role": "ring-segment",
           "label": "Light",
           "accessor": "light",
-          "unit": "h",
+          "format": "hm",
           "goalDaily": 4.5,
           "colour": "#54c7c7"
         }

--- a/public/js/components/eh-combination-card.js
+++ b/public/js/components/eh-combination-card.js
@@ -15,6 +15,7 @@
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
 import { registerRenderer } from '../renderer-registry.js';
 import { resolveCombines, canEditDonor } from '../lib/combines-resolver.esm.js';
+import { hoursToHM } from '../lib/format-hours.esm.js';
 import { loadECharts, chartTheme } from './eh-chart-base.js';
 import './eh-input-form.js';
 
@@ -389,7 +390,10 @@ export class EhCombinationCard extends LitElement {
     const pct = Math.round(resolved.ratio * 100);
     const valueStr = resolved.displayValue;
     const isWeekly = resolved.period === 'week';
-    const goalStr = String(isWeekly ? resolved.goalWeekly : resolved.goalDaily);
+    const rawGoal = isWeekly ? resolved.goalWeekly : resolved.goalDaily;
+    const goalStr = resolved.format === 'hm'
+      ? (hoursToHM(rawGoal) ?? String(rawGoal))
+      : String(rawGoal);
     const periodSuffix = isWeekly ? ' /wk' : '';
     return html`
       <div class="ring-legend-row ${resolved.complete ? 'complete' : ''}">

--- a/public/js/lib/combines-resolver.esm.js
+++ b/public/js/lib/combines-resolver.esm.js
@@ -5,6 +5,8 @@
 // combines-resolver.js (UMD) — Node tests use the UMD version, browser
 // components use this one.
 
+import { hoursToHM } from './format-hours.esm.js';
+
 export function getByPath(obj, pathStr) {
   if (!obj || !pathStr) return undefined;
   const parts = String(pathStr).split('.');
@@ -28,11 +30,15 @@ export function firstScalarKey(row) {
   return null;
 }
 
-export function stringifyValue(value, emojiMap) {
+export function stringifyValue(value, emojiMap, format) {
   if (value === null || value === undefined) return null;
   if (emojiMap) {
     const key = String(value);
     if (emojiMap[key]) return emojiMap[key];
+  }
+  if (format === 'hm') {
+    const hm = hoursToHM(value);
+    if (hm !== null) return hm;
   }
   if (typeof value === 'number') {
     if (Number.isInteger(value)) return String(value);
@@ -79,6 +85,7 @@ export function resolveEntry(entry, sources, date) {
     unit: entry?.unit || null,
     colour: entry?.colour || null,
     emojiMap: entry?.emojiMap || null,
+    format: entry?.format || null,
   };
 
   const isRingSegment = role === 'ring-segment';
@@ -133,7 +140,7 @@ export function resolveEntry(entry, sources, date) {
       ...base,
       state: 'ok',
       value: sum,
-      displayValue: stringifyValue(sum, base.emojiMap),
+      displayValue: stringifyValue(sum, base.emojiMap, base.format),
       row: null,
       period: 'week',
       goalWeekly: goalWeeklyN,
@@ -161,7 +168,7 @@ export function resolveEntry(entry, sources, date) {
     ...base,
     state: 'ok',
     value,
-    displayValue: stringifyValue(value, base.emojiMap),
+    displayValue: stringifyValue(value, base.emojiMap, base.format),
     row,
   };
 

--- a/public/js/lib/combines-resolver.js
+++ b/public/js/lib/combines-resolver.js
@@ -35,11 +35,13 @@
 
 (function (root, factory) {
   if (typeof module === 'object' && module.exports) {
-    module.exports = factory();
+    module.exports = factory(require('./format-hours.js'));
   } else {
-    root.ehCombinesResolver = factory();
+    root.ehCombinesResolver = factory(root.ehFormatHours);
   }
-}(typeof self !== 'undefined' ? self : this, function () {
+}(typeof self !== 'undefined' ? self : this, function (formatHours) {
+
+  const hoursToHM = formatHours && formatHours.hoursToHM;
 
   // Dotted-path accessor. Returns undefined if any hop is missing.
   function getByPath(obj, pathStr) {
@@ -68,11 +70,17 @@
 
   // Stringify the resolved value for display. The renderer can override
   // presentation (e.g. emojiMap lookup) but this gives a sensible default.
-  function stringifyValue(value, emojiMap) {
+  // `format` is an opt-in display hint; "hm" treats the number as decimal
+  // hours and renders as H:MM. emojiMap takes precedence over format.
+  function stringifyValue(value, emojiMap, format) {
     if (value === null || value === undefined) return null;
     if (emojiMap) {
       const key = String(value);
       if (emojiMap[key]) return emojiMap[key];
+    }
+    if (format === 'hm' && hoursToHM) {
+      const hm = hoursToHM(value);
+      if (hm !== null) return hm;
     }
     if (typeof value === 'number') {
       // Trim to 2dp unless already integral
@@ -124,6 +132,7 @@
       unit: entry?.unit || null,
       colour: entry?.colour || null,
       emojiMap: entry?.emojiMap || null,
+      format: entry?.format || null,
     };
 
     // Ring-segment entries need a positive finite target. goalWeekly wins
@@ -184,7 +193,7 @@
         ...base,
         state: 'ok',
         value: sum,
-        displayValue: stringifyValue(sum, base.emojiMap),
+        displayValue: stringifyValue(sum, base.emojiMap, base.format),
         row: null,
         period: 'week',
         goalWeekly: goalWeeklyN,
@@ -212,7 +221,7 @@
       ...base,
       state: 'ok',
       value,
-      displayValue: stringifyValue(value, base.emojiMap),
+      displayValue: stringifyValue(value, base.emojiMap, base.format),
       row,
     };
 

--- a/public/js/lib/display-template.esm.js
+++ b/public/js/lib/display-template.esm.js
@@ -5,6 +5,8 @@
 // display-template.js (UMD) — Node tests use the UMD version, browser
 // components use this one.
 
+import { hoursToHM } from './format-hours.esm.js';
+
 export function isEmpty(v) {
   return v === null || v === undefined || v === '';
 }
@@ -91,6 +93,13 @@ function resolveField(row, display, expr) {
     // stringify to "true"/"false" on the card. See #215.
     if (modifier === 'check') {
       return value ? '✅' : (fallback ?? '');
+    }
+    // :hm — treat the field as decimal hours and render as H:MM.
+    if (modifier === 'hm') {
+      if (isEmpty(value)) return fallback ?? '';
+      const hm = hoursToHM(value);
+      if (hm !== null) return hm;
+      return fallback ?? String(value);
     }
   }
   if (isEmpty(value)) return fallback ?? '';

--- a/public/js/lib/display-template.js
+++ b/public/js/lib/display-template.js
@@ -22,11 +22,13 @@
 
 (function (root, factory) {
   if (typeof module === 'object' && module.exports) {
-    module.exports = factory();
+    module.exports = factory(require('./format-hours.js'));
   } else {
-    root.ehDisplayTemplate = factory();
+    root.ehDisplayTemplate = factory(root.ehFormatHours);
   }
-}(typeof self !== 'undefined' ? self : this, function () {
+}(typeof self !== 'undefined' ? self : this, function (formatHours) {
+
+  const hoursToHM = formatHours && formatHours.hoursToHM;
 
   function isEmpty(v) {
     return v === null || v === undefined || v === '';
@@ -122,6 +124,14 @@
       // stringify to "true"/"false" on the card. See #215.
       if (modifier === 'check') {
         return value ? '✅' : (fallback ?? '');
+      }
+      // :hm — treat the field as decimal hours and render as H:MM.
+      // Non-numeric / missing values fall through to the fallback.
+      if (modifier === 'hm') {
+        if (isEmpty(value)) return fallback ?? '';
+        const hm = hoursToHM ? hoursToHM(value) : null;
+        if (hm !== null) return hm;
+        return fallback ?? String(value);
       }
       // Unknown modifier → ignore
     }

--- a/public/js/lib/format-hours.esm.js
+++ b/public/js/lib/format-hours.esm.js
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// public/js/lib/format-hours.esm.js
+// ES-module re-export of the decimal-hours formatter. Keep in sync
+// with format-hours.js (UMD) — Node tests use the UMD version,
+// browser components use this one.
+
+export function hoursToHM(value) {
+  if (value === null || value === undefined || value === '') return null;
+  const n = Number(value);
+  if (!Number.isFinite(n)) return null;
+  const clamped = n < 0 ? 0 : n;
+  const totalMinutes = Math.round(clamped * 60);
+  const h = Math.floor(totalMinutes / 60);
+  const m = totalMinutes % 60;
+  return `${h}:${String(m).padStart(2, '0')}`;
+}

--- a/public/js/lib/format-hours.js
+++ b/public/js/lib/format-hours.js
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// public/js/lib/format-hours.js
+// Decimal-hours → "H:MM" formatter shared by combines-resolver and
+// display-template. Dual-runtime: browser (ESM) + Node (CommonJS) via
+// UMD pattern. Keep in sync with format-hours.esm.js.
+
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.ehFormatHours = factory();
+  }
+}(typeof self !== 'undefined' ? self : this, function () {
+
+  // 0.999 hours rounds to 60 minutes; carry to the next hour so we
+  // never emit "0:60". Negative inputs clamp at "0:00" defensively;
+  // ring values can't go negative but goals or accessors might.
+  function hoursToHM(value) {
+    if (value === null || value === undefined || value === '') return null;
+    const n = Number(value);
+    if (!Number.isFinite(n)) return null;
+    const clamped = n < 0 ? 0 : n;
+    const totalMinutes = Math.round(clamped * 60);
+    const h = Math.floor(totalMinutes / 60);
+    const m = totalMinutes % 60;
+    return `${h}:${String(m).padStart(2, '0')}`;
+  }
+
+  return { hoursToHM };
+}));

--- a/templates/sleep-hours.klebb.json
+++ b/templates/sleep-hours.klebb.json
@@ -20,9 +20,8 @@
       "enabled": true,
       "component": "generic-card",
       "display": {
-        "template": "{hours:round(1)}",
-        "unit": "hrs",
-        "secondary": "{deep:round(1)|}h deep · {rem:round(1)|}h REM",
+        "template": "{hours:hm}",
+        "secondary": "{deep:hm|} deep · {rem:hm|} REM",
         "trendArrow": { "field": "hours" }
       }
     },

--- a/tests/combines-resolver.test.js
+++ b/tests/combines-resolver.test.js
@@ -68,6 +68,38 @@ describe('stringifyValue', () => {
     assert.equal(stringifyValue(true), 'yes');
     assert.equal(stringifyValue(false), 'no');
   });
+
+  // #312: hours-as-time hint, opt-in via the third arg. Off by default
+  // so non-time fields keep their existing 2dp behaviour.
+  describe('format: "hm" (decimal hours → H:MM, #312)', () => {
+    test('integer hours → H:00', () => {
+      assert.equal(stringifyValue(8, null, 'hm'), '8:00');
+    });
+    test('typical decimal → H:MM', () => {
+      assert.equal(stringifyValue(8.17, null, 'hm'), '8:10');
+      assert.equal(stringifyValue(0.92, null, 'hm'), '0:55');
+    });
+    test('carry boundary: 0.999 → 1:00, not 0:60', () => {
+      assert.equal(stringifyValue(0.999, null, 'hm'), '1:00');
+    });
+    test('null / undefined → null (unchanged)', () => {
+      assert.equal(stringifyValue(null, null, 'hm'), null);
+      assert.equal(stringifyValue(undefined, null, 'hm'), null);
+    });
+    test('non-numeric falls through to default stringification', () => {
+      assert.equal(stringifyValue('oops', null, 'hm'), 'oops');
+    });
+    test('negative clamps at 0:00', () => {
+      assert.equal(stringifyValue(-0.5, null, 'hm'), '0:00');
+    });
+    test('absent format leaves existing behaviour untouched', () => {
+      assert.equal(stringifyValue(8.17), '8.17');
+      assert.equal(stringifyValue(8.17, null), '8.17');
+    });
+    test('emojiMap still wins over format', () => {
+      assert.equal(stringifyValue(4, { '4':'🙂' }, 'hm'), '🙂');
+    });
+  });
 });
 
 describe('resolveEntry', () => {
@@ -178,6 +210,36 @@ describe('resolveEntry', () => {
     );
     assert.equal(r.state, 'no-accessor-match');
     assert.ok(r.row);
+  });
+
+  test('format: "hm" flows from entry to displayValue (#312)', () => {
+    const r = resolveEntry(
+      { sourceId: 'sleep-hours', role: 'primary', accessor: 'hours', format: 'hm' },
+      sources, '2026-05-04',
+    );
+    assert.equal(r.state, 'ok');
+    assert.equal(r.value, 8.1);
+    assert.equal(r.displayValue, '8:06');
+    assert.equal(r.format, 'hm');
+  });
+
+  test('format: "hm" applied to weekly ring sum (#312)', () => {
+    // Week of 2026-05-04 = Mon 2026-05-04..Sun 2026-05-10. Only the
+    // 2026-05-04 row falls inside, so the weekly sum is just 8.1 →
+    // 8:06. Tests the weekly path in resolveEntry.
+    const r = resolveEntry(
+      {
+        sourceId: 'sleep-hours',
+        role: 'ring-segment',
+        accessor: 'hours',
+        format: 'hm',
+        goalWeekly: 56,
+      },
+      sources, '2026-05-04',
+    );
+    assert.equal(r.state, 'ok');
+    assert.equal(r.period, 'week');
+    assert.equal(r.displayValue, '8:06');
   });
 
   test('emojiMap applied to displayValue', () => {

--- a/tests/display-template.test.js
+++ b/tests/display-template.test.js
@@ -144,6 +144,39 @@ describe('display-template', () => {
       assert.equal(renderTemplate('{xxx}', { yyy: 1 }), '');
     });
 
+    // #312: render decimal hours as H:MM on cards that surface
+    // durations (sleep, in-bed, awake). The on-disk shape stays
+    // decimal; this is purely a display-layer modifier.
+    describe(':hm modifier (#312)', () => {
+      test('integer hours render as H:00', () => {
+        assert.equal(renderTemplate('{hours:hm}', { hours: 8 }), '8:00');
+      });
+
+      test('typical decimal hours render as H:MM', () => {
+        assert.equal(renderTemplate('{hours:hm}', { hours: 8.17 }), '8:10');
+        assert.equal(renderTemplate('{hours:hm}', { hours: 0.92 }), '0:55');
+      });
+
+      test('carry boundary: 0.999 hours rounds up to 1:00, not 0:60', () => {
+        assert.equal(renderTemplate('{hours:hm}', { hours: 0.999 }), '1:00');
+      });
+
+      test('null / missing falls back to pipe default or empty', () => {
+        assert.equal(renderTemplate('{hours:hm}', { hours: null }), '');
+        assert.equal(renderTemplate('{hours:hm}', {}), '');
+        assert.equal(renderTemplate('{hours:hm|--}', {}), '--');
+      });
+
+      test('non-numeric falls back to pipe default or stringified value', () => {
+        assert.equal(renderTemplate('{hours:hm}', { hours: 'oops' }), 'oops');
+        assert.equal(renderTemplate('{hours:hm|--}', { hours: 'oops' }), '--');
+      });
+
+      test('negative clamps at 0:00', () => {
+        assert.equal(renderTemplate('{hours:hm}', { hours: -1 }), '0:00');
+      });
+    });
+
     // #215: booleans used to stringify to "true" / "false" which looked
     // silly on cards like workouts ("{trained} · {type}" → "true · ...").
     // The :check modifier renders a tick when truthy, empty string

--- a/tests/format-hours.test.js
+++ b/tests/format-hours.test.js
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/format-hours.test.js
+// Direct unit tests for the decimal-hours → H:MM helper.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { hoursToHM } = require('../public/js/lib/format-hours.js');
+
+describe('hoursToHM', () => {
+  test('integer hours render as H:00', () => {
+    assert.equal(hoursToHM(0), '0:00');
+    assert.equal(hoursToHM(1), '1:00');
+    assert.equal(hoursToHM(8), '8:00');
+  });
+
+  test('typical decimals render as H:MM', () => {
+    assert.equal(hoursToHM(8.17), '8:10');
+    assert.equal(hoursToHM(0.92), '0:55');
+    assert.equal(hoursToHM(7.5), '7:30');
+    assert.equal(hoursToHM(8.25), '8:15');
+  });
+
+  test('carries over when minutes round to 60', () => {
+    assert.equal(hoursToHM(0.999), '1:00');
+    assert.equal(hoursToHM(7.999), '8:00');
+  });
+
+  test('numeric strings work', () => {
+    assert.equal(hoursToHM('8.5'), '8:30');
+  });
+
+  test('non-numeric returns null', () => {
+    assert.equal(hoursToHM(null), null);
+    assert.equal(hoursToHM(undefined), null);
+    assert.equal(hoursToHM('oops'), null);
+    assert.equal(hoursToHM(NaN), null);
+    assert.equal(hoursToHM(Infinity), null);
+  });
+
+  test('negative clamps at 0:00', () => {
+    assert.equal(hoursToHM(-1), '0:00');
+    assert.equal(hoursToHM(-0.5), '0:00');
+  });
+});


### PR DESCRIPTION
# What changed

Decimal-hours fields on the sleep card no longer render as `8.17 / 8`;
with the new opt-in `format: "hm"` hint they render as `8:10 / 8:00`.
Atomic generic-cards get the same conversion via a new `{key:hm}`
template modifier.

# Why

Fixes #312. The sleep combination card surfaces durations (Total /
Deep / REM / Core / In Bed / Awake) as decimal hours, which reads as
"8 hours 17 minutes" instead of the actual "8 hours 10 minutes". Time
durations should display as `H:MM`, but other numeric fields (kg, bpm,
kcal) shouldn't be coerced — so the conversion is opt-in per field.

# How

- New tiny UMD/ESM helper `public/js/lib/format-hours.{js,esm.js}`
  exporting `hoursToHM(value)` with a 60-minute carry guard
  (`0.999` → `1:00`, not `0:60`) and defensive negative clamp.
- `combines-resolver` carries `format` through from each entry into
  the resolved row and routes `stringifyValue()` through `hoursToHM`
  when `format === "hm"`. emojiMap still wins over format.
- `eh-combination-card` runs `goalDaily` / `goalWeekly` through the
  same helper when the resolved entry has `format: "hm"`, so the
  legend reads `8:10 / 8:00`, not `8:10 / 8`.
- `display-template` gains a `:hm` modifier alongside the existing
  `:round`, `:emoji`, `:check`, `:truncate` family.
- `templates/sleep-hours.klebb.json` and `demo/fixtures/sleep-hours.json`
  pick up the new modifier so fresh instances and the public demo
  show H:MM by default.
- The on-disk shape is unchanged — manifests still store decimal
  hours.

# Testing

- [x] `npm test` passes locally (Node 20). 1047 pass, 1 pre-existing
      unrelated failure in `tests/no-personal-refs.test.js` flagging
      gitignored operator-only files (`BRIEF-FOR-CC.md`, `CLAUDE.md`,
      `data/sessions/`, `.claude/`); fails identically on `main`.
- [ ] `npm run test:e2e` — operator to run; this PR is pure
      display-layer logic with covered unit tests.
- [x] New regression coverage at the matching (pure-logic) layer:
  - `tests/format-hours.test.js` — direct helper tests.
  - `tests/combines-resolver.test.js` — `format: "hm"` cases on
    `stringifyValue` plus `resolveEntry` flow-through (daily + weekly).
  - `tests/display-template.test.js` — `{key:hm}` cases mirroring the
    helper.
- [x] Manual sanity: helper handles integer (`8` → `8:00`), typical
      decimal (`8.17` → `8:10`, `0.92` → `0:55`), carry boundary
      (`0.999` → `1:00`), null/undefined, non-numeric, and negative.

# Checklist

- [x] Commit messages follow conventions
- [x] `CHANGELOG.md` updated under `## Unreleased`
- [x] `MANIFEST-SCHEMA.md` documents `combines.format` and the
      `{key:hm}` template modifier
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Breaking changes

None. `format` is optional; absence preserves current behaviour
exactly. `{key:hm}` is a new modifier, doesn't affect existing
`{key:round}` etc.