### PR TITLE
feat(schedule-card): per-dose metadata and retroactive review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Schedule-card per-dose metadata + retroactive review of the
+  previous dose.** Setting `meta.view.checkOffForm` opts a
+  schedule-card into a form-driven check-off: tapping the ✓ now
+  expands an inline form sourced from `meta.writeable.inputs` instead
+  of hardcoding `{scheduledDate, takenAt}`. Two ordered field lists
+  drive the form: `currentDoseFields` (stamped onto the new dose
+  entry) and `previousDoseFields` (merged onto the most recent prior
+  dose with `takenAt` set — the retroactive-review channel). Above
+  the form, a "Last:" context line summarises the previous dose's
+  current-dose-field values plus a relative date (e.g. `Last: 3d ago
+  · right belly upper`). Hidden when no prior taken dose exists. An
+  optional `previousDosePrompt` string customises the label above the
+  previous-dose inputs. Untick is unchanged and never opens the form.
+  Schedule-cards without `checkOffForm` keep the original one-tap
+  behaviour exactly as before (purely additive). Documented in
+  `docs/CARDS.md` "Schedule-card per-dose metadata" + a new recipe
+  in `docs/RECIPES.md`. Renderer-source summary in `chat/docs.js`
+  updated so the chat agent's catalogue reflects the new contract.
+  Fixes #345.
+
 - **Chip pills as a new input type — `chips` and `chips-multi`.** Two
   new entries in `meta.writeable.inputs[*].type` for tappable pill
   chips. `chips` is single-select and stores the selected option's

--- a/MANIFEST-SCHEMA.md
+++ b/MANIFEST-SCHEMA.md
@@ -534,7 +534,7 @@ Use one of these names in `meta.view.component` / `meta.trends.component`:
 |------|-----------|
 | `generic-card` | Zero-code headline + secondary + input form (preferred default) |
 | `list-card` | Persistent roster of items (symptoms, allergies, etc.) — rows stay until explicitly deleted |
-| `schedule-card` | Peptide/medication schedule with dot-grid visualisation |
+| `schedule-card` | Peptide/medication schedule with dot-grid visualisation. Optional `meta.view.checkOffForm` opts the card into form-driven check-off with per-dose metadata + retroactive review of the previous dose — see `docs/CARDS.md` "Schedule-card per-dose metadata". |
 | `checklist-card` | Daily checklist |
 | `markdown-doc` | Static markdown content |
 | `line-chart` | Trends line chart |

--- a/chat/docs.js
+++ b/chat/docs.js
@@ -60,7 +60,7 @@ const DOC_INDEX = [
   { kind: 'source', path: 'public/js/components/eh-list-card.js',
     summary: 'list-card renderer (permanent roster, NOT per-day). ROUTES WRITES THROUGH meta.writeable.inputs (both add and per-row edit). Reads display.primaryField/secondaryTemplate/emptyMessage. Auto-stamps `added: ISO8601` on row creation.' },
   { kind: 'source', path: 'public/js/components/eh-schedule-card.js',
-    summary: 'schedule-card renderer. HARDCODES dose-write shape `{scheduledDate, takenAt, offSchedule?}`; DOES NOT consult meta.writeable.inputs on the ✓ check-off path. Reads data.items[].{schedule, cycles[], doses[]} and view.colorMap.' },
+    summary: 'schedule-card renderer. Default ✓ check-off HARDCODES `{scheduledDate, takenAt, offSchedule?}` to data.items[].doses[]. With meta.view.checkOffForm set (currentDoseFields + previousDoseFields), ✓ instead opens an inline form sourced from meta.writeable.inputs and merges previous-dose fields onto the most recent prior taken dose (retroactive review). Reads data.items[].{schedule, cycles[], doses[]} and view.colorMap.' },
   { kind: 'source', path: 'public/js/components/eh-checklist-card.js',
     summary: 'checklist-card renderer. HARDCODES the daily-tick write to either item.doses[].push({scheduledDate, takenAt}) or item.takenDates[].push(date); DOES NOT consult meta.writeable.inputs. Accepts data shapes items[], {items}, or {current}.' },
   { kind: 'source', path: 'public/js/components/eh-combination-card.js',

--- a/docs/CARDS.md
+++ b/docs/CARDS.md
@@ -930,7 +930,8 @@ of "I patched the manifest and nothing changed".
 | `list-card` | Yes |
 | `combination-card` (edit pencil) | Yes — but on the DONOR card's inputs, not its own |
 | `prompt-modal` with `mode:"modal"` | Yes |
-| `schedule-card` (check-off ✓) | **No** — write shape is hardcoded |
+| `schedule-card` (check-off ✓) with `meta.view.checkOffForm` set | Yes — only the keys named in `currentDoseFields` / `previousDoseFields` |
+| `schedule-card` (check-off ✓) without `meta.view.checkOffForm` | **No** — write shape is hardcoded |
 | `checklist-card` (tick) | **No** — write shape is hardcoded |
 | `prompt-modal` with `mode:"checklist"` | **No** — write shape is hardcoded |
 
@@ -982,27 +983,33 @@ of "I patched the manifest and nothing changed".
 **Reads:**
 - `meta.view.colorMap` (item-name → colour map; legacy alias
   `meta.colorMap` also accepted).
+- `meta.view.checkOffForm` (optional; opts the card into the per-dose
+  metadata flow — see "schedule-card per-dose metadata" below).
+- `meta.writeable.inputs[]` — ONLY when `meta.view.checkOffForm` is
+  set. Without `checkOffForm`, inputs are ignored.
 - Data shape: `{ items: [{ name, short_name?, dose_mg?, dose_units?,
   route?, action_label?, dose_label?, schedule, cycles[], doses[] }] }`.
 - Per-item `schedule` and `cycles[]` for the dot-grid and "scheduled
   today / rest day / off cycle" status.
-- Per-item `doses[].{scheduledDate, takenAt, offSchedule?}` for the
-  check-off state.
+- Per-item `doses[].{scheduledDate, takenAt, offSchedule?, ...}` for
+  the check-off state. Additional per-dose keys are written when
+  `checkOffForm` is set.
 
-**Writes:**
+**Writes (default — no `checkOffForm`):**
 - Tap the ✓ checkbox on a scheduled item → appends a hardcoded entry
   to that item's `doses[]`:
   `{ scheduledDate: <viewed date>, takenAt: <ISO now> }`.
   The off-schedule (dashed-border) variant adds `offSchedule: true`.
 - Untick → sets `takenAt: null` on the matching dose entry.
 
-**Ignores:**
-- `meta.writeable.inputs` — schedule-card's check-off flow does NOT
-  consult inputs. Adding fields to inputs does NOT make them appear in
-  the check-off path. Per-dose metadata beyond `{scheduledDate,
-  takenAt, offSchedule}` requires renderer changes; see
-  [issue #345](https://github.com/Aristocles/klebb/issues/345) for the
-  in-flight extension that wires inputs in via `meta.view.checkOffForm`.
+**Writes (with `meta.view.checkOffForm`):**
+- Tap the ✓ checkbox → expands an inline form below the row, sourced
+  from `meta.writeable.inputs`. On Submit, writes
+  `{ scheduledDate, takenAt, ...currentDoseFields }` to a new (or
+  same-date) dose entry, and merges any `previousDoseFields` values
+  onto the most recent prior dose with a `takenAt` set
+  (retroactive review — see "schedule-card per-dose metadata" below).
+- Untick → unchanged. Always immediate, never opens the form.
 
 ### `checklist-card`
 
@@ -1129,6 +1136,132 @@ Used in `meta.calendar.component`. Read-only.
 
 **Writes:**
 - None.
+
+---
+
+## Schedule-card per-dose metadata and retroactive review
+
+`schedule-card` defaults to a one-tap check-off: tapping the ✓ stamps
+`{ scheduledDate, takenAt }` (plus `offSchedule: true` on the
+dashed-border variant) and saves. That covers basic adherence
+tracking, but some scheduled regimens want richer per-dose metadata —
+where you injected, what reaction the previous site is showing, an
+energy-after rating, a free-text note. Setting
+`meta.view.checkOffForm` opts the card into the form-driven flow.
+
+### Shape
+
+```json
+"meta": {
+  "view": {
+    "component": "schedule-card",
+    "checkOffForm": {
+      "currentDoseFields":  ["site_side", "site_region", "site_position"],
+      "previousDoseFields": ["reactions"],
+      "previousDosePrompt": "How does the last injection site look?"
+    }
+  },
+  "writeable": {
+    "fromWebapp": true,
+    "todayAllowed": true,
+    "inputs": [
+      { "key": "site_side",     "label": "Side",     "type": "chips",
+        "options": ["left", "right", "centre"] },
+      { "key": "site_region",   "label": "Region",   "type": "chips",
+        "options": ["belly", "flank", "thigh", "delt", "glute", "tricep"] },
+      { "key": "site_position", "label": "Position", "type": "chips",
+        "options": ["upper", "middle", "lower"] },
+      { "key": "reactions",     "label": "Reactions", "type": "chips-multi",
+        "options": ["none", "bruised", "red", "swollen", "itchy", "tender", "welt", "lump"] }
+    ]
+  }
+}
+```
+
+### Fields
+
+- **`currentDoseFields`** (string[]): keys whose values are stamped
+  onto the new dose entry being created when the user submits the
+  form. Each key MUST exist in `meta.writeable.inputs[]`; keys not
+  declared in inputs are ignored.
+- **`previousDoseFields`** (string[]): keys whose values are merged
+  onto the most recent PRIOR dose entry that has a `takenAt`
+  timestamp set. This is the retroactive-review channel — the user is
+  rating the previous dose's outcome (a bruise, a welt, an itch)
+  while logging the new one. If no prior taken dose exists, this
+  section is hidden and only `currentDoseFields` are surfaced.
+- **`previousDosePrompt`** (string, optional): a short label rendered
+  above the previous-dose fields. Useful when "Reactions" alone isn't
+  obviously about the previous site (e.g. "How does the last
+  injection site look?").
+
+### What the user sees
+
+Tap the ✓ on a scheduled item → the row expands inline and shows:
+
+1. A muted "Last:" line with the relative date and a summary built by
+   joining the previous dose's `currentDoseFields` values with spaces
+   (e.g. `Last: 3d ago · right belly upper`). Hidden when no prior
+   taken dose exists.
+2. The `previousDoseFields` inputs (with the optional
+   `previousDosePrompt` above them).
+3. The `currentDoseFields` inputs.
+4. Submit / Cancel.
+
+Submit writes the new dose with current-dose fields stamped on, and
+merges the previous-dose fields onto the prior dose entry. Cancel
+collapses the form without writing.
+
+### Stored shape
+
+The new dose entry:
+
+```json
+{
+  "scheduledDate": "2026-06-08",
+  "takenAt": "2026-06-08T09:14:00Z",
+  "site_side": "left",
+  "site_region": "thigh",
+  "site_position": "upper"
+}
+```
+
+The previous dose entry (after merge) has whatever it had before plus
+the `previousDoseFields` keys:
+
+```json
+{
+  "scheduledDate": "2026-06-05",
+  "takenAt": "2026-06-05T09:30:00Z",
+  "site_side": "right",
+  "site_region": "belly",
+  "site_position": "upper",
+  "reactions": ["bruised", "itchy"]
+}
+```
+
+### Edge cases
+
+- **No previous dose at all (first dose ever):** the previous-dose
+  section is hidden entirely; only `currentDoseFields` are shown.
+- **Previous scheduled dose was skipped (`takenAt: null`):** the
+  renderer walks backwards through `doses[]` to find the most recent
+  entry with `takenAt` set. If every prior entry was skipped, the
+  previous-dose section is hidden.
+- **Untick:** unchanged. Untick is always immediate and clears
+  `takenAt` on the matching dose entry; it never opens the form.
+- **Off-schedule check-off:** opens the same form, with the same
+  fields. The new dose entry carries `offSchedule: true` in addition
+  to the field values.
+- **Field key not in inputs:** ignored. The renderer reads from
+  `meta.writeable.inputs[]` and silently drops any field key listed
+  in `checkOffForm` that doesn't have a matching input declaration.
+
+### Backwards compatibility
+
+A schedule-card without `meta.view.checkOffForm` (or with an empty
+config) keeps the original one-tap check-off behaviour exactly as
+before. This is purely additive.
 
 ---
 

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -730,6 +730,104 @@ and why only one pencil per donor renders.
 
 ---
 
+## Recipe 13 — Schedule-card with per-dose metadata + retroactive review
+
+For an injectable peptide cycle where you want to log WHERE you injected
+each time, AND rate how the previous site is reacting (bruise, welt,
+etch) when you log the new dose. Requires the `chips` and `chips-multi`
+input types.
+
+The two new pieces are `meta.view.checkOffForm` (which fields go on the
+new dose, which on the previous dose) and chip inputs for the actual
+options. See `docs/CARDS.md` "Schedule-card per-dose metadata" for the
+full reference.
+
+```json
+{
+  "$schema": "klebb.datafile.v1",
+  "meta": {
+    "id": "peptide-cycle",
+    "label": "Peptide Cycle",
+    "emoji": "💉",
+    "order": 320,
+    "view": {
+      "enabled": true,
+      "component": "schedule-card",
+      "checkOffForm": {
+        "currentDoseFields":  ["site_side", "site_region", "site_position"],
+        "previousDoseFields": ["reactions"],
+        "previousDosePrompt": "How does the last injection site look?"
+      }
+    },
+    "writeable": {
+      "fromWebapp": true,
+      "todayAllowed": true,
+      "pastAllowed": true,
+      "futureAllowed": false,
+      "inputs": [
+        { "key": "site_side",     "label": "Side",     "type": "chips",
+          "options": ["left", "right", "centre"] },
+        { "key": "site_region",   "label": "Region",   "type": "chips",
+          "options": ["belly", "flank", "thigh", "delt", "glute", "tricep"] },
+        { "key": "site_position", "label": "Position", "type": "chips",
+          "options": ["upper", "middle", "lower"] },
+        { "key": "reactions",     "label": "Reactions", "type": "chips-multi",
+          "options": ["none", "bruised", "red", "swollen", "itchy", "tender", "welt", "lump"] }
+      ]
+    }
+  },
+  "description": "Injectable peptide cycle with per-dose injection-site logging and retroactive reaction review on the previous dose.",
+  "data": {
+    "items": [
+      {
+        "name": "BPC-157",
+        "dose_mg": 0.25, "dose_units": "mg", "route": "subcutaneous",
+        "schedule": { "type": "daily", "times_per_day": 1, "start_date": "2026-06-01", "cycle_weeks": 6 },
+        "doses": []
+      }
+    ]
+  }
+}
+```
+
+What you see on the dashboard: tap the ✓ on a scheduled item, the row
+expands inline with a "Last: 3d ago · right belly upper" context line,
+the reaction chips for the previous site, and the side/region/position
+chips for the new dose. Submit writes the new dose with site fields
+stamped on, AND merges the reaction chips you ticked onto the previous
+dose entry.
+
+Stored shape per dose:
+
+```json
+{
+  "scheduledDate": "2026-06-08",
+  "takenAt": "2026-06-08T09:14:00Z",
+  "site_side": "left",
+  "site_region": "thigh",
+  "site_position": "upper"
+}
+```
+
+Plus, on the previous taken dose, whatever was already there + the
+reactions array:
+
+```json
+{
+  "scheduledDate": "2026-06-05",
+  "takenAt": "2026-06-05T09:30:00Z",
+  "site_side": "right",
+  "site_region": "belly",
+  "site_position": "upper",
+  "reactions": ["bruised", "itchy"]
+}
+```
+
+Schedule-cards without `meta.view.checkOffForm` keep the original
+one-tap check-off — the form-driven path is opt-in.
+
+---
+
 ## Next steps
 
 - For the full manifest spec (every field, every input type, every

--- a/public/js/components/eh-schedule-card.js
+++ b/public/js/components/eh-schedule-card.js
@@ -20,6 +20,7 @@ import { LitElement, html, css } from 'https://esm.sh/lit@3';
 import { EhBaseCard } from './eh-base-card.js';
 import { isScheduledOnDate, effectiveCycles } from '../lib/schedule.js';
 import { registerRenderer } from '../renderer-registry.js';
+import './eh-input-form.js';
 
 const DAY_LETTERS = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
 
@@ -79,6 +80,22 @@ function cycleProgress(item, dateStr) {
 }
 
 export class EhScheduleCard extends EhBaseCard {
+  // Extend the base reactive properties with one renderer-internal
+  // bit of state: which scheduled item (if any) currently has the
+  // check-off form expanded inline. The key is the item's `name` (or
+  // `short_name` if no name); only one item's form is open at a time.
+  static properties = {
+    ...EhBaseCard.properties,
+    _expandedItemKey: { state: true },
+    _formError: { state: true },
+  };
+
+  constructor() {
+    super();
+    this._expandedItemKey = null;
+    this._formError = null;
+  }
+
   static styles = [
     EhBaseCard.styles,
     css`
@@ -259,6 +276,42 @@ export class EhScheduleCard extends EhBaseCard {
         padding: 8px 0;
       }
 
+      /* --- Inline check-off form (per-dose metadata, see #345) --- */
+      .item-row { display: flex; flex-direction: column; gap: 0; }
+      .checkoff-form {
+        margin-top: 8px;
+        padding: 12px;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        background: var(--bg-card);
+      }
+      .prev-dose {
+        margin-bottom: 10px;
+        padding-bottom: 10px;
+        border-bottom: 1px dashed var(--border);
+      }
+      .prev-dose-line {
+        font-size: 12px;
+        color: var(--text-secondary);
+      }
+      .prev-dose-label {
+        font-weight: 600;
+        margin-right: 4px;
+      }
+      .prev-dose-summary {
+        color: var(--text-primary);
+      }
+      .prev-dose-prompt {
+        font-size: 11px;
+        color: var(--text-muted, var(--text-secondary));
+        margin-top: 4px;
+      }
+      .form-error {
+        color: #ff4466;
+        font-size: 12px;
+        margin-top: 8px;
+      }
+
       @media (max-width: 480px) {
         .item { grid-template-columns: 44px minmax(0, 1fr) auto; gap: 8px; }
         .ring, .ring svg { width: 40px; height: 40px; }
@@ -307,10 +360,99 @@ export class EhScheduleCard extends EhBaseCard {
     return '';
   }
 
+  // Per-dose-metadata config (see #345). When meta.view.checkOffForm is
+  // present with a non-empty currentDoseFields list, tapping ✓ expands
+  // an inline form sourced from meta.writeable.inputs instead of
+  // immediately stamping {scheduledDate, takenAt}.
+  _checkOffFormConfig() {
+    const cfg = this._config?.checkOffForm || this._meta?.checkOffForm;
+    if (!cfg || typeof cfg !== 'object') return null;
+    const current = Array.isArray(cfg.currentDoseFields) ? cfg.currentDoseFields : [];
+    const previous = Array.isArray(cfg.previousDoseFields) ? cfg.previousDoseFields : [];
+    if (current.length === 0 && previous.length === 0) return null;
+    return {
+      currentDoseFields: current,
+      previousDoseFields: previous,
+      previousDosePrompt: typeof cfg.previousDosePrompt === 'string'
+        ? cfg.previousDosePrompt : null,
+    };
+  }
+
+  _writeableInputs() {
+    const inputs = this._meta?.writeable?.inputs;
+    return Array.isArray(inputs) ? inputs : [];
+  }
+
+  // Inputs filtered to a list of keys, in the order that `keys` lists
+  // them (so the form renders previousDoseFields first, currentDoseFields
+  // second, regardless of the order in meta.writeable.inputs[]). Silently
+  // skips any field key the manifest's writeable.inputs[] doesn't
+  // actually declare.
+  _filteredInputs(keys) {
+    if (!Array.isArray(keys) || keys.length === 0) return [];
+    const byKey = new Map();
+    for (const input of this._writeableInputs()) byKey.set(input.key, input);
+    const out = [];
+    for (const key of keys) {
+      const input = byKey.get(key);
+      if (input) out.push(input);
+    }
+    return out;
+  }
+
+  // The most recent dose with a takenAt timestamp set, OR null. Walks
+  // backwards to skip scheduled-but-untaken entries (takenAt: null).
+  _findPreviousDose(item) {
+    if (!Array.isArray(item.doses)) return null;
+    for (let i = item.doses.length - 1; i >= 0; i--) {
+      const d = item.doses[i];
+      if (d && d.takenAt) return { dose: d, index: i };
+    }
+    return null;
+  }
+
+  _itemKey(item) {
+    return item.name || item.short_name || '';
+  }
+
+  _summarisePreviousDose(prevDose, currentDoseFields) {
+    if (!prevDose) return '';
+    const parts = [];
+    for (const key of currentDoseFields) {
+      const v = prevDose[key];
+      if (v === null || v === undefined || v === '') continue;
+      parts.push(Array.isArray(v) ? v.join(', ') : String(v));
+    }
+    return parts.join(' ');
+  }
+
+  _relativeDays(isoTimestamp) {
+    if (!isoTimestamp) return '';
+    const then = new Date(isoTimestamp);
+    if (Number.isNaN(then.getTime())) return '';
+    const today = new Date(this.date + 'T00:00:00');
+    const days = Math.round((today - new Date(then.toDateString())) / 86400000);
+    if (days <= 0) return 'today';
+    if (days === 1) return 'yesterday';
+    return `${days}d ago`;
+  }
+
   async _toggleDose(item, opts = {}) {
     if (!this._canWrite) return;
     const doses = Array.isArray(item.doses) ? [...item.doses] : [];
     const idx = doses.findIndex(d => d.scheduledDate === this.date);
+    const alreadyTaken = idx >= 0 && doses[idx].takenAt;
+
+    // Form-driven path: only fires on the "take a dose" tap, never on
+    // untick. Untick clears takenAt and saves immediately, same as
+    // before. The form also skips on disable.
+    const formCfg = this._checkOffFormConfig();
+    if (formCfg && !alreadyTaken) {
+      this._formError = null;
+      this._expandedItemKey = this._itemKey(item) + (opts.offSchedule ? ':offschedule' : '');
+      return;
+    }
+
     if (idx >= 0) {
       if (doses[idx].takenAt) doses[idx] = { ...doses[idx], takenAt: null };
       else {
@@ -323,20 +465,71 @@ export class EhScheduleCard extends EhBaseCard {
       if (opts.offSchedule) entry.offSchedule = true;
       doses.push(entry);
     }
-    // Update the item in this.data.items
+    await this._persistDoses(item, doses);
+  }
+
+  async _persistDoses(item, doses) {
     const d = this.data;
     const updatedItems = d.items.map(it => it === item ? { ...it, doses } : it);
     this.data = { ...d, items: updatedItems };
     this.requestUpdate();
     try {
-      await fetch(`/api/manifests/${encodeURIComponent(this.card.id)}/data`, {
+      const res = await fetch(`/api/manifests/${encodeURIComponent(this.card.id)}/data`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ data: this.data }),
       });
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(`save failed: ${res.status} ${text}`);
+      }
     } catch (e) {
       console.warn('[schedule] save failed', e);
+      this._formError = e.message || 'save failed';
     }
+  }
+
+  async _submitCheckOffForm(item, opts, e) {
+    const payload = (e && e.detail) || {};
+    const formCfg = this._checkOffFormConfig();
+    if (!formCfg) return;
+
+    // Build the new dose entry. eh-input-form auto-fills `date` from
+    // its .date property — drop it; schedule-card uses scheduledDate.
+    const newDose = { scheduledDate: this.date, takenAt: new Date().toISOString() };
+    if (opts.offSchedule) newDose.offSchedule = true;
+    for (const key of formCfg.currentDoseFields) {
+      if (key in payload) newDose[key] = payload[key];
+    }
+
+    // Clone the item's doses and resolve the previous-dose merge BEFORE
+    // pushing the new one (so "previous" doesn't accidentally point at
+    // itself).
+    const doses = Array.isArray(item.doses) ? [...item.doses] : [];
+    let prev = null;
+    for (let i = doses.length - 1; i >= 0; i--) {
+      if (doses[i] && doses[i].takenAt) { prev = { dose: doses[i], index: i }; break; }
+    }
+    if (prev && formCfg.previousDoseFields.length > 0) {
+      const merged = { ...prev.dose };
+      for (const key of formCfg.previousDoseFields) {
+        if (key in payload) merged[key] = payload[key];
+      }
+      doses[prev.index] = merged;
+    }
+
+    // Replace any existing same-date dose entry, otherwise append.
+    const idx = doses.findIndex(d => d.scheduledDate === this.date);
+    if (idx >= 0) doses[idx] = newDose; else doses.push(newDose);
+
+    this._expandedItemKey = null;
+    this._formError = null;
+    await this._persistDoses(item, doses);
+  }
+
+  _cancelCheckOffForm() {
+    this._expandedItemKey = null;
+    this._formError = null;
   }
 
   _renderRing(cp, colour) {
@@ -376,6 +569,56 @@ export class EhScheduleCard extends EhBaseCard {
     `;
   }
 
+  _renderCheckOffForm(item, opts) {
+    const cfg = this._checkOffFormConfig();
+    if (!cfg) return '';
+    const all = this._writeableInputs();
+    if (all.length === 0) return '';
+    const fieldKeys = [...cfg.previousDoseFields, ...cfg.currentDoseFields];
+    const inputs = this._filteredInputs(fieldKeys);
+    if (inputs.length === 0) return '';
+
+    const prev = this._findPreviousDose(item);
+    const summary = prev ? this._summarisePreviousDose(prev.dose, cfg.currentDoseFields) : '';
+    const ago = prev ? this._relativeDays(prev.dose.takenAt) : '';
+    const showPrevContext = !!(prev && (summary || cfg.previousDoseFields.length > 0));
+
+    // If there is no previous dose, hide the previous-dose fields by
+    // restricting the form to currentDoseFields only.
+    const visibleInputs = prev
+      ? inputs
+      : this._filteredInputs(cfg.currentDoseFields);
+
+    const onSubmit = (e) => this._submitCheckOffForm(item, opts, e);
+    const onCancel = () => this._cancelCheckOffForm();
+
+    return html`
+      <div class="checkoff-form">
+        ${showPrevContext ? html`
+          <div class="prev-dose">
+            <div class="prev-dose-line">
+              <span class="prev-dose-label">Last:</span>
+              <span class="prev-dose-summary">${ago}${summary ? ' · ' + summary : ''}</span>
+            </div>
+            ${cfg.previousDosePrompt ? html`
+              <div class="prev-dose-prompt">${cfg.previousDosePrompt}</div>
+            ` : ''}
+          </div>
+        ` : ''}
+        <eh-input-form
+          .inputs=${visibleInputs}
+          .values=${{}}
+          .date=${this.date}
+          submit-label=${opts.offSchedule ? 'Log off-schedule dose' : 'Log dose'}
+          cancel-label="Cancel"
+          @eh-submit=${onSubmit}
+          @eh-cancel=${onCancel}
+        ></eh-input-form>
+        ${this._formError ? html`<div class="form-error">${this._formError}</div>` : ''}
+      </div>
+    `;
+  }
+
   renderCard() {
     const items = this._items;
     if (items.length === 0) return html`<div class="empty">Nothing scheduled.</div>`;
@@ -396,36 +639,44 @@ export class EhScheduleCard extends EhBaseCard {
           const doseEntry = Array.isArray(item.doses)
             ? item.doses.find(d => d.scheduledDate === this.date) : null;
           const isOffScheduleTaken = !!(taken && (isRestToday || doseEntry?.offSchedule));
+          const itemKey = this._itemKey(item);
+          const formKey = this._expandedItemKey;
+          const formExpandedScheduled = formKey === itemKey;
+          const formExpandedOffSchedule = formKey === itemKey + ':offschedule';
           return html`
-            <div class="item">
-              ${this._renderRing(cp, colour)}
-              <div class="info">
-                <div class="name">${item.short_name || item.name}</div>
-                ${isScheduledToday ? html`<div class="dose">${this._doseLabel(item)}${item.dose_units ? ' · ' + item.dose_units + 'u' : ''}</div>` : ''}
-                <div class="cycle-text">
-                  ${cp.type === 'off' ? 'Off cycle' : 'Cycle'} · Day ${cp.day}${cp.total ? ' of ' + cp.total : ''}
+            <div class="item-row">
+              <div class="item">
+                ${this._renderRing(cp, colour)}
+                <div class="info">
+                  <div class="name">${item.short_name || item.name}</div>
+                  ${isScheduledToday ? html`<div class="dose">${this._doseLabel(item)}${item.dose_units ? ' · ' + item.dose_units + 'u' : ''}</div>` : ''}
+                  <div class="cycle-text">
+                    ${cp.type === 'off' ? 'Off cycle' : 'Cycle'} · Day ${cp.day}${cp.total ? ' of ' + cp.total : ''}
+                  </div>
+                  ${this._renderWeekDots(item, colour)}
                 </div>
-                ${this._renderWeekDots(item, colour)}
+                <div class="right">
+                  ${chip ? html`<span class="chip ${chip.cls}">${chip.text}</span>` : ''}
+                  ${isScheduledToday ? html`
+                    <div
+                      class="checkbox ${taken ? 'checked' : ''} ${this._canWrite ? '' : 'disabled'}"
+                      @click=${() => this._toggleDose(item)}
+                      role="button"
+                      aria-label="mark ${item.name} taken"
+                    ></div>
+                  ` : isRestToday ? html`
+                    <div
+                      class="checkbox off-schedule ${isOffScheduleTaken ? 'checked' : ''} ${this._canWrite ? '' : 'disabled'}"
+                      @click=${() => this._toggleDose(item, { offSchedule: true })}
+                      role="button"
+                      aria-label="log extra ${item.name} dose (off-schedule)"
+                      title="Log an off-schedule dose"
+                    ></div>
+                  ` : ''}
+                </div>
               </div>
-              <div class="right">
-                ${chip ? html`<span class="chip ${chip.cls}">${chip.text}</span>` : ''}
-                ${isScheduledToday ? html`
-                  <div
-                    class="checkbox ${taken ? 'checked' : ''} ${this._canWrite ? '' : 'disabled'}"
-                    @click=${() => this._toggleDose(item)}
-                    role="button"
-                    aria-label="mark ${item.name} taken"
-                  ></div>
-                ` : isRestToday ? html`
-                  <div
-                    class="checkbox off-schedule ${isOffScheduleTaken ? 'checked' : ''} ${this._canWrite ? '' : 'disabled'}"
-                    @click=${() => this._toggleDose(item, { offSchedule: true })}
-                    role="button"
-                    aria-label="log extra ${item.name} dose (off-schedule)"
-                    title="Log an off-schedule dose"
-                  ></div>
-                ` : ''}
-              </div>
+              ${formExpandedScheduled ? this._renderCheckOffForm(item, { offSchedule: false }) : ''}
+              ${formExpandedOffSchedule ? this._renderCheckOffForm(item, { offSchedule: true }) : ''}
             </div>
           `;
         })}

--- a/tests-e2e/schedule-card-checkoff-form.spec.js
+++ b/tests-e2e/schedule-card-checkoff-form.spec.js
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/schedule-card-checkoff-form.spec.js
+// Coverage for #345: schedule-card per-dose metadata + retroactive review.
+//
+// Seeds a schedule-card with a daily item, a prior taken dose on disk
+// (3 days ago), and today's dose unchecked. The manifest declares
+// meta.view.checkOffForm and chips/chips-multi inputs for site fields
+// and reactions. Drives the UI:
+//   1. Tap ✓ on the scheduled item → form expands.
+//   2. Verify the "Last:" context line summarises the prior dose.
+//   3. Pick reaction chips (those merge onto the PREVIOUS dose).
+//   4. Pick site chips (those go on the NEW dose).
+//   5. Submit.
+// Then reads the data file back and asserts the merged shape.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+const CARD_ID = 'peptide-checkoff-e2e';
+
+function todayISO() {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function shiftDays(iso, delta) {
+  const [y, m, d] = iso.split('-').map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  dt.setUTCDate(dt.getUTCDate() + delta);
+  return `${dt.getUTCFullYear()}-${String(dt.getUTCMonth() + 1).padStart(2, '0')}-${String(dt.getUTCDate()).padStart(2, '0')}`;
+}
+
+function manifest() {
+  const today = todayISO();
+  const startDate = shiftDays(today, -10);
+  const priorDoseDate = shiftDays(today, -3);
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: CARD_ID,
+      label: 'Peptide check-off (e2e)',
+      emoji: '💉',
+      order: 9200,
+      category: 'protocols',
+      view: {
+        enabled: true,
+        component: 'schedule-card',
+        checkOffForm: {
+          currentDoseFields: ['site_side', 'site_region', 'site_position'],
+          previousDoseFields: ['reactions'],
+          previousDosePrompt: 'How does the last injection site look?',
+        },
+      },
+      writeable: {
+        fromWebapp: true,
+        todayAllowed: true,
+        pastAllowed: true,
+        futureAllowed: false,
+        inputs: [
+          { key: 'site_side',     label: 'Side',     type: 'chips',
+            options: ['left', 'right', 'centre'] },
+          { key: 'site_region',   label: 'Region',   type: 'chips',
+            options: ['belly', 'flank', 'thigh', 'delt', 'glute', 'tricep'] },
+          { key: 'site_position', label: 'Position', type: 'chips',
+            options: ['upper', 'middle', 'lower'] },
+          { key: 'reactions',     label: 'Reactions', type: 'chips-multi',
+            options: ['none', 'bruised', 'red', 'swollen', 'itchy', 'tender', 'welt', 'lump'] },
+        ],
+      },
+    },
+    description: 'Schedule-card with checkOffForm exercising per-dose metadata + retroactive review (#345).',
+    data: {
+      items: [
+        {
+          name: 'TestPeptide-345',
+          short_name: 'TP-345',
+          dose_mg: 0.25, dose_units: 'mg', route: 'subcutaneous',
+          schedule: { type: 'daily', times_per_day: 1, start_date: startDate, cycle_weeks: 4 },
+          doses: [
+            // A prior taken dose three days ago, with site fields
+            // already filled in. Reactions field is absent — we want
+            // the e2e to add it via the form.
+            {
+              scheduledDate: priorDoseDate,
+              takenAt: `${priorDoseDate}T08:30:00Z`,
+              site_side: 'right',
+              site_region: 'belly',
+              site_position: 'upper',
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+async function seed(request, baseUrl, m) {
+  await request.delete(`${baseUrl}/api/manifests/${m.meta.id}`).catch(() => {});
+  const r = await request.post(`${baseUrl}/api/manifests`, { data: m });
+  expect([201, 409]).toContain(r.status());
+}
+
+async function cleanup(request, baseUrl, id) {
+  await request.delete(`${baseUrl}/api/manifests/${id}`).catch(() => {});
+}
+
+test.describe('#345: schedule-card check-off form with per-dose metadata', () => {
+  test('submitting the check-off form writes site fields onto new dose and reactions onto previous dose', async ({ page, sandboxState }) => {
+    const m = manifest();
+    await seed(page.request, sandboxState.baseUrl, m);
+
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible({ timeout: 10_000 });
+
+    const card = page.locator(`[data-card-id="${CARD_ID}"] eh-schedule-card`);
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    // Tap the ✓ checkbox to expand the inline form.
+    await card.locator('.checkbox').first().click();
+
+    const form = card.locator('.checkoff-form');
+    await expect(form).toBeVisible();
+
+    // The prior-dose context line should summarise "Nd ago · right belly upper".
+    const prevLine = form.locator('.prev-dose-summary');
+    await expect(prevLine).toContainText('right belly upper');
+
+    // Reactions (chips-multi) lives in the previous-dose section. Pick two.
+    const innerForm = form.locator('eh-input-form');
+    const chipRows = innerForm.locator('.chip-row');
+    // The form renders previousDoseFields first, then currentDoseFields,
+    // each input getting one .chip-row. So:
+    //   chipRows[0] = reactions (chips-multi, from previousDoseFields)
+    //   chipRows[1] = site_side
+    //   chipRows[2] = site_region
+    //   chipRows[3] = site_position
+    await chipRows.nth(0).locator('.chip', { hasText: 'bruised' }).click();
+    await chipRows.nth(0).locator('.chip', { hasText: 'itchy' }).click();
+    await chipRows.nth(1).locator('.chip', { hasText: 'left' }).click();
+    await chipRows.nth(2).locator('.chip', { hasText: 'thigh' }).click();
+    await chipRows.nth(3).locator('.chip', { hasText: 'upper' }).click();
+
+    // Submit.
+    await innerForm.getByRole('button', { name: /log dose/i }).click();
+
+    // Form should collapse.
+    await expect(form).toHaveCount(0);
+
+    // Round-trip: the data file should now have the previous dose with
+    // a `reactions` array, AND a new dose for today with the site
+    // fields stamped on.
+    const res = await page.request.get(`${sandboxState.baseUrl}/api/manifests/${CARD_ID}/data`);
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    const doses = body.data.items[0].doses;
+    expect(doses.length).toBe(2);
+
+    // The earlier dose (index 0) is the prior dose. It originally had
+    // {site_side: right, site_region: belly, site_position: upper}; the
+    // form merge should have added `reactions`.
+    const priorDose = doses[0];
+    expect(priorDose.site_region).toBe('belly');
+    expect(Array.isArray(priorDose.reactions)).toBe(true);
+    expect(priorDose.reactions.sort()).toEqual(['bruised', 'itchy']);
+
+    // The new dose (index 1) should be today's, with site fields.
+    const newDose = doses[1];
+    expect(newDose.scheduledDate).toBe(todayISO());
+    expect(newDose.takenAt).toBeTruthy();
+    expect(newDose.site_side).toBe('left');
+    expect(newDose.site_region).toBe('thigh');
+    expect(newDose.site_position).toBe('upper');
+    // Reactions should NOT have leaked onto the new dose; they belong
+    // on the previous one.
+    expect(newDose.reactions).toBeUndefined();
+
+    await cleanup(page.request, sandboxState.baseUrl, CARD_ID);
+  });
+
+  test('cancelling the check-off form leaves data unchanged', async ({ page, sandboxState }) => {
+    const m = manifest();
+    await seed(page.request, sandboxState.baseUrl, m);
+
+    await page.goto('/');
+    const card = page.locator(`[data-card-id="${CARD_ID}"] eh-schedule-card`);
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    await card.locator('.checkbox').first().click();
+    const form = card.locator('.checkoff-form');
+    await expect(form).toBeVisible();
+
+    // Tap a chip then cancel.
+    await form.locator('.chip', { hasText: 'bruised' }).click();
+    await form.getByRole('button', { name: /cancel/i }).click();
+    await expect(form).toHaveCount(0);
+
+    // Data file unchanged: still one dose, no reactions on it.
+    const res = await page.request.get(`${sandboxState.baseUrl}/api/manifests/${CARD_ID}/data`);
+    const body = await res.json();
+    expect(body.data.items[0].doses.length).toBe(1);
+    expect(body.data.items[0].doses[0].reactions).toBeUndefined();
+
+    await cleanup(page.request, sandboxState.baseUrl, CARD_ID);
+  });
+});


### PR DESCRIPTION
## Summary

Setting `meta.view.checkOffForm` opts a schedule-card into a form-driven check-off path. Tapping the ✓ now expands an inline form sourced from `meta.writeable.inputs` instead of immediately stamping `{scheduledDate, takenAt}`. Two ordered key lists drive the form:

- **`currentDoseFields`** — keys written onto the new dose entry being created.
- **`previousDoseFields`** — keys merged onto the most recent prior dose with a `takenAt` timestamp. The retroactive-review channel: useful when the value being captured (an injection-site reaction, a delayed-onset rating) only manifests 24-72h after the dose it describes.

Above the form, a muted "Last:" context line summarises the previous dose's `currentDoseFields` values + a relative date (e.g. `Last: 3d ago · right belly upper`). Hidden when no prior taken dose exists.

Schedule-cards without `meta.view.checkOffForm` keep the original one-tap behaviour exactly as before. Purely additive.

## Why

Captures the injection-site / reaction-tracking feature the operator's been wanting (right manifest declares chip inputs for side / region / position + a chips-multi reactions field; the renderer wires them into the right doses). It also fixes the long-standing oddness that schedule-card was the only renderer that completely ignored `meta.writeable.inputs`. Future per-dose fields (`energy_after`, `pain_score`, free-text notes) just work without renderer changes — the manifest declares them in `inputs[]` and lists them under `currentDoseFields`.

Closes #345. Depends on #344 (chips / chips-multi input types — already merged on main).

## How

- `public/js/components/eh-schedule-card.js`:
  - New helpers: `_checkOffFormConfig`, `_writeableInputs`, `_filteredInputs` (preserves caller's key order, not declaration order, so previous-dose fields render first), `_findPreviousDose`, `_summarisePreviousDose`, `_relativeDays`.
  - `_toggleDose` checks for `checkOffForm`. If set AND the user is taking (not unticking), it sets `_expandedItemKey` and bails — the form opens. Otherwise, original hardcoded behaviour.
  - `_submitCheckOffForm` builds the new dose entry from `currentDoseFields`, locates the previous taken dose, merges in `previousDoseFields`, replaces a same-date entry or appends, then persists. `_persistDoses` is the previously-inline save path, extracted.
  - `_cancelCheckOffForm` collapses without writing.
  - Render: each item is now wrapped in a `.item-row` flex container so the form can render inline below the row when expanded. Off-schedule check-off uses the same form, with `offSchedule: true` stamped on submit.
- Styling: `.checkoff-form`, `.prev-dose`, `.prev-dose-line / -label / -summary / -prompt`, `.form-error`. Dashed-border separator between the previous-dose context and the inputs.
- `chat/docs.js`: schedule-card source summary updated so the chat agent's catalogue reflects the new contract.
- Docs:
  - `docs/CARDS.md` — Renderer behaviour reference table updated; full new "Schedule-card per-dose metadata" section with shape, fields, edge cases, backwards-compat note.
  - `docs/RECIPES.md` — Recipe 13 (injection-site card end-to-end with chips, chips-multi, and `checkOffForm`).
  - `MANIFEST-SCHEMA.md` — schedule-card row in built-in renderers table mentions `checkOffForm`.

## Edge cases

- **No previous dose at all (first dose ever):** previous-dose section hidden; only `currentDoseFields` are surfaced.
- **Previous scheduled dose was skipped (`takenAt: null`):** renderer walks backwards through `doses[]` to find the most recent entry with `takenAt` set. If every prior entry was skipped, previous-dose section is hidden.
- **Untick:** unchanged. Always immediate, clears `takenAt` on the matching dose entry; never opens the form.
- **Field key not in inputs:** silently skipped, so the renderer doesn't surface ghost fields.
- **Same-date dose entry already exists:** replaced wholesale with the new payload (so re-tapping ✓ on a "today" entry that the user is editing replaces, doesn't double-add).

## Testing

- [x] `npm test` — 1090 pass, 0 fail, 3 skipped.
- [x] `npx playwright test tests-e2e/schedule-card-checkoff-form.spec.js` — 2 specs, both pass. Coverage:
  - Submit path: seed a prior taken dose, tap ✓, fill chips and chips-multi, submit, read data file back, assert reactions merged onto prior dose AND site fields stamped onto new dose. Verifies reactions did NOT leak onto the new dose (the bug-shape from earlier discussions).
  - Cancel path: tap ✓, click a chip, cancel, assert data file unchanged.
- [x] Adjacent schedule-card specs (`schedule-card-nested-cycles`, `schedule-card-selected-day-ring`) re-run clean — no regressions on cards without `checkOffForm`.
- [x] `hygiene-check` — clean.

## Out of scope

- Site-rotation reports / heatmaps. Defer until the basic feature has been used long enough to know what cuts are useful.
- Generalising "retroactive review" to other renderers. Schedule-card is the only renderer with a meaningful "previous entry I should annotate later" model. YAGNI elsewhere.
- Migrating live peptide manifests. The feature is opt-in via `meta.view.checkOffForm`; existing manifests keep working unchanged. The operator (or the chat agent via `patch_manifest`) can opt a card in by hand.

Fixes #345