### PR TITLE
fix(chat): correct list-card description in agent system prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,16 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Chat-agent system prompt steers event logs at `generic-card`, not
+  `list-card`.** The renderer summary previously described `list-card`
+  as a "persistent chronological list of entries; data is `[{date,
+  ...}]`", which was wrong on both counts (`list-card` is a permanent
+  roster, rows do not carry a `date`). The agent therefore reached for
+  `list-card` whenever the user asked for any kind of repeated log,
+  and the resulting card showed every row on every day with no
+  per-date scoping. The renderer summary now matches the actual
+  contract and explicitly points event-style multi-entry logs at
+  `generic-card` with `maxReadingsPerDay`. Fixes #334.
 - **`list-card` honours the declared input type on the primary field.**
   In edit mode the primary field was hardcoded to `<input type="text">`
   regardless of what `writeable.inputs[primary].type` declared, so a

--- a/config/env.js
+++ b/config/env.js
@@ -296,8 +296,8 @@ For a workouts card specifically: use \`"template": "{trained:check} {type}"\` (
 
 ### Known renderers (meta.view.component)
 
-- \`generic-card\` — single latest value + delta. Data is \`[{date, <field>...}]\`. Uses \`meta.view.display\` (object: \`{template, secondary?, emptyHeadline?, unit?, emojiMap?, thresholds?, trendArrow?}\`) to format the headline.
-- \`list-card\` — persistent chronological list of entries; data is \`[{date, ...fields}]\`.
+- \`generic-card\` — per-day card. Data is \`[{date, <field>...}]\`. Each row carries the date it applies to, and the card on Today shows just that day's row (with optional \`fallbackToLatest\` and a "from N days ago" indicator). Set \`writeable.maxReadingsPerDay > 1\` for multiple entries per day (e.g. \`3\` for blood-pressure morning/noon/night, \`99\` for an open-ended event log). Uses \`meta.view.display\` (object: \`{template, secondary?, emptyHeadline?, unit?, emojiMap?, thresholds?, trendArrow?}\`) to format the headline.
+- \`list-card\` — permanent roster, NOT per-day. Renders the entire \`data\` array on every day until rows are explicitly deleted. Rows do NOT carry a \`date\`. Use ONLY for "things that are currently true": tracked symptoms, allergies, ongoing conditions, future appointments. Do NOT use for event logs (food log, stool log, doses-taken, journal entries) — those need per-day scoping; pick \`generic-card\` with \`maxReadingsPerDay\` instead.
 - \`checklist-card\` — tickable daily items; data \`{items:[{id,doses:[...]}]}\`-ish.
 - \`schedule-card\` — scheduled doses/events with recurrence; data is \`{items:[{name, dose_mg?, dose_units?, route?, schedule, doses?:[]}]}\`. Each item's \`schedule\` is a schedule-shape object (see below). **Items ALWAYS live in \`data.items[]\`; never in \`meta.schedule\`.** \`meta.schedule\` is only used by the \`schedule-timeline\` renderer for a single card-level cadence, and it's rare.
 - \`schedule-timeline\` — stacked timeline across a window; reads \`meta.schedule\`.

--- a/tests/chat-prompt-cards.test.js
+++ b/tests/chat-prompt-cards.test.js
@@ -128,6 +128,34 @@ describe('chat proxy dynamic card-list injection', () => {
     assert.ok(/never in .?meta\.schedule.?/i.test(sp), 'prompt warns against meta.schedule');
   });
 
+  test('system prompt steers event-style logs at generic-card, not list-card', async () => {
+    // Regression for #334: the prompt previously described list-card as
+    // "persistent chronological list of entries; data is [{date,...}]",
+    // which is wrong on both counts and led the agent to pick list-card
+    // for per-day event logs (food log, stool log, etc.). The corrected
+    // text must (a) NOT call list-card chronological/per-row-dated, and
+    // (b) name maxReadingsPerDay or generic-card as the right answer
+    // for multi-entry-per-day logging.
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'hi' }], voiceMode: false },
+    });
+    assert.equal(res.status, 200);
+    const sp = gateway.getLastPrompt();
+    assert.ok(
+      !/list-card[^.\n]*chronological/i.test(sp),
+      'prompt must not describe list-card as chronological'
+    );
+    assert.ok(
+      /list-card[\s\S]{0,400}(permanent roster|currently true|NOT per-day)/i.test(sp),
+      'prompt must describe list-card as a non-per-day roster'
+    );
+    assert.ok(
+      /maxReadingsPerDay/.test(sp),
+      'prompt must mention maxReadingsPerDay as the multi-entry-per-day knob'
+    );
+  });
+
   test('system prompt forbids silent embellishments on create', async () => {
     const res = await req(server.baseUrl, '/api/chat', {
       method: 'POST',


### PR DESCRIPTION
# What changed

The chat-agent system prompt in \`config/env.js\` previously described \`list-card\` as:

> \`list-card\` - persistent chronological list of entries; data is \`[{date, ...fields}]\`

That's wrong on both counts. \`list-card\` is a permanent roster: it renders the entire data array on every day, regardless of viewed date, and rows do not carry a \`date\` field. It's the right renderer for "things that are currently true" (tracked symptoms, allergies, ongoing conditions, future appointments), not for event logs.

This PR rewrites the line to match the actual contract (sourced from \`docs/CARDS.md:589-599\` and the renderer's own header comment in \`public/js/components/eh-list-card.js\`), and explicitly points event-style multi-entry-per-day logging at \`generic-card\` with \`writeable.maxReadingsPerDay\`. The \`generic-card\` summary on the line above is also expanded to mention \`maxReadingsPerDay\` and the per-day scoping behaviour, so the agent has both halves of the decision in one place.

# Why

Fixes #334.

The chat agent is the primary path users now take to create cards. With the misleading description, it reached for \`list-card\` whenever the user asked for any repeated log — food log, stool log, doses-taken — and the resulting card showed every row on every day with no per-date scoping. Surfaced while debugging a user's Stool Log card on the live \`mazklebb\` instance.

# How

Two edits in \`config/env.js\`:

- \`generic-card\` line gains a sentence about per-day scoping and \`maxReadingsPerDay\`.
- \`list-card\` line is rewritten to "permanent roster, NOT per-day", spells out the no-\`date\` row shape, lists the right use cases, and ends with an explicit "do NOT use for event logs; pick \`generic-card\` instead" cue.

New test in \`tests/chat-prompt-cards.test.js\` asserts:

- Prompt does NOT describe \`list-card\` as chronological.
- Prompt mentions one of {permanent roster / currently true / NOT per-day}.
- Prompt mentions \`maxReadingsPerDay\`.

No code paths change. Renderer behaviour is unchanged.

# Testing

- [x] \`npm test\` passes locally (1076 tests, 2 pre-existing skips).
- [x] New test \`system prompt steers event-style logs at generic-card, not list-card\` covers the regression.

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [x] Docs updated if behaviour or schema changed (no schema change; the prompt now matches \`docs/CARDS.md\`)
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens

# Breaking changes

None. Existing cards on disk are unaffected. Operators with existing mis-classified \`list-card\` cards (where the user wanted per-day scoping) will need to delete and recreate them via chat once this lands; that's a data fix, not a code path.