### PR TITLE
fix(ui): generic-card multi-entry display + per-row edit/delete (#336)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **`generic-card` renders every entry per day when
+  `maxReadingsPerDay > 1`.** The save path already capped multiple
+  rows correctly, but the display path returned the first matching
+  row only and the UI offered a single edit/add affordance, so cards
+  intended as event logs (stool, BMs, BP across the day) silently lost
+  earlier entries from view. Cards with `maxReadingsPerDay > 1` now
+  render every row dated the current day as its own list line, sorted
+  by `time` if present, with per-row edit + delete and a separate
+  ➕ Add control. `fallbackToLatest` is suppressed in this mode (showing
+  yesterday's *list* on Today is more confusing than helpful). The
+  default `maxReadingsPerDay: 1` path is unchanged. Fixes #336.
 - **Chat-agent system prompt steers event logs at `generic-card`, not
   `list-card`.** The renderer summary previously described `list-card`
   as a "persistent chronological list of entries; data is `[{date,

--- a/public/js/components/eh-generic-card.js
+++ b/public/js/components/eh-generic-card.js
@@ -48,6 +48,7 @@ export class EhGenericCard extends EhBaseCard {
   static properties = {
     ...EhBaseCard.properties,
     _editing: { state: true },
+    _editingIndex: { state: true },
     _saving: { state: true },
     _formError: { state: true },
   };
@@ -55,8 +56,33 @@ export class EhGenericCard extends EhBaseCard {
   constructor() {
     super();
     this._editing = false;
+    // Absolute index in the data array of the row being edited, or null
+    // when the form is in "add new" mode. Only meaningful when
+    // maxReadingsPerDay > 1; ignored in the single-entry path.
+    this._editingIndex = null;
     this._saving = false;
     this._formError = null;
+  }
+
+  _maxReadingsPerDay() {
+    return this._m()?.writeable?.maxReadingsPerDay ?? 1;
+  }
+
+  // For multi-entry mode: every row whose date === this.date, paired
+  // with its absolute index in the underlying data array (so edit + delete
+  // mutate the right row even after time-sorting for display).
+  _rowsForExactDate() {
+    const rows = this._entries();
+    const sameDay = [];
+    rows.forEach((row, idx) => {
+      if (row && row.date === this.date) sameDay.push({ row, idx });
+    });
+    sameDay.sort((a, b) => {
+      const at = a.row.time || '';
+      const bt = b.row.time || '';
+      return String(at).localeCompare(String(bt));
+    });
+    return sameDay;
   }
 
   // Local aliases — don't shadow EhBaseCard's _meta getter
@@ -100,13 +126,37 @@ export class EhGenericCard extends EhBaseCard {
     return entries.find(e => e.date === this.date) || null;
   }
 
-  _openEdit() {
+  _openEdit(index = null) {
     this._editing = true;
+    this._editingIndex = (typeof index === 'number') ? index : null;
     this._formError = null;
   }
   _closeEdit() {
     this._editing = false;
+    this._editingIndex = null;
     this._formError = null;
+  }
+
+  async _onDeleteRow(index) {
+    const existing = this._entries();
+    if (index < 0 || index >= existing.length) return;
+    this._saving = true;
+    this._formError = null;
+    try {
+      const updated = existing.filter((_, i) => i !== index);
+      const r = await fetch(`/api/manifests/${encodeURIComponent(this.card.id)}/data`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ data: updated }),
+      });
+      if (!r.ok) throw await errorFromResponse(r);
+      invalidateManifestCache(this.card.id);
+      this.data = updated;
+    } catch (err) {
+      this._formError = err.message;
+    } finally {
+      this._saving = false;
+    }
   }
 
   async _onSubmit(e) {
@@ -119,17 +169,23 @@ export class EhGenericCard extends EhBaseCard {
       if (!entry.date) entry.date = this.date;
       const existing = this._entries();
       const max = meta?.writeable?.maxReadingsPerDay ?? 1;
-
-      const sameDay = existing.filter(d => d.date === entry.date);
-      const others = existing.filter(d => d.date !== entry.date);
+      const editIdx = this._editingIndex;
 
       let updated;
-      if (max === 1) {
-        updated = [...others, entry];
+      if (max > 1 && typeof editIdx === 'number'
+          && editIdx >= 0 && editIdx < existing.length) {
+        // Replace the targeted row in place (multi-entry edit).
+        updated = existing.map((row, i) => (i === editIdx ? entry : row));
       } else {
-        const combined = [...sameDay, entry];
-        const capped = combined.slice(-max);
-        updated = [...others, ...capped];
+        const sameDay = existing.filter(d => d.date === entry.date);
+        const others = existing.filter(d => d.date !== entry.date);
+        if (max === 1) {
+          updated = [...others, entry];
+        } else {
+          const combined = [...sameDay, entry];
+          const capped = combined.slice(-max);
+          updated = [...others, ...capped];
+        }
       }
       updated.sort((a, b) => (a.date || '').localeCompare(b.date || ''));
 
@@ -143,6 +199,7 @@ export class EhGenericCard extends EhBaseCard {
       invalidateManifestCache(this.card.id);
       this.data = updated;
       this._editing = false;
+      this._editingIndex = null;
     } catch (err) {
       this._formError = err.message;
     } finally {
@@ -261,6 +318,88 @@ export class EhGenericCard extends EhBaseCard {
       .card-inner { position: relative; padding-right: 4px; padding-left: 10px; }
       .err { color: #ff4466; font-size: 12px; margin-top: 6px; }
 
+      .gen-rows {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .gen-list-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 0;
+        border-top: 1px solid var(--border);
+        min-height: 36px;
+      }
+      .gen-list-row:first-child { border-top: none; }
+      .gen-list-text {
+        flex: 1;
+        min-width: 0;
+        font-size: 14px;
+        color: var(--text-primary);
+        overflow-wrap: anywhere;
+      }
+      .gen-list-secondary {
+        margin-top: 2px;
+        font-size: 12px;
+        color: var(--text-secondary);
+      }
+      .gen-list-actions {
+        display: inline-flex;
+        gap: 4px;
+        flex-shrink: 0;
+      }
+      .gen-row-btn {
+        background: transparent;
+        border: 1px solid var(--border);
+        color: var(--text-secondary);
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        font-size: 13px;
+        cursor: pointer;
+        font-family: inherit;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        line-height: 1;
+        padding: 0;
+      }
+      .gen-row-btn:hover, .gen-row-btn:focus-visible {
+        border-color: var(--accent);
+        color: var(--accent);
+        outline: none;
+      }
+      .gen-row-btn.danger:hover, .gen-row-btn.danger:focus-visible {
+        border-color: #d0323e;
+        color: #d0323e;
+      }
+      .gen-add-row {
+        padding: 10px 0 0 0;
+        border-top: 1px dashed var(--border);
+        margin-top: 4px;
+      }
+      .gen-add-btn {
+        background: transparent;
+        border: 1px dashed var(--border);
+        color: var(--accent);
+        padding: 8px 14px;
+        border-radius: 8px;
+        cursor: pointer;
+        font-size: 13px;
+        font-family: inherit;
+        font-weight: 600;
+        width: 100%;
+      }
+      .gen-add-btn:hover {
+        border-color: var(--accent);
+        background: var(--accent-bg, rgba(0,212,170,0.05));
+      }
+      .gen-add-btn:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+
       @media (prefers-reduced-motion: reduce) {
         .edit-btn { transition: none; }
       }
@@ -294,6 +433,14 @@ export class EhGenericCard extends EhBaseCard {
   renderCard() {
     const meta = this._m();
     const display = this._display();
+    // When the manifest opts into multiple readings per day, render a
+    // per-day list with per-row edit/delete + an Add action. The single-
+    // entry path below is left untouched. fallbackToLatest is suppressed
+    // here: showing yesterday's *list* on Today is more confusing than
+    // helpful.
+    if (this._maxReadingsPerDay() > 1) {
+      return this._renderMultiEntry();
+    }
     // Two different resolutions:
     //   - displayEntry:  what the card headline shows. Honours
     //     fallbackToLatest on Today, so a card with no row today
@@ -415,6 +562,90 @@ export class EhGenericCard extends EhBaseCard {
             </div>` : ''}
         ` : html`
           <div class="gen-empty">${headline}</div>
+        `}
+
+        ${this._formError ? html`<div class="err">${this._formError}</div>` : ''}
+      </div>
+    `;
+  }
+
+  // Multi-entry path: render every row dated this.date as its own line,
+  // with per-row edit + delete and a separate ➕ Add control. Triggered
+  // by meta.writeable.maxReadingsPerDay > 1.
+  _renderMultiEntry() {
+    const meta = this._m();
+    const display = this._display();
+    const entries = this._entries();
+    const sameDay = this._rowsForExactDate();
+    const canWrite = this._canWrite
+      && Array.isArray(meta?.writeable?.inputs)
+      && meta.writeable.inputs.length > 0;
+
+    // When the form is open, resolve the row being edited (if any) by
+    // its absolute index in the data array. _editingIndex === null means
+    // the form is in "add new" mode.
+    const editIdx = this._editingIndex;
+    const editEntry = (typeof editIdx === 'number' && editIdx >= 0 && editIdx < entries.length)
+      ? entries[editIdx]
+      : null;
+
+    return html`
+      <div class="card-inner">
+        ${this._editing ? html`
+          <eh-input-form
+            .inputs=${meta.writeable.inputs}
+            .values=${editEntry || {}}
+            .date=${this.date}
+            .display=${display}
+            .requireAny=${meta.writeable.requireAny || null}
+            submit-label=${editEntry ? 'Update' : 'Add'}
+            ?busy=${this._saving}
+            @eh-submit=${this._onSubmit}
+            @eh-cancel=${this._closeEdit}
+          ></eh-input-form>
+        ` : html`
+          ${sameDay.length === 0 ? html`
+            <div class="gen-empty">${display.emptyHeadline || 'No entries yet'}</div>
+          ` : html`
+            <ul class="gen-rows">
+              ${sameDay.map(({ row, idx }) => {
+                const text = display.template
+                  ? renderTemplate(display.template, row, display)
+                  : (row[Object.keys(row).find(k => k !== 'date' && k !== 'added')] ?? '');
+                const sub = display.secondary
+                  ? renderTemplate(display.secondary, row, display)
+                  : '';
+                return html`
+                  <li class="gen-list-row">
+                    <div class="gen-list-text">
+                      ${text}
+                      ${sub ? html`<div class="gen-list-secondary">${sub}</div>` : ''}
+                    </div>
+                    ${canWrite ? html`
+                      <span class="gen-list-actions">
+                        <button class="gen-row-btn"
+                          @click=${() => this._openEdit(idx)}
+                          aria-label="Edit entry"
+                          title="Edit">✏️</button>
+                        <button class="gen-row-btn danger"
+                          @click=${() => this._onDeleteRow(idx)}
+                          ?disabled=${this._saving}
+                          aria-label="Delete entry"
+                          title="Delete">➖</button>
+                      </span>
+                    ` : ''}
+                  </li>
+                `;
+              })}
+            </ul>
+          `}
+          ${canWrite ? html`
+            <div class="gen-add-row">
+              <button class="gen-add-btn"
+                @click=${() => this._openEdit(null)}
+                aria-label="Add entry">➕ Add</button>
+            </div>
+          ` : ''}
         `}
 
         ${this._formError ? html`<div class="err">${this._formError}</div>` : ''}

--- a/tests-e2e/generic-card-multi-entry.spec.js
+++ b/tests-e2e/generic-card-multi-entry.spec.js
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/generic-card-multi-entry.spec.js
+// Regression for #336: a generic-card manifest with
+// `meta.writeable.maxReadingsPerDay > 1` could only show one entry per
+// day. The save path correctly appended (capped at the max), but the
+// display path returned the first matching row only and the UI had no
+// per-row edit/delete affordances. This spec drives the multi-entry
+// flow end-to-end.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+const STOOL_LOG_ID = 'stool-log-multi-e2e';
+
+function stoolLogManifest(today) {
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: STOOL_LOG_ID,
+      label: 'Stool Log (multi e2e)',
+      emoji: '🚽',
+      order: 9200,
+      category: 'lifestyle',
+      view: {
+        enabled: true,
+        component: 'generic-card',
+        display: {
+          template: '{bristolType} at {time}',
+          emptyHeadline: 'No entries yet',
+        },
+      },
+      writeable: {
+        fromWebapp: true,
+        todayAllowed: true,
+        pastAllowed: true,
+        futureAllowed: false,
+        maxReadingsPerDay: 99,
+        inputs: [
+          { key: 'time', label: 'Time', type: 'time' },
+          {
+            key: 'bristolType',
+            label: 'Bristol Type',
+            type: 'select',
+            options: [
+              '1 - Hard lumps',
+              '4 - Smooth sausage',
+              '7 - Watery',
+            ],
+            required: true,
+          },
+          { key: 'notes', label: 'Notes', type: 'textarea' },
+        ],
+      },
+    },
+    description: 'Generic-card with maxReadingsPerDay > 1, for the #336 regression.',
+    data: [
+      { date: today, time: '07:30', bristolType: '4 - Smooth sausage', notes: '' },
+      { date: today, time: '14:15', bristolType: '1 - Hard lumps', notes: 'busy day' },
+    ],
+  };
+}
+
+function todayISO() {
+  const d = new Date();
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+async function seed(request, baseUrl, manifest) {
+  await request.delete(`${baseUrl}/api/manifests/${manifest.meta.id}`).catch(() => {});
+  const r = await request.post(`${baseUrl}/api/manifests`, { data: manifest });
+  expect([201, 409]).toContain(r.status());
+}
+
+async function cleanup(request, baseUrl, id) {
+  await request.delete(`${baseUrl}/api/manifests/${id}`).catch(() => {});
+}
+
+test.describe('#336: generic-card with maxReadingsPerDay > 1 renders every row for the day', () => {
+  test('shows both seeded rows, with edit + delete + add affordances', async ({ page, sandboxState }) => {
+    const today = todayISO();
+    await seed(page.request, sandboxState.baseUrl, stoolLogManifest(today));
+
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible({ timeout: 10_000 });
+
+    const card = page.locator(`[data-card-id="${STOOL_LOG_ID}"] eh-generic-card`);
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    // Both seeded rows render; before the fix only one would appear.
+    const rows = card.locator('.gen-list-row');
+    await expect(rows).toHaveCount(2);
+    await expect(card).toContainText('07:30');
+    await expect(card).toContainText('14:15');
+    await expect(card).toContainText('4 - Smooth sausage');
+    await expect(card).toContainText('1 - Hard lumps');
+
+    // Per-row edit + delete buttons exist.
+    await expect(card.locator('button[aria-label="Edit entry"]')).toHaveCount(2);
+    await expect(card.locator('button[aria-label="Delete entry"]')).toHaveCount(2);
+
+    // Add control is always visible alongside the list.
+    await expect(card.locator('button[aria-label="Add entry"]')).toBeVisible();
+
+    await cleanup(page.request, sandboxState.baseUrl, STOOL_LOG_ID);
+  });
+
+  test('Add appends a third row without overwriting the existing two', async ({ page, sandboxState }) => {
+    const today = todayISO();
+    await seed(page.request, sandboxState.baseUrl, stoolLogManifest(today));
+
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible({ timeout: 10_000 });
+
+    const card = page.locator(`[data-card-id="${STOOL_LOG_ID}"] eh-generic-card`);
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await expect(card.locator('.gen-list-row')).toHaveCount(2);
+
+    await card.locator('button[aria-label="Add entry"]').click();
+    const form = card.locator('eh-input-form');
+    await expect(form).toBeVisible();
+
+    await form.locator('input[type="time"]').fill('20:00');
+    await form.locator('select').selectOption('7 - Watery');
+    await form.locator('button[type="submit"]').click();
+
+    await expect(card.locator('.gen-list-row')).toHaveCount(3);
+    await expect(card).toContainText('20:00');
+    await expect(card).toContainText('7 - Watery');
+    // Earlier entries still there.
+    await expect(card).toContainText('07:30');
+    await expect(card).toContainText('14:15');
+
+    await cleanup(page.request, sandboxState.baseUrl, STOOL_LOG_ID);
+  });
+
+  test('Delete removes a row in place', async ({ page, sandboxState }) => {
+    const today = todayISO();
+    await seed(page.request, sandboxState.baseUrl, stoolLogManifest(today));
+
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible({ timeout: 10_000 });
+
+    const card = page.locator(`[data-card-id="${STOOL_LOG_ID}"] eh-generic-card`);
+    await expect(card.locator('.gen-list-row')).toHaveCount(2);
+
+    await card.locator('button[aria-label="Delete entry"]').first().click();
+
+    await expect(card.locator('.gen-list-row')).toHaveCount(1);
+    await expect(card).not.toContainText('07:30');
+    await expect(card).toContainText('14:15');
+
+    await cleanup(page.request, sandboxState.baseUrl, STOOL_LOG_ID);
+  });
+});


### PR DESCRIPTION
# What changed

Cards using `generic-card` with `meta.writeable.maxReadingsPerDay > 1`
now render every row dated the current day as its own list line, with
per-row edit + delete and a separate ➕ Add control. The single-entry
path (default `maxReadingsPerDay: 1`) is unchanged.

# Why

Fixes #336.

The save path in `_onSubmit` already capped multiple rows correctly
(append, slice to max). The display path however resolved a single
row per day via `_currentEntry()` and the UI offered a single
edit/add affordance, so any card intended as an event log silently
lost earlier entries from view. The user could only ever see one
entry per day even on a card declared with `maxReadingsPerDay: 99`.

# How

- New `_maxReadingsPerDay()` + `_rowsForExactDate()` helpers; the
  latter returns rows for `this.date` paired with their absolute index
  in the data array, sorted by `time` so display order is stable.
- `renderCard()` short-circuits to a new `_renderMultiEntry()` when
  the manifest opts in.
- Multi-entry mode renders a `<ul class="gen-rows">` with one row per
  same-day entry; each row carries an Edit (✏️) and Delete (➖) button.
  An always-visible ➕ Add button sits below the list.
- `_openEdit(index)` now tracks `_editingIndex` so the form can target
  an existing row by absolute index. `_onSubmit` honours that index
  when set (in-place replace) and falls through to the existing append
  + cap behaviour for new rows.
- `_onDeleteRow(idx)` removes the targeted row and POSTs the trimmed
  array.
- `fallbackToLatest` is intentionally suppressed for `max > 1` cards;
  showing yesterday's *list* on Today is more confusing than helpful.

# Testing

- [x] `npm test` passes locally (1075 / 1075 unit tests; existing
      suites unchanged).
- [x] `npm run test:e2e` passes locally (45 / 45 specs including the
      new `tests-e2e/generic-card-multi-entry.spec.js` covering: every
      seeded row appears with edit/delete affordances; Add appends
      without overwriting; Delete removes a row in place).
- [x] Manual QA: a stool-log card with `maxReadingsPerDay: 99` shows
      every entry for the day and the Add button stays available; a
      single-entry card (weight) is visually unchanged.

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [ ] Docs updated if behaviour or schema changed (no schema change;
      `maxReadingsPerDay` already documented)
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens

# Breaking changes

None. The single-entry render path (`maxReadingsPerDay === 1`, the
default) is untouched. Cards already declaring `> 1` simply start
displaying entries that were already on disk but previously hidden.