### PR TITLE
Phase 1: manifest path parser + resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Internal
+
+- **Manifest path parser + resolver.** New pure module
+  `manifests/path.js` providing `parsePath()` and `resolvePath()`
+  for an equality-only path language (`segment.segment[k=v]`,
+  with `[index=N]` for direct array indexing). Returns
+  `{container, key, value}` so callers can mutate via the parent
+  reference; throws typed `BadPath` / `NoMatch` / `Ambiguous` /
+  `WrongType` errors with stable `code` fields. Phase 1 of the
+  row-level chat tools work; nothing user-visible yet. Refs #363.
+
 ## [2.3.1] - 2026-06-08
 
 ### Added

--- a/manifests/path.js
+++ b/manifests/path.js
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// manifests/path.js
+// Tiny equality-only path language for addressing rows inside a manifest's
+// data block. Pure: no I/O, no registry coupling.
+//
+// Grammar:
+//   path     := segment ('.' segment)*
+//   segment  := identifier ('[' filter ']')?
+//   filter   := identifier '=' literal
+//   literal  := "..." | '...' | number | true | false
+//
+// The reserved filter key 'index' against an integer literal is interpreted
+// as an array index when the parent is an array. Any other use of 'index'
+// (string literal, parent is object) falls through to a normal property
+// match, so cards storing {index: "foo"} still work.
+//
+// Empty input string parses to an empty segment list; resolvePath then
+// returns the root data value unchanged.
+
+class BadPath extends Error {
+  constructor(message, position, hint) {
+    super(message);
+    this.name = 'BadPath';
+    this.code = 'BAD_PATH';
+    this.position = position;
+    if (hint) this.hint = hint;
+  }
+}
+
+class NoMatch extends Error {
+  constructor(message, segmentIndex) {
+    super(message);
+    this.name = 'NoMatch';
+    this.code = 'NO_MATCH';
+    this.segmentIndex = segmentIndex;
+  }
+}
+
+class Ambiguous extends Error {
+  constructor(message, count, segmentIndex) {
+    super(message);
+    this.name = 'Ambiguous';
+    this.code = 'AMBIGUOUS';
+    this.count = count;
+    this.segmentIndex = segmentIndex;
+  }
+}
+
+class WrongType extends Error {
+  constructor(message, segmentIndex) {
+    super(message);
+    this.name = 'WrongType';
+    this.code = 'WRONG_TYPE';
+    this.segmentIndex = segmentIndex;
+  }
+}
+
+const IDENT_START = /[A-Za-z_]/;
+const IDENT_REST = /[A-Za-z0-9_\-]/;
+const DIGIT = /[0-9]/;
+
+// Parse a path string into an array of segments. Each segment is
+// { name: string, filter: null | {by: string, value: string|number|boolean} }.
+// Throws BadPath on any grammar error.
+function parsePath(input) {
+  if (input === undefined || input === null) {
+    throw new BadPath('path is required', 0, 'pass an empty string for root, or a segment like "items"');
+  }
+  if (typeof input !== 'string') {
+    throw new BadPath('path must be a string', 0);
+  }
+  if (input.length === 0) return [];
+
+  const s = input;
+  let i = 0;
+  const segments = [];
+
+  function peek() { return i < s.length ? s[i] : null; }
+  function advance() { return s[i++]; }
+  function expect(ch) {
+    if (peek() !== ch) {
+      throw new BadPath(`expected '${ch}' at position ${i}, got ${describeChar(peek())}`, i);
+    }
+    advance();
+  }
+  function describeChar(c) {
+    if (c === null) return 'end of input';
+    return `'${c}'`;
+  }
+
+  function readIdent() {
+    if (!IDENT_START.test(peek() || '')) {
+      throw new BadPath(`expected identifier at position ${i}, got ${describeChar(peek())}`, i,
+        'identifiers start with a letter or underscore');
+    }
+    const start = i;
+    while (peek() && IDENT_REST.test(peek())) advance();
+    return s.slice(start, i);
+  }
+
+  function readLiteral() {
+    const c = peek();
+    if (c === '"' || c === "'") return readString(c);
+    if (c === '-' || (c && DIGIT.test(c))) return readNumber();
+    // bare identifier literal (true/false only)
+    if (c && IDENT_START.test(c)) {
+      const start = i;
+      const word = readIdent();
+      if (word === 'true') return true;
+      if (word === 'false') return false;
+      throw new BadPath(`unknown bare literal '${word}' at position ${start}`, start,
+        'literals must be quoted strings, numbers, true, or false');
+    }
+    throw new BadPath(`expected literal at position ${i}, got ${describeChar(c)}`, i,
+      'literals are quoted strings, numbers, true, or false');
+  }
+
+  function readString(quote) {
+    const start = i;
+    advance(); // consume opening quote
+    let out = '';
+    while (true) {
+      const c = peek();
+      if (c === null) {
+        throw new BadPath(`unterminated string starting at position ${start}`, start);
+      }
+      if (c === quote) { advance(); return out; }
+      if (c === '\\') {
+        advance();
+        const esc = peek();
+        if (esc === null) {
+          throw new BadPath(`dangling backslash at end of string starting at position ${start}`, start);
+        }
+        if (esc === 'n') out += '\n';
+        else if (esc === 't') out += '\t';
+        else if (esc === 'r') out += '\r';
+        else out += esc; // \\, \", \', \?, etc.
+        advance();
+        continue;
+      }
+      out += c;
+      advance();
+    }
+  }
+
+  function readNumber() {
+    const start = i;
+    if (peek() === '-') advance();
+    let sawDigit = false;
+    while (peek() && DIGIT.test(peek())) { advance(); sawDigit = true; }
+    if (peek() === '.') {
+      advance();
+      while (peek() && DIGIT.test(peek())) { advance(); sawDigit = true; }
+    }
+    if (!sawDigit) {
+      throw new BadPath(`malformed number at position ${start}`, start);
+    }
+    const text = s.slice(start, i);
+    const n = Number(text);
+    if (!Number.isFinite(n)) {
+      throw new BadPath(`malformed number '${text}' at position ${start}`, start);
+    }
+    return n;
+  }
+
+  function readSegment() {
+    const name = readIdent();
+    let filter = null;
+    if (peek() === '[') {
+      advance();
+      const by = readIdent();
+      if (peek() !== '=') {
+        throw new BadPath(`expected '=' after filter key at position ${i}`, i,
+          "filters look like [key=value], e.g. [name=\"BPC-157\"]");
+      }
+      advance();
+      const value = readLiteral();
+      if (peek() !== ']') {
+        throw new BadPath(`expected ']' to close filter at position ${i}, got ${describeChar(peek())}`, i);
+      }
+      advance();
+      filter = { by, value };
+    }
+    return { name, filter };
+  }
+
+  segments.push(readSegment());
+  while (peek() === '.') {
+    advance();
+    segments.push(readSegment());
+  }
+  if (i !== s.length) {
+    throw new BadPath(`unexpected ${describeChar(peek())} at position ${i}`, i,
+      "segments are separated by '.', filters by '[k=v]'");
+  }
+  return segments;
+}
+
+// Resolve a parsed path against a data value. Returns
+//   { container, key, value }
+// where container[key] === value, or container/key are null for the root.
+//
+// Options:
+//   allowMultiple: if true, returns { matches: [{container, key, value}, ...] }
+//                  instead of throwing AMBIGUOUS.
+//
+// Throws NoMatch / Ambiguous / WrongType. The caller decides whether to
+// catch (e.g. update_row should always treat AMBIGUOUS as an error;
+// read_manifest_rows may pass allowMultiple:true).
+function resolvePath(data, segments, opts) {
+  const options = opts || {};
+  if (!Array.isArray(segments)) {
+    throw new TypeError('segments must be an array (call parsePath first)');
+  }
+  if (segments.length === 0) {
+    return { container: null, key: null, value: data };
+  }
+
+  let container = null;
+  let key = null;
+  let current = data;
+
+  for (let idx = 0; idx < segments.length; idx++) {
+    const seg = segments[idx];
+    if (current === null || current === undefined) {
+      throw new NoMatch(`segment '${seg.name}' traverses through ${current === null ? 'null' : 'undefined'}`, idx);
+    }
+    if (typeof current !== 'object') {
+      throw new WrongType(`segment '${seg.name}' expects an object/array but found ${typeof current}`, idx);
+    }
+    if (Array.isArray(current)) {
+      throw new WrongType(`segment '${seg.name}' expects an object property but found an array`, idx);
+    }
+
+    // Step into the named property.
+    if (!Object.prototype.hasOwnProperty.call(current, seg.name)) {
+      throw new NoMatch(`property '${seg.name}' not found`, idx);
+    }
+    container = current;
+    key = seg.name;
+    current = current[seg.name];
+
+    if (seg.filter) {
+      const matches = applyFilter(current, seg.filter, idx);
+      if (matches.length === 0) {
+        throw new NoMatch(`${seg.name}[${describeFilter(seg.filter)}] matched no rows`, idx);
+      }
+      if (matches.length > 1 && !options.allowMultiple) {
+        throw new Ambiguous(
+          `${seg.name}[${describeFilter(seg.filter)}] matched ${matches.length} rows`,
+          matches.length,
+          idx,
+        );
+      }
+      if (options.allowMultiple && idx === segments.length - 1) {
+        return { matches };
+      }
+      // Pick the unique match and continue.
+      const m = matches[0];
+      container = m.container;
+      key = m.key;
+      current = m.value;
+    }
+  }
+
+  return { container, key, value: current };
+}
+
+function applyFilter(arr, filter, segmentIndex) {
+  if (!Array.isArray(arr)) {
+    throw new WrongType(`filter [${describeFilter(filter)}] expects an array but found ${describeNonArray(arr)}`, segmentIndex);
+  }
+  // Special-case: index=<integer> against an array.
+  if (filter.by === 'index' && Number.isInteger(filter.value)) {
+    const n = filter.value;
+    if (n < 0 || n >= arr.length) {
+      return [];
+    }
+    return [{ container: arr, key: n, value: arr[n] }];
+  }
+  const out = [];
+  for (let n = 0; n < arr.length; n++) {
+    const row = arr[n];
+    if (row !== null && typeof row === 'object' && !Array.isArray(row) &&
+        Object.prototype.hasOwnProperty.call(row, filter.by) &&
+        row[filter.by] === filter.value) {
+      out.push({ container: arr, key: n, value: row });
+    }
+  }
+  return out;
+}
+
+function describeFilter(f) {
+  let v;
+  if (typeof f.value === 'string') v = JSON.stringify(f.value);
+  else v = String(f.value);
+  return `${f.by}=${v}`;
+}
+
+function describeNonArray(v) {
+  if (v === null) return 'null';
+  if (Array.isArray(v)) return 'array'; // unreachable but safe
+  return typeof v;
+}
+
+module.exports = {
+  parsePath,
+  resolvePath,
+  BadPath,
+  NoMatch,
+  Ambiguous,
+  WrongType,
+};

--- a/tests/manifest-path.test.js
+++ b/tests/manifest-path.test.js
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/manifest-path.test.js
+// Unit tests for manifests/path.js: the equality-only path language used
+// by the row-level chat tools. Pure module, no I/O, no fixtures on disk.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const {
+  parsePath,
+  resolvePath,
+  BadPath,
+  NoMatch,
+  Ambiguous,
+  WrongType,
+} = require('../manifests/path');
+
+// Minimal manifest-shaped fixture used across resolution tests.
+const FIXTURE = {
+  items: [
+    { name: 'BPC-157', doses: [
+      { scheduledDate: '2026-03-25', takenAt: '2026-03-25T03:25:00Z' },
+      { scheduledDate: '2026-03-26', takenAt: '2026-03-26T10:50:00Z' },
+    ]},
+    { name: 'TB-500', doses: [
+      { scheduledDate: '2026-03-27', takenAt: '2026-03-27T11:56:00Z' },
+    ]},
+    { name: 'Klow Stack', doses: [] },
+  ],
+  groups: [
+    { id: 'repair-stack', label: 'Repair Stack' },
+  ],
+  flags: { active: true, archived: false },
+  notes: 'plain string',
+};
+
+describe('parsePath: empty + trivial', () => {
+  test('empty string returns empty segment list', () => {
+    assert.deepEqual(parsePath(''), []);
+  });
+
+  test('single segment, no filter', () => {
+    assert.deepEqual(parsePath('items'), [{ name: 'items', filter: null }]);
+  });
+
+  test('underscore-prefixed identifier', () => {
+    assert.deepEqual(parsePath('_archive'), [{ name: '_archive', filter: null }]);
+  });
+
+  test('hyphenated identifier mid-name', () => {
+    assert.deepEqual(parsePath('repair-stack'), [{ name: 'repair-stack', filter: null }]);
+  });
+
+  test('digits inside identifier', () => {
+    assert.deepEqual(parsePath('items2'), [{ name: 'items2', filter: null }]);
+  });
+
+  test('chained segments', () => {
+    assert.deepEqual(parsePath('a.b.c'), [
+      { name: 'a', filter: null },
+      { name: 'b', filter: null },
+      { name: 'c', filter: null },
+    ]);
+  });
+});
+
+describe('parsePath: filters', () => {
+  test('double-quoted string literal', () => {
+    assert.deepEqual(parsePath('items[name="BPC-157"]'), [
+      { name: 'items', filter: { by: 'name', value: 'BPC-157' } },
+    ]);
+  });
+
+  test('single-quoted string literal', () => {
+    assert.deepEqual(parsePath("items[name='BPC-157']"), [
+      { name: 'items', filter: { by: 'name', value: 'BPC-157' } },
+    ]);
+  });
+
+  test('escaped quote inside double-quoted literal', () => {
+    assert.deepEqual(parsePath('items[name="say \\"hi\\""]'), [
+      { name: 'items', filter: { by: 'name', value: 'say "hi"' } },
+    ]);
+  });
+
+  test('integer literal', () => {
+    assert.deepEqual(parsePath('items[index=3]'), [
+      { name: 'items', filter: { by: 'index', value: 3 } },
+    ]);
+  });
+
+  test('negative integer literal', () => {
+    assert.deepEqual(parsePath('items[score=-5]'), [
+      { name: 'items', filter: { by: 'score', value: -5 } },
+    ]);
+  });
+
+  test('decimal number literal', () => {
+    assert.deepEqual(parsePath('items[ratio=1.5]'), [
+      { name: 'items', filter: { by: 'ratio', value: 1.5 } },
+    ]);
+  });
+
+  test('true literal', () => {
+    assert.deepEqual(parsePath('items[active=true]'), [
+      { name: 'items', filter: { by: 'active', value: true } },
+    ]);
+  });
+
+  test('false literal', () => {
+    assert.deepEqual(parsePath('items[active=false]'), [
+      { name: 'items', filter: { by: 'active', value: false } },
+    ]);
+  });
+
+  test('chain with filter on intermediate segment', () => {
+    assert.deepEqual(parsePath('items[name="BPC-157"].doses'), [
+      { name: 'items', filter: { by: 'name', value: 'BPC-157' } },
+      { name: 'doses', filter: null },
+    ]);
+  });
+
+  test('chain with filters on multiple segments', () => {
+    assert.deepEqual(
+      parsePath('items[name="BPC-157"].doses[scheduledDate="2026-03-25"]'),
+      [
+        { name: 'items', filter: { by: 'name', value: 'BPC-157' } },
+        { name: 'doses', filter: { by: 'scheduledDate', value: '2026-03-25' } },
+      ],
+    );
+  });
+
+  test('literal containing a closing bracket character is fine inside quotes', () => {
+    assert.deepEqual(parsePath('items[name="]"]'), [
+      { name: 'items', filter: { by: 'name', value: ']' } },
+    ]);
+  });
+
+  test('literal containing a dot is fine inside quotes', () => {
+    assert.deepEqual(parsePath('items[name="a.b.c"]'), [
+      { name: 'items', filter: { by: 'name', value: 'a.b.c' } },
+    ]);
+  });
+});
+
+describe('parsePath: errors', () => {
+  function bad(input) {
+    try { parsePath(input); }
+    catch (e) {
+      assert.equal(e.code, 'BAD_PATH');
+      assert.ok(e instanceof BadPath, 'expected BadPath instance');
+      assert.equal(typeof e.position, 'number');
+      return e;
+    }
+    assert.fail(`expected BadPath for input ${JSON.stringify(input)}`);
+  }
+
+  test('null path', () => bad(null));
+  test('non-string path', () => bad(123));
+  test('lone dot', () => bad('.'));
+  test('leading dot', () => bad('.items'));
+  test('trailing dot', () => bad('items.'));
+  test('double dot', () => bad('items..doses'));
+  test('open bracket no close', () => bad('items[name="x"'));
+  test('close bracket without open', () => bad('items]'));
+  test('filter without equals', () => bad('items[name]'));
+  test('filter without value', () => bad('items[name=]'));
+  test('unterminated string', () => bad('items[name="hello'));
+  test('bare identifier as literal value', () => bad('items[name=foo]'));
+  test('digit-leading identifier', () => bad('1items'));
+  test('garbage trailing chars', () => bad('items&'));
+  test('empty filter brackets', () => bad('items[]'));
+  test('hint included for filter-without-equals', () => {
+    const e = bad('items[name]');
+    assert.ok(typeof e.hint === 'string' && e.hint.length > 0);
+  });
+});
+
+describe('resolvePath: trivial', () => {
+  test('empty segment list returns root', () => {
+    const r = resolvePath(FIXTURE, []);
+    assert.equal(r.value, FIXTURE);
+    assert.equal(r.container, null);
+    assert.equal(r.key, null);
+  });
+
+  test('single segment property', () => {
+    const r = resolvePath(FIXTURE, parsePath('items'));
+    assert.equal(r.value, FIXTURE.items);
+    assert.equal(r.container, FIXTURE);
+    assert.equal(r.key, 'items');
+  });
+
+  test('nested object property', () => {
+    const r = resolvePath(FIXTURE, parsePath('flags.active'));
+    assert.equal(r.value, true);
+    assert.equal(r.container, FIXTURE.flags);
+    assert.equal(r.key, 'active');
+  });
+});
+
+describe('resolvePath: filters', () => {
+  test('match unique row by string key', () => {
+    const r = resolvePath(FIXTURE, parsePath('items[name="BPC-157"]'));
+    assert.equal(r.value, FIXTURE.items[0]);
+    assert.equal(r.container, FIXTURE.items);
+    assert.equal(r.key, 0);
+  });
+
+  test('match into row, then descend further', () => {
+    const r = resolvePath(FIXTURE, parsePath('items[name="BPC-157"].doses'));
+    assert.equal(r.value, FIXTURE.items[0].doses);
+    assert.equal(r.container, FIXTURE.items[0]);
+    assert.equal(r.key, 'doses');
+  });
+
+  test('chained filter to leaf row', () => {
+    const r = resolvePath(
+      FIXTURE,
+      parsePath('items[name="BPC-157"].doses[scheduledDate="2026-03-26"]'),
+    );
+    assert.equal(r.value, FIXTURE.items[0].doses[1]);
+    assert.equal(r.container, FIXTURE.items[0].doses);
+    assert.equal(r.key, 1);
+  });
+
+  test('index= filter on array', () => {
+    const r = resolvePath(FIXTURE, parsePath('items[index=2]'));
+    assert.equal(r.value, FIXTURE.items[2]);
+    assert.equal(r.key, 2);
+  });
+
+  test('index out of range -> NO_MATCH', () => {
+    assert.throws(
+      () => resolvePath(FIXTURE, parsePath('items[index=99]')),
+      e => e.code === 'NO_MATCH',
+    );
+  });
+
+  test('negative index -> NO_MATCH (not supported)', () => {
+    assert.throws(
+      () => resolvePath(FIXTURE, parsePath('items[index=-1]')),
+      e => e.code === 'NO_MATCH',
+    );
+  });
+
+  test('filter on empty array -> NO_MATCH', () => {
+    const r = resolvePath(FIXTURE, parsePath('items[name="Klow Stack"].doses'));
+    assert.equal(r.value, FIXTURE.items[2].doses);
+    assert.throws(
+      () => resolvePath(FIXTURE, parsePath('items[name="Klow Stack"].doses[scheduledDate="anything"]')),
+      e => e.code === 'NO_MATCH',
+    );
+  });
+
+  test('boolean filter matches', () => {
+    const data = { rows: [{flag: true, n: 1}, {flag: false, n: 2}] };
+    const r = resolvePath(data, parsePath('rows[flag=true]'));
+    assert.deepEqual(r.value, {flag: true, n: 1});
+  });
+
+  test('numeric filter does NOT match string-encoded number', () => {
+    const data = { rows: [{n: 1}, {n: '1'}] };
+    // filter literal 1 (number) only matches the numeric row
+    const r = resolvePath(data, parsePath('rows[n=1]'));
+    assert.deepEqual(r.value, {n: 1});
+  });
+});
+
+describe('resolvePath: error codes', () => {
+  test('NO_MATCH on missing property', () => {
+    assert.throws(
+      () => resolvePath(FIXTURE, parsePath('does_not_exist')),
+      e => e.code === 'NO_MATCH' && e instanceof NoMatch,
+    );
+  });
+
+  test('NO_MATCH on filter that finds nothing', () => {
+    assert.throws(
+      () => resolvePath(FIXTURE, parsePath('items[name="NOPE"]')),
+      e => e.code === 'NO_MATCH',
+    );
+  });
+
+  test('AMBIGUOUS when multiple rows match', () => {
+    const data = { rows: [{tag: 'a', n: 1}, {tag: 'a', n: 2}] };
+    assert.throws(
+      () => resolvePath(data, parsePath('rows[tag="a"]')),
+      e => e.code === 'AMBIGUOUS' && e instanceof Ambiguous && e.count === 2,
+    );
+  });
+
+  test('AMBIGUOUS suppressed when allowMultiple:true', () => {
+    const data = { rows: [{tag: 'a', n: 1}, {tag: 'a', n: 2}, {tag: 'b', n: 3}] };
+    const r = resolvePath(data, parsePath('rows[tag="a"]'), { allowMultiple: true });
+    assert.equal(r.matches.length, 2);
+    assert.deepEqual(r.matches[0].value, {tag: 'a', n: 1});
+    assert.deepEqual(r.matches[1].value, {tag: 'a', n: 2});
+    assert.equal(r.matches[0].key, 0);
+    assert.equal(r.matches[1].key, 1);
+    assert.equal(r.matches[0].container, data.rows);
+  });
+
+  test('WRONG_TYPE: filter on non-array', () => {
+    const data = { obj: { a: 1, b: 2 } };
+    assert.throws(
+      () => resolvePath(data, parsePath('obj[a=1]')),
+      e => e.code === 'WRONG_TYPE' && e instanceof WrongType,
+    );
+  });
+
+  test('WRONG_TYPE: descending into a primitive', () => {
+    assert.throws(
+      () => resolvePath(FIXTURE, parsePath('notes.subfield')),
+      e => e.code === 'WRONG_TYPE',
+    );
+  });
+
+  test('NO_MATCH: traverse through null', () => {
+    const data = { a: null };
+    assert.throws(
+      () => resolvePath(data, parsePath('a.b')),
+      e => e.code === 'NO_MATCH',
+    );
+  });
+
+  test('WRONG_TYPE: trying to access a property of an array directly', () => {
+    // items is an array; bare 'items.length' is not allowed (use [index=N])
+    assert.throws(
+      () => resolvePath(FIXTURE, parsePath('items.length')),
+      e => e.code === 'WRONG_TYPE',
+    );
+  });
+});
+
+describe('resolvePath: container/key let callers mutate via parent', () => {
+  test('caller can replace a row through the returned handle', () => {
+    const data = { rows: [{name: 'a', n: 1}, {name: 'b', n: 2}] };
+    const r = resolvePath(data, parsePath('rows[name="b"]'));
+    r.container[r.key] = { name: 'b', n: 99 };
+    assert.deepEqual(data.rows[1], { name: 'b', n: 99 });
+  });
+
+  test('caller can splice a row out via the returned handle', () => {
+    const data = { rows: [{name: 'a'}, {name: 'b'}, {name: 'c'}] };
+    const r = resolvePath(data, parsePath('rows[name="b"]'));
+    r.container.splice(r.key, 1);
+    assert.deepEqual(data.rows.map(x => x.name), ['a', 'c']);
+  });
+
+  test('caller can append onto an array reached via path', () => {
+    const data = { rows: [{name: 'a'}] };
+    const r = resolvePath(data, parsePath('rows'));
+    r.value.push({name: 'b'});
+    assert.equal(data.rows.length, 2);
+  });
+});
+
+describe('index= edge cases', () => {
+  test('string-valued index= falls through to normal property match', () => {
+    const data = { rows: [{ index: 'foo' }, { index: 'bar' }] };
+    const r = resolvePath(data, parsePath('rows[index="foo"]'));
+    assert.deepEqual(r.value, { index: 'foo' });
+  });
+
+  test('index=0 returns the first element', () => {
+    const r = resolvePath(FIXTURE, parsePath('items[index=0]'));
+    assert.equal(r.value, FIXTURE.items[0]);
+  });
+});


### PR DESCRIPTION
# What changed

New pure module `manifests/path.js` implementing an equality-only path
language for addressing rows inside a manifest's data block, plus a
59-test unit suite at `tests/manifest-path.test.js`.

# Why

Phase 1 of #363. The chat agent's `write_manifest_data` tool requires
the LLM to round-trip the entire `data` block on any edit. On the
peptides card (~67 kB) this regularly breaches the 180 s gateway
timeout: the user's edit is lost. The fix is row-level read/write
tools, which need an addressable path mini-language under them. This
PR lands that mini-language in isolation, before any registry or
chat-tool wiring.

# How

- `parsePath(input)` — hand-written tokeniser, emits an array of
  `{name, filter}` segments. Grammar:
  ```
  path     := segment ('.' segment)*
  segment  := identifier ('[' filter ']')?
  filter   := identifier '=' literal
  literal  := "..." | '...' | number | true | false
  ```
- `resolvePath(data, segments, opts?)` — walks the data tree and
  returns `{container, key, value}` so callers can mutate via the
  parent reference (`r.container[r.key] = newValue`,
  `r.container.splice(r.key, 1)`, etc.).
- Four typed error classes (`BadPath`, `NoMatch`, `Ambiguous`,
  `WrongType`) each carry a stable `code` field, ready for the
  row-level chat tools to surface to the LLM as structured failures.
- `[index=N]` is a special case for direct integer array indexing;
  string-valued `index=` falls through to a normal property match so
  cards storing `{index: "foo"}` still work.
- Ambiguous matches default to throwing; opt-in `allowMultiple` returns
  all matches, ready for the eventual `read_manifest_rows` use case.

No I/O, no registry coupling, no chat wiring. Phases 2 and 3 land on
top of this in separate PRs.

# Testing

- [x] `npm test` passes locally — 1149/1149 (3 pre-existing skips,
  unrelated)
- [ ] `npm run test:e2e` not run: pure-module addition, no UI surface
- [x] New regression test added: `tests/manifest-path.test.js` —
  pure-logic layer matches the `tests/*.test.js` rubric. 59 cases:
  grammar happy paths, every error code, quoting edge cases (single +
  double quotes, escaped quote inside literal, integers vs strings),
  `index=N` against arrays, deep nesting, empty path, paths through
  `null`, and that returned handles let callers splice/replace parent
  arrays in place.
- [x] Manual QA: not applicable — no runtime path exercises this code
  yet.

# Checklist

- [x] Conventional-commit subjects
- [x] `CHANGELOG.md` updated under `## Unreleased / Internal`
- [x] Docs: not updated. The path grammar is a tool-internal concept
  and will be documented in the tool descriptions in phase 3, not in
  `MANIFEST-SCHEMA.md` (which is the public schema reference).
- [x] No personal identifiers
- [x] No secrets

# Breaking changes

None. Pure addition.

Refs #363, Closes #364.