### PR TITLE
fix(chat): tell agent to verify renderer behaviour from docs first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Renderer behaviour reference in `docs/CARDS.md`.** New section
+  documenting, per built-in renderer, what it reads from the manifest,
+  what it writes to data on user interaction, and what it ignores. The
+  most load-bearing fact is the table of which renderers route their
+  write path through `meta.writeable.inputs` (generic-card, list-card,
+  combination-card edit, prompt-modal in modal mode) and which
+  hardcode the write shape (schedule-card check-off, checklist-card,
+  prompt-modal in checklist mode). Refs #346.
+
 - **Hours-as-time display hint.** New optional `format: "hm"` field on
   `meta.view.combines[]` entries renders the legend value and goal as
   `H:MM` instead of decimal hours (e.g. `8.17` → `8:10`, `8` → `8:00`).
@@ -36,6 +45,18 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
   matter what calendar day the demo is reset on. Refs #296.
 
 ### Changed
+
+- **Chat agent verifies renderer behaviour from docs first.** The
+  default system prompt now carries a "Verifying renderer behaviour"
+  section telling the agent to consult the new **Renderer behaviour
+  reference** in `docs/CARDS.md` before claiming what a built-in
+  renderer reads / writes / ignores, and to declare uncertainty
+  ("I can't verify this from the docs") when the answer isn't there.
+  Reasoning by analogy across renderers is forbidden — the fact that
+  one renderer consults `meta.writeable.inputs` is not evidence that
+  another does. Closes the failure mode where the agent confidently
+  proposed a `meta.writeable.inputs` patch for `schedule-card`'s
+  check-off path, which the renderer doesn't consult. Fixes #346.
 
 - **Chat agent stance.** The default system prompt now carries a
   short "Your stance" section that frames the user as an informed

--- a/config/env.js
+++ b/config/env.js
@@ -212,6 +212,19 @@ Choose the smallest-blast-radius tool for the job:
 - \`patch_manifest\` when the patch removes any \`inputs[]\` from a writeable card, or flips \`writeable.fromWebapp\` from \`true\` to \`false\` on a card that has data.
 Pure additions / non-destructive patches (adding a new threshold band, renaming a label, changing an emoji map) don't need confirmation.
 
+## Verifying renderer behaviour
+
+Before claiming what a built-in renderer (\`generic-card\`, \`list-card\`, \`schedule-card\`, \`checklist-card\`, \`combination-card\`, \`markdown-doc\`, \`line-chart\`, \`schedule-timeline\`, \`table-list\`, \`adherence-report\`, \`greeting-banner\`, \`day-marker\`) does in response to user interaction — what it reads from the manifest, what it writes to data, what it ignores — you MUST first call \`read_doc("docs/CARDS.md")\` and consult the **Renderer behaviour reference** section, plus \`read_doc("MANIFEST-SCHEMA.md")\` if the question touches the schema. Use only what those docs explicitly state.
+
+If the renderer behaviour you'd need to assert is NOT documented in those files, say so plainly: "I can't verify this from the docs." Then offer to inspect the actual data shape with \`read_manifest\` so the user can see what the renderer is currently writing — that's the closest you can get to ground truth without the renderer source.
+
+Hard rules:
+- Do NOT reason by analogy from how OTHER renderers work. Renderers do not share check-off, form, or write semantics. The fact that \`generic-card\` consults \`meta.writeable.inputs\` for its edit form does NOT mean \`schedule-card\` does. Each renderer's contract is independent.
+- Do NOT promise a manifest patch will produce a behaviour change until you have verified, from the docs, that the renderer reads the field you're patching. Patching a key the renderer ignores is a footgun: the data shape changes, nothing on screen does, the user wastes a round-trip.
+- Do NOT assume the renderer source file exists at any particular path or guess at its content. The renderer source is not exposed through \`read_doc\`; the docs are the only authoritative reference available to you.
+
+The honest answer is always better than a confident wrong one.
+
 ## HTTP API (reference for external agents)
 
 External agents running outside this app (with \`AGENT_API_TOKEN\`) hit these endpoints directly. You do NOT use them — you call the tools above. The list is reference material so you can answer user questions about the API surface.

--- a/docs/CARDS.md
+++ b/docs/CARDS.md
@@ -896,6 +896,236 @@ agent API surface.
 
 ---
 
+## Renderer behaviour reference
+
+This section is the authoritative answer to "what does renderer X actually
+read from the manifest, and what does it write to data on user
+interaction". Use it before claiming that a manifest patch will produce
+a behaviour change — if the renderer doesn't read the field you're
+patching, the patch does nothing visible.
+
+Each entry has three parts:
+
+- **Reads** — manifest keys and data fields the renderer consults.
+- **Writes** — what the renderer puts into `data` on user interaction,
+  and which user actions trigger it.
+- **Ignores** — manifest keys the schema permits on this card but the
+  renderer does NOT consult. Patching these has no effect on this
+  renderer.
+
+The most important question per renderer is: **does this renderer's
+write path consult `meta.writeable.inputs`, or does it hardcode the
+shape?** Both patterns exist; mixing them up is the most common cause
+of "I patched the manifest and nothing changed".
+
+| Renderer | Write path consults `writeable.inputs`? |
+|----------|------------------------------------------|
+| `generic-card` | Yes |
+| `list-card` | Yes |
+| `combination-card` (edit pencil) | Yes — but on the DONOR card's inputs, not its own |
+| `prompt-modal` with `mode:"modal"` | Yes |
+| `schedule-card` (check-off ✓) | **No** — write shape is hardcoded |
+| `checklist-card` (tick) | **No** — write shape is hardcoded |
+| `prompt-modal` with `mode:"checklist"` | **No** — write shape is hardcoded |
+
+### `generic-card`
+
+**Reads:**
+- `meta.view.fallbackToLatest`, `meta.view.dateContext` (legacy alias).
+- `meta.view.display.template`, `.secondary`, `.unit`, `.emojiMap`,
+  `.emptyHeadline`, `.thresholds`, `.trendArrow.field`.
+- `meta.writeable.fromWebapp`, `.inputs[]`, `.maxReadingsPerDay`,
+  `.prefillFromLatest`, `.requireAny`.
+- Data rows by date: `{date, time?, ...templateKeys}`.
+
+**Writes:**
+- Tap the ➕ / ✏️ button → opens an `eh-input-form` built from
+  `meta.writeable.inputs`. Submit upserts a row at the viewed date.
+- With `maxReadingsPerDay > 1`, multiple rows for the same date are
+  appended (capped to N most recent).
+
+**Ignores:**
+- Any data field not referenced by the display template or the inputs
+  list. They persist in the file but neither render nor become
+  editable.
+
+### `list-card`
+
+**Reads:**
+- `meta.view.display.primaryField` (default `"name"`),
+  `.secondaryTemplate`, `.emptyMessage`.
+- `meta.writeable.inputs[]` — drives both the add form and the
+  per-row "..." edit popover. Both primary and secondary fields are
+  editable from inputs alone.
+- Data rows: free-form objects; the renderer doesn't impose a shape.
+  `added: ISO8601` is auto-stamped on row creation.
+
+**Writes:**
+- Add a row → `eh-input-form` built from `meta.writeable.inputs`.
+- Edit a row's secondary fields → same form, pre-filled from the row.
+- Delete a row → splices the row out of the array.
+- Rows do NOT carry a `date`. List-card is a permanent roster, not a
+  per-day log.
+
+**Ignores:**
+- Layout / display keys beyond the three above. The renderer always
+  shows the full roster on every viewed date.
+
+### `schedule-card`
+
+**Reads:**
+- `meta.view.colorMap` (item-name → colour map; legacy alias
+  `meta.colorMap` also accepted).
+- Data shape: `{ items: [{ name, short_name?, dose_mg?, dose_units?,
+  route?, action_label?, dose_label?, schedule, cycles[], doses[] }] }`.
+- Per-item `schedule` and `cycles[]` for the dot-grid and "scheduled
+  today / rest day / off cycle" status.
+- Per-item `doses[].{scheduledDate, takenAt, offSchedule?}` for the
+  check-off state.
+
+**Writes:**
+- Tap the ✓ checkbox on a scheduled item → appends a hardcoded entry
+  to that item's `doses[]`:
+  `{ scheduledDate: <viewed date>, takenAt: <ISO now> }`.
+  The off-schedule (dashed-border) variant adds `offSchedule: true`.
+- Untick → sets `takenAt: null` on the matching dose entry.
+
+**Ignores:**
+- `meta.writeable.inputs` — schedule-card's check-off flow does NOT
+  consult inputs. Adding fields to inputs does NOT make them appear in
+  the check-off path. Per-dose metadata beyond `{scheduledDate,
+  takenAt, offSchedule}` requires renderer changes; see
+  [issue #345](https://github.com/Aristocles/klebb/issues/345) for the
+  in-flight extension that wires inputs in via `meta.view.checkOffForm`.
+
+### `checklist-card`
+
+**Reads:**
+- Data shapes accepted: `items[]`, `{ items: [...] }`, or
+  `{ current: [...] }`.
+- Per-item: `name`, `schedule` | `cycles`, `frequency`, `day`,
+  `startDate`, `dose`, `timing`.
+- Check state: `item.doses[].{scheduledDate, takenAt}` OR
+  `item.takenDates[]` (array of ISO dates).
+
+**Writes:**
+- Tap the row checkbox → if the item has a `doses[]` array, append
+  `{ scheduledDate, takenAt }`. Otherwise append the date string to
+  `item.takenDates[]`. Both shapes hardcoded.
+
+**Ignores:**
+- `meta.writeable.inputs` — checklist-card has no input-driven write
+  path. The renderer is daily-tick only.
+
+### `combination-card`
+
+**Reads:**
+- `meta.view.layout` (`"stack"` | `"rings"`).
+- `meta.view.combines[]`: each entry is `{sourceId, role, label?,
+  accessor?, unit?, emojiMap?, goalDaily?, goalWeekly?, colour?,
+  format?}`.
+- For each `sourceId`, fetches that DONOR card's full manifest
+  (including its `meta.writeable.inputs`) and its data.
+
+**Writes:**
+- Edit pencil next to a row → opens an `eh-input-form` built from the
+  DONOR's `meta.writeable.inputs`. Save writes back into the donor's
+  data file, not the combination card. The combination card's own
+  `data` array stays empty by contract.
+- Fires a `manifest-data-changed` event so the sibling donor card on
+  screen refreshes.
+
+**Ignores:**
+- Its own `meta.writeable.inputs` (combination cards are read-only
+  windows; only donors are editable through them).
+- `data` on the combination card itself — must be `[]` (see
+  `MANIFEST-SCHEMA.md` — empty-data contract).
+
+### `markdown-doc`
+
+**Reads:**
+- `data.markdown` — a single string of CommonMark.
+
+**Writes:**
+- None from the dashboard UI. Edit the file (or use the chat agent's
+  `write_manifest_data`) to update.
+
+**Ignores:**
+- `meta.writeable` entirely — the renderer has no edit affordance.
+
+### `line-chart` (and `area-chart`, `bar-chart`)
+
+Used in `meta.trends.component`, not `meta.view.component`. Read-only
+in the Trends view.
+
+**Reads:**
+- `meta.trends.xKey`, `.yKey`, `.field`, `.series[]`, `.unit`.
+- Data rows by date for the configured field(s).
+
+**Writes:**
+- None.
+
+### `schedule-timeline`
+
+Used in `meta.trends.component` (rare) or `meta.reports.component`.
+Read-only in those views.
+
+**Reads:**
+- `meta.schedule` (single card-level cadence) OR `data.items[]` and
+  per-item `schedule` / `doses[]`.
+- `meta.reports.windowDays`, `.showPast`, `.showFuture`.
+
+**Writes:**
+- None.
+
+### `table-list`
+
+Used in `meta.reports.component`. Read-only.
+
+**Reads:**
+- `meta.reports.columns[]` (`{field, header, format?}`),
+  `.sort.{field, dir}`.
+- Data rows are surfaced as table rows.
+
+**Writes:**
+- None.
+
+### `adherence-report`
+
+Used in `meta.reports.component`. Read-only.
+
+**Reads:**
+- `data.items[].doses[]` and per-item `schedule` / `cycles[]` for the
+  expected-vs-taken calculation.
+- `meta.reports.showCompliance`, `.showInventory`.
+
+**Writes:**
+- None.
+
+### `greeting-banner`
+
+**Reads:**
+- `meta.view.slot:"top"` to claim the top banner row.
+- `meta.label`, `meta.emoji`, `meta.view.display.template`.
+
+**Writes:**
+- None.
+
+### `day-marker`
+
+Used in `meta.calendar.component`. Read-only.
+
+**Reads:**
+- `meta.calendar.marker` — static emoji string, or one of the four
+  shapes (`field-emoji`, `trend-arrow`, `threshold`, `template`)
+  documented in the Calendar markers section above.
+- Data rows for the date being painted.
+
+**Writes:**
+- None.
+
+---
+
 ## Schema version
 
 The `$schema` field identifies the manifest format. The only currently

--- a/tests/chat-prompt-cc-schema.test.js
+++ b/tests/chat-prompt-cc-schema.test.js
@@ -139,4 +139,18 @@ describe('chat proxy injects CC schema into system prompt', () => {
     assert.match(prompt, /MANIFEST-SCHEMA\.md/);
     assert.match(prompt, /docs\/CARDS\.md/);
   });
+
+  test('system prompt tells the agent to verify renderer behaviour from docs first', async () => {
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'hello' }] },
+    });
+    assert.equal(res.status, 200);
+    const prompt = gateway.getLastPrompt();
+    assert.ok(prompt);
+    assert.match(prompt, /## Verifying renderer behaviour/);
+    assert.match(prompt, /Renderer behaviour reference/);
+    assert.match(prompt, /reason by analogy/i);
+    assert.match(prompt, /can't verify this from the docs/i);
+  });
 });


### PR DESCRIPTION
## Summary

- Adds a "Verifying renderer behaviour" section to the default chat system prompt: docs first, declare uncertainty when not covered, never analogise across renderers.
- Adds a "Renderer behaviour reference" section to `docs/CARDS.md`: per-renderer reads / writes / ignores, headlined by a table of which renderers route writes through `meta.writeable.inputs` and which hardcode the shape.

## Why

The chat agent recently asserted that patching `meta.writeable.inputs` on a `schedule-card` would surface the new fields in the check-off form. `schedule-card` hardcodes its dose write (`{scheduledDate, takenAt}`) and ignores `inputs` entirely; the proposed patch would have done nothing visible. The agent had no doc to check (the per-renderer write contract wasn't documented anywhere `read_doc` could see) and reasoned by analogy from how `generic-card` / `list-card` use `inputs`. Both gaps fixed in this PR.

## How

- `config/env.js`: new section in `DEFAULT_HEALTH_SYSTEM_PROMPT` listing the contract (verify from docs, no analogy, declare uncertainty, do not promise patches will produce behaviour changes you can't verify).
- `docs/CARDS.md`: new "Renderer behaviour reference" section near the end. Covers `generic-card`, `list-card`, `schedule-card`, `checklist-card`, `combination-card`, `markdown-doc`, `line-chart`, `schedule-timeline`, `table-list`, `adherence-report`, `greeting-banner`, `day-marker`. Each entry has Reads / Writes / Ignores. Headline table at the top calls out the writeable-inputs split.
- `tests/chat-prompt-cc-schema.test.js`: assertion that the new section reaches the prompt.
- `CHANGELOG.md`: Added + Changed entries under `[Unreleased]`.

The renderer-behaviour facts came from reading the source of each `eh-*-card.js` directly (not from training intuition); the docs reflect what the code actually does today, including the in-flight schedule-card extension at #345 noted in the schedule-card entry.

## Testing

- [x] `npm test` — 1083 pass, 0 fail, 2 skipped (pre-existing).
- [x] New test `system prompt tells the agent to verify renderer behaviour from docs first` passes.
- [x] `hygiene-check` skill — clean.
- [ ] No e2e or runtime UX changes; doc + system-prompt only.

Fixes #346