### PR TITLE
Guard writeData against malformed data writes (#342)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Guard `manifests.writeData` against malformed `data` writes.** A
+  card's `data` block could be persisted as a JSON-encoded string
+  (`"data": "{...}"` instead of `"data": {...}`) when an upstream
+  caller double-serialised before write, breaking renderers. The
+  registry now coerces a string `data` value: it parses once, accepts
+  the result if it's a structured object/array (with a console warn
+  naming the manifest), and throws otherwise. When a manifest declares
+  a top-level `schema.type`, the runtime shape of the new value is
+  also checked against it before any disk write. The HTTP boundary
+  (`POST /api/manifests/:id/data`) returns 400 instead of silently
+  rescuing string `data`. Fixes #342.
 - **Modal prompt fires for hidden donor surfaced by a visible combo
   card.** The #316 carve-out ("a hidden atomic card surfaced by a
   visible combination card still prompts") worked in the unit-test

--- a/manifests/registry.js
+++ b/manifests/registry.js
@@ -240,11 +240,58 @@ function errors() {
   return [..._errors];
 }
 
+// Reject (or rescue) a `data` value that arrived as a JSON-encoded string,
+// which is what happens when an upstream caller has stringified twice. If
+// the parsed result is a structured value, accept it and warn so the
+// offending writer is traceable; if it stays scalar, throw — there's no
+// safe interpretation. See #342.
+function _coerceWriteData(id, newData) {
+  if (typeof newData !== 'string') return newData;
+  let parsed;
+  try {
+    parsed = JSON.parse(newData);
+  } catch {
+    throw new Error(`writeData(${id}): data is a string and not valid JSON; pass an object/array, not a pre-serialised string`);
+  }
+  if (parsed === null || typeof parsed !== 'object') {
+    throw new Error(`writeData(${id}): data must be an object or array, got string that parsed to ${parsed === null ? 'null' : typeof parsed}`);
+  }
+  console.warn(`[manifest] writeData(${id}): rescued double-serialised data (caller passed a JSON string); accepting parsed value`);
+  return parsed;
+}
+
+// Sanity-check the runtime shape of `newData` against the manifest's
+// declared `schema.type`, when present. Catches a wider class of writer
+// bugs (bare value where an array is expected, etc.) without pulling a
+// full JSON-Schema validator. See #342.
+function _assertSchemaShape(id, schema, newData) {
+  if (!schema || typeof schema !== 'object' || typeof schema.type !== 'string') return;
+  const declared = schema.type;
+  const actual = Array.isArray(newData)
+    ? 'array'
+    : newData === null
+      ? 'null'
+      : typeof newData;
+  if (declared === 'array' && actual !== 'array') {
+    throw new Error(`writeData(${id}): schema declares type "array" but received ${actual}`);
+  }
+  if (declared === 'object' && actual !== 'object') {
+    throw new Error(`writeData(${id}): schema declares type "object" but received ${actual}`);
+  }
+  if (declared !== 'array' && declared !== 'object' && actual !== declared) {
+    throw new Error(`writeData(${id}): schema declares type "${declared}" but received ${actual}`);
+  }
+}
+
 // Write full file back with updated data block. Preserves meta/description/schema.
 // Uses atomic tmp+rename to avoid partial writes.
 function writeData(id, newData) {
   const entry = _entries.get(id);
   if (!entry) throw new Error(`unknown manifest: ${id}`);
+
+  newData = _coerceWriteData(id, newData);
+  _assertSchemaShape(id, entry.schema, newData);
+
   const full = {
     $schema: entry.version,
     meta: entry.meta,

--- a/server.js
+++ b/server.js
@@ -707,6 +707,13 @@ const server = http.createServer(async (req, res) => {
           const parsed = JSON.parse(body);
           if (!('data' in parsed)) return sendJSON(res, { error: 'missing data field in body' }, 400);
 
+          // Reject pre-serialised data outright at the HTTP boundary.
+          // The registry has a rescue path as a safety net, but a string
+          // here is always a writer bug we want loud feedback on. See #342.
+          if (typeof parsed.data === 'string') {
+            return sendJSON(res, { error: 'data must be a JSON object or array, not a string' }, 400);
+          }
+
           // Safety net: if an external agent still sends date-keyed data
           // (the legacy mood/notes shape), auto-convert to array on the way in.
           // Logs a warning so the offending writer can be tracked down.

--- a/tests/manifest-registry.test.js
+++ b/tests/manifest-registry.test.js
@@ -242,6 +242,98 @@ describe('manifest registry', () => {
     }
   });
 
+  // --- writeData hardening (#342) ---
+
+  test('writeData rescues a JSON-string that parses to an object/array, with a warn', () => {
+    const sandbox = createSandbox({
+      seed: {
+        'weight.json': {
+          $schema: 'klebb.datafile.v1',
+          meta: { id: 'weight', label: 'Weight', view: { enabled: true, component: 'generic-card' } },
+          data: [{ date: '2026-04-20', kg: 85 }],
+        },
+      },
+    });
+    const origWarn = console.warn;
+    let warned = '';
+    console.warn = (msg) => { warned += String(msg); };
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      const payload = JSON.stringify([{ date: '2026-04-21', kg: 86 }]);
+      registry.writeData('weight', payload);
+      const raw = fs.readFileSync(path.join(sandbox, 'data', 'weight.json'), 'utf8');
+      const parsed = JSON.parse(raw);
+      assert.ok(Array.isArray(parsed.data), 'data persisted as array, not a string');
+      assert.equal(parsed.data[0].kg, 86);
+      assert.match(warned, /rescued double-serialised/);
+    } finally {
+      console.warn = origWarn;
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('writeData throws when data is a string that parses to a scalar', () => {
+    const sandbox = createSandbox({
+      seed: {
+        'weight.json': {
+          $schema: 'klebb.datafile.v1',
+          meta: { id: 'weight', label: 'Weight', view: { enabled: true, component: 'generic-card' } },
+          data: [],
+        },
+      },
+    });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      assert.throws(() => registry.writeData('weight', '"hello"'), /must be an object or array/);
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('writeData throws when data is a string that is not valid JSON', () => {
+    const sandbox = createSandbox({
+      seed: {
+        'weight.json': {
+          $schema: 'klebb.datafile.v1',
+          meta: { id: 'weight', label: 'Weight', view: { enabled: true, component: 'generic-card' } },
+          data: [],
+        },
+      },
+    });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      assert.throws(() => registry.writeData('weight', 'not json{'), /not valid JSON/);
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
+  test('writeData throws when newData shape conflicts with declared schema.type', () => {
+    const sandbox = createSandbox({
+      seed: {
+        'mood.json': {
+          $schema: 'klebb.datafile.v1',
+          meta: { id: 'mood', label: 'Mood', view: { enabled: true, component: 'generic-card' } },
+          schema: { type: 'array' },
+          data: [],
+        },
+      },
+    });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      assert.throws(
+        () => registry.writeData('mood', { items: [] }),
+        /schema declares type "array" but received object/,
+      );
+    } finally {
+      cleanupSandbox(sandbox);
+    }
+  });
+
   // --- Malformed manifest handling ---
 
   test('invalid JSON is silently skipped as an error', () => {

--- a/tests/server-api.test.js
+++ b/tests/server-api.test.js
@@ -87,6 +87,19 @@ describe('server HTTP API', () => {
       assert.equal(check.json.data[1].kg, 86.5);
     });
 
+    test('POST /api/manifests/:id/data rejects pre-serialised string data with 400 (#342)', async () => {
+      const res = await req(server.baseUrl, '/api/manifests/weight/data', {
+        method: 'POST',
+        body: { data: JSON.stringify([{ date: '2026-04-22', kg: 87 }]) },
+      });
+      assert.equal(res.status, 400);
+      assert.match(res.json.error || '', /JSON object or array, not a string/);
+
+      // Persisted data must NOT have been clobbered
+      const check = await req(server.baseUrl, '/api/manifests/weight/data');
+      assert.ok(Array.isArray(check.json.data), 'data still an array');
+    });
+
     test('GET /api/views/view returns cards with view.enabled', async () => {
       const res = await req(server.baseUrl, '/api/views/view');
       assert.equal(res.status, 200);


### PR DESCRIPTION
## Summary

Closes the door on a class of corruption where a card's `data` block
gets persisted as a JSON-encoded string (`\"data\": \"{...}\"`) instead
of a parsed object/array, which silently breaks renderers. The shared
chokepoint for all data writes is `manifests.registry.writeData`, hit
by both the HTTP endpoint and the in-process `write_manifest_data`
chat tool, so the guard goes there to cover every caller.

## Why

A live instance lost a card's render after a chat agent double-serialised
its tool arguments. Data was recoverable but the failure mode is
silent and easy to repeat. The HTTP boundary already had an
auto-converter for the legacy date-keyed shape, but no defence against
a stringified blob, and the in-process tool path had no defence at all.

## How

- `registry.writeData` now coerces a string `newData`: one `JSON.parse`,
  accept the parsed value if it's a structured object/array (with a
  `console.warn` naming the manifest so the offending writer is
  traceable), throw otherwise.
- When a manifest declares a top-level `schema.type`, the runtime
  shape of `newData` is checked against it (`array` vs `object` vs
  scalar) before any disk write. Cheap mismatch detection without
  pulling in a JSON-Schema validator.
- `POST /api/manifests/:id/data` returns `400` with a clear message
  when the body's `data` field is a string instead of silently
  rescuing. Registry-level guard remains as a safety net for paths
  that don't go through HTTP (e.g. internal tools).

## Testing

- [x] `npm test` — 1082 pass, 2 skipped (unchanged), 0 fail.
- [x] New unit tests in `tests/manifest-registry.test.js`:
  - string-data that parses to array → rescued + warned
  - string-data that parses to scalar → throws
  - string-data that is invalid JSON → throws
  - schema-type mismatch (`array` declared, object passed) → throws
- [x] New API test in `tests/server-api.test.js`:
  - POST with stringified `data` → 400, persisted file untouched
- [ ] Verify on `klebbtest` after merge.

Fixes #342.