### PR TITLE
feat(inputs): chips and chips-multi input types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Chip pills as a new input type — `chips` and `chips-multi`.** Two
+  new entries in `meta.writeable.inputs[*].type` for tappable pill
+  chips. `chips` is single-select and stores the selected option's
+  value (string); tapping the selected chip clears it. `chips-multi`
+  is multi-select and stores an array of values; `required: true`
+  means at least one chip must be selected. Both share `select`'s
+  `options` shape (`["a", "b"]` or `[{value, label}]`). Used in
+  every renderer that already routes through `eh-input-form` —
+  generic-card, list-card, combination-card edit, prompt-modal in
+  modal mode. Prefer `chips` over `select` for short option lists
+  (≤ 8) where all options should be visible at once; stay on `select`
+  for long lists. Documented in `docs/CARDS.md` and
+  `MANIFEST-SCHEMA.md`. Fixes #344.
+
 - **Chat agent can fetch built-in renderer source through `read_doc`.**
   The `chat/docs.js` allowlist now exposes the twelve `eh-*.js` Lit
   components under `public/js/components/` (every built-in card

--- a/MANIFEST-SCHEMA.md
+++ b/MANIFEST-SCHEMA.md
@@ -462,6 +462,8 @@ other. Up to ~20 entries per card are reasonable. The hardcoded
 | `date` | — |
 | `time` | — |
 | `rating` | `min`, `max` (1..5 default) |
+| `chips` | `options: [string]` or `[{value,label}]` (single-select pill chips; tap selected to clear) |
+| `chips-multi` | `options: [string]` or `[{value,label}]` (multi-select pill chips; stores an array; `required` means ≥1 selected) |
 
 All support: `key` (required), `label`, `required`, `default`, `help`.
 

--- a/docs/CARDS.md
+++ b/docs/CARDS.md
@@ -458,8 +458,14 @@ input form renders the right widget per type.
 | `date` | date picker | — |
 | `time` | time picker | — |
 | `rating` | 1..N buttons | `min`, `max` (default 1..5) |
+| `chips` | single-select pill chips | `options: [string]` or `[{value, label}]` |
+| `chips-multi` | multi-select pill chips | `options: [string]` or `[{value, label}]` |
 
 All types support: `key` (required), `label`, `required`, `default`, `help`.
+
+**`chips` vs `select`.** Both accept the same `options` shape and store a single string value. `select` renders as a dropdown; `chips` renders as tappable pills. Prefer `chips` when the option list is short (≤ 8) and you want all options visible at once — much faster on mobile than opening a dropdown. Tapping the currently-selected chip clears the value (so a non-required chips field can be left empty after a stray tap). For long lists, stay on `select`.
+
+**`chips-multi`.** Stores an array of selected option values, in selection order. Empty array = unset. With `required: true`, validation requires at least one chip selected. Useful for tag-style fields (workout categories, mood descriptors, reaction notes) where multiple options can apply at once.
 
 **`required` on inputs.** Defaults to `false` (optional). When `required: true`:
 - The inline edit form blocks Save with an error message if the field is empty.

--- a/public/js/components/eh-input-form.js
+++ b/public/js/components/eh-input-form.js
@@ -9,10 +9,17 @@
 // upserted entry).
 //
 // Input types supported:
-//   number, text, textarea, select, emoji-picker, colour, checkbox, date, time, rating
+//   number, stepper, text, textarea, select, emoji-picker, colour, checkbox,
+//   date, time, rating, chips, chips-multi
 //
 // Each input entry (in meta.writeable.inputs) has:
 //   { key, type, label?, placeholder?, required?, min?, max?, step?, options?, emojis? }
+//
+// chips / chips-multi share `select`'s `options` shape (string array, or
+// [{value, label}] for display-vs-stored splits). chips stores the
+// selected option's value as a string. chips-multi stores an array of
+// selected values; empty array = unset, and required: true means at
+// least one chip selected.
 //
 // Card renderers pass the current date (for defaulting) and any prefilled values
 // (for edit mode):
@@ -76,8 +83,14 @@ export class EhInputForm extends LitElement {
           // Sensible per-type defaults
           if (input.type === 'checkbox') s[input.key] = !!input.default;
           else if (input.type === 'number' || input.type === 'rating' || input.type === 'stepper') s[input.key] = input.default ?? null;
+          else if (input.type === 'chips-multi') s[input.key] = Array.isArray(input.default) ? [...input.default] : [];
           else if ('default' in input) s[input.key] = input.default;
           else s[input.key] = '';
+        } else if (input.type === 'chips-multi' && !Array.isArray(s[input.key])) {
+          // Coerce a non-array prefilled value (legacy single-string)
+          // to the array shape this type expects.
+          const v = s[input.key];
+          s[input.key] = (v === null || v === undefined || v === '') ? [] : [v];
         }
       }
       this._state = s;
@@ -93,6 +106,7 @@ export class EhInputForm extends LitElement {
       if (input.required) {
         const v = this._state[input.key];
         if (v === null || v === undefined || v === '') return false;
+        if (input.type === 'chips-multi' && (!Array.isArray(v) || v.length === 0)) return false;
       }
     }
     // requireAny: at least one of the listed keys must have a value.
@@ -101,7 +115,9 @@ export class EhInputForm extends LitElement {
     if (Array.isArray(this.requireAny) && this.requireAny.length > 0) {
       const hasAny = this.requireAny.some(k => {
         const v = this._state[k];
-        return v !== null && v !== undefined && v !== '';
+        if (v === null || v === undefined || v === '') return false;
+        if (Array.isArray(v)) return v.length > 0;
+        return true;
       });
       if (!hasAny) return false;
     }
@@ -233,6 +249,72 @@ export class EhInputForm extends LitElement {
               return html`<option value=${val} ?selected=${String(v) === String(val)}>${label}</option>`;
             })}
           </select>`;
+      case 'chips': {
+        // Single-select pill chips. Stores the option's `value` as a
+        // string. Tap an unselected chip to select it; tapping the
+        // selected chip again clears the value (so a non-required
+        // chips field can be left empty after a stray tap).
+        const opts = (input.options || []).map(o => (
+          typeof o === 'string' ? { value: o, label: o } : { value: o.value, label: o.label || o.value }
+        ));
+        const selectedStr = v === null || v === undefined ? '' : String(v);
+        return html`
+          <div
+            class="chip-row"
+            id=${id}
+            role="group"
+            aria-label="${input.label || input.key}"
+          >
+            ${opts.map(o => {
+              const isSel = selectedStr === String(o.value);
+              return html`
+                <button
+                  type="button"
+                  class="chip ${isSel ? 'selected' : ''}"
+                  role="button"
+                  aria-pressed=${isSel ? 'true' : 'false'}
+                  @click=${() => this._update(input.key, isSel ? '' : o.value)}
+                >${o.label}</button>
+              `;
+            })}
+          </div>`;
+      }
+      case 'chips-multi': {
+        // Multi-select pill chips. Stores an array of option values.
+        // Tap to toggle. Required: at least one chip selected.
+        const opts = (input.options || []).map(o => (
+          typeof o === 'string' ? { value: o, label: o } : { value: o.value, label: o.label || o.value }
+        ));
+        const arr = Array.isArray(v) ? v : [];
+        const selectedSet = new Set(arr.map(x => String(x)));
+        const onToggle = (val) => {
+          const sval = String(val);
+          const next = selectedSet.has(sval)
+            ? arr.filter(x => String(x) !== sval)
+            : [...arr, val];
+          this._update(input.key, next);
+        };
+        return html`
+          <div
+            class="chip-row"
+            id=${id}
+            role="group"
+            aria-label="${input.label || input.key}"
+          >
+            ${opts.map(o => {
+              const isSel = selectedSet.has(String(o.value));
+              return html`
+                <button
+                  type="button"
+                  class="chip ${isSel ? 'selected' : ''}"
+                  role="button"
+                  aria-pressed=${isSel ? 'true' : 'false'}
+                  @click=${() => onToggle(o.value)}
+                >${o.label}</button>
+              `;
+            })}
+          </div>`;
+      }
       case 'emoji-picker': {
         const emojis = input.emojis || DEFAULT_EMOJIS;
         const onPick = (i, e) => {
@@ -408,6 +490,42 @@ export class EhInputForm extends LitElement {
       border-color: var(--accent);
       background: var(--accent);
       color: var(--text-inverse, white);
+    }
+
+    /* --- Chip pills (chips / chips-multi) --- */
+    .chip-row {
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+    }
+    .chip {
+      border: 1px solid var(--border);
+      background: var(--bg-card);
+      color: var(--text-primary);
+      padding: 6px 12px;
+      border-radius: 999px;
+      font-size: 13px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.12s;
+      font-family: inherit;
+      line-height: 1.2;
+    }
+    .chip:hover:not(.selected) {
+      border-color: var(--accent);
+      color: var(--accent);
+    }
+    .chip.selected {
+      border-color: var(--accent);
+      background: var(--accent);
+      color: var(--text-inverse, white);
+    }
+    .chip:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .chip { transition: none; }
     }
 
     /* --- Stepper (number with −/+ buttons on either side) --- */

--- a/tests-e2e/chips-input-types.spec.js
+++ b/tests-e2e/chips-input-types.spec.js
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/chips-input-types.spec.js
+// Coverage for #344: chips (single-select) and chips-multi (multi-select)
+// input types in eh-input-form. Seeds a list-card whose secondary fields
+// include one of each chip type, opens the per-row detail form, taps
+// chips, applies, saves, and asserts the on-disk shape.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+const CARD_ID = 'chips-e2e';
+
+function chipsManifest() {
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: CARD_ID,
+      label: 'Chips e2e',
+      emoji: '🏷️',
+      order: 9100,
+      category: 'lifestyle',
+      view: {
+        enabled: true,
+        component: 'list-card',
+        display: {
+          primaryField: 'note',
+          emptyMessage: 'No entries yet.',
+        },
+      },
+      writeable: {
+        fromWebapp: true,
+        todayAllowed: true,
+        pastAllowed: true,
+        futureAllowed: false,
+        maxReadingsPerDay: 20,
+        inputs: [
+          { key: 'note', label: 'Note', type: 'text', required: true },
+          {
+            key: 'category',
+            label: 'Category',
+            type: 'chips',
+            options: ['breakfast', 'lunch', 'dinner', 'snack'],
+          },
+          {
+            key: 'tags',
+            label: 'Tags',
+            type: 'chips-multi',
+            options: ['home-cooked', 'takeaway', 'vegetarian', 'protein'],
+          },
+        ],
+      },
+    },
+    description: 'List-card exercising chips and chips-multi inputs (#344).',
+    data: [
+      // Seed one row so we can target an existing per-row detail
+      // button rather than going through the add-row flow.
+      { added: '2026-04-01T08:00:00Z', note: 'Eggs and toast', category: '', tags: [] },
+    ],
+  };
+}
+
+async function seed(request, baseUrl, manifest) {
+  await request.delete(`${baseUrl}/api/manifests/${manifest.meta.id}`).catch(() => {});
+  const r = await request.post(`${baseUrl}/api/manifests`, { data: manifest });
+  expect([201, 409]).toContain(r.status());
+}
+
+async function cleanup(request, baseUrl, id) {
+  await request.delete(`${baseUrl}/api/manifests/${id}`).catch(() => {});
+}
+
+test.describe('#344: chips and chips-multi input types', () => {
+  test('selecting chips and chips-multi values round-trips to disk', async ({ page, sandboxState }) => {
+    await seed(page.request, sandboxState.baseUrl, chipsManifest());
+
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible({ timeout: 10_000 });
+
+    const card = page.locator(`[data-card-id="${CARD_ID}"] eh-list-card`);
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    // Enter edit mode, then open the seeded row's detail form.
+    await card.locator('button[aria-label="Edit list"]').click();
+    await card.locator('button[aria-label*="Edit extra fields"]').first().click();
+
+    const form = card.locator('eh-input-form');
+    await expect(form).toBeVisible();
+
+    // chips: pick "breakfast".
+    const categoryGroup = form.locator('.chip-row').nth(0);
+    await categoryGroup.locator('.chip', { hasText: 'breakfast' }).click();
+    await expect(categoryGroup.locator('.chip.selected', { hasText: 'breakfast' })).toBeVisible();
+
+    // chips-multi: pick "home-cooked" and "protein".
+    const tagsGroup = form.locator('.chip-row').nth(1);
+    await tagsGroup.locator('.chip', { hasText: 'home-cooked' }).click();
+    await tagsGroup.locator('.chip', { hasText: 'protein' }).click();
+    await expect(tagsGroup.locator('.chip.selected')).toHaveCount(2);
+
+    // Apply to merge into the draft row, then Done to persist.
+    await form.getByRole('button', { name: /^apply$/i }).click();
+    await card.locator('button[aria-label="Done — save changes"]').click();
+
+    // Round-trip: read the data file back and assert the shape.
+    const res = await page.request.get(`${sandboxState.baseUrl}/api/manifests/${CARD_ID}/data`);
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(body.data.length).toBe(1);
+    const row = body.data[0];
+    expect(row.note).toBe('Eggs and toast');
+    expect(row.category).toBe('breakfast');
+    expect(Array.isArray(row.tags)).toBe(true);
+    expect(row.tags.sort()).toEqual(['home-cooked', 'protein']);
+
+    await cleanup(page.request, sandboxState.baseUrl, CARD_ID);
+  });
+
+  test('tapping the selected chip clears the chips value', async ({ page, sandboxState }) => {
+    await seed(page.request, sandboxState.baseUrl, chipsManifest());
+
+    await page.goto('/');
+    const card = page.locator(`[data-card-id="${CARD_ID}"] eh-list-card`);
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await card.locator('button[aria-label="Edit list"]').click();
+    await card.locator('button[aria-label*="Edit extra fields"]').first().click();
+    const form = card.locator('eh-input-form');
+
+    const categoryGroup = form.locator('.chip-row').nth(0);
+    await categoryGroup.locator('.chip', { hasText: 'lunch' }).click();
+    await expect(categoryGroup.locator('.chip.selected', { hasText: 'lunch' })).toBeVisible();
+
+    // Tap the same chip again — should clear.
+    await categoryGroup.locator('.chip.selected', { hasText: 'lunch' }).click();
+    await expect(categoryGroup.locator('.chip.selected')).toHaveCount(0);
+
+    await cleanup(page.request, sandboxState.baseUrl, CARD_ID);
+  });
+});


### PR DESCRIPTION
## Summary

- `eh-input-form` gains two new entries in its `meta.writeable.inputs[*].type` switch: `chips` (single-select pill chips) and `chips-multi` (multi-select pill chips).
- Both share `select`'s `options` shape (`["a", "b"]` or `[{value, label}]`).
- `chips` stores the selected option's value as a string; tapping the selected chip clears it. `chips-multi` stores an array of values; `required: true` means ≥ 1 selected.
- Documented in `docs/CARDS.md` (input types table + chips-vs-select guidance) and `MANIFEST-SCHEMA.md`.

## Why

Two reasons to add this primitive now:

1. **#345 needs it.** The injection-site / per-dose-metadata feature in #345 is built around three small chip inputs (side / region / position) plus a multi-select reaction field. Without `chips` / `chips-multi` the only pre-existing primitive that fits is `select` — a dropdown is the wrong shape for "tap one or two of these six options" on mobile.
2. **It's a generic mobile primitive.** Tag-style inputs come up in workouts, mood, meal logs, symptom tracking — anywhere multiple options can apply to one row. Adding it as a primitive (vs. a one-off renderer feature) means every renderer that already routes through `eh-input-form` gets it for free.

## How

- `public/js/components/eh-input-form.js`:
  - Two new `case` branches in `_renderInput`. Both reuse the existing `options` normalisation pattern from `select` (string vs `{value, label}`).
  - State seeding in `willUpdate`: `chips-multi` defaults to an array; a non-array prefilled value gets coerced to a single-element array.
  - Validation in `_isValid`: `required` on a `chips-multi` requires `length > 0`. `requireAny` now recognises an empty array as unsatisfied (a small generalisation that also fixes the previously-undefined edge case where an inputs array contained a `chips-multi` listed in `requireAny`).
  - Styling: pill-shaped buttons with the same selected/hover treatment as `.emoji` / `.rating` rows. Reduced-motion respected.
- `docs/CARDS.md` + `MANIFEST-SCHEMA.md`: input types tables updated, plus a short paragraph on chips-vs-select selection guidance.

The hardcoded-write renderers (`schedule-card`, `checklist-card`, `prompt-modal` in checklist mode) stay unchanged. They don't consult `meta.writeable.inputs`, so the new types don't affect them. Adding chip-driven per-dose metadata to schedule-card is the work in #345.

## Testing

- [x] `npm test` — 1090 pass, 0 fail, 3 skipped (pre-existing).
- [x] `npx playwright test tests-e2e/chips-input-types.spec.js` — 2 specs, both pass on first run. End-to-end coverage: seed a list-card with `chips` + `chips-multi` secondary inputs, drive through the per-row detail form, save, read the data file back, assert shape. Second spec exercises the tap-to-clear behaviour on `chips`.
- [x] Adjacent input-form e2e specs (`water-stepper`, `list-card-row-detail-edit`, `mood-rating-shows-emojis`, `mood-requireany-either-or`) re-run clean — no regressions.
- [x] `hygiene-check` — clean.

## Out of scope

- A unit test for `eh-input-form` rendering — the codebase has no Lit unit-test harness for this component (it's only exercised through e2e specs); adding one is its own piece of work.
- A new recipe in `docs/RECIPES.md`. The natural recipe is the injection-site card from #345 — adding it here would be a half-recipe without the schedule-card form support that #345 brings.

Fixes #344