### PR TITLE
fix(tests): scan only tracked files in no-personal-refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,15 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
   so the textarea re-enables, suppresses the spurious "Request timed
   out" error in the freshly-cleared chat, and refocuses the input on
   desktop. Fixes #325.
+- **`no-personal-refs` test honours gitignore.** The scanner walked
+  the working tree directly and so flagged operator-private files
+  that exist on disk but never ship (`BRIEF-FOR-CC.md`, `CLAUDE.md`,
+  `.claude/`, `data/sessions/*.json`). CI was unaffected (clean
+  checkout) but local `npm test` was noisy with up to 17 spurious
+  hits, conditioning developers to ignore the scanner. The scanner
+  now drives off `git ls-files`, so it only sees what actually
+  ships. Real residue in tracked files still fails the test.
+  Fixes #330.
 - **Chat client no longer times out on slow multi-iter turns.** The
   chat widget aborted at 120s while the server-side tool-calling loop
   could legitimately take longer (a single gateway hop is capped at

--- a/tests/no-personal-refs.test.js
+++ b/tests/no-personal-refs.test.js
@@ -11,23 +11,25 @@
 
 const { test, describe } = require('node:test');
 const assert = require('node:assert');
+const { execFileSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
 const REPO_ROOT = path.join(__dirname, '..');
 
-// Directories to skip entirely.
-const SKIP_DIRS = new Set([
-  'node_modules',
-  '.git',
-  'tests',                 // tests can legitimately mention names (they are fixtures)
-  '_legacy-v1',            // legacy UI not loaded anymore
-]);
+// Top-level directory prefixes to skip. The scanner is driven off
+// git ls-files so node_modules / .git are already excluded; this list
+// covers tracked paths whose contents legitimately mention names
+// (test fixtures, legacy UI).
+const SKIP_PREFIXES = [
+  'tests/',
+  '_legacy-v1/',
+];
 
 // File suffixes to scan.
 const SCAN_EXTS = new Set(['.js', '.md', '.html', '.css', '.json']);
 
-// Files to skip individually (by absolute path from repo root).
+// Files to skip individually (paths relative to repo root, forward-slash form).
 const SKIP_FILES = new Set([
   'package-lock.json',
   'CHANGELOG.md', // historical notes legitimately mention pre-rename values
@@ -53,41 +55,53 @@ const FORBIDDEN = [
   { pattern: /['"][0-9a-f]{48,}['"]/, name: 'hex token ≥48 chars' },
 ];
 
-function scanDir(dir) {
+// List tracked files via git so the scan only sees what actually ships.
+// Local-only artefacts (BRIEF-FOR-CC.md, CLAUDE.md, .claude/, data/, etc.)
+// are gitignored and therefore invisible here, even though they exist
+// on the operator's working copy. Fixes #330.
+function listTrackedFiles() {
+  const out = execFileSync('git', ['-C', REPO_ROOT, 'ls-files', '-z'], {
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return out.split('\0').filter(Boolean);
+}
+
+function scanRepo() {
   const findings = [];
-  const entries = fs.readdirSync(dir, { withFileTypes: true });
-  for (const ent of entries) {
-    if (ent.isDirectory()) {
-      if (SKIP_DIRS.has(ent.name)) continue;
-      findings.push(...scanDir(path.join(dir, ent.name)));
-    } else if (ent.isFile()) {
-      const full = path.join(dir, ent.name);
-      const rel = path.relative(REPO_ROOT, full);
-      if (SKIP_FILES.has(rel)) continue;
-      const ext = path.extname(ent.name);
-      if (!SCAN_EXTS.has(ext)) continue;
-      const content = fs.readFileSync(full, 'utf8');
-      const lines = content.split('\n');
-      lines.forEach((line, idx) => {
-        for (const rule of FORBIDDEN) {
-          if (rule.pattern.test(line)) {
-            findings.push({
-              file: rel,
-              line: idx + 1,
-              rule: rule.name,
-              text: line.trim().slice(0, 120),
-            });
-          }
-        }
-      });
+  for (const rel of listTrackedFiles()) {
+    if (SKIP_FILES.has(rel)) continue;
+    if (SKIP_PREFIXES.some(p => rel.startsWith(p))) continue;
+    const ext = path.extname(rel);
+    if (!SCAN_EXTS.has(ext)) continue;
+    const full = path.join(REPO_ROOT, rel);
+    let content;
+    try {
+      content = fs.readFileSync(full, 'utf8');
+    } catch {
+      // File listed by git but not on disk (e.g. case-only rename mid-checkout).
+      continue;
     }
+    const lines = content.split('\n');
+    lines.forEach((line, idx) => {
+      for (const rule of FORBIDDEN) {
+        if (rule.pattern.test(line)) {
+          findings.push({
+            file: rel,
+            line: idx + 1,
+            rule: rule.name,
+            text: line.trim().slice(0, 120),
+          });
+        }
+      }
+    });
   }
   return findings;
 }
 
 describe('no-personal-refs (repo hygiene)', () => {
   test('no personal identifiers or hardcoded paths in source', () => {
-    const findings = scanDir(REPO_ROOT);
+    const findings = scanRepo();
     if (findings.length > 0) {
       const report = findings
         .map(f => `  ${f.file}:${f.line}  [${f.rule}]  ${f.text}`)


### PR DESCRIPTION
# What changed

`tests/no-personal-refs.test.js` now lists files via `git ls-files` instead of `fs.readdirSync`, so it only scans content that actually ships. Operator-private files that exist on a developer's working copy but are gitignored (`BRIEF-FOR-CC.md`, `CLAUDE.md`, `.claude/skills/*`, `data/sessions/*.json`) are no longer scanned and no longer trigger spurious failures locally.

# Why

Fixes #330. The previous scanner flagged 17 hits on a fresh local checkout where the operator-private files exist on disk. CI stayed green (clean checkout, none of those files present) but local `npm test` was noisy enough that real residue could be skimmed past as "the usual noise". A scanner that's noisy where the noise is not actionable erodes trust in the scanner.

# How

Replaced the recursive `scanDir` walker with a `scanRepo` function that:

1. Calls `git -C <repo> ls-files -z` and splits on NUL to get the list of tracked paths.
2. Applies the existing extension and skip-list filters on those paths only.
3. Reads each file with `fs.readFileSync` and runs the existing rule set against each line, unchanged.

Renamed `SKIP_DIRS` to `SKIP_PREFIXES` and switched it to a path-prefix match (`'tests/'`, `'_legacy-v1/'`) since `git ls-files` returns full paths, not directory entries. `node_modules` and `.git` no longer need explicit entries: git won't list them.

Verified the scanner still catches real hits by appending `// Eddy was here` to a tracked file and watching the test fail with that hit reported.

# Testing

- [x] `npm test` passes locally (Node 20, full suite)
- [ ] `npm run test:e2e` — N/A, no behaviour change in shipped code
- [x] New regression test added at the right layer: existing `tests/no-personal-refs.test.js` now passes; positive verification done by temporarily inserting a forbidden token and confirming the test fails.
- [x] Test fails against `main` before the fix (17 spurious hits) and passes with it
- [x] Manual QA: ran `node --test tests/no-personal-refs.test.js` standalone — green; appended a forbidden token to `server.js` and re-ran — flagged correctly.

# Checklist

- [x] Commit messages follow the conventions in `CONTRIBUTING.md`
- [x] `CHANGELOG.md` updated under `## Unreleased`
- [ ] Docs updated — N/A, behaviour of test infrastructure only
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Breaking changes

None. The scanner's contract is unchanged from a CI perspective: it still scans tracked source for the same forbidden patterns.