### PR TITLE
fix(voice): strip markdown before TTS so Fish doesn't read syntax aloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,16 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Voice replies no longer read markdown syntax aloud.** The
+  voice-mode chat agent is told to put plain prose in `speak`, but
+  occasionally leaks bold/italic, links, or inline code through. Fish
+  Audio then read the syntax verbatim ("asterisk asterisk bold
+  asterisk asterisk"). The TTS endpoint now sanitises text before it
+  reaches Fish: bold/italic/strike, inline + fenced code, markdown
+  links (`[label](url)` keeps the label), bare URLs, bare square
+  brackets, and leading line markers (`#`, `>`, `-`, `*`, `+`,
+  `1.`) are all stripped. Parentheses are left alone so prose like
+  "your weight (in kg) trended down" still reads naturally. Fixes #314.
 - **PWA / apple-touch-icon home-screen artwork.** The five
   `public/icons/icon-*.png` tiles still showed the legacy "Eddz"
   wordmark and rocket image, so adding Klebb to the iOS home screen

--- a/server.js
+++ b/server.js
@@ -16,6 +16,7 @@ const { listTemplates, listPrompts } = require('./server/content');
 const voice = require('./voice/fish');
 const voiceCache = require('./voice/cache');
 const { transcodeToWav } = require('./voice/transcode');
+const { sanitiseForTts } = require('./voice/sanitise-for-tts');
 const { TOOL_DEFS, dispatchToolCall } = require('./chat/tools');
 const { pickEmbellishments } = require('./chat/embellish');
 const { buildDateContextBlock } = require('./chat/date-context');
@@ -1617,7 +1618,12 @@ Original system prompt follows:
           if (!text || typeof text !== 'string' || !text.trim()) {
             return sendJSON(res, { error: 'text required' }, 400);
           }
-          const capped = text.slice(0, 4000);
+          // Strip markdown / URLs so Fish doesn't read syntax aloud
+          // ("asterisk asterisk bold asterisk asterisk"). Cache keys
+          // off the cleaned text so repeated speakings hit cache.
+          const cleaned = sanitiseForTts(text);
+          if (!cleaned) return sendJSON(res, { error: 'text required' }, 400);
+          const capped = cleaned.slice(0, 4000);
           const fmt = format === 'wav' ? 'wav' : 'mp3';
           const voiceId = require('./voice/fish').getCurrentBackend ? undefined : undefined;
           const key = voiceCache.hashKey(capped, 'default', fmt);

--- a/tests/voice-sanitise-for-tts.test.js
+++ b/tests/voice-sanitise-for-tts.test.js
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/voice-sanitise-for-tts.test.js
+// Markdown and URL stripping for text on its way to Fish Audio TTS.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { sanitiseForTts } = require('../voice/sanitise-for-tts');
+
+describe('sanitiseForTts', () => {
+  test('strips bold (**)', () => {
+    assert.equal(sanitiseForTts('hello **world** there'), 'hello world there');
+  });
+
+  test('strips italic (*)', () => {
+    assert.equal(sanitiseForTts('hello *world* there'), 'hello world there');
+  });
+
+  test('strips bold-italic (***)', () => {
+    assert.equal(sanitiseForTts('hello ***world*** there'), 'hello world there');
+  });
+
+  test('strips bold (__)', () => {
+    assert.equal(sanitiseForTts('hello __world__ there'), 'hello world there');
+  });
+
+  test('strips italic (_) but leaves snake_case alone', () => {
+    assert.equal(sanitiseForTts('hello _world_ there'), 'hello world there');
+    assert.equal(sanitiseForTts('snake_case_var'), 'snake_case_var');
+  });
+
+  test('strips strikethrough (~~)', () => {
+    assert.equal(sanitiseForTts('hello ~~world~~ there'), 'hello world there');
+  });
+
+  test('strips inline code backticks', () => {
+    assert.equal(sanitiseForTts('use `git commit` here'), 'use git commit here');
+  });
+
+  test('strips fenced code blocks but keeps contents', () => {
+    const input = 'before\n```js\nconst x = 1;\n```\nafter';
+    assert.equal(sanitiseForTts(input), 'before const x = 1; after');
+  });
+
+  test('markdown link: keeps label, drops URL', () => {
+    assert.equal(
+      sanitiseForTts('see [the docs](https://example.com/docs) for more'),
+      'see the docs for more'
+    );
+  });
+
+  test('bare URL: dropped', () => {
+    assert.equal(
+      sanitiseForTts('visit https://example.com today'),
+      'visit today'
+    );
+  });
+
+  test('bare square brackets: drop brackets, keep contents', () => {
+    assert.equal(sanitiseForTts('and [aside] then more'), 'and aside then more');
+  });
+
+  test('curly braces: drop braces, keep contents', () => {
+    assert.equal(sanitiseForTts('value is {42}'), 'value is 42');
+  });
+
+  test('strips heading markers', () => {
+    assert.equal(sanitiseForTts('# Heading\nbody'), 'Heading body');
+    assert.equal(sanitiseForTts('### Subheading\nbody'), 'Subheading body');
+  });
+
+  test('strips bullet markers', () => {
+    const input = '- one\n- two\n* three\n+ four';
+    assert.equal(sanitiseForTts(input), 'one two three four');
+  });
+
+  test('strips ordered-list markers', () => {
+    assert.equal(sanitiseForTts('1. first\n2. second'), 'first second');
+  });
+
+  test('strips blockquote markers', () => {
+    assert.equal(sanitiseForTts('> quoted\nfollowup'), 'quoted followup');
+  });
+
+  test('keeps parentheses (read aloud naturally)', () => {
+    assert.equal(
+      sanitiseForTts('your weight (in kg) trended down'),
+      'your weight (in kg) trended down'
+    );
+  });
+
+  test('collapses whitespace runs', () => {
+    assert.equal(sanitiseForTts('a   b\n\n\nc'), 'a b c');
+  });
+
+  test('the actual reported case: bold reads cleanly', () => {
+    assert.equal(
+      sanitiseForTts('unformatted text here **formatted text here**'),
+      'unformatted text here formatted text here'
+    );
+  });
+
+  test('combined markdown survives all passes', () => {
+    const input = '## Summary\n\nYour **HRV** is `42ms`, see [details](https://x.com).';
+    assert.equal(
+      sanitiseForTts(input),
+      'Summary Your HRV is 42ms, see details.'
+    );
+  });
+
+  test('non-string input returns empty string', () => {
+    assert.equal(sanitiseForTts(null), '');
+    assert.equal(sanitiseForTts(undefined), '');
+    assert.equal(sanitiseForTts(42), '');
+  });
+
+  test('empty string returns empty string', () => {
+    assert.equal(sanitiseForTts(''), '');
+    assert.equal(sanitiseForTts('   \n  '), '');
+  });
+});

--- a/voice/sanitise-for-tts.js
+++ b/voice/sanitise-for-tts.js
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// voice/sanitise-for-tts.js — strip markdown + URLs from text before TTS.
+// The voice-mode chat agent is told to emit plain prose in `speak`, but the
+// model occasionally leaks markdown anyway. Without this, Fish Audio reads
+// the syntax aloud ("asterisk asterisk bold asterisk asterisk").
+
+function sanitiseForTts(input) {
+  if (typeof input !== 'string') return '';
+  let s = input;
+
+  // Fenced code blocks: keep contents, drop the fences and any language tag.
+  s = s.replace(/```[a-zA-Z0-9_-]*\n?([\s\S]*?)```/g, '$1');
+
+  // Inline code: keep contents, drop the backticks.
+  s = s.replace(/`([^`]+)`/g, '$1');
+
+  // Markdown links: [label](url) -> label
+  s = s.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '$1');
+
+  // Bare URLs (http/https): drop entirely.
+  s = s.replace(/https?:\/\/\S+/g, '');
+
+  // Bold / italic / strikethrough — handle longest delimiters first.
+  s = s.replace(/\*\*\*([^*]+)\*\*\*/g, '$1');
+  s = s.replace(/\*\*([^*]+)\*\*/g, '$1');
+  s = s.replace(/\*([^*\n]+)\*/g, '$1');
+  s = s.replace(/___([^_]+)___/g, '$1');
+  s = s.replace(/__([^_]+)__/g, '$1');
+  s = s.replace(/(^|[\s(])_([^_\n]+)_(?=[\s).,!?;:]|$)/g, '$1$2');
+  s = s.replace(/~~([^~]+)~~/g, '$1');
+
+  // Bare square brackets that survived the link pass: drop brackets, keep contents.
+  s = s.replace(/\[([^\]]*)\]/g, '$1');
+
+  // Curly braces (rare in prose): drop braces, keep contents.
+  s = s.replace(/\{([^}]*)\}/g, '$1');
+
+  // Strip leading line markers: '#', '>', '-', '*', '+', and ordered-list digits.
+  s = s.replace(/^[ \t]*(?:#{1,6}|>|[-*+]|\d+\.)[ \t]+/gm, '');
+
+  // Collapse whitespace runs (multiple spaces / blank lines) into single space.
+  s = s.replace(/\s+/g, ' ').trim();
+
+  return s;
+}
+
+module.exports = { sanitiseForTts };


### PR DESCRIPTION
## Summary

- `/api/voice/tts` now sanitises text before handing it to Fish Audio, so markdown that leaks through the voice-mode chat reply is no longer spoken aloud as syntax.
- Added `voice/sanitise-for-tts.js` plus 22 unit tests in `tests/voice-sanitise-for-tts.test.js`.

## Why

On iPhone, an assistant reply containing `**bold**` was read out as "asterisk asterisk bold asterisk asterisk". The voice-mode system prompt asks the model to put plain prose in `speak`, but compliance is best-effort, so we needed defence-in-depth at the TTS boundary.

## How

A small sanitiser strips:

- bold / italic / strike (`**`, `*`, `__`, `_`, `~~`)
- inline + fenced backtick code (keeps contents)
- markdown links `[label](url)` -> `label`
- bare http(s) URLs (dropped)
- bare square brackets (`[note]` -> `note`)
- curly braces (drop braces, keep contents)
- leading line markers (`#`, `>`, `-`, `*`, `+`, `1.`)
- collapses whitespace runs

Parentheses are deliberately left alone: Fish reads `(in kg)` with the right cadence and dropping them would mangle normal prose.

The sanitiser sits server-side in the `/api/voice/tts` POST handler so the cache key is computed on the cleaned text (repeated speakings of the same logical reply hit cache). All existing callers (`health-chat.js` `_generateAndAutoplay`, manual replays, future ones) get clean speech for free.

## Testing

- [x] `node --test tests/voice-sanitise-for-tts.test.js` — 22/22 pass
- [x] `npm test` — 1047/1048 pass; the one failure (`tests/no-personal-refs.test.js`) is pre-existing on `main` and unrelated.
- [ ] Manual: speak a reply containing markdown via the iPhone PWA after deploy and confirm Fish reads only the words.

Fixes #314.