### PR TITLE
fix(chat): abort in-flight reply when 'new chat' clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,14 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **"New chat" button now aborts the in-flight reply.** Clicking the
+  📝 button while a chat reply was still on the wire cleared the
+  message list but left the textarea disabled until the server eventually
+  responded (and the reply was discarded into the empty chat). The button
+  now aborts the `/api/chat` fetch, drops the loading state immediately
+  so the textarea re-enables, suppresses the spurious "Request timed
+  out" error in the freshly-cleared chat, and refocuses the input on
+  desktop. Fixes #325.
 - **Chat client no longer times out on slow multi-iter turns.** The
   chat widget aborted at 120s while the server-side tool-calling loop
   could legitimately take longer (a single gateway hop is capped at

--- a/public/js/components/health-chat.js
+++ b/public/js/components/health-chat.js
@@ -707,6 +707,15 @@ class HealthChat extends LitElement {
   }
 
   async _clearHistory() {
+    // If a reply is in flight, abort it so the textarea re-enables
+    // immediately. The flag is read by _sendText / _handleRecordedBlob's
+    // catch blocks so they don't push a stale error into the cleared chat.
+    if (this._abortController) {
+      this._userAbortedChat = true;
+      this._abortController.abort();
+      this._abortController = null;
+    }
+    this._loading = false;
     stopSharedAudio();
     this._audioCache.forEach(v => { try { URL.revokeObjectURL(v.url); } catch {} });
     this._audioCache.clear();
@@ -714,6 +723,14 @@ class HealthChat extends LitElement {
     this._playingMsgId = null;
     this._voiceArmed = false;
     if (this._saveTimer) { clearTimeout(this._saveTimer); this._saveTimer = null; }
+    // Refocus the textarea so the user can type the next message right
+    // away. Desktop only: touch keyboards re-popping is jarring.
+    this.updateComplete.then(() => {
+      if (this._recording) return;
+      if (matchMedia('(max-width: 480px)').matches) return;
+      const input = this.shadowRoot?.querySelector('.chat-input');
+      if (input && !input.disabled) input.focus();
+    });
     try {
       await fetch('/api/chat/history', { method: 'DELETE', cache: 'no-store' });
     } catch {}
@@ -947,7 +964,11 @@ class HealthChat extends LitElement {
         }
       }
     } catch (e) {
-      this._pushError(e.name === 'AbortError' ? 'Request timed out' : 'Failed to connect');
+      if (this._userAbortedChat) {
+        this._userAbortedChat = false;
+      } else {
+        this._pushError(e.name === 'AbortError' ? 'Request timed out' : 'Failed to connect');
+      }
     }
     this._loading = false;
     this._abortController = null;
@@ -1091,7 +1112,11 @@ class HealthChat extends LitElement {
       let replyData;
       try { replyData = await this._fetchChat(chatMessages, true); }
       catch (e) {
-        this._pushError(e.name === 'AbortError' ? 'Request timed out' : 'Failed to connect');
+        if (this._userAbortedChat) {
+          this._userAbortedChat = false;
+        } else {
+          this._pushError(e.name === 'AbortError' ? 'Request timed out' : 'Failed to connect');
+        }
         return;
       }
 

--- a/tests-e2e/chat-clear-aborts-inflight.spec.js
+++ b/tests-e2e/chat-clear-aborts-inflight.spec.js
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/chat-clear-aborts-inflight.spec.js
+// Regression for #325: clicking the "new chat" button while a chat
+// reply is in flight must abort the request immediately, re-enable
+// the textarea, and not push a stale "Request timed out" error into
+// the cleared chat.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+test.describe('#325: clear chat aborts in-flight reply', () => {
+  test('new-chat button re-enables the textarea while /api/chat is pending', async ({ page }) => {
+    // Stall /api/chat so the reply is still in flight when we click
+    // "new chat". We never resolve it; aborting on the client side is
+    // the whole point.
+    await page.route('**/api/chat', async (route) => {
+      const req = route.request();
+      // Only stall the POST that actually triggers a reply.
+      if (req.method() !== 'POST') return route.fallback();
+      // Hold the route open. If the test ends first, Playwright tears
+      // it down; if the client aborts, fulfill rejects harmlessly.
+      await new Promise((resolve) => setTimeout(resolve, 30_000));
+      try {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ reply: 'never sent' }),
+        });
+      } catch {}
+    });
+
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible();
+
+    const promptModal = page.locator('eh-prompt-modal dialog');
+    await promptModal.waitFor({ state: 'visible', timeout: 3000 }).catch(() => {});
+    if (await promptModal.isVisible().catch(() => false)) {
+      await promptModal.locator('button[aria-label="Dismiss"]').click();
+      await expect(promptModal).not.toBeVisible();
+    }
+
+    await page.getByRole('button', { name: /open chat/i }).click();
+
+    const widget = page.locator('health-chat');
+    const input = widget.locator('.chat-input');
+    await expect(input).toBeVisible();
+
+    await input.fill('this question takes forever');
+    await input.press('Enter');
+
+    // Textarea should be disabled while the request is in flight.
+    await expect(input).toBeDisabled();
+
+    // Click the "new chat" button. It's the 📝 button in the header.
+    await widget.locator('button[aria-label="New chat"]').click();
+
+    // Textarea must re-enable immediately, without waiting for the
+    // server to respond.
+    await expect(input).toBeEnabled({ timeout: 2_000 });
+
+    // No spurious error bubble in the cleared chat.
+    await expect(widget.locator('.msg.error')).toHaveCount(0);
+    // The user's own message has been cleared too.
+    await expect(widget.locator('.msg.user')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
# What changed

Clicking the 📝 *new chat* button in the chat widget while a reply was still on the wire used to clear the message list but leave the textarea disabled until the server eventually responded. The discarded reply also pushed a stale 'Request timed out' error into the freshly-cleared chat. Now the button aborts the `/api/chat` fetch immediately, drops `_loading` so the textarea re-enables, suppresses the abort-as-error in both the text and voice catch blocks, and refocuses the textarea on desktop.

# Why

Fixes #325. The new-chat button is the user's "kill this and start over" affordance. Forcing them to wait out a reply they're never going to see (and then watching a phantom error appear in the new chat) is a small but noticeable bug, especially on slow tool-using turns where the wait can be 30s+.

# How

`_clearHistory` (`public/js/components/health-chat.js`) now:

1. Aborts the existing `AbortController` if one is in flight, sets a `_userAbortedChat` flag, and nulls the controller.
2. Sets `_loading = false` synchronously so the textarea + send button re-enable immediately, without waiting for the aborted fetch's catch path to run.
3. Refocuses the textarea on desktop only (mobile keeps existing behaviour to avoid the soft keyboard re-popping uninvited).
4. Continues the prior cleanup: stop audio, clear audio cache, drop voice arming, cancel pending history save, `DELETE /api/chat/history`.

The `_userAbortedChat` flag is read in `_sendText`'s catch block and `_handleRecordedBlob`'s ASR catch block so a user-initiated abort doesn't surface as a 'Request timed out' or 'Failed to connect' bubble in the cleared chat.

# Testing

- [x] `npm test` passes locally (pre-existing `no-personal-refs` failure on local dev tree only, unrelated to this PR; tracked separately)
- [x] `npm run test:e2e` passes locally (new spec runs in 8s)
- [x] New regression test added at the right layer:
  - User-visible interaction → `tests-e2e/chat-clear-aborts-inflight.spec.js`
- [x] Test fails against `main` before the fix and passes with it
- [x] Manual QA: opened the chat widget, sent a message, clicked 📝 mid-flight; textarea re-enabled instantly with no error bubble.

# Checklist

- [x] Commit messages follow the conventions in `CONTRIBUTING.md`
- [x] `CHANGELOG.md` updated under `## Unreleased`
- [ ] Docs updated (`README.md` / `docs/*.md` / `MANIFEST-SCHEMA.md`) — N/A, behaviour fix only
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Breaking changes

None.