### PR TITLE
Phase 2: registry row-level read/write functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,23 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 - **Manifest path parser + resolver.** New pure module
   `manifests/path.js` providing `parsePath()` and `resolvePath()`
   for an equality-only path language (`segment.segment[k=v]`,
-  with `[index=N]` for direct array indexing). Returns
+  with `[index=N]` for direct array indexing, and a leading
+  `[k=v]` form for filtering an array-typed root). Returns
   `{container, key, value}` so callers can mutate via the parent
   reference; throws typed `BadPath` / `NoMatch` / `Ambiguous` /
   `WrongType` errors with stable `code` fields. Phase 1 of the
   row-level chat tools work; nothing user-visible yet. Refs #363.
+- **Registry row-level read/write functions.** New `readRows`,
+  `appendRow`, `updateRow`, `removeRow` on `manifests/registry.js`
+  composed on top of the path module above. All writers atomically
+  deep-clone, mutate, schema-check, and persist via the existing
+  tmp+rename idiom; on any error before rename, on-disk state and
+  the in-memory cache are unchanged. Path / shape failures bubble
+  up with their `code` fields preserved. Step-0 cleanup pulled the
+  envelope-build and atomic-persist patterns out of `writeData` /
+  `setMasterEnabled` / `patchManifest` into shared helpers so all
+  callers share one persistence path. Phase 2 of #363; nothing
+  user-visible yet. Refs #366.
 
 ## [2.3.1] - 2026-06-08
 

--- a/manifests/path.js
+++ b/manifests/path.js
@@ -164,31 +164,44 @@ function parsePath(input) {
     return n;
   }
 
-  function readSegment() {
-    const name = readIdent();
+  function readFilterBody() {
+    // assumes leading '[' is at peek(); advances past the closing ']'
+    advance();
+    const by = readIdent();
+    if (peek() !== '=') {
+      throw new BadPath(`expected '=' after filter key at position ${i}`, i,
+        "filters look like [key=value], e.g. [name=\"BPC-157\"]");
+    }
+    advance();
+    const value = readLiteral();
+    if (peek() !== ']') {
+      throw new BadPath(`expected ']' to close filter at position ${i}, got ${describeChar(peek())}`, i);
+    }
+    advance();
+    return { by, value };
+  }
+
+  function readSegment(allowLeadingFilter) {
+    let name = '';
     let filter = null;
+    if (allowLeadingFilter && peek() === '[') {
+      // Root-array filter: [k=v] with no property step. Only allowed as
+      // the first segment so callers can address elements of an array-
+      // typed data block directly.
+      filter = readFilterBody();
+      return { name, filter };
+    }
+    name = readIdent();
     if (peek() === '[') {
-      advance();
-      const by = readIdent();
-      if (peek() !== '=') {
-        throw new BadPath(`expected '=' after filter key at position ${i}`, i,
-          "filters look like [key=value], e.g. [name=\"BPC-157\"]");
-      }
-      advance();
-      const value = readLiteral();
-      if (peek() !== ']') {
-        throw new BadPath(`expected ']' to close filter at position ${i}, got ${describeChar(peek())}`, i);
-      }
-      advance();
-      filter = { by, value };
+      filter = readFilterBody();
     }
     return { name, filter };
   }
 
-  segments.push(readSegment());
+  segments.push(readSegment(true));
   while (peek() === '.') {
     advance();
-    segments.push(readSegment());
+    segments.push(readSegment(false));
   }
   if (i !== s.length) {
     throw new BadPath(`unexpected ${describeChar(peek())} at position ${i}`, i,
@@ -223,32 +236,34 @@ function resolvePath(data, segments, opts) {
 
   for (let idx = 0; idx < segments.length; idx++) {
     const seg = segments[idx];
-    if (current === null || current === undefined) {
-      throw new NoMatch(`segment '${seg.name}' traverses through ${current === null ? 'null' : 'undefined'}`, idx);
+    const stepIntoProperty = seg.name !== '';
+    if (stepIntoProperty) {
+      if (current === null || current === undefined) {
+        throw new NoMatch(`segment '${seg.name}' traverses through ${current === null ? 'null' : 'undefined'}`, idx);
+      }
+      if (typeof current !== 'object') {
+        throw new WrongType(`segment '${seg.name}' expects an object/array but found ${typeof current}`, idx);
+      }
+      if (Array.isArray(current)) {
+        throw new WrongType(`segment '${seg.name}' expects an object property but found an array`, idx);
+      }
+      if (!Object.prototype.hasOwnProperty.call(current, seg.name)) {
+        throw new NoMatch(`property '${seg.name}' not found`, idx);
+      }
+      container = current;
+      key = seg.name;
+      current = current[seg.name];
     }
-    if (typeof current !== 'object') {
-      throw new WrongType(`segment '${seg.name}' expects an object/array but found ${typeof current}`, idx);
-    }
-    if (Array.isArray(current)) {
-      throw new WrongType(`segment '${seg.name}' expects an object property but found an array`, idx);
-    }
-
-    // Step into the named property.
-    if (!Object.prototype.hasOwnProperty.call(current, seg.name)) {
-      throw new NoMatch(`property '${seg.name}' not found`, idx);
-    }
-    container = current;
-    key = seg.name;
-    current = current[seg.name];
 
     if (seg.filter) {
+      const label = seg.name === '' ? '' : seg.name;
       const matches = applyFilter(current, seg.filter, idx);
       if (matches.length === 0) {
-        throw new NoMatch(`${seg.name}[${describeFilter(seg.filter)}] matched no rows`, idx);
+        throw new NoMatch(`${label}[${describeFilter(seg.filter)}] matched no rows`, idx);
       }
       if (matches.length > 1 && !options.allowMultiple) {
         throw new Ambiguous(
-          `${seg.name}[${describeFilter(seg.filter)}] matched ${matches.length} rows`,
+          `${label}[${describeFilter(seg.filter)}] matched ${matches.length} rows`,
           matches.length,
           idx,
         );
@@ -256,7 +271,6 @@ function resolvePath(data, segments, opts) {
       if (options.allowMultiple && idx === segments.length - 1) {
         return { matches };
       }
-      // Pick the unique match and continue.
       const m = matches[0];
       container = m.container;
       key = m.key;

--- a/manifests/registry.js
+++ b/manifests/registry.js
@@ -283,6 +283,34 @@ function _assertSchemaShape(id, schema, newData) {
   }
 }
 
+// Build the on-disk JSON envelope for an entry. When a 2-arg form is used,
+// the override is set unconditionally (so callers can emit data:null
+// deliberately). When the 1-arg form is used, falls back to entry.data and
+// skips the key when null/undefined (matches setMasterEnabled / patchManifest
+// pre-existing behaviour). Caller is responsible for any pre-write validation.
+function _buildEntryEnvelope(entry, ...rest) {
+  const overridden = rest.length > 0;
+  const full = {
+    $schema: entry.version,
+    meta: entry.meta,
+  };
+  if (entry.description) full.description = entry.description;
+  if (entry.schema) full.schema = entry.schema;
+  if (overridden) {
+    full.data = rest[0];
+  } else if (entry.data !== null && entry.data !== undefined) {
+    full.data = entry.data;
+  }
+  return full;
+}
+
+// Atomic write of a fully-formed envelope to entry.source via tmp+rename.
+function _persistEnvelope(entry, envelope) {
+  const tmp = entry.source + '.tmp';
+  fs.writeFileSync(tmp, JSON.stringify(envelope, null, 2));
+  fs.renameSync(tmp, entry.source);
+}
+
 // Write full file back with updated data block. Preserves meta/description/schema.
 // Uses atomic tmp+rename to avoid partial writes.
 function writeData(id, newData) {
@@ -292,17 +320,7 @@ function writeData(id, newData) {
   newData = _coerceWriteData(id, newData);
   _assertSchemaShape(id, entry.schema, newData);
 
-  const full = {
-    $schema: entry.version,
-    meta: entry.meta,
-  };
-  if (entry.description) full.description = entry.description;
-  if (entry.schema) full.schema = entry.schema;
-  full.data = newData;
-
-  const tmp = entry.source + '.tmp';
-  fs.writeFileSync(tmp, JSON.stringify(full, null, 2));
-  fs.renameSync(tmp, entry.source);
+  _persistEnvelope(entry, _buildEntryEnvelope(entry, newData));
   entry.data = newData;
   return true;
 }
@@ -328,16 +346,7 @@ function setMasterEnabled(id, enabled) {
   const entry = _entries.get(id);
   if (!entry) throw new Error(`unknown manifest: ${id}`);
   entry.meta = { ...entry.meta, enabled: !!enabled };
-  const full = {
-    $schema: entry.version,
-    meta: entry.meta,
-  };
-  if (entry.description) full.description = entry.description;
-  if (entry.schema) full.schema = entry.schema;
-  if (entry.data !== null) full.data = entry.data;
-  const tmp = entry.source + '.tmp';
-  fs.writeFileSync(tmp, JSON.stringify(full, null, 2));
-  fs.renameSync(tmp, entry.source);
+  _persistEnvelope(entry, _buildEntryEnvelope(entry));
   return !!enabled;
 }
 
@@ -563,34 +572,33 @@ function patchManifest(id, patch) {
     throw new Error('patch touches protected field: data (use writeData)');
   }
 
-  const merged = {
-    $schema: entry.version,
-    meta: isPlainObject(patch.meta)
-      ? mergePatch(entry.meta, patch.meta)
-      : entry.meta,
-  };
+  const newMeta = isPlainObject(patch.meta)
+    ? mergePatch(entry.meta, patch.meta)
+    : entry.meta;
+  let newDescription = entry.description || null;
   // description: patch can set (string) or remove (null). Undefined = keep.
   if ('description' in patch) {
     if (patch.description === null) {
-      // removed
+      newDescription = null;
     } else if (typeof patch.description === 'string') {
-      merged.description = patch.description;
+      newDescription = patch.description;
     } else {
       throw new Error('description must be a string or null');
     }
-  } else if (entry.description) {
-    merged.description = entry.description;
   }
-  if (entry.schema) merged.schema = entry.schema;
-  if (entry.data !== null) merged.data = entry.data;
+
+  const stagedEntry = {
+    ...entry,
+    meta: newMeta,
+    description: newDescription,
+  };
+  const merged = _buildEntryEnvelope(stagedEntry);
 
   // Re-validate. strictId:false so we don't reject legacy ids that already
   // loaded; we already blocked id changes above.
   validateManifestShape(merged, { strictId: false });
 
-  const tmp = entry.source + '.tmp';
-  fs.writeFileSync(tmp, JSON.stringify(merged, null, 2));
-  fs.renameSync(tmp, entry.source);
+  _persistEnvelope(entry, merged);
   entry.meta = merged.meta;
   entry.description = merged.description || null;
   return { id };

--- a/manifests/registry.js
+++ b/manifests/registry.js
@@ -16,6 +16,7 @@ const fs = require('fs');
 const path = require('path');
 const PATHS = require('../config/paths');
 const { mergePatch, isPlainObject } = require('./merge-patch');
+const { parsePath, resolvePath } = require('./path');
 
 const { isValidCategory } = require('../config/categories');
 
@@ -325,6 +326,107 @@ function writeData(id, newData) {
   return true;
 }
 
+// Resolve a path against a manifest's data block. Pure read, no I/O.
+// pathString is parsed via manifests/path.js; opts.allowMultiple plumbs
+// through. Throws BadPath / NoMatch / Ambiguous / WrongType (each carries
+// a `code` field), or Error('unknown manifest: <id>') if id is unknown.
+function readRows(id, pathString, opts) {
+  const entry = _entries.get(id);
+  if (!entry) throw new Error(`unknown manifest: ${id}`);
+  const segments = parsePath(pathString || '');
+  return resolvePath(entry.data, segments, opts);
+}
+
+// Apply a path-targeted mutation to entry.data atomically. Caller supplies
+// a `mutate(stagedData) -> result` callback that mutates a deep clone in
+// place and returns the result the registry should bubble out to its
+// caller. After the callback returns, the rebuilt envelope is shape-checked
+// and persisted via tmp+rename. On any error before rename, the on-disk
+// file and in-memory cache are unchanged.
+function _mutateData(id, mutate) {
+  const entry = _entries.get(id);
+  if (!entry) throw new Error(`unknown manifest: ${id}`);
+  if (entry.data === null || entry.data === undefined) {
+    throw new Error(`${id} has no data block to address`);
+  }
+  // Deep clone so a mid-mutation throw can't leave the cache half-edited.
+  const staged = JSON.parse(JSON.stringify(entry.data));
+  const result = mutate(staged);
+  _assertSchemaShape(id, entry.schema, staged);
+  _persistEnvelope(entry, _buildEntryEnvelope(entry, staged));
+  entry.data = staged;
+  return result;
+}
+
+// Append one row to the array at pathString. Throws WRONG_TYPE if the
+// resolved target isn't an array. NO_MATCH / BAD_PATH bubble up from the
+// path module unchanged.
+function appendRow(id, pathString, value) {
+  return _mutateData(id, (staged) => {
+    const segments = parsePath(pathString || '');
+    const r = resolvePath(staged, segments);
+    if (!Array.isArray(r.value)) {
+      const err = new Error(`appendRow target at "${pathString}" is not an array`);
+      err.code = 'WRONG_TYPE';
+      throw err;
+    }
+    r.value.push(value);
+    return { added: 1, totalAfter: r.value.length };
+  });
+}
+
+// Apply RFC 7396 JSON Merge Patch to the single row at pathString. The
+// resolved target must be a plain object. Path must resolve unambiguously
+// (no allowMultiple here): an AMBIGUOUS error is what we want.
+function updateRow(id, pathString, changes) {
+  if (!isPlainObject(changes)) {
+    const err = new Error('updateRow changes must be a plain object');
+    err.code = 'WRONG_TYPE';
+    throw err;
+  }
+  return _mutateData(id, (staged) => {
+    const segments = parsePath(pathString || '');
+    const r = resolvePath(staged, segments);
+    if (r.container === null) {
+      const err = new Error('updateRow cannot patch the root data value (use writeData)');
+      err.code = 'WRONG_TYPE';
+      throw err;
+    }
+    if (!isPlainObject(r.value)) {
+      const err = new Error(`updateRow target at "${pathString}" is not a plain object`);
+      err.code = 'WRONG_TYPE';
+      throw err;
+    }
+    const before = r.value;
+    const after = mergePatch(before, changes);
+    r.container[r.key] = after;
+    return { updated: 1, before, after };
+  });
+}
+
+// Splice the single row at pathString out of its parent array. Path must
+// resolve unambiguously and the parent must be an array (i.e. the leaf
+// segment was a filter, or the parent is an items[] / rows[] container).
+function removeRow(id, pathString) {
+  return _mutateData(id, (staged) => {
+    const segments = parsePath(pathString || '');
+    const r = resolvePath(staged, segments);
+    if (r.container === null) {
+      const err = new Error('removeRow cannot remove the root data value (use writeData)');
+      err.code = 'WRONG_TYPE';
+      throw err;
+    }
+    if (!Array.isArray(r.container)) {
+      const err = new Error(`removeRow target at "${pathString}" is not an element of an array`);
+      err.code = 'WRONG_TYPE';
+      throw err;
+    }
+    const removed = r.container[r.key];
+    r.container.splice(r.key, 1);
+    return { removed, totalAfter: r.container.length };
+  });
+}
+
 // Has a card opted into a particular view? Respects the master meta.enabled
 // switch (when explicitly set to false, card is hidden everywhere).
 function isEnabledIn(entry, viewName) {
@@ -630,6 +732,10 @@ module.exports = {
   get,
   data,
   writeData,
+  readRows,
+  appendRow,
+  updateRow,
+  removeRow,
   errors,
   isMasterEnabled,
   setMasterEnabled,

--- a/tests/manifest-path.test.js
+++ b/tests/manifest-path.test.js
@@ -141,6 +141,28 @@ describe('parsePath: filters', () => {
       { name: 'items', filter: { by: 'name', value: 'a.b.c' } },
     ]);
   });
+
+  test('leading bracket filter (root-array form)', () => {
+    assert.deepEqual(parsePath('[date="2026-05-04"]'), [
+      { name: '', filter: { by: 'date', value: '2026-05-04' } },
+    ]);
+  });
+
+  test('leading bracket filter then property descent', () => {
+    assert.deepEqual(parsePath('[index=2].notes'), [
+      { name: '', filter: { by: 'index', value: 2 } },
+      { name: 'notes', filter: null },
+    ]);
+  });
+
+  test('after a dot, leading bracket is rejected (only root may filter without ident)', () => {
+    try { parsePath('items.[index=0]'); }
+    catch (e) {
+      assert.equal(e.code, 'BAD_PATH');
+      return;
+    }
+    assert.fail('expected BadPath');
+  });
 });
 
 describe('parsePath: errors', () => {
@@ -353,6 +375,38 @@ describe('resolvePath: container/key let callers mutate via parent', () => {
     const r = resolvePath(data, parsePath('rows'));
     r.value.push({name: 'b'});
     assert.equal(data.rows.length, 2);
+  });
+});
+
+describe('resolvePath: root-array filter', () => {
+  test('filter the root value when it is an array', () => {
+    const data = [
+      { date: '2026-05-04', mood: 4 },
+      { date: '2026-05-05', mood: 5 },
+    ];
+    const r = resolvePath(data, parsePath('[date="2026-05-05"]'));
+    assert.deepEqual(r.value, { date: '2026-05-05', mood: 5 });
+    assert.equal(r.container, data);
+    assert.equal(r.key, 1);
+  });
+
+  test('root-array filter then property descent', () => {
+    const data = [
+      { name: 'a', tags: ['x', 'y'] },
+      { name: 'b', tags: ['z'] },
+    ];
+    const r = resolvePath(data, parsePath('[name="b"].tags'));
+    assert.deepEqual(r.value, ['z']);
+    assert.equal(r.container, data[1]);
+    assert.equal(r.key, 'tags');
+  });
+
+  test('root-array filter on a non-array root throws WRONG_TYPE', () => {
+    const data = { items: [] };
+    assert.throws(
+      () => resolvePath(data, parsePath('[name="x"]')),
+      e => e.code === 'WRONG_TYPE',
+    );
   });
 });
 

--- a/tests/registry-rows.test.js
+++ b/tests/registry-rows.test.js
@@ -1,0 +1,433 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/registry-rows.test.js
+// Integration tests for registry.readRows / appendRow / updateRow /
+// removeRow against a real sandbox HEALTH_HOME. Atomicity, error codes,
+// and that on-disk state and the in-memory cache stay aligned.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const { createSandbox, cleanupSandbox } = require('./helpers/sandbox');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const MANIFESTS_DIR = path.resolve(REPO_ROOT, 'manifests') + path.sep;
+const CONFIG_DIR = path.resolve(REPO_ROOT, 'config') + path.sep;
+
+function freshRegistry(sandboxRoot) {
+  for (const key of Object.keys(require.cache)) {
+    if (key.startsWith(MANIFESTS_DIR) || key.startsWith(CONFIG_DIR)) {
+      delete require.cache[key];
+    }
+  }
+  process.env.HEALTH_HOME = sandboxRoot;
+  return require(path.join(REPO_ROOT, 'manifests', 'registry.js'));
+}
+
+function readBack(sandbox, file) {
+  return JSON.parse(fs.readFileSync(path.join(sandbox, 'data', file), 'utf8'));
+}
+
+// Object-shaped data block (matches the schedule-card peptides shape).
+const PEPTIDES = {
+  $schema: 'klebb.datafile.v1',
+  meta: {
+    id: 'peptides',
+    label: 'Schedule',
+    emoji: '💉',
+    writeable: { fromWebapp: true, inputs: [] },
+  },
+  data: {
+    items: [
+      { name: 'BPC-157', doses: [
+        { scheduledDate: '2026-03-25' },
+        { scheduledDate: '2026-03-26' },
+      ]},
+      { name: 'TB-500', doses: [
+        { scheduledDate: '2026-03-27' },
+      ]},
+    ],
+    groups: [
+      { id: 'repair-stack', label: 'Repair Stack' },
+    ],
+  },
+};
+
+// Array-shaped data block (matches mood-card style).
+const MOOD = {
+  $schema: 'klebb.datafile.v1',
+  meta: {
+    id: 'mood',
+    label: 'Mood',
+    writeable: { fromWebapp: true, inputs: [] },
+  },
+  schema: { type: 'array' },
+  data: [
+    { date: '2026-05-04', mood: 4 },
+    { date: '2026-05-05', mood: 5 },
+  ],
+};
+
+describe('registry.readRows', () => {
+  test('returns the resolved row by content-addressed path', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      const r = registry.readRows('peptides', 'items[name="BPC-157"]');
+      assert.equal(r.value.name, 'BPC-157');
+      assert.equal(r.value.doses.length, 2);
+      assert.equal(r.key, 0);
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('empty path returns the whole data block', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      const r = registry.readRows('peptides', '');
+      assert.equal(r.container, null);
+      assert.deepEqual(Object.keys(r.value), ['items', 'groups']);
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('allowMultiple plumbs through to resolvePath', () => {
+    const data = {
+      $schema: 'klebb.datafile.v1',
+      meta: { id: 'tags', label: 'T', writeable: { fromWebapp: true, inputs: [] } },
+      data: { rows: [{ tag: 'a', n: 1 }, { tag: 'a', n: 2 }, { tag: 'b', n: 3 }] },
+    };
+    const sandbox = createSandbox({ seed: { 'tags.json': data } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      const r = registry.readRows('tags', 'rows[tag="a"]', { allowMultiple: true });
+      assert.equal(r.matches.length, 2);
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('unknown manifest throws', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      assert.throws(
+        () => registry.readRows('does-not-exist', 'items'),
+        /unknown manifest/,
+      );
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('bubbles BAD_PATH from parser', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      assert.throws(
+        () => registry.readRows('peptides', 'items[bad'),
+        e => e.code === 'BAD_PATH',
+      );
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('bubbles NO_MATCH from resolver', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      assert.throws(
+        () => registry.readRows('peptides', 'items[name="NOPE"]'),
+        e => e.code === 'NO_MATCH',
+      );
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('does not mutate the cache on read', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      const before = JSON.stringify(registry.get('peptides').data);
+      registry.readRows('peptides', 'items[name="BPC-157"].doses');
+      const after = JSON.stringify(registry.get('peptides').data);
+      assert.equal(before, after);
+    } finally { cleanupSandbox(sandbox); }
+  });
+});
+
+describe('registry.appendRow', () => {
+  test('appends a dose to an existing item; persists to disk and cache', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      const out = registry.appendRow(
+        'peptides',
+        'items[name="BPC-157"].doses',
+        { scheduledDate: '2026-03-27', takenAt: '2026-03-27T08:00:00Z' },
+      );
+      assert.equal(out.added, 1);
+      assert.equal(out.totalAfter, 3);
+
+      const onDisk = readBack(sandbox, 'peptides.json');
+      assert.equal(onDisk.data.items[0].doses.length, 3);
+      assert.equal(onDisk.data.items[0].doses[2].scheduledDate, '2026-03-27');
+
+      const cached = registry.get('peptides').data;
+      assert.equal(cached.items[0].doses.length, 3);
+      assert.equal(cached.items[0].doses[2].takenAt, '2026-03-27T08:00:00Z');
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('appends a top-level item to data.items', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      const klow = { name: 'Klow Stack', doses: [] };
+      registry.appendRow('peptides', 'items', klow);
+      const onDisk = readBack(sandbox, 'peptides.json');
+      assert.equal(onDisk.data.items.length, 3);
+      assert.equal(onDisk.data.items[2].name, 'Klow Stack');
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('appends to an array-shaped data block (no parent key)', () => {
+    const sandbox = createSandbox({ seed: { 'mood.json': MOOD } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      registry.appendRow('mood', '', { date: '2026-05-06', mood: 3 });
+      const onDisk = readBack(sandbox, 'mood.json');
+      assert.equal(onDisk.data.length, 3);
+      assert.equal(onDisk.data[2].mood, 3);
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('WRONG_TYPE when target is not an array', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      assert.throws(
+        () => registry.appendRow('peptides', 'items[name="BPC-157"].name', 'X'),
+        e => e.code === 'WRONG_TYPE',
+      );
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('NO_MATCH bubbles when target item does not exist', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      assert.throws(
+        () => registry.appendRow('peptides', 'items[name="NOPE"].doses', {}),
+        e => e.code === 'NO_MATCH',
+      );
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('mid-mutation throw leaves on-disk file unchanged', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      const beforeRaw = fs.readFileSync(path.join(sandbox, 'data', 'peptides.json'), 'utf8');
+      assert.throws(() => registry.appendRow('peptides', 'items[name="NOPE"]', {}), e => e.code === 'NO_MATCH');
+      const afterRaw = fs.readFileSync(path.join(sandbox, 'data', 'peptides.json'), 'utf8');
+      assert.equal(beforeRaw, afterRaw);
+      // Cache is also untouched.
+      assert.equal(registry.get('peptides').data.items.length, 2);
+    } finally { cleanupSandbox(sandbox); }
+  });
+});
+
+describe('registry.updateRow', () => {
+  test('merge-patches a row identified by filter', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      const out = registry.updateRow(
+        'peptides',
+        'items[name="BPC-157"].doses[scheduledDate="2026-03-25"]',
+        { takenAt: '2026-03-25T03:25:00Z', site: 'belly' },
+      );
+      assert.equal(out.updated, 1);
+      assert.equal(out.after.takenAt, '2026-03-25T03:25:00Z');
+      assert.equal(out.after.site, 'belly');
+      // scheduledDate preserved via merge
+      assert.equal(out.after.scheduledDate, '2026-03-25');
+
+      const onDisk = readBack(sandbox, 'peptides.json');
+      assert.equal(onDisk.data.items[0].doses[0].site, 'belly');
+      assert.equal(onDisk.data.items[0].doses[0].scheduledDate, '2026-03-25');
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('null in changes removes a key (RFC 7396)', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      registry.updateRow(
+        'peptides',
+        'items[name="BPC-157"].doses[scheduledDate="2026-03-25"]',
+        { scheduledDate: null, takenAt: '2026-03-25T03:25:00Z' },
+      );
+      const onDisk = readBack(sandbox, 'peptides.json');
+      const dose = onDisk.data.items[0].doses[0];
+      assert.equal('scheduledDate' in dose, false);
+      assert.equal(dose.takenAt, '2026-03-25T03:25:00Z');
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('AMBIGUOUS bubbles when multiple rows match', () => {
+    const data = {
+      $schema: 'klebb.datafile.v1',
+      meta: { id: 'tags', label: 'T', writeable: { fromWebapp: true, inputs: [] } },
+      data: { rows: [{ tag: 'a', n: 1 }, { tag: 'a', n: 2 }] },
+    };
+    const sandbox = createSandbox({ seed: { 'tags.json': data } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      assert.throws(
+        () => registry.updateRow('tags', 'rows[tag="a"]', { flagged: true }),
+        e => e.code === 'AMBIGUOUS',
+      );
+      // Cache unchanged
+      assert.equal('flagged' in registry.get('tags').data.rows[0], false);
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('WRONG_TYPE when target is not a plain object', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      assert.throws(
+        () => registry.updateRow('peptides', 'items[name="BPC-157"].doses', { x: 1 }),
+        e => e.code === 'WRONG_TYPE',
+      );
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('rejects non-object changes', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      assert.throws(
+        () => registry.updateRow('peptides', 'items[name="BPC-157"]', null),
+        e => e.code === 'WRONG_TYPE',
+      );
+      assert.throws(
+        () => registry.updateRow('peptides', 'items[name="BPC-157"]', [1, 2]),
+        e => e.code === 'WRONG_TYPE',
+      );
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('cannot patch the root data value', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      assert.throws(
+        () => registry.updateRow('peptides', '', { extraKey: 1 }),
+        e => e.code === 'WRONG_TYPE',
+      );
+    } finally { cleanupSandbox(sandbox); }
+  });
+});
+
+describe('registry.removeRow', () => {
+  test('removes a dose by content-addressed path', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      const out = registry.removeRow(
+        'peptides',
+        'items[name="BPC-157"].doses[scheduledDate="2026-03-25"]',
+      );
+      assert.equal(out.removed.scheduledDate, '2026-03-25');
+      assert.equal(out.totalAfter, 1);
+      const onDisk = readBack(sandbox, 'peptides.json');
+      assert.equal(onDisk.data.items[0].doses.length, 1);
+      assert.equal(onDisk.data.items[0].doses[0].scheduledDate, '2026-03-26');
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('removes a top-level item', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      registry.removeRow('peptides', 'items[name="TB-500"]');
+      const onDisk = readBack(sandbox, 'peptides.json');
+      assert.equal(onDisk.data.items.length, 1);
+      assert.equal(onDisk.data.items[0].name, 'BPC-157');
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('removes from an array-shaped data block', () => {
+    const sandbox = createSandbox({ seed: { 'mood.json': MOOD } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      registry.removeRow('mood', '[date="2026-05-04"]');
+      const onDisk = readBack(sandbox, 'mood.json');
+      assert.equal(onDisk.data.length, 1);
+      assert.equal(onDisk.data[0].date, '2026-05-05');
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('AMBIGUOUS bubbles for a non-unique match', () => {
+    const data = {
+      $schema: 'klebb.datafile.v1',
+      meta: { id: 'tags', label: 'T', writeable: { fromWebapp: true, inputs: [] } },
+      data: { rows: [{ tag: 'a' }, { tag: 'a' }] },
+    };
+    const sandbox = createSandbox({ seed: { 'tags.json': data } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      assert.throws(
+        () => registry.removeRow('tags', 'rows[tag="a"]'),
+        e => e.code === 'AMBIGUOUS',
+      );
+      // Both rows still present
+      assert.equal(registry.get('tags').data.rows.length, 2);
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('cannot remove a non-array element (e.g. a property of an object)', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      // 'items' is itself a property of data, not an element of an array.
+      assert.throws(
+        () => registry.removeRow('peptides', 'items'),
+        e => e.code === 'WRONG_TYPE',
+      );
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('cannot remove the root data value', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const registry = freshRegistry(sandbox);
+      registry.init();
+      assert.throws(
+        () => registry.removeRow('peptides', ''),
+        e => e.code === 'WRONG_TYPE',
+      );
+    } finally { cleanupSandbox(sandbox); }
+  });
+});


### PR DESCRIPTION
# What changed

Four new functions on `manifests/registry.js`:

- `readRows(id, pathString, opts?)` — pure read, no I/O. Thin wrapper
  over `parsePath` + `resolvePath` against the entry's cached `data`.
- `appendRow(id, pathString, value)` — push one row onto an array
  identified by `pathString`.
- `updateRow(id, pathString, changes)` — RFC 7396 JSON Merge Patch
  applied to the single row at `pathString`. Path must resolve
  unambiguously to a plain object.
- `removeRow(id, pathString)` — splice out the single row at
  `pathString`. Path must resolve unambiguously and the parent must
  be an array.

Path module from #364 gains a leading-bracket grammar form for
filtering an array-typed root: `[date="2026-05-04"]` and
`[index=2].notes` both parse. Restricted to the first segment.

Step-0 cleanup of the registry: pull the envelope-build and
atomic-persist patterns out of `writeData` / `setMasterEnabled` /
`patchManifest` into shared helpers (`_buildEntryEnvelope`,
`_persistEnvelope`). Behaviour-preserving; full suite stays green.

# Why

Phase 2 of #363. The chat agent's only write tool today is
`write_manifest_data` — full data block rewrite. On the peptides
card (~67 kB) this regularly times out the chat gateway because the
LLM has to regenerate the whole block. The registry functions in
this PR are the substrate the new row-level chat tools (phase 3)
will dispatch into.

# How

- All three writers run through one `_mutateData` helper that
  deep-clones `entry.data`, hands the clone to a callback for in-
  place mutation, runs `_assertSchemaShape` against the result, and
  then persists via tmp+rename. On any error before rename, the
  on-disk file and `entry.data` are both untouched.
- Path / shape failures bubble up with their typed `code` fields
  intact (`BAD_PATH`, `NO_MATCH`, `AMBIGUOUS`, `WRONG_TYPE`) so the
  eventual chat-tool dispatcher can return structured failure
  payloads to the LLM without re-mapping.
- The `meta.writeable.fromWebapp` gate stays in the chat layer (same
  posture as `write_manifest_data` today). Internal callers don't
  hit a gate; chat callers wrap.

# Testing

- [x] `npm test` passes locally — 1180/1180 (3 pre-existing skips,
  unrelated). Was 1149; +31 new tests = +6 path grammar +
  25 row functions.
- [ ] `npm run test:e2e` not run: no UI surface in this PR.
- [x] New regression tests:
  - `tests/manifest-path.test.js` (extended): 6 new cases for the
    leading-bracket grammar form.
  - `tests/registry-rows.test.js` (new): 25 cases covering every
    error code, atomicity (mid-mutation throw leaves disk + cache
    unchanged), `null` removes key (RFC 7396), and both object-shaped
    (peptides `items[]`) and array-shaped (mood log) data blocks.
- [x] Manual QA: not applicable — no runtime path exercises this code
  yet (phase 3 wires it).

# Checklist

- [x] Conventional-commit subject
- [x] `CHANGELOG.md` updated under `## Unreleased / Internal`
- [x] Docs: not updated. Path grammar will surface in tool
  descriptions in phase 3, not in `MANIFEST-SCHEMA.md`.
- [x] No personal identifiers
- [x] No secrets

# Breaking changes

None. Pure addition + a behaviour-preserving cleanup.

Refs #363, Closes #366.