### PR TITLE
fix(prompt-queue): keep hidden donor's prompt firing through visible combo in network path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,15 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Modal prompt fires for hidden donor surfaced by a visible combo
+  card.** The #316 carve-out ("a hidden atomic card surfaced by a
+  visible combination card still prompts") worked in the unit-test
+  path but was undone in the live app: `checkPromptsForToday`
+  fetched data only for prompt candidates, then handed that slim
+  list to `buildPromptQueue`, whose internal `surfaced` recompute
+  no longer saw the combo card. `buildPromptQueue` now accepts a
+  pre-computed `surfaced` set, and the network wrapper passes one
+  derived from the full manifest list. Fixes #338.
 - **`generic-card` renders every entry per day when
   `maxReadingsPerDay > 1`.** The save path already capped multiple
   rows correctly, but the display path returned the first matching

--- a/public/js/lib/prompt-queue.js
+++ b/public/js/lib/prompt-queue.js
@@ -129,12 +129,18 @@ function surfacedByVisibleCombo(manifests) {
 
 // Build the queue. Pure function separated so tests can run it against
 // a synthetic manifest list without hitting the network.
+//
+// `surfaced` (optional) lets the caller pre-compute donor-visibility from
+// a wider manifest list than `manifests` itself. The network path passes
+// only candidate cards in `manifests`, so combo cards aren't there to
+// rediscover the surfacing relationship — see #338.
 export function buildPromptQueue(manifests, {
   date = todayStr(),
   storage = globalThis.localStorage,
+  surfaced = null,
 } = {}) {
   const out = [];
-  const surfaced = surfacedByVisibleCombo(manifests);
+  if (!surfaced) surfaced = surfacedByVisibleCombo(manifests);
   for (const card of manifests || []) {
     const meta = card?.meta;
     if (!meta) continue;
@@ -213,5 +219,5 @@ export async function checkPromptsForToday() {
     }
   }));
 
-  return buildPromptQueue(withData, { date });
+  return buildPromptQueue(withData, { date, surfaced });
 }

--- a/tests/prompt-queue.test.js
+++ b/tests/prompt-queue.test.js
@@ -13,6 +13,7 @@ import assert from 'node:assert/strict';
 
 import {
   buildPromptQueue,
+  checkPromptsForToday,
   entryExistsForDate,
   allScheduledTakenForDate,
   wasShownToday,
@@ -383,6 +384,60 @@ test('buildPromptQueue: combo inheritance still respects today-entry suppression
   ];
   const q = buildPromptQueue(manifests, { date: '2026-04-23', storage });
   assert.deepEqual(q, []);
+});
+
+// --- checkPromptsForToday integration (#338) ---
+//
+// The unit tests above call buildPromptQueue with the full manifest list,
+// so the in-function `surfaced` recompute always sees the visible combo.
+// The live network path slices manifests down to candidates before
+// building the queue, which used to drop the donor-surfacing relationship
+// and silently kill prompts for hidden donors. The fix passes a
+// pre-computed `surfaced` set through.
+
+function withGlobals({ fetchImpl, storage }, fn) {
+  const prevFetch = globalThis.fetch;
+  const prevStorage = globalThis.localStorage;
+  globalThis.fetch = fetchImpl;
+  globalThis.localStorage = storage;
+  return Promise.resolve(fn()).finally(() => {
+    globalThis.fetch = prevFetch;
+    globalThis.localStorage = prevStorage;
+  });
+}
+
+test('checkPromptsForToday: hidden donor surfaced by visible combo still prompts', async () => {
+  const storage = makeStorage();
+  const entries = [
+    { id: 'mood', meta: { id: 'mood', enabled: false, prompt: { enabled: true } } },
+    {
+      id: 'wellbeing',
+      meta: {
+        id: 'wellbeing',
+        view: {
+          component: 'combination-card',
+          combines: [{ sourceId: 'mood', role: 'primary' }],
+        },
+      },
+    },
+  ];
+  const dataById = { mood: [] };
+  const fetchImpl = async (url) => {
+    if (url === '/api/manifests') {
+      return { ok: true, json: async () => ({ entries }) };
+    }
+    const m = url.match(/^\/api\/manifests\/([^/]+)\/data$/);
+    if (m) {
+      const id = decodeURIComponent(m[1]);
+      return { ok: true, json: async () => ({ data: dataById[id] ?? null }) };
+    }
+    return { ok: false, json: async () => ({}) };
+  };
+  await withGlobals({ fetchImpl, storage }, async () => {
+    const q = await checkPromptsForToday();
+    assert.equal(q.length, 1);
+    assert.equal(q[0].meta.id, 'mood');
+  });
 });
 
 test('buildPromptQueue: defends against malformed manifest entries', () => {


### PR DESCRIPTION
## Summary

- The #316 carve-out (hidden atomic card surfaced by a visible combination card still prompts) only held in the unit-test path. The live `checkPromptsForToday` fetched data for candidates only, handed that slice to `buildPromptQueue`, and the internal `surfaced` recompute lost the combo card — so the hidden donor was dropped again on line 147.
- Fix: `buildPromptQueue` now accepts a pre-computed `surfaced` set; the network wrapper derives it once from the full manifest list and threads it through.
- New integration test for `checkPromptsForToday` (mocked `fetch`) so the regression is caught at the orchestration layer next time, not just at the pure-function layer.

## Why

A user hiding the atomic Mood card to roll it into a combo silently lost the daily modal even though the combo was visible. The previous fix was tested but the orchestration around it wasn't, so the regression slipped through.

## How

- `public/js/lib/prompt-queue.js` — `buildPromptQueue` takes optional `surfaced`; falls back to recomputing from `manifests` when absent (existing tests unaffected). `checkPromptsForToday` passes the set it already computes from the full manifest list.
- `tests/prompt-queue.test.js` — added `checkPromptsForToday: hidden donor surfaced by visible combo still prompts` with a fetch stub.
- `CHANGELOG.md` — entry under Unreleased / Fixed.

## Testing

- [x] `npm test` — 1077 pass, 2 skipped, 0 fail
- [x] Targeted: `node --test tests/prompt-queue.test.js` — 31 pass
- [ ] Manual smoke once merged: hide an atomic card with `prompt.enabled` that's referenced by a visible combo; reload the app; modal should fire.

Fixes #338.