### PR TITLE
fix(chat): raise client _fetchChat ceiling to 600s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,13 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Chat client no longer times out on slow multi-iter turns.** The
+  chat widget aborted at 120s while the server-side tool-calling loop
+  could legitimately take longer (a single gateway hop is capped at
+  180s, and a turn can chain several). The client default now matches
+  the other long-poll routes at 600s, and both call sites use that
+  default. The matching nginx ceiling on `/api/chat` is raised
+  separately at the operator level. Fixes #323.
 - **Hidden donor cards keep their daily prompts when surfaced through
   a combination card.** The prompt queue used to skip any card with
   `meta.enabled: false`, even when the user had hidden the atomic card

--- a/public/js/components/health-chat.js
+++ b/public/js/components/health-chat.js
@@ -886,7 +886,7 @@ class HealthChat extends LitElement {
 
   // ---------- Chat pipeline ----------
 
-  async _fetchChat(messages, voiceMode, timeoutMs = 180000) {
+  async _fetchChat(messages, voiceMode, timeoutMs = 600000) {
     if (this._abortController) this._abortController.abort();
     this._abortController = new AbortController();
     const timeoutId = setTimeout(() => this._abortController?.abort(), timeoutMs);
@@ -929,7 +929,7 @@ class HealthChat extends LitElement {
       // Single request, generous timeout. Earlier two-phase retry was meant
       // for stale TCP sockets after visibility-change; in practice it caused
       // confusing "Gateway unavailable" errors on slow (tool-using) replies.
-      const data = await this._fetchChat(chatMessages, useVoice, 120000);
+      const data = await this._fetchChat(chatMessages, useVoice);
       if (data.error) this._pushError(data.error);
       else {
         const extra = data.followup ? {
@@ -1089,7 +1089,7 @@ class HealthChat extends LitElement {
       // Chat (voice mode)
       const chatMessages = this._messages.filter(m => m.role !== 'error');
       let replyData;
-      try { replyData = await this._fetchChat(chatMessages, true, 120000); }
+      try { replyData = await this._fetchChat(chatMessages, true); }
       catch (e) {
         this._pushError(e.name === 'AbortError' ? 'Request timed out' : 'Failed to connect');
         return;


### PR DESCRIPTION
## Summary

Fixes #323. The chat widget aborted at 120s while the server-side
tool-calling loop could legitimately run longer; users saw a
request-timeout error while container logs showed
`done total=193280ms`.

## Why

Three timeouts gate a `/api/chat` round-trip. The server's
per-gateway-hop cap is 180s (one LLM call), which is fine. The
*overall* user-visible budget needs to exceed the worst-case
multi-iter total. Both client call sites passed an explicit
`120000` that quietly overrode the `180000` default, so the
real client ceiling was 120s, not 180s.

## How

- Default `_fetchChat(... timeoutMs)` raised from `180000` to
  `600000`.
- Dropped the explicit `120000` overrides at the two call sites
  so there is one ceiling to reason about.

The matching nginx `proxy_read_timeout` on `location = /api/chat`
is being raised from 180s to 600s on the four affected vhosts at
the operator level (out of repo).

## Testing

- [x] `npm test` — same single failure as `main`
      (`tests/no-personal-refs.test.js`, unrelated, hits in
      gitignored files only).
- [ ] After merge + deploy, send a chat turn known to take >180s
      and confirm the assistant message renders instead of the
      "Request timed out" toast.