### PR TITLE
fix(demo): drop 'none' from reactions chips-multi options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Changed
+
+- **`"none"` removed from the canonical reactions chips-multi
+  options** in `demo/fixtures/peptide-cycle.json`, `docs/RECIPES.md`
+  Recipe 13, and the `docs/CARDS.md` schedule-card per-dose metadata
+  example. The chips-multi field allows multi-select, so offering
+  `"none"` as an option meant a user could tick `"none"` alongside
+  `"bruised"` — nonsensical. Absence of selection is already the
+  implicit "no reaction" state. The renderer's defensive
+  `'none'`-filter in `_summariseDoseForCard` (#354) stays in place
+  so any legacy dose entries that already carry `reactions:
+  ["none"]` continue to render cleanly. Refs #357.
+
 ### Added
 
 - **Schedule-card surfaces logged per-dose metadata on the card and

--- a/demo/fixtures/peptide-cycle.json
+++ b/demo/fixtures/peptide-cycle.json
@@ -9,8 +9,14 @@
       "enabled": true,
       "component": "schedule-card",
       "checkOffForm": {
-        "currentDoseFields": ["site_side", "site_region", "site_position"],
-        "previousDoseFields": ["reactions"],
+        "currentDoseFields": [
+          "site_side",
+          "site_region",
+          "site_position"
+        ],
+        "previousDoseFields": [
+          "reactions"
+        ],
         "previousDosePrompt": "How does the last injection site look?"
       }
     },
@@ -35,14 +41,53 @@
       "todayAllowed": true,
       "futureAllowed": false,
       "inputs": [
-        { "key": "site_side",     "label": "Side",     "type": "chips",
-          "options": ["left", "right", "centre"] },
-        { "key": "site_region",   "label": "Region",   "type": "chips",
-          "options": ["belly", "flank", "thigh", "delt", "glute", "tricep"] },
-        { "key": "site_position", "label": "Position", "type": "chips",
-          "options": ["upper", "middle", "lower"] },
-        { "key": "reactions",     "label": "Reactions", "type": "chips-multi",
-          "options": ["none", "bruised", "red", "swollen", "itchy", "tender", "welt", "lump"] }
+        {
+          "key": "site_side",
+          "label": "Side",
+          "type": "chips",
+          "options": [
+            "left",
+            "right",
+            "centre"
+          ]
+        },
+        {
+          "key": "site_region",
+          "label": "Region",
+          "type": "chips",
+          "options": [
+            "belly",
+            "flank",
+            "thigh",
+            "delt",
+            "glute",
+            "tricep"
+          ]
+        },
+        {
+          "key": "site_position",
+          "label": "Position",
+          "type": "chips",
+          "options": [
+            "upper",
+            "middle",
+            "lower"
+          ]
+        },
+        {
+          "key": "reactions",
+          "label": "Reactions",
+          "type": "chips-multi",
+          "options": [
+            "bruised",
+            "red",
+            "swollen",
+            "itchy",
+            "tender",
+            "welt",
+            "lump"
+          ]
+        }
       ]
     }
   },
@@ -57,7 +102,11 @@
         "route": "subcutaneous",
         "schedule": {
           "type": "weekly",
-          "on_days": ["Mon", "Wed", "Fri"]
+          "on_days": [
+            "Mon",
+            "Wed",
+            "Fri"
+          ]
         },
         "cycles": [
           {
@@ -71,32 +120,76 @@
           }
         ],
         "doses": [
-          { "scheduledDate": "__OFFSET_DAYS:-21__", "takenAt": "__OFFSET_DAYS:-21__T08:14:00",
-            "site_side": "left",  "site_region": "belly", "site_position": "upper" },
-          { "scheduledDate": "__OFFSET_DAYS:-19__", "takenAt": "__OFFSET_DAYS:-19__T08:02:00",
-            "site_side": "right", "site_region": "belly", "site_position": "upper",
-            "reactions": ["none"] },
-          { "scheduledDate": "__OFFSET_DAYS:-17__", "takenAt": "__OFFSET_DAYS:-17__T08:30:00",
-            "site_side": "left",  "site_region": "belly", "site_position": "lower",
-            "reactions": ["none"] },
-          { "scheduledDate": "__OFFSET_DAYS:-14__", "takenAt": "__OFFSET_DAYS:-14__T07:55:00",
-            "site_side": "right", "site_region": "belly", "site_position": "lower",
-            "reactions": ["bruised"] },
-          { "scheduledDate": "__OFFSET_DAYS:-12__", "takenAt": "__OFFSET_DAYS:-12__T08:11:00",
-            "site_side": "left",  "site_region": "flank", "site_position": "middle",
-            "reactions": ["none"] },
-          { "scheduledDate": "__OFFSET_DAYS:-10__", "takenAt": "__OFFSET_DAYS:-10__T08:24:00",
-            "site_side": "right", "site_region": "flank", "site_position": "middle",
-            "reactions": ["none"] },
-          { "scheduledDate": "__OFFSET_DAYS:-7__",  "takenAt": "__OFFSET_DAYS:-7__T08:08:00",
-            "site_side": "left",  "site_region": "belly", "site_position": "upper",
-            "reactions": ["red", "itchy"] },
-          { "scheduledDate": "__OFFSET_DAYS:-5__",  "takenAt": "__OFFSET_DAYS:-5__T08:33:00",
-            "site_side": "right", "site_region": "belly", "site_position": "upper",
-            "reactions": ["none"] },
-          { "scheduledDate": "__OFFSET_DAYS:-3__",  "takenAt": "__OFFSET_DAYS:-3__T07:48:00",
-            "site_side": "left",  "site_region": "flank", "site_position": "middle",
-            "reactions": ["none"] }
+          {
+            "scheduledDate": "__OFFSET_DAYS:-21__",
+            "takenAt": "__OFFSET_DAYS:-21__T08:14:00",
+            "site_side": "left",
+            "site_region": "belly",
+            "site_position": "upper"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-19__",
+            "takenAt": "__OFFSET_DAYS:-19__T08:02:00",
+            "site_side": "right",
+            "site_region": "belly",
+            "site_position": "upper"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-17__",
+            "takenAt": "__OFFSET_DAYS:-17__T08:30:00",
+            "site_side": "left",
+            "site_region": "belly",
+            "site_position": "lower"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-14__",
+            "takenAt": "__OFFSET_DAYS:-14__T07:55:00",
+            "site_side": "right",
+            "site_region": "belly",
+            "site_position": "lower",
+            "reactions": [
+              "bruised"
+            ]
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-12__",
+            "takenAt": "__OFFSET_DAYS:-12__T08:11:00",
+            "site_side": "left",
+            "site_region": "flank",
+            "site_position": "middle"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-10__",
+            "takenAt": "__OFFSET_DAYS:-10__T08:24:00",
+            "site_side": "right",
+            "site_region": "flank",
+            "site_position": "middle"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-7__",
+            "takenAt": "__OFFSET_DAYS:-7__T08:08:00",
+            "site_side": "left",
+            "site_region": "belly",
+            "site_position": "upper",
+            "reactions": [
+              "red",
+              "itchy"
+            ]
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-5__",
+            "takenAt": "__OFFSET_DAYS:-5__T08:33:00",
+            "site_side": "right",
+            "site_region": "belly",
+            "site_position": "upper"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-3__",
+            "takenAt": "__OFFSET_DAYS:-3__T07:48:00",
+            "site_side": "left",
+            "site_region": "flank",
+            "site_position": "middle"
+          }
         ]
       },
       {
@@ -107,7 +200,9 @@
         "route": "subcutaneous",
         "schedule": {
           "type": "weekly",
-          "on_days": ["Sun"]
+          "on_days": [
+            "Sun"
+          ]
         },
         "cycles": [
           {
@@ -121,29 +216,68 @@
           }
         ],
         "doses": [
-          { "scheduledDate": "__OFFSET_DAYS:-56__", "takenAt": "__OFFSET_DAYS:-56__T19:42:00",
-            "site_side": "left",  "site_region": "thigh", "site_position": "upper" },
-          { "scheduledDate": "__OFFSET_DAYS:-49__", "takenAt": "__OFFSET_DAYS:-49__T20:05:00",
-            "site_side": "right", "site_region": "thigh", "site_position": "upper",
-            "reactions": ["none"] },
-          { "scheduledDate": "__OFFSET_DAYS:-42__", "takenAt": "__OFFSET_DAYS:-42__T19:11:00",
-            "site_side": "left",  "site_region": "thigh", "site_position": "middle",
-            "reactions": ["none"] },
-          { "scheduledDate": "__OFFSET_DAYS:-35__", "takenAt": "__OFFSET_DAYS:-35__T19:48:00",
-            "site_side": "right", "site_region": "thigh", "site_position": "middle",
-            "reactions": ["tender"] },
-          { "scheduledDate": "__OFFSET_DAYS:-28__", "takenAt": "__OFFSET_DAYS:-28__T20:21:00",
-            "site_side": "left",  "site_region": "belly", "site_position": "lower",
-            "reactions": ["none"] },
-          { "scheduledDate": "__OFFSET_DAYS:-21__", "takenAt": "__OFFSET_DAYS:-21__T19:34:00",
-            "site_side": "right", "site_region": "belly", "site_position": "lower",
-            "reactions": ["none"] },
-          { "scheduledDate": "__OFFSET_DAYS:-14__", "takenAt": "__OFFSET_DAYS:-14__T19:50:00",
-            "site_side": "left",  "site_region": "thigh", "site_position": "lower",
-            "reactions": ["none"] },
-          { "scheduledDate": "__OFFSET_DAYS:-7__",  "takenAt": "__OFFSET_DAYS:-7__T20:08:00",
-            "site_side": "right", "site_region": "thigh", "site_position": "lower",
-            "reactions": ["bruised"] }
+          {
+            "scheduledDate": "__OFFSET_DAYS:-56__",
+            "takenAt": "__OFFSET_DAYS:-56__T19:42:00",
+            "site_side": "left",
+            "site_region": "thigh",
+            "site_position": "upper"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-49__",
+            "takenAt": "__OFFSET_DAYS:-49__T20:05:00",
+            "site_side": "right",
+            "site_region": "thigh",
+            "site_position": "upper"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-42__",
+            "takenAt": "__OFFSET_DAYS:-42__T19:11:00",
+            "site_side": "left",
+            "site_region": "thigh",
+            "site_position": "middle"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-35__",
+            "takenAt": "__OFFSET_DAYS:-35__T19:48:00",
+            "site_side": "right",
+            "site_region": "thigh",
+            "site_position": "middle",
+            "reactions": [
+              "tender"
+            ]
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-28__",
+            "takenAt": "__OFFSET_DAYS:-28__T20:21:00",
+            "site_side": "left",
+            "site_region": "belly",
+            "site_position": "lower"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-21__",
+            "takenAt": "__OFFSET_DAYS:-21__T19:34:00",
+            "site_side": "right",
+            "site_region": "belly",
+            "site_position": "lower"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-14__",
+            "takenAt": "__OFFSET_DAYS:-14__T19:50:00",
+            "site_side": "left",
+            "site_region": "thigh",
+            "site_position": "lower"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-7__",
+            "takenAt": "__OFFSET_DAYS:-7__T20:08:00",
+            "site_side": "right",
+            "site_region": "thigh",
+            "site_position": "lower",
+            "reactions": [
+              "bruised"
+            ]
+          }
         ]
       },
       {
@@ -164,46 +298,140 @@
           }
         ],
         "doses": [
-          { "scheduledDate": "__OFFSET_DAYS:-30__", "takenAt": "__OFFSET_DAYS:-30__T22:08:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-29__", "takenAt": "__OFFSET_DAYS:-29__T22:14:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-28__", "takenAt": "__OFFSET_DAYS:-28__T22:02:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-27__", "takenAt": "__OFFSET_DAYS:-27__T22:21:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-26__", "takenAt": "__OFFSET_DAYS:-26__T22:11:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-25__", "takenAt": "__OFFSET_DAYS:-25__T22:18:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-24__", "takenAt": "__OFFSET_DAYS:-24__T22:25:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-23__", "takenAt": "__OFFSET_DAYS:-23__T22:09:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-22__", "takenAt": "__OFFSET_DAYS:-22__T22:16:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-21__", "takenAt": "__OFFSET_DAYS:-21__T22:31:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-20__", "takenAt": "__OFFSET_DAYS:-20__T22:14:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-19__", "takenAt": "__OFFSET_DAYS:-19__T22:22:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-18__", "takenAt": "__OFFSET_DAYS:-18__T22:08:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-17__", "takenAt": "__OFFSET_DAYS:-17__T22:35:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-16__", "takenAt": "__OFFSET_DAYS:-16__T22:11:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-15__", "takenAt": "__OFFSET_DAYS:-15__T22:19:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-14__", "takenAt": "__OFFSET_DAYS:-14__T22:24:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-13__", "takenAt": "__OFFSET_DAYS:-13__T22:07:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-12__", "takenAt": "__OFFSET_DAYS:-12__T22:13:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-11__", "takenAt": "__OFFSET_DAYS:-11__T22:29:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-10__", "takenAt": "__OFFSET_DAYS:-10__T22:17:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-9__", "takenAt": "__OFFSET_DAYS:-9__T22:22:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-8__", "takenAt": "__OFFSET_DAYS:-8__T22:08:00" },
-          { "scheduledDate": "__OFFSET_DAYS:-6__", "takenAt": "__OFFSET_DAYS:-6__T22:42:00",
-            "site_side": "left",  "site_region": "thigh", "site_position": "upper" },
-          { "scheduledDate": "__OFFSET_DAYS:-5__", "takenAt": "__OFFSET_DAYS:-5__T22:11:00",
-            "site_side": "right", "site_region": "thigh", "site_position": "upper",
-            "reactions": ["none"] },
-          { "scheduledDate": "__OFFSET_DAYS:-4__", "takenAt": "__OFFSET_DAYS:-4__T22:18:00",
-            "site_side": "left",  "site_region": "belly", "site_position": "lower",
-            "reactions": ["none"] },
-          { "scheduledDate": "__OFFSET_DAYS:-3__", "takenAt": "__OFFSET_DAYS:-3__T22:25:00",
-            "site_side": "right", "site_region": "belly", "site_position": "lower",
-            "reactions": ["none"] },
-          { "scheduledDate": "__OFFSET_DAYS:-2__", "takenAt": "__OFFSET_DAYS:-2__T22:14:00",
-            "site_side": "left",  "site_region": "thigh", "site_position": "middle",
-            "reactions": ["none"] },
-          { "scheduledDate": "__OFFSET_DAYS:-1__", "takenAt": "__OFFSET_DAYS:-1__T22:21:00",
-            "site_side": "right", "site_region": "thigh", "site_position": "middle",
-            "reactions": ["none"] }
+          {
+            "scheduledDate": "__OFFSET_DAYS:-30__",
+            "takenAt": "__OFFSET_DAYS:-30__T22:08:00"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-29__",
+            "takenAt": "__OFFSET_DAYS:-29__T22:14:00"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-28__",
+            "takenAt": "__OFFSET_DAYS:-28__T22:02:00"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-27__",
+            "takenAt": "__OFFSET_DAYS:-27__T22:21:00"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-26__",
+            "takenAt": "__OFFSET_DAYS:-26__T22:11:00"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-25__",
+            "takenAt": "__OFFSET_DAYS:-25__T22:18:00"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-24__",
+            "takenAt": "__OFFSET_DAYS:-24__T22:25:00"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-23__",
+            "takenAt": "__OFFSET_DAYS:-23__T22:09:00"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-22__",
+            "takenAt": "__OFFSET_DAYS:-22__T22:16:00"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-21__",
+            "takenAt": "__OFFSET_DAYS:-21__T22:31:00"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-20__",
+            "takenAt": "__OFFSET_DAYS:-20__T22:14:00"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-19__",
+            "takenAt": "__OFFSET_DAYS:-19__T22:22:00"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-18__",
+            "takenAt": "__OFFSET_DAYS:-18__T22:08:00"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-17__",
+            "takenAt": "__OFFSET_DAYS:-17__T22:35:00"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-16__",
+            "takenAt": "__OFFSET_DAYS:-16__T22:11:00"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-15__",
+            "takenAt": "__OFFSET_DAYS:-15__T22:19:00"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-14__",
+            "takenAt": "__OFFSET_DAYS:-14__T22:24:00"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-13__",
+            "takenAt": "__OFFSET_DAYS:-13__T22:07:00"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-12__",
+            "takenAt": "__OFFSET_DAYS:-12__T22:13:00"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-11__",
+            "takenAt": "__OFFSET_DAYS:-11__T22:29:00"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-10__",
+            "takenAt": "__OFFSET_DAYS:-10__T22:17:00"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-9__",
+            "takenAt": "__OFFSET_DAYS:-9__T22:22:00"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-8__",
+            "takenAt": "__OFFSET_DAYS:-8__T22:08:00"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-6__",
+            "takenAt": "__OFFSET_DAYS:-6__T22:42:00",
+            "site_side": "left",
+            "site_region": "thigh",
+            "site_position": "upper"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-5__",
+            "takenAt": "__OFFSET_DAYS:-5__T22:11:00",
+            "site_side": "right",
+            "site_region": "thigh",
+            "site_position": "upper"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-4__",
+            "takenAt": "__OFFSET_DAYS:-4__T22:18:00",
+            "site_side": "left",
+            "site_region": "belly",
+            "site_position": "lower"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-3__",
+            "takenAt": "__OFFSET_DAYS:-3__T22:25:00",
+            "site_side": "right",
+            "site_region": "belly",
+            "site_position": "lower"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-2__",
+            "takenAt": "__OFFSET_DAYS:-2__T22:14:00",
+            "site_side": "left",
+            "site_region": "thigh",
+            "site_position": "middle"
+          },
+          {
+            "scheduledDate": "__OFFSET_DAYS:-1__",
+            "takenAt": "__OFFSET_DAYS:-1__T22:21:00",
+            "site_side": "right",
+            "site_region": "thigh",
+            "site_position": "middle"
+          }
         ]
       }
     ]

--- a/docs/CARDS.md
+++ b/docs/CARDS.md
@@ -1018,8 +1018,10 @@ of "I patched the manifest and nothing changed".
 - A muted summary line on the item itself for the viewed date,
   showing the dose's `currentDoseFields` and `previousDoseFields`
   values. Hidden when no logged dose exists for the date or the
-  entry carries no form-relevant values. The chips-multi reactions
-  value `"none"` is filtered from the rendered line.
+  entry carries no form-relevant values. As a defensive filter for
+  legacy data, the chips-multi value `"none"` is filtered from the
+  rendered line — but the canonical recipe omits `"none"` from the
+  reactions options entirely (absence of selection is implicit).
 
 ### `checklist-card`
 
@@ -1182,7 +1184,7 @@ energy-after rating, a free-text note. Setting
       { "key": "site_position", "label": "Position", "type": "chips",
         "options": ["upper", "middle", "lower"] },
       { "key": "reactions",     "label": "Reactions", "type": "chips-multi",
-        "options": ["none", "bruised", "red", "swollen", "itchy", "tender", "welt", "lump"] }
+        "options": ["bruised", "red", "swollen", "itchy", "tender", "welt", "lump"] }
     ]
   }
 }
@@ -1228,9 +1230,13 @@ were just logged for the viewed date. Format: current-dose values
 joined with spaces, optionally a ` · ` separator, then any
 `previousDoseFields` values joined with `, `. Same line format on
 past dates — the card becomes a per-day record, not just a check-off
-button. The `none` value in chips-multi reactions is filtered from
-the rendered line; it's implicit, either by ticking the chip or by
-leaving the field empty.
+button. The canonical recipe omits `"none"` from the reactions
+options — absence of selection is the implicit "no reaction" state,
+so a separate chip would just be a way to make the multi-select
+inconsistent (e.g. ticking `"none"` alongside `"bruised"`). For
+defensive measure the renderer also filters any legacy
+`reactions: ["none"]` value from the rendered line, so old data
+from before this change continues to render cleanly.
 
 ### Editing a logged dose
 

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -772,7 +772,7 @@ full reference.
         { "key": "site_position", "label": "Position", "type": "chips",
           "options": ["upper", "middle", "lower"] },
         { "key": "reactions",     "label": "Reactions", "type": "chips-multi",
-          "options": ["none", "bruised", "red", "swollen", "itchy", "tender", "welt", "lump"] }
+          "options": ["bruised", "red", "swollen", "itchy", "tender", "welt", "lump"] }
       ]
     }
   },


### PR DESCRIPTION
## Summary

Removes `"none"` from the canonical reactions chips-multi options in the demo fixture and the two doc surfaces that publish the recipe.

## Why

The chips-multi field is multi-select. With `"none"` in options, a user can tick `"none"` alongside `"bruised"` or `"itchy"` — nonsensical. Absence of selection is already the implicit "no reaction" state, so the chip adds nothing except a way to make the multi-select inconsistent.

The renderer's `_summariseDoseForCard` defensive filter for legacy `reactions: ["none"]` (added in #354) stays in place — it costs nothing and lets old data render cleanly without forcing a data migration.

## How

- `demo/fixtures/peptide-cycle.json`: `"none"` removed from the reactions options array. The 16 historical doses that carried `reactions: ["none"]` (which was purely an annotation cue for the renderer's filter — now redundant) had that field dropped instead. Doses with real reactions (`["bruised"]`, `["red", "itchy"]`, `["tender"]`) untouched.
- `docs/RECIPES.md` Recipe 13: same options change.
- `docs/CARDS.md` schedule-card per-dose metadata example: same options change. Surrounding prose now explains both that the canonical recipe omits `"none"` and that the renderer's defensive filter stays for legacy data.

## Testing

- [x] `npm test` — 1090 pass, 0 fail, 3 skipped (pre-existing).
- [x] `npx playwright test tests-e2e/schedule-card-checkoff-form.spec.js` — 5/5 pass. The `none` filtering spec (test 5) seeds its own manifest with `"none"` in options to drive the defensive-filter path, which is the correct test shape.
- [x] `hygiene-check` — clean.

## Follow-up

After merge, the operator's `eddzklebb` prod manifest gets the same options change via `patch_manifest`. No data migration needed there either; any future logged dose just won't have the option to select `"none"`, and any existing `reactions: ["none"]` (none expected) would render cleanly via the defensive filter.

Fixes #357