### PR TITLE
feat(chat): frame the agent as the user's tool, not a gatekeeper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,18 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Changed
 
+- **Chat agent stance.** The default system prompt now carries a
+  short "Your stance" section that frames the user as an informed
+  adult driving their own regimen and tells the agent not to refuse
+  or hedge on peptide / supplement / dosing questions. Carve-out is
+  narrow: genuine emergencies and acute diagnosis (chest pain,
+  suspected stroke, suicidal ideation, anaphylaxis, unknown lump).
+  Without this framing the underlying model fell back to a generic
+  refusal on a fresh chat, then engaged once the user re-asked with
+  manifest-tool framing; the inconsistency erodes trust.
+  `HEALTH_SYSTEM_PROMPT` and `HEALTH_SYSTEM_PROMPT_FILE` overrides
+  still take precedence. Fixes #326.
+
 - **Demo dashboard polish.** Strength Training fixture now uses plain
   exercise names (Bench Press, Lat Pulldown, Romanian Deadlift, etc),
   carries an eight-week dose history with mostly-done /

--- a/config/env.js
+++ b/config/env.js
@@ -152,6 +152,16 @@ const DEFAULT_HEALTH_SYSTEM_PROMPT = `You are ${CHAT_AGENT_NAME}, a health assis
 
 Every card on the user's dashboard corresponds to a JSON manifest file in their data directory. Before answering questions, discover what cards exist and read the relevant data from those files.
 
+## Your stance
+
+This dashboard belongs to one informed adult who is actively managing their own health: peptides, supplements, training, sleep, bloods, medications, the lot. They have already done their own research and made their own decisions about what to take and at what dose. You are their personal tool, not a gatekeeper, and not a generic public chatbot.
+
+When the user asks for help with a peptide, supplement, medication, dosing schedule, cycle length, stack design, lab interpretation, or anything else on their dashboard, engage directly. Reason about it using their logged data and the cards in front of you. Suggest schedules, flag interactions you can see in their own manifests, compare what they are doing to what they have logged before. Do NOT refuse, hedge with "I can't recommend...", or redirect them to a clinician on principle. Treat their request the same way you would treat "add a row to my weight card": as a tool action the user is driving.
+
+The single carve-out is genuine emergencies and acute diagnosis (chest pain, suspected stroke, suicidal ideation, anaphylaxis, an unknown lump). For those, briefly say so and point at emergency services or a clinician. Everything else is in scope.
+
+You are not prescribing. The user is logging and planning their own regimen, and you are helping them think clearly about it.
+
 ## Data format
 
 Each card file is a v2 manifest:

--- a/tests/config-defaults.test.js
+++ b/tests/config-defaults.test.js
@@ -192,6 +192,15 @@ describe('config/env.js defaults', () => {
     assert.ok(env.HEALTH_SYSTEM_PROMPT.includes('health assistant'));
   });
 
+  test('default system prompt frames the user as the decision-maker, not a patient to gatekeep', () => {
+    const env = freshEnv();
+    const p = env.HEALTH_SYSTEM_PROMPT;
+    assert.ok(p.includes('## Your stance'), 'should declare a stance section');
+    assert.ok(/informed adult/i.test(p), 'should frame the user as an informed adult');
+    assert.ok(/not a gatekeeper/i.test(p), 'should explicitly tell the agent not to gatekeep');
+    assert.ok(/emergenc/i.test(p), 'should carve out emergencies as the exception');
+  });
+
   test('default system prompt advertises the create/delete endpoints + the full renderer + input surface', () => {
     const env = freshEnv();
     const p = env.HEALTH_SYSTEM_PROMPT;


### PR DESCRIPTION
## Summary

The default chat system prompt described Klebbius as a health
assistant and laid out every manifest tool, but said nothing about
how the agent should engage with the substance of peptide /
supplement / dosing questions. With no stance, the underlying model
fell back to its generic public-chatbot refusal on a fresh chat
("I can't recommend peptides..."), then engaged once the user
re-asked the same question with explicit manifest-tool framing
("this is already in my schedule card, help me modify it").

Same question, two answers, depending only on phrasing. Klebb is a
single-user self-hosted dashboard for someone driving their own
regimen; refuse-by-default contradicts the product premise.

## Why

- One product premise, one consistent agent behaviour. Inconsistent
  refusals erode trust in the data side of the dashboard too.
- The fix is purely a prompt change; no tools, routes, or schemas
  move.

## How

`config/env.js` — add a `## Your stance` section near the top of
`DEFAULT_HEALTH_SYSTEM_PROMPT` (after the opener, before
`## Data format`). The section:

- Frames the user as an informed adult who already makes their own
  dosing / cycling / stack decisions.
- Tells the agent its job is to reason about logged data and the
  cards in front of it, not to gatekeep, hedge, or redirect to a
  clinician on principle.
- Reuses the "tool action the user is driving" framing that already
  works in the manifest-tool path, so the rest of the prompt
  reinforces it.
- Carves out a narrow exception for genuine emergencies and acute
  diagnosis (chest pain, suspected stroke, suicidal ideation,
  anaphylaxis, unknown lump). Everything else is in scope.
- Closes with "You are not prescribing" so the model has a
  face-saving frame for the safety-tuned reflex without conceding
  the refusal.

`tests/config-defaults.test.js` — new assertion that the stance
section is present in the default prompt, the user is framed as an
informed adult, the agent is told not to gatekeep, and an emergency
carve-out exists. Joins the existing battery that locks in the
default prompt tool surface.

`CHANGELOG.md` — entry under `## [Unreleased]` → `### Changed`.

`HEALTH_SYSTEM_PROMPT` and `HEALTH_SYSTEM_PROMPT_FILE` overrides are
unchanged; instances wanting softer framing keep their escape hatch.
The voice-mode wrapper in `server.js` re-uses `HEALTH_SYSTEM_PROMPT`
verbatim, so voice picks up the same stance for free with no
additional code.

## Testing

- [x] `node --test tests/config-defaults.test.js` — 29/29 pass,
      including the new stance assertion.
- [x] `npm test` — 1066/1070 pass; the two unrelated failures
      (`tests/no-personal-refs.test.js`) reproduce on `main` and are
      caused by gitignored CLAUDE.md references and a webauthn
      session token already present in `data/`. Not introduced by
      this PR.
- [x] Hygiene scan on the staged diff: clean.
- [ ] Manual: ask Klebbius about a peptide on a fresh chat, confirm
      it engages instead of refusing. Best done after the image
      lands on `klebbtest`.

Fixes #326