### PR TITLE
fix(list-card): primary field honours its declared input type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,14 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **`list-card` honours the declared input type on the primary field.**
+  In edit mode the primary field was hardcoded to `<input type="text">`
+  regardless of what `writeable.inputs[primary].type` declared, so a
+  card with a `select` primary rendered as an empty text box. The
+  primary now dispatches on `type` (text, select, time, date, number,
+  textarea), and view mode resolves `{value, label}` option labels
+  before display. Existing list-cards (text primaries) are unchanged.
+  Fixes #332.
 - **"New chat" button now aborts the in-flight reply.** Clicking the
   📝 button while a chat reply was still on the wire cleared the
   message list but left the textarea disabled until the server eventually

--- a/public/js/components/eh-list-card.js
+++ b/public/js/components/eh-list-card.js
@@ -82,6 +82,90 @@ export class EhListCard extends EhBaseCard {
     return inputs.filter(i => i.key !== this._primaryField());
   }
 
+  _resolveOptionLabel(input, value) {
+    const opts = input?.options || [];
+    for (const o of opts) {
+      if (typeof o === 'string') {
+        if (o === value) return o;
+      } else if (o && typeof o === 'object') {
+        if (String(o.value) === String(value)) return o.label || o.value;
+      }
+    }
+    return value;
+  }
+
+  _renderPrimaryInput(input, row, idx, isDeleted) {
+    const v = row[input.key];
+    const update = (val) => this._updateDraftField(idx, input.key, val);
+    const placeholder = input.placeholder || input.label || '';
+    switch (input?.type) {
+      case 'select':
+        return html`
+          <select
+            class="primary-input"
+            ?disabled=${isDeleted}
+            ?required=${input.required}
+            @change=${(e) => update(e.target.value)}
+          >
+            <option value="" ?selected=${v === '' || v == null}>${placeholder || 'Select...'}</option>
+            ${(input.options || []).map(o => {
+              const val = typeof o === 'string' ? o : o.value;
+              const label = typeof o === 'string' ? o : (o.label || o.value);
+              return html`<option value=${val} ?selected=${String(v) === String(val)}>${label}</option>`;
+            })}
+          </select>`;
+      case 'time':
+      case 'date':
+        return html`
+          <input
+            class="primary-input"
+            type=${input.type}
+            .value=${v ?? ''}
+            ?disabled=${isDeleted}
+            ?required=${input.required}
+            @input=${(e) => update(e.target.value)}
+          />`;
+      case 'number':
+        return html`
+          <input
+            class="primary-input"
+            type="number"
+            .value=${v ?? ''}
+            placeholder=${placeholder}
+            min=${input.min ?? ''}
+            max=${input.max ?? ''}
+            step=${input.step ?? ''}
+            ?disabled=${isDeleted}
+            ?required=${input.required}
+            @input=${(e) => update(e.target.value === '' ? null : Number(e.target.value))}
+          />`;
+      case 'textarea':
+        return html`
+          <textarea
+            class="primary-input"
+            .value=${v ?? ''}
+            placeholder=${placeholder}
+            rows=${input.rows || 2}
+            maxlength=${input.maxLength ?? ''}
+            ?disabled=${isDeleted}
+            ?required=${input.required}
+            @input=${(e) => update(e.target.value)}
+          ></textarea>`;
+      case 'text':
+      default:
+        return html`
+          <input
+            class="primary-input"
+            type="text"
+            .value=${v ?? ''}
+            placeholder=${placeholder}
+            maxlength=${input.maxLength ?? ''}
+            ?disabled=${isDeleted}
+            @input=${(e) => update(e.target.value)}
+          />`;
+    }
+  }
+
   _truncate(s, n) {
     if (typeof s !== 'string') return s == null ? '' : String(s);
     if (s.length <= n) return s;
@@ -444,11 +528,15 @@ export class EhListCard extends EhBaseCard {
     }
     const maxChars = this._maxCharPreview();
     const primaryField = this._primaryField();
+    const primaryInput = this._primaryInput();
     const secondaryInputs = this._secondaryInputs();
     return html`
       <ul class="rows">
         ${rows.map((row, idx) => {
-          const primary = row[primaryField] ?? '';
+          const rawPrimary = row[primaryField] ?? '';
+          const primary = primaryInput?.type === 'select'
+            ? this._resolveOptionLabel(primaryInput, rawPrimary)
+            : rawPrimary;
           const truncated = this._truncate(primary, maxChars);
           const expanded = this._expandedRow === idx;
           const secondary = display.secondaryTemplate
@@ -519,10 +607,8 @@ export class EhListCard extends EhBaseCard {
   }
 
   _renderEditMode(rows, display) {
-    const primaryField = this._primaryField();
     const primaryInput = this._primaryInput();
     const secondaryInputs = this._secondaryInputs();
-    const maxLen = primaryInput?.maxLength;
     const hasSecondaryFields = secondaryInputs.length > 0;
     return html`
       <ul class="rows">
@@ -538,15 +624,9 @@ export class EhListCard extends EhBaseCard {
                   aria-label="${isDeleted ? 'Restore' : 'Delete'} row ${idx + 1}"
                   title="${isDeleted ? 'Restore' : 'Delete'}"
                 >${isDeleted ? '↺' : '➖'}</button>
-                <input
-                  class="primary-input"
-                  type="text"
-                  .value=${row[primaryField] ?? ''}
-                  placeholder="${primaryInput?.placeholder || primaryInput?.label || ''}"
-                  maxlength="${maxLen || ''}"
-                  ?disabled=${isDeleted}
-                  @input=${(e) => this._updateDraftField(idx, primaryField, e.target.value)}
-                />
+                ${primaryInput
+                  ? this._renderPrimaryInput(primaryInput, row, idx, isDeleted)
+                  : html`<span class="primary">${row[this._primaryField()] ?? ''}</span>`}
                 ${hasSecondaryFields && !isDeleted ? html`
                   <button
                     class="detail-btn"

--- a/tests-e2e/list-card-primary-select.spec.js
+++ b/tests-e2e/list-card-primary-select.spec.js
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/list-card-primary-select.spec.js
+// Regression for #332: list-card hardcoded the primary field to a
+// text input, so a manifest declaring type:"select" on the primary
+// rendered as an empty text box instead of a dropdown.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+const STOOL_LOG_ID = 'stool-log-e2e';
+
+function stoolLogManifest() {
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: STOOL_LOG_ID,
+      label: 'Stool Log (e2e)',
+      emoji: '🚽',
+      order: 9100,
+      category: 'lifestyle',
+      view: {
+        enabled: true,
+        component: 'list-card',
+        display: {
+          primaryField: 'bristolType',
+          emptyMessage: 'No entries today.',
+        },
+      },
+      writeable: {
+        fromWebapp: true,
+        todayAllowed: true,
+        pastAllowed: true,
+        futureAllowed: false,
+        maxReadingsPerDay: 20,
+        inputs: [
+          { key: 'time', label: 'Time', type: 'time' },
+          {
+            key: 'bristolType',
+            label: 'Bristol Type',
+            type: 'select',
+            options: [
+              '1 - Hard lumps',
+              '2 - Lumpy sausage',
+              '3 - Cracked sausage',
+              '4 - Smooth sausage',
+              '5 - Soft blobs',
+              '6 - Mushy',
+              '7 - Watery',
+            ],
+            required: true,
+          },
+          { key: 'notes', label: 'Notes', type: 'textarea' },
+        ],
+      },
+    },
+    description: 'List-card with a select primary, for the #332 regression.',
+    data: [
+      { added: '2026-04-01T08:00:00Z', time: '08:00', bristolType: '4 - Smooth sausage', notes: '' },
+    ],
+  };
+}
+
+async function seed(request, baseUrl, manifest) {
+  await request.delete(`${baseUrl}/api/manifests/${manifest.meta.id}`).catch(() => {});
+  const r = await request.post(`${baseUrl}/api/manifests`, { data: manifest });
+  expect([201, 409]).toContain(r.status());
+}
+
+async function cleanup(request, baseUrl, id) {
+  await request.delete(`${baseUrl}/api/manifests/${id}`).catch(() => {});
+}
+
+test.describe('#332: list-card primary field honours its declared type', () => {
+  test('a select primary renders a <select> in edit mode, not a text input', async ({ page, sandboxState }) => {
+    await seed(page.request, sandboxState.baseUrl, stoolLogManifest());
+
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible({ timeout: 10_000 });
+
+    const card = page.locator(`[data-card-id="${STOOL_LOG_ID}"] eh-list-card`);
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    await card.locator('button[aria-label="Edit list"]').click();
+
+    const primarySelect = card.locator('.row select.primary-input').first();
+    await expect(primarySelect).toBeVisible();
+
+    const optionCount = await primarySelect.locator('option').count();
+    expect(optionCount).toBeGreaterThanOrEqual(7);
+
+    await expect(card.locator('.row input.primary-input[type="text"]')).toHaveCount(0);
+
+    await cleanup(page.request, sandboxState.baseUrl, STOOL_LOG_ID);
+  });
+});


### PR DESCRIPTION
# What changed

In edit mode, `eh-list-card` was rendering the primary field with a hardcoded `<input type="text">` regardless of the `type` declared on that input in `writeable.inputs`. Secondary fields on the same card go through `<eh-input-form>` and render correctly for every supported type, so the asymmetry was visible whenever someone built a list-card whose primary wasn't a free-text title (e.g. a select with seven Bristol-stool options rendered as an empty text box).

The primary slot now dispatches on `primaryInput.type` for `text`, `select`, `time`, `date`, `number`, and `textarea`. View mode also resolves `{value, label}` option shapes to their human label before display, so a future select primary using object options shows the label rather than the bare value. Plain-string options keep working as today.

# Why

Fixes #332.

The chat agent now lets users describe arbitrary cards, and the first attempt at a card with a non-text primary hit this dead end. There is no technical reason for the hardcode; it predates the richer set of input types now supported by `eh-input-form` and survived only because every existing list-card in the wild happens to use a free-text primary.

# How

- New private helper `_renderPrimaryInput(input, row, idx, isDeleted)` on the renderer dispatches the primary widget on `input.type`. Edit mode uses it in place of the hardcoded `<input>`.
- New `_resolveOptionLabel(input, value)` looks up the matching option label for a `select` primary; view mode uses it.
- Existing styling is unchanged: the new widgets all carry the same `.primary-input` class, so layout/typography/iOS-zoom behaviour is preserved across `<input>`, `<select>`, `<textarea>`.
- `_addNewRow` already seeded `''` for non-checkbox/non-number inputs and `null` for numbers, both of which match the empty-primary filter in `_saveEdit` (i.e. a row with no select choice is dropped on save). No changes needed there.

# Testing

- [x] `npm test` passes locally (1075 tests, 2 pre-existing skips).
- [x] `npm run test:e2e` passes locally (42 specs).
- [x] New regression spec at `tests-e2e/list-card-primary-select.spec.js` was confirmed failing on this branch before the fix and passing after.
- [x] `tests-e2e/list-card-row-detail-edit.spec.js` (the #317 regression for the secondary form) still passes.

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [x] Docs updated if behaviour or schema changed (no schema change; behaviour is the same for existing manifests)
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens

# Breaking changes

None. Existing list-cards (all text primaries) render and save identically.