### PR TITLE
fix(prompt-queue): keep hidden donors prompting via visible combo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,14 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Hidden donor cards keep their daily prompts when surfaced through
+  a combination card.** The prompt queue used to skip any card with
+  `meta.enabled: false`, even when the user had hidden the atomic card
+  only because it was rolled into a visible combination card. Now the
+  queue checks whether at least one visible combination card lists the
+  donor in its `meta.view.combines[].sourceId`; if so, the donor's
+  prompt fires as before. Hidden cards with no combo references stay
+  suppressed. Fixes #316.
 - **Voice ASR works on iOS Safari again.** `MediaRecorder` on iOS only
   produces fragmented MP4, whose `moov` atom sits at the end of the
   stream. The transcode helper was piping bytes into `ffmpeg -i pipe:0`,

--- a/public/js/lib/prompt-queue.js
+++ b/public/js/lib/prompt-queue.js
@@ -106,6 +106,27 @@ export function allScheduledTakenForDate(data, date) {
   return scheduledCount > 0;
 }
 
+// Build the set of donor ids surfaced by at least one visible
+// combination card. A combination card lists its donors in
+// meta.view.combines[].sourceId; if the combo itself is visible, those
+// donors are effectively visible to the user even when their atomic
+// card has meta.enabled:false. See #316 — without this, hiding the
+// atomic Mood card to roll it into a combo silently kills its prompt.
+function surfacedByVisibleCombo(manifests) {
+  const out = new Set();
+  for (const card of manifests || []) {
+    const meta = card?.meta;
+    if (!meta) continue;
+    if (meta.enabled === false) continue;
+    const combines = meta.view?.combines;
+    if (!Array.isArray(combines)) continue;
+    for (const c of combines) {
+      if (c?.sourceId) out.add(c.sourceId);
+    }
+  }
+  return out;
+}
+
 // Build the queue. Pure function separated so tests can run it against
 // a synthetic manifest list without hitting the network.
 export function buildPromptQueue(manifests, {
@@ -113,14 +134,17 @@ export function buildPromptQueue(manifests, {
   storage = globalThis.localStorage,
 } = {}) {
   const out = [];
+  const surfaced = surfacedByVisibleCombo(manifests);
   for (const card of manifests || []) {
     const meta = card?.meta;
     if (!meta) continue;
     const prompt = meta.prompt;
     if (!prompt || prompt.enabled !== true) continue;
     // Respect disabled cards at the registry level — don't nag about
-    // cards the user has hidden.
-    if (meta.enabled === false) continue;
+    // cards the user has hidden. Exception: a hidden card surfaced by
+    // a visible combination card still prompts, since the user is
+    // seeing it through the combo (#316).
+    if (meta.enabled === false && !surfaced.has(meta.id)) continue;
     if (wasShownToday(meta.id, date, storage)) continue;
     const whenMissing = prompt.whenMissing !== false; // default true
     if (whenMissing) {
@@ -158,12 +182,18 @@ export async function checkPromptsForToday() {
   // AND haven't already been shown today. This avoids a data fetch for
   // every card on the homepage every time the app loads.
   const date = todayStr();
+  // A hidden donor that's referenced by a visible combination card
+  // still warrants a prompt (#316). Compute this against the full
+  // manifest list before filtering out hidden cards.
+  const surfaced = surfacedByVisibleCombo(
+    entries.map(e => ({ meta: e.meta || e })),
+  );
   const candidates = [];
   for (const e of entries) {
     const meta = e.meta || e;
     const prompt = meta?.prompt;
     if (!prompt || prompt.enabled !== true) continue;
-    if (meta.enabled === false) continue;
+    if (meta.enabled === false && !surfaced.has(meta.id)) continue;
     if (wasShownToday(meta.id, date)) continue;
     candidates.push(meta);
   }

--- a/tests/prompt-queue.test.js
+++ b/tests/prompt-queue.test.js
@@ -283,6 +283,108 @@ test('buildPromptQueue: checklist mode includes card when NONE taken', () => {
   assert.equal(q.length, 1);
 });
 
+// --- combination-card inheritance (#316) ---
+//
+// A hidden atomic card that is referenced as a sourceId by a visible
+// combination card should still produce a prompt, since the user is
+// surfacing it through the combo. Without this, the only way to roll
+// Mood (or similar) into a combo is to drop its daily prompt entirely.
+
+test('buildPromptQueue: hidden donor referenced by visible combo card → prompts', () => {
+  const storage = makeStorage();
+  const manifests = [
+    {
+      meta: {
+        id: 'mood',
+        enabled: false,
+        prompt: { enabled: true },
+      },
+      data: [],
+    },
+    {
+      meta: {
+        id: 'wellbeing',
+        view: {
+          component: 'combination-card',
+          combines: [{ sourceId: 'mood', role: 'primary' }],
+        },
+      },
+      data: [],
+    },
+  ];
+  const q = buildPromptQueue(manifests, { date: '2026-04-23', storage });
+  assert.equal(q.length, 1);
+  assert.equal(q[0].meta.id, 'mood');
+});
+
+test('buildPromptQueue: hidden donor with no combo references → still skipped', () => {
+  // Preserves the existing behaviour from "skips disabled cards even
+  // with prompt.enabled": a hidden card not surfaced anywhere stays
+  // suppressed, so the user genuinely-hidden cards stop nagging.
+  const storage = makeStorage();
+  const manifests = [
+    { meta: { id: 'mood', enabled: false, prompt: { enabled: true } }, data: [] },
+    {
+      meta: {
+        id: 'unrelated',
+        view: {
+          component: 'combination-card',
+          combines: [{ sourceId: 'weight', role: 'primary' }],
+        },
+      },
+      data: [],
+    },
+  ];
+  const q = buildPromptQueue(manifests, { date: '2026-04-23', storage });
+  assert.deepEqual(q, []);
+});
+
+test('buildPromptQueue: combo card itself hidden does NOT keep donor alive', () => {
+  // If the combo card is also hidden, the donor isn't being surfaced
+  // anywhere visible, so the prompt should stay suppressed.
+  const storage = makeStorage();
+  const manifests = [
+    { meta: { id: 'mood', enabled: false, prompt: { enabled: true } }, data: [] },
+    {
+      meta: {
+        id: 'wellbeing',
+        enabled: false,
+        view: {
+          component: 'combination-card',
+          combines: [{ sourceId: 'mood', role: 'primary' }],
+        },
+      },
+      data: [],
+    },
+  ];
+  const q = buildPromptQueue(manifests, { date: '2026-04-23', storage });
+  assert.deepEqual(q, []);
+});
+
+test('buildPromptQueue: combo inheritance still respects today-entry suppression', () => {
+  // The whenMissing rule still applies: if mood already has today's
+  // entry, the prompt is suppressed regardless of combo inheritance.
+  const storage = makeStorage();
+  const manifests = [
+    {
+      meta: { id: 'mood', enabled: false, prompt: { enabled: true } },
+      data: [{ date: '2026-04-23', mood: 4 }],
+    },
+    {
+      meta: {
+        id: 'wellbeing',
+        view: {
+          component: 'combination-card',
+          combines: [{ sourceId: 'mood', role: 'primary' }],
+        },
+      },
+      data: [],
+    },
+  ];
+  const q = buildPromptQueue(manifests, { date: '2026-04-23', storage });
+  assert.deepEqual(q, []);
+});
+
 test('buildPromptQueue: defends against malformed manifest entries', () => {
   const storage = makeStorage();
   const manifests = [


### PR DESCRIPTION
## Summary

A card configured with `meta.prompt.enabled` would silently stop firing its daily modal when the operator hid its atomic dashboard tile to roll it into a combination card. The prompt queue was treating `meta.enabled: false` as "user doesn't want this", but in the combo-card pattern, hiding the atomic tile is exactly how you avoid double-rendering — the user is still seeing the donor data through the combo.

The fix: when computing prompt eligibility, treat a hidden donor as still surfaced if at least one visible combination card references it via `meta.view.combines[].sourceId`. Hidden cards with no combo references stay suppressed, preserving the existing "don't nag about cards I've hidden" behaviour.

Fixes #316.

## Why

Inheritance over duplication. The combination card already inherits the donor's input form via `canEditDonor`; the prompt path was the odd one out. Adding a parallel `meta.prompt` config to combination cards would have meant two sources of truth for what is one user intent.

## How

`public/js/lib/prompt-queue.js` gains a `surfacedByVisibleCombo()` helper that builds a Set of donor ids referenced by any visible combo. Both `buildPromptQueue()` (pure, used by tests) and `checkPromptsForToday()` (network wrapper) consult it before short-circuiting on `meta.enabled === false`.

## Testing checklist

- [x] `npm test` passes the four new prompt-queue cases:
  - Hidden donor + visible combo → prompts.
  - Hidden donor + no combo references → still suppressed.
  - Combo also hidden → donor stays suppressed.
  - Hidden donor + visible combo + today's entry already exists → still suppressed (whenMissing rule).
- [x] Full suite: 1073 pass, 1 unrelated pre-existing failure (`tests/no-personal-refs.test.js`, fails on clean main).
- [ ] Manual verification on a live instance: hide atomic Mood, confirm modal still fires on app load via the combo path.