### PR TITLE
feat(chat): expose built-in renderer source through read_doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Chat agent can fetch built-in renderer source through `read_doc`.**
+  The `chat/docs.js` allowlist now exposes the twelve `eh-*.js` Lit
+  components under `public/js/components/` (every built-in card
+  renderer plus `eh-input-form` and `eh-prompt-modal`) as a separate
+  "Renderer source" subsection in the system-prompt catalogue. The
+  agent reaches for docs first; renderer source is the second-stop
+  source of truth when the docs leave a gap on a specific behaviour or
+  the user asks for a code-level explanation. Each entry's one-line
+  summary states the renderer's most-asked contract fact (consults
+  `meta.writeable.inputs` vs hardcodes the write shape, primarily) so
+  the agent can usually answer without fetching the file. Same
+  allowlist + path-traversal guard + 200KB cap as before; no globbing,
+  manual entries only. The "Verifying renderer behaviour" section in
+  the system prompt is updated to a three-step ladder: docs first,
+  renderer source if the docs leave a gap, declare uncertainty
+  otherwise. Fixes #348.
+
 - **Renderer behaviour reference in `docs/CARDS.md`.** New section
   documenting, per built-in renderer, what it reads from the manifest,
   what it writes to data on user interaction, and what it ignores. The

--- a/chat/docs.js
+++ b/chat/docs.js
@@ -15,27 +15,66 @@ const path = require('path');
 const REPO_ROOT = path.resolve(__dirname, '..');
 
 // Hand-curated allowlist. Every entry is (a) a path relative to the
-// repo root, in POSIX form, and (b) a one-line summary used in the
-// system-prompt catalogue. Add to this list as new docs are added.
-// `.claude/`, BRIEF-FOR-CC.md, CLAUDE.md, data/, credentials/ are NOT
-// listed and cannot be read through this tool, by design.
+// repo root, in POSIX form, (b) a one-line summary used in the
+// system-prompt catalogue, and (c) a `kind` ('doc' | 'source') so the
+// catalogue can group documentation separately from renderer source.
+// Add to this list as new docs are added; renderer source must be
+// added manually (no globbing) so each new exposure is a deliberate
+// choice.
+//
+// `.claude/`, BRIEF-FOR-CC.md, CLAUDE.md, data/, credentials/,
+// sessions/, .env, anything under server.js / chat/ / manifests/ etc.
+// are NOT listed and cannot be read through this tool, by design.
 const DOC_INDEX = [
-  { path: 'README.md',                    summary: 'Quickstart, architecture overview, env vars, Docker section.' },
-  { path: 'MANIFEST-SCHEMA.md',           summary: 'Full klebb.datafile.v1 reference. The authoritative schema doc.' },
-  { path: 'CHANGELOG.md',                 summary: 'Per-release changelog; useful for "when did X land" questions.' },
-  { path: 'CONTRIBUTING.md',              summary: 'Repo workflow, commit conventions, branch naming.' },
-  { path: 'CONTRIBUTING-PROMPTS.md',      summary: 'Authoring starter prompts for the chat widget.' },
-  { path: 'CONTRIBUTING-TEMPLATES.md',    summary: 'Authoring .klebb.json templates that ship under templates/.' },
-  { path: 'SECURITY.md',                  summary: 'Threat model, reporting, secrets handling.' },
-  { path: 'docs/CARDS.md',                summary: 'Card authoring guide. How to write a manifest end-to-end.' },
-  { path: 'docs/RECIPES.md',              summary: 'Copy-pasteable manifest examples by card type.' },
-  { path: 'docs/CHAT-AGENT.md',           summary: 'Chat widget + gateway integration; AGENT_API_TOKEN write contract.' },
-  { path: 'docs/HEALTH-AUTO-EXPORT.md',   summary: 'iPhone Health Auto Export ingest: catalogue, row shapes, setup.' },
-  { path: 'docs/DEPLOY.md',               summary: 'Single-user and multi-user deploy guide; systemd + Docker.' },
-  { path: 'docs/DEMO.md',                 summary: 'Running a public Klebb demo (KLEBB_DEMO=1, hourly reset cron, image-tag gotchas).' },
-  { path: 'docs/TESTING.md',              summary: 'Three test layers, bug-fix workflow rubric.' },
-  { path: 'docs/VOICE.md',                summary: 'Voice chat (Fish Audio) configuration and usage.' },
-  { path: 'docs/CI.md',                   summary: 'GitHub Actions CI overview; what runs and when.' },
+  // --- Documentation ---
+  { kind: 'doc', path: 'README.md',                    summary: 'Quickstart, architecture overview, env vars, Docker section.' },
+  { kind: 'doc', path: 'MANIFEST-SCHEMA.md',           summary: 'Full klebb.datafile.v1 reference. The authoritative schema doc.' },
+  { kind: 'doc', path: 'CHANGELOG.md',                 summary: 'Per-release changelog; useful for "when did X land" questions.' },
+  { kind: 'doc', path: 'CONTRIBUTING.md',              summary: 'Repo workflow, commit conventions, branch naming.' },
+  { kind: 'doc', path: 'CONTRIBUTING-PROMPTS.md',      summary: 'Authoring starter prompts for the chat widget.' },
+  { kind: 'doc', path: 'CONTRIBUTING-TEMPLATES.md',    summary: 'Authoring .klebb.json templates that ship under templates/.' },
+  { kind: 'doc', path: 'SECURITY.md',                  summary: 'Threat model, reporting, secrets handling.' },
+  { kind: 'doc', path: 'docs/CARDS.md',                summary: 'Card authoring guide. Includes the Renderer behaviour reference (reads/writes/ignores per renderer).' },
+  { kind: 'doc', path: 'docs/RECIPES.md',              summary: 'Copy-pasteable manifest examples by card type.' },
+  { kind: 'doc', path: 'docs/CHAT-AGENT.md',           summary: 'Chat widget + gateway integration; AGENT_API_TOKEN write contract.' },
+  { kind: 'doc', path: 'docs/HEALTH-AUTO-EXPORT.md',   summary: 'iPhone Health Auto Export ingest: catalogue, row shapes, setup.' },
+  { kind: 'doc', path: 'docs/DEPLOY.md',               summary: 'Single-user and multi-user deploy guide; systemd + Docker.' },
+  { kind: 'doc', path: 'docs/DEMO.md',                 summary: 'Running a public Klebb demo (KLEBB_DEMO=1, hourly reset cron, image-tag gotchas).' },
+  { kind: 'doc', path: 'docs/TESTING.md',              summary: 'Three test layers, bug-fix workflow rubric.' },
+  { kind: 'doc', path: 'docs/VOICE.md',                summary: 'Voice chat (Fish Audio) configuration and usage.' },
+  { kind: 'doc', path: 'docs/CI.md',                   summary: 'GitHub Actions CI overview; what runs and when.' },
+
+  // --- Renderer source ---
+  // Reach for these only when the docs in CARDS.md / MANIFEST-SCHEMA.md
+  // don't cover the specific behaviour you need to verify, or when the
+  // user is asking for a code-level explanation. Each summary states
+  // the renderer's most-asked contract fact (consults
+  // meta.writeable.inputs vs hardcodes the write shape, primarily) so
+  // the agent can usually answer without reading the file.
+  { kind: 'source', path: 'public/js/components/eh-base-card.js',
+    summary: 'Base class for every card renderer. Owns the shell (header, expand/collapse, loading, error), data fetch + 20s cache, .card / .data / .date / .config / .writeable props passed down to subclass renderCard().' },
+  { kind: 'source', path: 'public/js/components/eh-input-form.js',
+    summary: 'Manifest-driven form. Reads meta.writeable.inputs; renders one widget per input type (number, stepper, text, textarea, select, emoji-picker, colour, checkbox, date, time, rating). Used by generic-card, list-card, combination-card edit, prompt-modal modal mode.' },
+  { kind: 'source', path: 'public/js/components/eh-generic-card.js',
+    summary: 'generic-card renderer. ROUTES WRITES THROUGH meta.writeable.inputs. Reads display.template/secondary/unit/emojiMap/emptyHeadline/thresholds, fallbackToLatest, maxReadingsPerDay, prefillFromLatest, requireAny.' },
+  { kind: 'source', path: 'public/js/components/eh-list-card.js',
+    summary: 'list-card renderer (permanent roster, NOT per-day). ROUTES WRITES THROUGH meta.writeable.inputs (both add and per-row edit). Reads display.primaryField/secondaryTemplate/emptyMessage. Auto-stamps `added: ISO8601` on row creation.' },
+  { kind: 'source', path: 'public/js/components/eh-schedule-card.js',
+    summary: 'schedule-card renderer. HARDCODES dose-write shape `{scheduledDate, takenAt, offSchedule?}`; DOES NOT consult meta.writeable.inputs on the ✓ check-off path. Reads data.items[].{schedule, cycles[], doses[]} and view.colorMap.' },
+  { kind: 'source', path: 'public/js/components/eh-checklist-card.js',
+    summary: 'checklist-card renderer. HARDCODES the daily-tick write to either item.doses[].push({scheduledDate, takenAt}) or item.takenDates[].push(date); DOES NOT consult meta.writeable.inputs. Accepts data shapes items[], {items}, or {current}.' },
+  { kind: 'source', path: 'public/js/components/eh-combination-card.js',
+    summary: 'combination-card renderer (read-only window). Reads meta.view.combines[] and fetches each donor sourceId. Edit pencil opens an eh-input-form built from the DONOR card\'s meta.writeable.inputs (not its own). Combination card\'s own data must stay [].' },
+  { kind: 'source', path: 'public/js/components/eh-prompt-modal.js',
+    summary: 'prompt-modal — daily "log this now" full-screen modal. mode:"modal" routes through meta.writeable.inputs (same shape as eh-input-form). mode:"checklist" hardcodes per-item dose / takenDates writes. Once-per-day localStorage gate (klebb-prompt-shown-{cardId}-{YYYY-MM-DD}).' },
+  { kind: 'source', path: 'public/js/components/eh-schedule-timeline.js',
+    summary: 'schedule-timeline renderer (read-only). Dot-grid per-cycle adherence. Dot states: solid accent (taken), solid red (missed), hollow grey (rest), solid amber (off-schedule), accent ring (today), dim hollow (future). One row per cycle (NOT per item).' },
+  { kind: 'source', path: 'public/js/components/eh-cc-suggestion-card.js',
+    summary: 'cc-suggestion-card — pinned suggestion surface. Fires when ≥3 enabled atomic cards share a meta.category. Read-only; "Ask klebbius" seeds a chat prompt that negotiates a combination-card manifest. Server-side clustering in meta/cc-suggestions.js.' },
+  { kind: 'source', path: 'public/js/components/eh-hae-discovery-card.js',
+    summary: 'hae-discovery-card — pinned card surfacing HAE metrics not yet subscribed. Reads /api/health-auto-export/discoveries. Per-metric "Build a card" seeds a chat prompt; "Dismiss" persists a Settings-restorable hide.' },
+  { kind: 'source', path: 'public/js/components/eh-welcome-card.js',
+    summary: 'welcome-card — onboarding card on a fresh install. Auto-hidden by registry.createManifest on first user-card creation; can be restored from Settings.' },
 ];
 
 const ALLOWED_PATHS = new Set(DOC_INDEX.map(d => d.path));
@@ -82,8 +121,13 @@ function readDoc(relPath) {
 
 // Markdown-formatted catalogue for embedding in the chat system
 // prompt. Lists every path on the allowlist with its one-line
-// summary; the agent uses this to pick which doc to fetch.
+// summary; the agent uses this to pick which doc to fetch. Two
+// subsections: Documentation (always reach for this first) and
+// Renderer source (only when the docs leave a gap, or for code-level
+// questions).
 function describeDocsCatalogue() {
+  const docs = DOC_INDEX.filter(d => d.kind !== 'source');
+  const sources = DOC_INDEX.filter(d => d.kind === 'source');
   const lines = [
     '## Available docs',
     '',
@@ -93,9 +137,29 @@ function describeDocsCatalogue() {
     'instead of guessing from training data when the user asks about',
     'schema, renderer contracts, or workflows.',
     '',
+    '### Documentation',
+    '',
+    'Reach for these FIRST. They are the authoritative answer for',
+    'schema, renderer contracts, and workflows.',
+    '',
   ];
-  for (const d of DOC_INDEX) {
+  for (const d of docs) {
     lines.push(`- \`${d.path}\` — ${d.summary}`);
+  }
+  if (sources.length > 0) {
+    lines.push('');
+    lines.push('### Renderer source');
+    lines.push('');
+    lines.push('The Lit components that drive each card on the dashboard.');
+    lines.push('Reach for these ONLY when the docs above leave a gap on a');
+    lines.push('specific behaviour you need to verify, or when the user');
+    lines.push('is asking for a code-level explanation. Each summary');
+    lines.push('states the renderer\'s most-asked contract fact, so you');
+    lines.push('can usually answer without fetching the file.');
+    lines.push('');
+    for (const d of sources) {
+      lines.push(`- \`${d.path}\` — ${d.summary}`);
+    }
   }
   lines.push('');
   return lines.join('\n');

--- a/config/env.js
+++ b/config/env.js
@@ -214,14 +214,16 @@ Pure additions / non-destructive patches (adding a new threshold band, renaming 
 
 ## Verifying renderer behaviour
 
-Before claiming what a built-in renderer (\`generic-card\`, \`list-card\`, \`schedule-card\`, \`checklist-card\`, \`combination-card\`, \`markdown-doc\`, \`line-chart\`, \`schedule-timeline\`, \`table-list\`, \`adherence-report\`, \`greeting-banner\`, \`day-marker\`) does in response to user interaction — what it reads from the manifest, what it writes to data, what it ignores — you MUST first call \`read_doc("docs/CARDS.md")\` and consult the **Renderer behaviour reference** section, plus \`read_doc("MANIFEST-SCHEMA.md")\` if the question touches the schema. Use only what those docs explicitly state.
+Before claiming what a built-in renderer (\`generic-card\`, \`list-card\`, \`schedule-card\`, \`checklist-card\`, \`combination-card\`, \`markdown-doc\`, \`line-chart\`, \`schedule-timeline\`, \`table-list\`, \`adherence-report\`, \`greeting-banner\`, \`day-marker\`) does in response to user interaction — what it reads from the manifest, what it writes to data, what it ignores — work through these steps in order:
 
-If the renderer behaviour you'd need to assert is NOT documented in those files, say so plainly: "I can't verify this from the docs." Then offer to inspect the actual data shape with \`read_manifest\` so the user can see what the renderer is currently writing — that's the closest you can get to ground truth without the renderer source.
+1. **Docs first.** Call \`read_doc("docs/CARDS.md")\` and consult the **Renderer behaviour reference** section. Add \`read_doc("MANIFEST-SCHEMA.md")\` if the question touches the schema. The docs are the fastest source of truth and cover the most-asked contracts.
+2. **Renderer source if the docs leave a gap.** The catalogue's **Renderer source** subsection lists each renderer's Lit component (\`public/js/components/eh-*.js\`) — call \`read_doc\` on the relevant path and read the actual code. The summary line in the catalogue often answers the question without you needing to fetch the file. Reach for source only when the docs don't cover the specific behaviour you need to verify, or when the user is asking for a code-level explanation; the source files are larger than docs and bloat your context if pulled by default.
+3. **Declare uncertainty if neither covers it.** Say plainly: "I can't verify this from the docs or source." Then offer to inspect the actual data shape with \`read_manifest\` so the user can see what the renderer is currently writing.
 
 Hard rules:
 - Do NOT reason by analogy from how OTHER renderers work. Renderers do not share check-off, form, or write semantics. The fact that \`generic-card\` consults \`meta.writeable.inputs\` for its edit form does NOT mean \`schedule-card\` does. Each renderer's contract is independent.
-- Do NOT promise a manifest patch will produce a behaviour change until you have verified, from the docs, that the renderer reads the field you're patching. Patching a key the renderer ignores is a footgun: the data shape changes, nothing on screen does, the user wastes a round-trip.
-- Do NOT assume the renderer source file exists at any particular path or guess at its content. The renderer source is not exposed through \`read_doc\`; the docs are the only authoritative reference available to you.
+- Do NOT promise a manifest patch will produce a behaviour change until you have verified, from the docs or source, that the renderer reads the field you're patching. Patching a key the renderer ignores is a footgun: the data shape changes, nothing on screen does, the user wastes a round-trip.
+- Do NOT guess at renderer source paths or content. The catalogue lists every readable path; anything not listed is not reachable.
 
 The honest answer is always better than a confident wrong one.
 

--- a/tests/chat-prompt-cc-schema.test.js
+++ b/tests/chat-prompt-cc-schema.test.js
@@ -140,6 +140,20 @@ describe('chat proxy injects CC schema into system prompt', () => {
     assert.match(prompt, /docs\/CARDS\.md/);
   });
 
+  test('system prompt exposes renderer source as a separate subsection', async () => {
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'hello' }] },
+    });
+    assert.equal(res.status, 200);
+    const prompt = gateway.getLastPrompt();
+    assert.ok(prompt);
+    assert.match(prompt, /### Documentation/);
+    assert.match(prompt, /### Renderer source/);
+    assert.match(prompt, /public\/js\/components\/eh-schedule-card\.js/);
+    assert.match(prompt, /public\/js\/components\/eh-input-form\.js/);
+  });
+
   test('system prompt tells the agent to verify renderer behaviour from docs first', async () => {
     const res = await req(server.baseUrl, '/api/chat', {
       method: 'POST',
@@ -152,5 +166,7 @@ describe('chat proxy injects CC schema into system prompt', () => {
     assert.match(prompt, /Renderer behaviour reference/);
     assert.match(prompt, /reason by analogy/i);
     assert.match(prompt, /can't verify this from the docs/i);
+    assert.match(prompt, /Docs first/);
+    assert.match(prompt, /Renderer source if the docs leave a gap/);
   });
 });

--- a/tests/chat-tools-docs.test.js
+++ b/tests/chat-tools-docs.test.js
@@ -67,6 +67,20 @@ describe('chat/docs.readDoc: success path', () => {
     assert.equal(res.path, 'docs/CARDS.md');
     assert.ok(res.content.length > 0);
   });
+
+  test('reads a renderer source file (eh-schedule-card.js)', () => {
+    const res = readDoc('public/js/components/eh-schedule-card.js');
+    assert.equal(res.path, 'public/js/components/eh-schedule-card.js');
+    assert.ok(res.content.length > 0);
+    assert.match(res.content, /registerRenderer\('schedule-card', 'eh-schedule-card'\)/);
+  });
+
+  test('reads eh-input-form.js (the inputs router)', () => {
+    const res = readDoc('public/js/components/eh-input-form.js');
+    assert.equal(res.path, 'public/js/components/eh-input-form.js');
+    assert.ok(res.content.length > 0);
+    assert.match(res.content, /meta\.writeable\.inputs/);
+  });
 });
 
 describe('chat/docs.readDoc: rejection path', () => {
@@ -115,6 +129,24 @@ describe('chat/docs.describeDocsCatalogue', () => {
     for (const entry of DOC_INDEX) {
       assert.ok(out.includes('`' + entry.path + '`'),
         `catalogue missing ${entry.path}`);
+    }
+  });
+
+  test('splits into Documentation and Renderer source subsections', () => {
+    const out = describeDocsCatalogue();
+    assert.match(out, /### Documentation/);
+    assert.match(out, /### Renderer source/);
+    // Documentation must appear before Renderer source so the agent
+    // reaches for docs first by default.
+    assert.ok(out.indexOf('### Documentation') < out.indexOf('### Renderer source'));
+  });
+
+  test('every renderer-source entry actually exists on disk', () => {
+    const sources = DOC_INDEX.filter(e => e.kind === 'source');
+    assert.ok(sources.length > 0, 'expected at least one source entry');
+    for (const entry of sources) {
+      assert.ok(entry.path.startsWith('public/js/components/'),
+        `source entry not under public/js/components/: ${entry.path}`);
     }
   });
 });


### PR DESCRIPTION
## Summary

- `chat/docs.js` allowlist gains entries for the twelve `eh-*.js` Lit components under `public/js/components/` — every built-in card renderer plus `eh-input-form` and `eh-prompt-modal`.
- The system-prompt catalogue now splits into two subsections: **Documentation** (reach for first) and **Renderer source** (when the docs leave a gap, or for code-level questions).
- The "Verifying renderer behaviour" section in the system prompt is updated to a three-step ladder: docs first, renderer source if the docs leave a gap, declare uncertainty otherwise.

## Why

`docs/CARDS.md` now carries a "Renderer behaviour reference" section (#346 / #347) that covers the high-traffic renderer questions, but the docs can drift from source over time, and edge cases will always exist that the docs don't cover. This PR gives the agent a second-stop source of truth — the actual code — without weakening any of the existing guardrails. Renderer files are AGPL-licensed and already shipped to every browser that loads the dashboard, so exposure through `read_doc` adds zero new surface.

## How

- `chat/docs.js`:
  - Each `DOC_INDEX` entry now carries a `kind` (`'doc'` | `'source'`).
  - Twelve renderer entries added with hand-written one-line summaries pulled from the actual code (e.g. schedule-card's summary calls out that it HARDCODES the dose write and DOES NOT consult `meta.writeable.inputs`).
  - `describeDocsCatalogue` splits into `### Documentation` and `### Renderer source` subsections; documentation comes first.
- `config/env.js` — `DEFAULT_HEALTH_SYSTEM_PROMPT`: rewrites the verification section as numbered steps (1. docs first, 2. source if gap, 3. declare uncertainty), warning that source files are larger and bloat context if pulled by default.
- Tests:
  - `tests/chat-tools-docs.test.js` — reads two renderer files end-to-end, asserts non-empty content and a known token; asserts the catalogue splits into the two subsections in the right order; asserts every source entry lives under `public/js/components/`.
  - `tests/chat-prompt-cc-schema.test.js` — asserts the catalogue subsections and the new "Docs first" / "Renderer source if the docs leave a gap" wording reach the gateway prompt.

`tests/dockerfile-docs-coverage.test.js` already enforces that every `DOC_INDEX` path is covered by a `COPY` directive; the renderer paths fall under the existing `COPY public ./public` (Dockerfile L68), so the test passes without changes.

## Out of scope

- Tier 2 — shared libs (`public/js/lib/schedule.js`, `combines-resolver.js`, etc.). Add when a renderer-source read dead-ends on a function call into one of them.
- Tier 3 — server + chat tools (`server.js`, `manifests/registry.js`, `chat/tools.js`, `chat/embellish.js`). Larger surface, more privacy considerations, separate decision.
- Globbing the allowlist. Manual entries are 30 seconds per file and force a deliberate exposure choice; a glob would auto-expose any new renderer in a feature PR.

## Testing

- [x] `npm test` — 1090 pass, 0 fail, 3 skipped (pre-existing).
- [x] New tests for renderer-source reads pass; catalogue subsection ordering verified.
- [x] `dockerfile-docs-coverage` continues to pass against the new entries.
- [x] `hygiene-check` skill — clean.

Fixes #348