### PR TITLE
fix(list-card): pass display config to edit-mode renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,14 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **List-card row detail form no longer crashes in edit mode.** On a
+  list-card with secondary fields, tapping the per-row `…` button after
+  pressing the pencil to enter edit mode replaced the card with
+  `Render failed: Can't find variable: display`. `_renderEditMode` was
+  passing a `display` identifier to the inline `eh-input-form` that was
+  only defined in `renderCard` / `_renderViewMode`. The variable is now
+  threaded through to edit mode the same way it is to view mode.
+  Fixes #317.
 - **Voice replies no longer read markdown syntax aloud.** The
   voice-mode chat agent is told to put plain prose in `speak`, but
   occasionally leaks bold/italic, links, or inline code through. Fish

--- a/public/js/components/eh-list-card.js
+++ b/public/js/components/eh-list-card.js
@@ -430,7 +430,7 @@ export class EhListCard extends EhBaseCard {
         ` : ''}
 
         ${this._editing
-          ? this._renderEditMode(rows)
+          ? this._renderEditMode(rows, display)
           : this._renderViewMode(rows, display)}
 
         ${this._formError ? html`<div class="err">${this._formError}</div>` : ''}
@@ -518,7 +518,7 @@ export class EhListCard extends EhBaseCard {
     this._expandedRow = null;
   }
 
-  _renderEditMode(rows) {
+  _renderEditMode(rows, display) {
     const primaryField = this._primaryField();
     const primaryInput = this._primaryInput();
     const secondaryInputs = this._secondaryInputs();

--- a/tests-e2e/list-card-row-detail-edit.spec.js
+++ b/tests-e2e/list-card-row-detail-edit.spec.js
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/list-card-row-detail-edit.spec.js
+// Regression for #317: opening a list-card row's inline detail form in
+// edit mode crashed the renderer with "Render failed: Can't find
+// variable: display". The bug was a bare `display` reference in
+// _renderEditMode (the variable was only computed in renderCard /
+// _renderViewMode). It fired any time a list-card had secondary
+// fields and the user tapped the per-row `…` (more) button.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+const FOOD_LOG_ID = 'food-log-e2e';
+
+function foodLogManifest() {
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: FOOD_LOG_ID,
+      label: 'Food Log (e2e)',
+      emoji: '📝',
+      order: 9000,
+      category: 'lifestyle',
+      view: {
+        enabled: true,
+        component: 'list-card',
+        display: {
+          primaryField: 'notes',
+          emptyMessage: 'No food entries today.',
+        },
+      },
+      writeable: {
+        fromWebapp: true,
+        todayAllowed: true,
+        pastAllowed: true,
+        futureAllowed: false,
+        maxReadingsPerDay: 20,
+        inputs: [
+          { key: 'time', label: 'Time', type: 'time' },
+          {
+            key: 'meal',
+            label: 'Meal',
+            type: 'select',
+            options: ['Breakfast', 'Lunch', 'Dinner', 'Snack'],
+            required: true,
+          },
+          {
+            key: 'notes',
+            label: 'What did you eat?',
+            type: 'textarea',
+            required: true,
+          },
+        ],
+      },
+    },
+    description: 'List-card with secondary fields, for the #317 regression.',
+    data: [
+      { added: '2026-04-01T08:00:00Z', time: '08:00', meal: 'Breakfast', notes: 'Oats with banana' },
+    ],
+  };
+}
+
+async function seed(request, baseUrl, manifest) {
+  await request.delete(`${baseUrl}/api/manifests/${manifest.meta.id}`).catch(() => {});
+  const r = await request.post(`${baseUrl}/api/manifests`, { data: manifest });
+  expect([201, 409]).toContain(r.status());
+}
+
+async function cleanup(request, baseUrl, id) {
+  await request.delete(`${baseUrl}/api/manifests/${id}`).catch(() => {});
+}
+
+test.describe('#317: list-card row detail form does not crash on open', () => {
+  test('tapping the per-row `…` button in edit mode does not throw', async ({ page, sandboxState }) => {
+    await seed(page.request, sandboxState.baseUrl, foodLogManifest());
+
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible({ timeout: 10_000 });
+
+    const card = page.locator(`[data-card-id="${FOOD_LOG_ID}"] eh-list-card`);
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    // Enter edit mode via the pencil tool-btn.
+    await card.locator('button[aria-label="Edit list"]').click();
+
+    // The seed row should now show a per-row `…` button (it's only
+    // rendered when there are secondary fields).
+    const detailBtn = card.locator('button[aria-label*="Edit extra fields"]').first();
+    await expect(detailBtn).toBeVisible();
+
+    await detailBtn.click();
+
+    // Before the fix, _renderEditMode crashed with
+    // "Render failed: Can't find variable: display" and the card body
+    // was replaced with that string. Assert no such placeholder.
+    await expect(card.locator('.error-placeholder')).toHaveCount(0);
+    await expect(card).not.toContainText("Can't find variable");
+    await expect(card).not.toContainText('Render failed');
+
+    // The inline form should have rendered.
+    await expect(card.locator('eh-input-form')).toBeVisible();
+
+    await cleanup(page.request, sandboxState.baseUrl, FOOD_LOG_ID);
+  });
+});


### PR DESCRIPTION
## Summary

Threads the `display` config object into `_renderEditMode` on `eh-list-card` so the inline `eh-input-form` for per-row detail editing stops crashing with `Render failed: Can't find variable: display`.

## Why

PR #220 wired `.display=\${display}` onto the `eh-input-form` inside `_renderEditMode`, but `display` was only ever defined in `renderCard` and threaded into `_renderViewMode`. The bare identifier in edit-mode was undefined at render time. The crash was dormant until a list-card had secondary fields (i.e. `meta.writeable.inputs` carried more than just the primary field) **and** the user tapped the per-row \`…\` button to open the detail form. Food Log hit both.

## How

- \`_renderEditMode\` now takes \`(rows, display)\`; \`renderCard\` passes \`display\` in alongside \`rows\`, mirroring how \`_renderViewMode\` already gets it.
- New e2e regression at \`tests-e2e/list-card-row-detail-edit.spec.js\`: seeds a list-card with secondary fields, enters edit mode, taps the per-row detail button, asserts no \`.error-placeholder\`, no \`Render failed\` text, and that \`eh-input-form\` mounts.

## Testing

- [x] \`npm test\` (only pre-existing \`no-personal-refs\` failure, which also fails on main and only scans gitignored files)
- [ ] \`npm run test:e2e -- list-card-row-detail-edit\` — please verify against sandbox
- [x] Manual reproduction path: pencil → add row → tap \`…\` no longer replaces the card with the error string

Fixes #317