### PR TITLE
feat(demo): showcase injection-site logging on the Injections card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Changed
+
+- **Demo Injections card showcases per-dose injection-site logging.**
+  `demo/fixtures/peptide-cycle.json` now declares
+  `meta.view.checkOffForm` and the four chip inputs (side / region /
+  position + reactions) introduced in #344 / #345. Historical doses
+  on BPC-157 and Ozempic are annotated with plausible rotation
+  patterns and the occasional `bruised` / `tender` / `red, itchy`
+  reaction so the "Last:" context line renders something real when
+  a visitor taps ✓ on demo.klebb.app. Insulin's last six doses are
+  annotated; the 24 older daily entries stay bare. Refs #352.
+
 ## [2.2.0] - 2026-06-08
 
 ### Added

--- a/demo/fixtures/peptide-cycle.json
+++ b/demo/fixtures/peptide-cycle.json
@@ -7,7 +7,12 @@
     "order": 300,
     "view": {
       "enabled": true,
-      "component": "schedule-card"
+      "component": "schedule-card",
+      "checkOffForm": {
+        "currentDoseFields": ["site_side", "site_region", "site_position"],
+        "previousDoseFields": ["reactions"],
+        "previousDosePrompt": "How does the last injection site look?"
+      }
     },
     "trends": {
       "enabled": true,
@@ -28,7 +33,17 @@
       "fromWebapp": true,
       "pastAllowed": true,
       "todayAllowed": true,
-      "futureAllowed": false
+      "futureAllowed": false,
+      "inputs": [
+        { "key": "site_side",     "label": "Side",     "type": "chips",
+          "options": ["left", "right", "centre"] },
+        { "key": "site_region",   "label": "Region",   "type": "chips",
+          "options": ["belly", "flank", "thigh", "delt", "glute", "tricep"] },
+        { "key": "site_position", "label": "Position", "type": "chips",
+          "options": ["upper", "middle", "lower"] },
+        { "key": "reactions",     "label": "Reactions", "type": "chips-multi",
+          "options": ["none", "bruised", "red", "swollen", "itchy", "tender", "welt", "lump"] }
+      ]
     }
   },
   "description": "Injectables tracked together: BPC-157 (peptide healing protocol), semaglutide (weekly GLP-1), and basal insulin (daily). Each item carries its own schedule and cycle, so the schedule-card and adherence-report both render multi-protocol histories cleanly.",
@@ -56,15 +71,32 @@
           }
         ],
         "doses": [
-          { "scheduledDate": "__OFFSET_DAYS:-21__", "takenAt": "__OFFSET_DAYS:-21__T08:14:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-19__", "takenAt": "__OFFSET_DAYS:-19__T08:02:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-17__", "takenAt": "__OFFSET_DAYS:-17__T08:30:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-14__", "takenAt": "__OFFSET_DAYS:-14__T07:55:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-12__", "takenAt": "__OFFSET_DAYS:-12__T08:11:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-10__", "takenAt": "__OFFSET_DAYS:-10__T08:24:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-7__", "takenAt": "__OFFSET_DAYS:-7__T08:08:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-5__", "takenAt": "__OFFSET_DAYS:-5__T08:33:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-3__", "takenAt": "__OFFSET_DAYS:-3__T07:48:00" }
+          { "scheduledDate": "__OFFSET_DAYS:-21__", "takenAt": "__OFFSET_DAYS:-21__T08:14:00",
+            "site_side": "left",  "site_region": "belly", "site_position": "upper" },
+          { "scheduledDate": "__OFFSET_DAYS:-19__", "takenAt": "__OFFSET_DAYS:-19__T08:02:00",
+            "site_side": "right", "site_region": "belly", "site_position": "upper",
+            "reactions": ["none"] },
+          { "scheduledDate": "__OFFSET_DAYS:-17__", "takenAt": "__OFFSET_DAYS:-17__T08:30:00",
+            "site_side": "left",  "site_region": "belly", "site_position": "lower",
+            "reactions": ["none"] },
+          { "scheduledDate": "__OFFSET_DAYS:-14__", "takenAt": "__OFFSET_DAYS:-14__T07:55:00",
+            "site_side": "right", "site_region": "belly", "site_position": "lower",
+            "reactions": ["bruised"] },
+          { "scheduledDate": "__OFFSET_DAYS:-12__", "takenAt": "__OFFSET_DAYS:-12__T08:11:00",
+            "site_side": "left",  "site_region": "flank", "site_position": "middle",
+            "reactions": ["none"] },
+          { "scheduledDate": "__OFFSET_DAYS:-10__", "takenAt": "__OFFSET_DAYS:-10__T08:24:00",
+            "site_side": "right", "site_region": "flank", "site_position": "middle",
+            "reactions": ["none"] },
+          { "scheduledDate": "__OFFSET_DAYS:-7__",  "takenAt": "__OFFSET_DAYS:-7__T08:08:00",
+            "site_side": "left",  "site_region": "belly", "site_position": "upper",
+            "reactions": ["red", "itchy"] },
+          { "scheduledDate": "__OFFSET_DAYS:-5__",  "takenAt": "__OFFSET_DAYS:-5__T08:33:00",
+            "site_side": "right", "site_region": "belly", "site_position": "upper",
+            "reactions": ["none"] },
+          { "scheduledDate": "__OFFSET_DAYS:-3__",  "takenAt": "__OFFSET_DAYS:-3__T07:48:00",
+            "site_side": "left",  "site_region": "flank", "site_position": "middle",
+            "reactions": ["none"] }
         ]
       },
       {
@@ -89,14 +121,29 @@
           }
         ],
         "doses": [
-          { "scheduledDate": "__OFFSET_DAYS:-56__", "takenAt": "__OFFSET_DAYS:-56__T19:42:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-49__", "takenAt": "__OFFSET_DAYS:-49__T20:05:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-42__", "takenAt": "__OFFSET_DAYS:-42__T19:11:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-35__", "takenAt": "__OFFSET_DAYS:-35__T19:48:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-28__", "takenAt": "__OFFSET_DAYS:-28__T20:21:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-21__", "takenAt": "__OFFSET_DAYS:-21__T19:34:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-14__", "takenAt": "__OFFSET_DAYS:-14__T19:50:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-7__", "takenAt": "__OFFSET_DAYS:-7__T20:08:00" }
+          { "scheduledDate": "__OFFSET_DAYS:-56__", "takenAt": "__OFFSET_DAYS:-56__T19:42:00",
+            "site_side": "left",  "site_region": "thigh", "site_position": "upper" },
+          { "scheduledDate": "__OFFSET_DAYS:-49__", "takenAt": "__OFFSET_DAYS:-49__T20:05:00",
+            "site_side": "right", "site_region": "thigh", "site_position": "upper",
+            "reactions": ["none"] },
+          { "scheduledDate": "__OFFSET_DAYS:-42__", "takenAt": "__OFFSET_DAYS:-42__T19:11:00",
+            "site_side": "left",  "site_region": "thigh", "site_position": "middle",
+            "reactions": ["none"] },
+          { "scheduledDate": "__OFFSET_DAYS:-35__", "takenAt": "__OFFSET_DAYS:-35__T19:48:00",
+            "site_side": "right", "site_region": "thigh", "site_position": "middle",
+            "reactions": ["tender"] },
+          { "scheduledDate": "__OFFSET_DAYS:-28__", "takenAt": "__OFFSET_DAYS:-28__T20:21:00",
+            "site_side": "left",  "site_region": "belly", "site_position": "lower",
+            "reactions": ["none"] },
+          { "scheduledDate": "__OFFSET_DAYS:-21__", "takenAt": "__OFFSET_DAYS:-21__T19:34:00",
+            "site_side": "right", "site_region": "belly", "site_position": "lower",
+            "reactions": ["none"] },
+          { "scheduledDate": "__OFFSET_DAYS:-14__", "takenAt": "__OFFSET_DAYS:-14__T19:50:00",
+            "site_side": "left",  "site_region": "thigh", "site_position": "lower",
+            "reactions": ["none"] },
+          { "scheduledDate": "__OFFSET_DAYS:-7__",  "takenAt": "__OFFSET_DAYS:-7__T20:08:00",
+            "site_side": "right", "site_region": "thigh", "site_position": "lower",
+            "reactions": ["bruised"] }
         ]
       },
       {
@@ -140,12 +187,23 @@
           { "scheduledDate": "__OFFSET_DAYS:-10__", "takenAt": "__OFFSET_DAYS:-10__T22:17:00" },
           { "scheduledDate": "__OFFSET_DAYS:-9__", "takenAt": "__OFFSET_DAYS:-9__T22:22:00" },
           { "scheduledDate": "__OFFSET_DAYS:-8__", "takenAt": "__OFFSET_DAYS:-8__T22:08:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-6__", "takenAt": "__OFFSET_DAYS:-6__T22:42:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-5__", "takenAt": "__OFFSET_DAYS:-5__T22:11:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-4__", "takenAt": "__OFFSET_DAYS:-4__T22:18:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-3__", "takenAt": "__OFFSET_DAYS:-3__T22:25:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-2__", "takenAt": "__OFFSET_DAYS:-2__T22:14:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-1__", "takenAt": "__OFFSET_DAYS:-1__T22:21:00" }
+          { "scheduledDate": "__OFFSET_DAYS:-6__", "takenAt": "__OFFSET_DAYS:-6__T22:42:00",
+            "site_side": "left",  "site_region": "thigh", "site_position": "upper" },
+          { "scheduledDate": "__OFFSET_DAYS:-5__", "takenAt": "__OFFSET_DAYS:-5__T22:11:00",
+            "site_side": "right", "site_region": "thigh", "site_position": "upper",
+            "reactions": ["none"] },
+          { "scheduledDate": "__OFFSET_DAYS:-4__", "takenAt": "__OFFSET_DAYS:-4__T22:18:00",
+            "site_side": "left",  "site_region": "belly", "site_position": "lower",
+            "reactions": ["none"] },
+          { "scheduledDate": "__OFFSET_DAYS:-3__", "takenAt": "__OFFSET_DAYS:-3__T22:25:00",
+            "site_side": "right", "site_region": "belly", "site_position": "lower",
+            "reactions": ["none"] },
+          { "scheduledDate": "__OFFSET_DAYS:-2__", "takenAt": "__OFFSET_DAYS:-2__T22:14:00",
+            "site_side": "left",  "site_region": "thigh", "site_position": "middle",
+            "reactions": ["none"] },
+          { "scheduledDate": "__OFFSET_DAYS:-1__", "takenAt": "__OFFSET_DAYS:-1__T22:21:00",
+            "site_side": "right", "site_region": "thigh", "site_position": "middle",
+            "reactions": ["none"] }
         ]
       }
     ]


### PR DESCRIPTION
## Summary

- `demo/fixtures/peptide-cycle.json` now declares `meta.view.checkOffForm` and the four chip inputs (`site_side`, `site_region`, `site_position`, `reactions`) introduced in v2.2.0.
- Historical doses on all three items get plausible site annotations so the "Last:" context line renders real data when a demo visitor taps ✓.

## Why

The schedule-card per-dose metadata feature shipped in v2.2.0 (#345) but the public demo's Injections card stayed on the bare default check-off. Visitors couldn't see one of the more compelling features the codebase offers.

## How

- `meta.view.checkOffForm` matches the same shape used in the operator's prod manifest: three `currentDoseFields` (the site axes), one `previousDoseFields` (`reactions`), and the documented `previousDosePrompt`.
- `meta.writeable.inputs[]` adds the four chip inputs (three `chips`, one `chips-multi`) with the canonical option lists from the recipe.
- BPC-157 (9 doses) and Ozempic (8 doses) get site fields on every entry. Reactions are mostly `["none"]`; one BPC dose has `["bruised"]`, one Ozempic dose `["bruised"]`, one `["tender"]`, one `["red", "itchy"]` so chips-multi has variety.
- Insulin (29 doses) gets site fields on the most recent six only. The 24 older daily entries stay bare — they're background data, not foreground; annotating every one bloats the fixture without showing more feature.

## Deploy path

`feat(deploy): auto-deploy demo.klebb.app on every main merge` (#285) means demo.klebb.app picks this up automatically when the publish workflow finishes after merge.

## Testing

- [x] `npm test` — 1090 pass, 0 fail, 3 skipped (pre-existing).
- [x] JSON parses; checkOffForm config + writeable.inputs verified via Node.
- [x] Last dose per item carries site fields, so the "Last:" context line will render on demo.klebb.app for all three items.
- [x] `hygiene-check` — clean.

## Out of scope

- Annotating every old insulin dose. Bloats the fixture without showing more feature.
- Touching reset-demo.js or the demo-deployment cron.

Closes #352