### PR TITLE
chore(welcome-card): drop intro paragraph

### DIFF
--- a/public/js/components/eh-welcome-card.js
+++ b/public/js/components/eh-welcome-card.js
@@ -14,12 +14,6 @@ export class EhWelcomeCard extends EhBaseCard {
   static styles = [
     EhBaseCard.styles,
     css`
-      .intro {
-        font-size: 14px;
-        line-height: 1.55;
-        color: var(--text-primary);
-        margin: 0 0 16px;
-      }
       .paths {
         display: grid;
         grid-template-columns: 1fr;
@@ -153,11 +147,6 @@ export class EhWelcomeCard extends EhBaseCard {
 
   renderCard() {
     return html`
-      <p class="intro">
-        Klebb is a file-driven dashboard powered by a chat agent: every
-        card is a JSON file on disk, and the chat agent writes those
-        files for you. Start with one of the three paths below.
-      </p>
       <div class="paths">
         <button type="button" class="path featured" @click=${this._openPrompts}>
           <span class="start-chip">★ Start here</span>


### PR DESCRIPTION
## Summary
- Remove the redundant intro sentence from the Welcome card; let the three path tiles speak for themselves.

## Why
The intro paragraph repeated what the tiles already communicate. Tighter onboarding.

## How
Dropped the `<p class=\"intro\">` block and its `.intro` style rule from `eh-welcome-card.js`.

## Testing
- [x] Manual: Welcome card now renders straight into the three paths.
- [x] No behaviour change to the path tiles themselves.