### PR TITLE
Phase 3: row-level chat tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Added
+
+- **Row-level chat tools.** The chat agent gains five new tools that
+  operate on a single row at a time instead of round-tripping the
+  whole `data` block: `read_manifest_meta` (meta + description +
+  schema only, no rows), `read_manifest_rows` (addressable slice of
+  the data block, auto-truncates long arrays to 10 with
+  `{truncated, total}` and collapses long sub-arrays to
+  `{omittedArray, count}`; `order: "desc"` for the latest entries),
+  `append_row`, `update_row`, `remove_row`. All three writers respect
+  the existing `meta.writeable.fromWebapp` gate and surface typed
+  failure codes (`BAD_PATH`, `NO_MATCH`, `AMBIGUOUS`, `WRONG_TYPE`)
+  so the model can self-correct without a wholesale retry. The path
+  language is documented inline in each tool's description: tiny
+  equality-only grammar, `seg.seg[k=v]` with `[index=N]` and a
+  leading `[k=v]` for array-rooted cards. Existing `read_manifest`
+  and `write_manifest_data` stay as fallbacks for non-array shapes
+  and wholesale restructures. Closes the long-running cause of chat
+  gateway timeouts on edits to large schedule cards: a row append
+  that previously rewrote ~67 kB of JSON now round-trips a single
+  dose. Closes #363.
+
 ### Internal
 
 - **Manifest path parser + resolver.** New pure module

--- a/chat/tools.js
+++ b/chat/tools.js
@@ -191,6 +191,104 @@ const TOOL_DEFS = [
       },
     },
   },
+  {
+    type: 'function',
+    function: {
+      name: 'read_manifest_meta',
+      description:
+        "Return ONLY a card's meta + description + schema, NOT its data block. Cheap (~2 kB) even for cards with thousands of rows. Call this before any write to confirm the card's writeable rules and shape; it has the same role read_manifest used to play, minus the row-bulk that bloats your context. If you actually need to inspect rows, follow up with read_manifest_rows.",
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'Manifest id.' },
+        },
+        required: ['id'],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'read_manifest_rows',
+      description:
+        "Return a slice of a card's data block, addressed by a tiny path language. Use INSTEAD of read_manifest when a card has lots of rows (peptides, mood logs, anything that grew over time). Path grammar (equality-only): `seg.seg[k=v]`, where `seg` is a property name (letters, digits, _, -) and `[k=v]` filters an array element by exact equality. Numeric literals are bare (1, 1.5, -3); strings are quoted (\"BPC-157\" or 'BPC-157'); true/false bare. Special filter `[index=N]` picks the Nth element of an array. A leading `[k=v]` (no property) filters an array-typed root. Empty path returns the whole data block. Examples: `items` (top-level array), `items[name=\"BPC-157\"]` (one item), `items[name=\"BPC-157\"].doses` (its doses), `[date=\"2026-05-04\"]` (one row of an array-rooted card), `[index=2].notes` (notes prop of the 3rd row). IMPORTANT auto-truncation: if the resolved value is an array longer than 10, only the first 10 rows are returned with {truncated:true, total:N}; if it's an object whose properties contain arrays longer than 10, those arrays are replaced with {omittedArray:true, count:N}. The response payload is therefore NOT the full data; re-fetch by a deeper path if you need the omitted rows. Pass {order:'desc'} to flip the truncation window to the LAST 10 rows (use this for `last dose` / `latest entry` questions). Errors return {error, code} with code in {BAD_PATH, NO_MATCH, AMBIGUOUS, WRONG_TYPE} so you can self-correct: BAD_PATH = grammar error, NO_MATCH = path resolves to nothing, AMBIGUOUS = filter matches >1 row (narrow the filter), WRONG_TYPE = wrong shape at the resolved spot.",
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'Manifest id.' },
+          path: {
+            type: 'string',
+            description: "Path expression in the grammar above. Empty string returns the whole data block (use sparingly; prefer a more targeted path).",
+          },
+          order: {
+            type: 'string',
+            enum: ['asc', 'desc'],
+            description: "When the resolved value is an array longer than 10, controls which window is returned. 'asc' (default) returns the first 10 in their on-disk order; 'desc' returns the last 10 (i.e. the most recent rows for an append-only log). Has no effect when the array is <=10 rows.",
+          },
+        },
+        required: ['id', 'path'],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'append_row',
+      description:
+        "Append one row to the array at `path` inside a card's data block. Path resolves the SAME way read_manifest_rows resolves; see that tool's description for the full grammar. The target must be an array; appending a peptide goes to `items`, appending a dose goes to `items[name=\"BPC-157\"].doses`, appending to an array-rooted card uses `''` (empty path). Rejected if meta.writeable.fromWebapp is not true. Errors return {error, code} with the same codes as read_manifest_rows. ALWAYS call read_manifest_meta or read_manifest_rows first to confirm the card's existing shape and writeable rules; appending into a path that doesn't exist returns NO_MATCH (no auto-create; create the parent row first if needed).",
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'Manifest id.' },
+          path: { type: 'string', description: 'Path to the array to append to. May be empty for an array-rooted card.' },
+          value: { description: 'The row to append. Shape matches the existing rows in that array.' },
+        },
+        required: ['id', 'path', 'value'],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'update_row',
+      description:
+        "Apply RFC 7396 JSON Merge Patch to ONE row identified by `path`. Nested objects deep-merge; arrays in `changes` replace wholesale; null removes a key. Path resolves the SAME way read_manifest_rows resolves. The target must be a plain object. The path MUST resolve unambiguously: if the filter matches more than one row, you get AMBIGUOUS; narrow the filter (add a second key, use [index=N], etc.). Rejected if meta.writeable.fromWebapp is not true. Errors return {error, code}. Confirm with the user EXACTLY ONCE before any update that removes data (passing `null` for an existing key, or replacing an array with a shorter one).",
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'Manifest id.' },
+          path: { type: 'string', description: 'Path to a single row (must resolve to one plain object, not the root).' },
+          changes: {
+            type: 'object',
+            description: 'RFC 7396 patch. Only the keys you want to change. null removes a key.',
+            additionalProperties: true,
+          },
+        },
+        required: ['id', 'path', 'changes'],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'remove_row',
+      description:
+        "Remove ONE row from its parent array, identified by `path`. Path resolves the SAME way read_manifest_rows resolves. The path's leaf must be an array element (a filtered segment, e.g. `items[name=\"X\"]` or `items[name=\"X\"].doses[scheduledDate=\"YYYY-MM-DD\"]`); you cannot remove a property of an object with this tool, and you cannot remove the root data value (use write_manifest_data for those). The path MUST resolve unambiguously. Rejected if meta.writeable.fromWebapp is not true. Errors return {error, code}. Confirm with the user EXACTLY ONCE before calling: removal is destructive and not undoable.",
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'Manifest id.' },
+          path: { type: 'string', description: "Path to a single row (leaf must be a filtered array element, e.g. items[name=\"X\"])." },
+        },
+        required: ['id', 'path'],
+        additionalProperties: false,
+      },
+    },
+  },
 ];
 
 // Execute a single tool_call from an assistant response. Always returns a
@@ -268,6 +366,59 @@ function dispatchToolCall(tc, ctx) {
         recordTouch(ctx, { id: args.id, flow: 'edit' });
         return JSON.stringify({ ok: true, ...result });
       }
+      case 'read_manifest_meta': {
+        const entry = registry.get(args.id);
+        if (!entry) {
+          return JSON.stringify({ error: `unknown manifest: ${args.id}` });
+        }
+        return JSON.stringify({
+          meta: entry.meta,
+          description: entry.description || null,
+          schema: entry.schema || null,
+        });
+      }
+      case 'read_manifest_rows': {
+        try {
+          const r = registry.readRows(args.id, args.path || '');
+          const order = args.order === 'desc' ? 'desc' : 'asc';
+          return JSON.stringify(_summariseReadResult(r.value, order));
+        } catch (e) {
+          return _toolErrorPayload(e, args);
+        }
+      }
+      case 'append_row': {
+        const gateErr = _writeableGate(args.id);
+        if (gateErr) return gateErr;
+        try {
+          const out = registry.appendRow(args.id, args.path || '', args.value);
+          recordTouch(ctx, { id: args.id, flow: 'edit' });
+          return JSON.stringify({ ok: true, id: args.id, ...out });
+        } catch (e) {
+          return _toolErrorPayload(e, args);
+        }
+      }
+      case 'update_row': {
+        const gateErr = _writeableGate(args.id);
+        if (gateErr) return gateErr;
+        try {
+          const out = registry.updateRow(args.id, args.path || '', args.changes);
+          recordTouch(ctx, { id: args.id, flow: 'edit' });
+          return JSON.stringify({ ok: true, id: args.id, after: out.after });
+        } catch (e) {
+          return _toolErrorPayload(e, args);
+        }
+      }
+      case 'remove_row': {
+        const gateErr = _writeableGate(args.id);
+        if (gateErr) return gateErr;
+        try {
+          const out = registry.removeRow(args.id, args.path || '');
+          recordTouch(ctx, { id: args.id, flow: 'edit' });
+          return JSON.stringify({ ok: true, id: args.id, removed: out.removed, totalAfter: out.totalAfter });
+        } catch (e) {
+          return _toolErrorPayload(e, args);
+        }
+      }
       case 'read_doc': {
         return JSON.stringify(readDoc(args.path));
       }
@@ -280,6 +431,63 @@ function dispatchToolCall(tc, ctx) {
   } catch (e) {
     return JSON.stringify({ error: e.message || String(e) });
   }
+}
+
+const SUMMARY_LIMIT = 10;
+
+// Shape the read_manifest_rows return so the model never receives an
+// unbounded array. Two passes:
+//   - if value is an array longer than SUMMARY_LIMIT, slice to a window
+//     (head for 'asc', tail for 'desc') and emit {rows, total, truncated, window}.
+//   - if value is a plain object, walk one level into its props; any
+//     array property longer than SUMMARY_LIMIT collapses to
+//     {omittedArray:true, count:N}. Shorter arrays and non-array props
+//     are returned as-is.
+//   - primitives and short arrays return as-is.
+function _summariseReadResult(value, order) {
+  if (Array.isArray(value)) {
+    if (value.length <= SUMMARY_LIMIT) {
+      return { rows: value, total: value.length, truncated: false };
+    }
+    const rows = order === 'desc'
+      ? value.slice(-SUMMARY_LIMIT)
+      : value.slice(0, SUMMARY_LIMIT);
+    return { rows, total: value.length, truncated: true, window: order };
+  }
+  if (value !== null && typeof value === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(value)) {
+      if (Array.isArray(v) && v.length > SUMMARY_LIMIT) {
+        out[k] = { omittedArray: true, count: v.length };
+      } else {
+        out[k] = v;
+      }
+    }
+    return { row: out };
+  }
+  return { value };
+}
+
+function _writeableGate(id) {
+  const entry = registry.get(id);
+  if (!entry) {
+    return JSON.stringify({ error: `unknown manifest: ${id}` });
+  }
+  const w = entry.meta?.writeable;
+  if (!w || !w.fromWebapp) {
+    return JSON.stringify({
+      error: `${id} is not writeable from the webapp (meta.writeable.fromWebapp is not true). Use patch_manifest to flip the flag first if the user wants to make it writeable.`,
+    });
+  }
+  return null;
+}
+
+function _toolErrorPayload(e, args) {
+  const payload = { error: e.message || String(e) };
+  if (e && typeof e.code === 'string') payload.code = e.code;
+  if (args && typeof args.path === 'string') payload.path = args.path;
+  if (args && typeof args.id === 'string') payload.id = args.id;
+  return JSON.stringify(payload);
 }
 
 // Record a manifest-touch for post-turn consumers. If the same id is

--- a/config/env.js
+++ b/config/env.js
@@ -185,8 +185,13 @@ You, ${CHAT_AGENT_NAME}, are embedded in the dashboard itself. You act by callin
 - \`hide_card(id)\` → sets master \`meta.enabled:false\`. Hides the card from every view but keeps the file + data intact. This is the right tool for "stop showing me the hydration card", "hide this for now", etc. No confirmation needed — it's reversible with \`show_card\`.
 - \`show_card(id)\` → sets master \`meta.enabled:true\`. Reverses \`hide_card\`.
 - \`list_manifests()\` → compact card list (id, label, description, enabled). Useful to re-check state or to look up an id.
-- \`read_manifest(id)\` → full card content: meta + description + schema + data. No confirmation. Use before any write so you can see what you're changing and preserve everything else.
-- \`write_manifest_data(id, data)\` → replace the full data block of a card. Full-array rewrite, not a row-level patch — to add/edit/delete one row you first read_manifest, mutate the array in memory, then write it back. Rejected if \`meta.writeable.fromWebapp\` is not \`true\` (ingest-only cards are untouchable; use \`patch_manifest\` to flip the flag first if the user really wants to make the card writeable). Confirm with the user EXACTLY ONCE before a write that removes rows.
+- \`read_manifest_meta(id)\` → ONLY meta + description + schema, NOT data. Cheap (~2 kB) even for cards with thousands of rows. This is the right "what shape is this card" call before any write. Replaces \`read_manifest\` for the common pre-write inspection.
+- \`read_manifest_rows(id, path, opts?)\` → addressable read of a slice of a card's data. Path grammar: \`seg.seg[k=v]\`, \`[index=N]\` for direct array indexing, leading \`[k=v]\` for an array-rooted card, empty path for the whole data block. Long arrays auto-truncate to 10 rows with \`{truncated, total}\`; pass \`{order:"desc"}\` for the most recent 10. Long sub-arrays inside an object are replaced with \`{omittedArray, count}\`. Re-fetch by a deeper path to drill in. Errors return \`{error, code}\` with code in \`{BAD_PATH, NO_MATCH, AMBIGUOUS, WRONG_TYPE}\`.
+- \`append_row(id, path, value)\` → push one row onto an array. Same path grammar. Rejected if \`meta.writeable.fromWebapp\` is not true.
+- \`update_row(id, path, changes)\` → RFC 7396 Merge Patch on ONE row. Path must resolve unambiguously to a plain object. Same writeable gate.
+- \`remove_row(id, path)\` → splice out ONE row from its parent array. Path's leaf must be a filtered array element. Same writeable gate. Confirm with the user ONCE before calling.
+- \`read_manifest(id)\` → FALLBACK: full card content including the entire data block. Only use when you genuinely need the whole data array (rare; usually a sign you should have used \`read_manifest_rows\` with a deeper path). For cards with hundreds of rows this is expensive on both ends and slow.
+- \`write_manifest_data(id, data)\` → FALLBACK: replace the full data block. Use only for non-array data shapes (markdown blob, single object) or when the change really is a wholesale restructure. For row-level changes prefer \`append_row\` / \`update_row\` / \`remove_row\`; they don't round-trip the whole file. Rejected if \`meta.writeable.fromWebapp\` is not true. Confirm with the user EXACTLY ONCE before a write that removes rows.
 - \`patch_manifest(id, patch)\` → edit meta or description without touching data. RFC 7396 JSON Merge Patch: nested objects deep-merge, ARRAYS REPLACE, \`null\` removes a key. Use for thresholds, labels, emoji maps, input types, writeable flags. Cannot change \`$schema\` or \`meta.id\`. Confirm ONCE before destructive-feeling patches (removing inputs from a writeable card, flipping \`writeable.fromWebapp\` from \`true\` to \`false\` on a card that has data).
 - \`read_doc(path)\` → fetch the full text of a Klebb doc shipped with this app. The "## Available docs" section below lists every callable path with a one-line summary. Reach for this whenever the user asks about schema, renderer contracts, deploy steps, ingest formats, or any other topic where the docs are authoritative — you'll get the same version the running app shipped with, so you won't be misled by training-data drift.
 
@@ -196,15 +201,20 @@ Choose the smallest-blast-radius tool for the job:
 
 | User intent | Tool |
 |-------------|------|
-| "What's my BP threshold?" / "What did I log yesterday?" | \`read_manifest\` |
-| Add / edit / remove a row in a card's data | \`read_manifest\` → mutate in memory → \`write_manifest_data\` |
-| Change a threshold, label, emoji map, input type, writeable flag | \`read_manifest\` → \`patch_manifest\` |
+| "What's my BP threshold?" / "What did I log yesterday?" | \`read_manifest_meta\` then \`read_manifest_rows\` |
+| Add ONE row to a card's data | \`read_manifest_meta\` → \`append_row\` |
+| Edit ONE existing row | \`read_manifest_rows\` (find it) → \`update_row\` |
+| Remove ONE row | \`read_manifest_rows\` (confirm it's the right one) → \`remove_row\` |
+| Wholesale data restructure / non-array data shape | \`read_manifest\` → mutate → \`write_manifest_data\` |
+| Change a threshold, label, emoji map, input type, writeable flag | \`read_manifest_meta\` → \`patch_manifest\` |
 | "Stop showing this card" / "show it again" | \`hide_card\` / \`show_card\` |
 | "I want a new tracker for X" | \`create_manifest\` |
 | "Throw this card away and start over" (explicit data loss OK) | \`delete_manifest\` then \`create_manifest\` |
 | "How does X work?" / "What fields does Y accept?" / questions about schema, renderers, deploy, ingest | \`read_doc\` |
 
-**Read before write.** Any call to \`write_manifest_data\` or \`patch_manifest\` MUST be preceded by \`read_manifest\` in the same turn. Never blind-write — you'll clobber fields you didn't mean to touch. Arrays in JSON Merge Patch replace wholesale, so if you \`patch_manifest(id, {meta:{writeable:{inputs:[…]}}})\` you must include every input you want to keep, not just the one you're changing.
+**Read before write.** Any call to \`write_manifest_data\`, \`append_row\`, \`update_row\`, \`remove_row\`, or \`patch_manifest\` MUST be preceded by either \`read_manifest_meta\` or \`read_manifest_rows\` in the same turn. Never blind-write: you'll clobber fields you didn't mean to touch or hit the wrong row. Arrays in JSON Merge Patch replace wholesale, so if you \`patch_manifest(id, {meta:{writeable:{inputs:[…]}}})\` you must include every input you want to keep, not just the one you're changing.
+
+**Prefer the row tools over write_manifest_data.** When the user's edit is "add a dose", "fix yesterday's mood entry", "delete this morning's BP reading", reach for \`append_row\` / \`update_row\` / \`remove_row\`; they only round-trip the row, not the whole card. \`write_manifest_data\` regenerates and re-uploads the entire data block, which on a card with hundreds of rows can be slow enough to time out the chat gateway.
 
 **Confirmation rules.** One-shot confirmation (same pattern as \`delete_manifest\`) is mandatory before:
 - \`delete_manifest\` (always).

--- a/tests/chat-tools-rows.test.js
+++ b/tests/chat-tools-rows.test.js
@@ -1,0 +1,443 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/chat-tools-rows.test.js
+// Direct-dispatch tests for the row-level chat tools: read_manifest_meta,
+// read_manifest_rows, append_row, update_row, remove_row. Bypasses the
+// chat agent loop; verifies the dispatch contract end-to-end.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const { createSandbox, cleanupSandbox } = require('./helpers/sandbox');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const MANIFESTS_DIR = path.resolve(REPO_ROOT, 'manifests') + path.sep;
+const CONFIG_DIR = path.resolve(REPO_ROOT, 'config') + path.sep;
+const CHAT_DIR = path.resolve(REPO_ROOT, 'chat') + path.sep;
+
+function freshTools(sandboxRoot) {
+  for (const key of Object.keys(require.cache)) {
+    if (key.startsWith(MANIFESTS_DIR) ||
+        key.startsWith(CONFIG_DIR) ||
+        key.startsWith(CHAT_DIR)) {
+      delete require.cache[key];
+    }
+  }
+  process.env.HEALTH_HOME = sandboxRoot;
+  const registry = require(path.join(REPO_ROOT, 'manifests', 'registry.js'));
+  registry.init();
+  const { TOOL_DEFS, dispatchToolCall } = require(path.join(REPO_ROOT, 'chat', 'tools.js'));
+  return { registry, TOOL_DEFS, dispatchToolCall };
+}
+
+function makeToolCall(name, args) {
+  return { function: { name, arguments: JSON.stringify(args) } };
+}
+
+function call(dispatchToolCall, name, args, ctx) {
+  return JSON.parse(dispatchToolCall(makeToolCall(name, args), ctx));
+}
+
+const PEPTIDES = {
+  $schema: 'klebb.datafile.v1',
+  meta: {
+    id: 'peptides',
+    label: 'Schedule',
+    emoji: '💉',
+    view: { enabled: true, component: 'schedule-card' },
+    writeable: { fromWebapp: true, inputs: [] },
+  },
+  description: 'Scheduled peptide doses.',
+  data: {
+    items: [
+      { name: 'BPC-157', doses: [
+        { scheduledDate: '2026-03-25' },
+        { scheduledDate: '2026-03-26' },
+        { scheduledDate: '2026-03-27' },
+        { scheduledDate: '2026-03-28' },
+        { scheduledDate: '2026-03-29' },
+        { scheduledDate: '2026-03-30' },
+        { scheduledDate: '2026-03-31' },
+        { scheduledDate: '2026-04-01' },
+        { scheduledDate: '2026-04-02' },
+        { scheduledDate: '2026-04-03' },
+        { scheduledDate: '2026-04-04' },
+        { scheduledDate: '2026-04-05' },
+      ]},
+      { name: 'TB-500', doses: [{ scheduledDate: '2026-03-27' }] },
+    ],
+    groups: [{ id: 'repair-stack', label: 'Repair Stack' }],
+  },
+};
+
+const INGEST_ONLY = {
+  $schema: 'klebb.datafile.v1',
+  meta: {
+    id: 'steps',
+    label: 'Steps',
+    view: { enabled: true, component: 'generic-card' },
+    writeable: { fromWebapp: false },
+  },
+  description: 'Ingest-only.',
+  data: [{ date: '2026-05-05', count: 7200 }],
+};
+
+describe('row tools: TOOL_DEFS exposure', () => {
+  test('all five new tool names are registered', () => {
+    const sandbox = createSandbox();
+    try {
+      const { TOOL_DEFS } = freshTools(sandbox);
+      const names = TOOL_DEFS.map(t => t.function.name);
+      for (const want of ['read_manifest_meta', 'read_manifest_rows', 'append_row', 'update_row', 'remove_row']) {
+        assert.ok(names.includes(want), `${want} missing from TOOL_DEFS`);
+      }
+    } finally { cleanupSandbox(sandbox); }
+  });
+});
+
+describe('read_manifest_meta', () => {
+  test('returns meta + description + schema, NOT data', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = call(dispatchToolCall, 'read_manifest_meta', { id: 'peptides' });
+      assert.equal(res.meta.id, 'peptides');
+      assert.equal(res.description, 'Scheduled peptide doses.');
+      assert.equal('data' in res, false, 'data must NOT be returned');
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('unknown id returns {error}', () => {
+    const sandbox = createSandbox();
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = call(dispatchToolCall, 'read_manifest_meta', { id: 'ghost' });
+      assert.match(res.error, /unknown manifest/);
+    } finally { cleanupSandbox(sandbox); }
+  });
+});
+
+describe('read_manifest_rows: auto-summarisation', () => {
+  test('long array auto-truncates to 10 with {truncated, total}', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = call(dispatchToolCall, 'read_manifest_rows', {
+        id: 'peptides',
+        path: 'items[name="BPC-157"].doses',
+      });
+      assert.equal(res.truncated, true);
+      assert.equal(res.total, 12);
+      assert.equal(res.rows.length, 10);
+      assert.equal(res.window, 'asc');
+      assert.equal(res.rows[0].scheduledDate, '2026-03-25');
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('short array returns all rows, untruncated', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = call(dispatchToolCall, 'read_manifest_rows', {
+        id: 'peptides',
+        path: 'items[name="TB-500"].doses',
+      });
+      assert.equal(res.truncated, false);
+      assert.equal(res.total, 1);
+      assert.equal(res.rows.length, 1);
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('order=desc returns the LAST 10 rows', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = call(dispatchToolCall, 'read_manifest_rows', {
+        id: 'peptides',
+        path: 'items[name="BPC-157"].doses',
+        order: 'desc',
+      });
+      assert.equal(res.window, 'desc');
+      assert.equal(res.rows[0].scheduledDate, '2026-03-27');
+      assert.equal(res.rows[9].scheduledDate, '2026-04-05');
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('object resolution collapses long sub-arrays to {omittedArray, count}', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = call(dispatchToolCall, 'read_manifest_rows', {
+        id: 'peptides',
+        path: 'items[name="BPC-157"]',
+      });
+      assert.equal(res.row.name, 'BPC-157');
+      assert.deepEqual(res.row.doses, { omittedArray: true, count: 12 });
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('object resolution keeps short sub-arrays inline', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = call(dispatchToolCall, 'read_manifest_rows', {
+        id: 'peptides',
+        path: 'items[name="TB-500"]',
+      });
+      assert.equal(res.row.name, 'TB-500');
+      assert.deepEqual(res.row.doses, [{ scheduledDate: '2026-03-27' }]);
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('top-level data block: groups inline (length 1), items inline (length 2 < 10) but each item still expands', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = call(dispatchToolCall, 'read_manifest_rows', { id: 'peptides', path: '' });
+      // root is an object: rows -> {row: {items: [...], groups: [...]}}
+      // items is short (length 2) so it's inlined at the top level; per-item
+      // doses[] are NOT collapsed at this level (only top-level walk).
+      assert.ok(Array.isArray(res.row.items));
+      assert.equal(res.row.items.length, 2);
+    } finally { cleanupSandbox(sandbox); }
+  });
+});
+
+describe('read_manifest_rows: errors', () => {
+  test('BAD_PATH bubbles with code', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = call(dispatchToolCall, 'read_manifest_rows', { id: 'peptides', path: 'items[bad' });
+      assert.equal(res.code, 'BAD_PATH');
+      assert.ok(res.error);
+      assert.equal(res.path, 'items[bad');
+      assert.equal(res.id, 'peptides');
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('NO_MATCH bubbles with code', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = call(dispatchToolCall, 'read_manifest_rows', { id: 'peptides', path: 'items[name="NOPE"]' });
+      assert.equal(res.code, 'NO_MATCH');
+    } finally { cleanupSandbox(sandbox); }
+  });
+});
+
+describe('append_row: dispatch', () => {
+  test('appends a dose; persists to disk; recordTouch fires for embellishment', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const ctx = { touches: [] };
+      const res = JSON.parse(dispatchToolCall(makeToolCall('append_row', {
+        id: 'peptides',
+        path: 'items[name="TB-500"].doses',
+        value: { scheduledDate: '2026-03-28', takenAt: '2026-03-28T08:00:00Z' },
+      }), ctx));
+      assert.equal(res.ok, true);
+      assert.equal(res.totalAfter, 2);
+
+      const onDisk = JSON.parse(fs.readFileSync(path.join(sandbox, 'data', 'peptides.json'), 'utf8'));
+      const tb = onDisk.data.items.find(x => x.name === 'TB-500');
+      assert.equal(tb.doses.length, 2);
+      assert.deepEqual(ctx.touches, [{ id: 'peptides', flow: 'edit' }]);
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('appends a brand-new top-level item', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = call(dispatchToolCall, 'append_row', {
+        id: 'peptides',
+        path: 'items',
+        value: { name: 'Klow Stack', doses: [] },
+      });
+      assert.equal(res.ok, true);
+      const onDisk = JSON.parse(fs.readFileSync(path.join(sandbox, 'data', 'peptides.json'), 'utf8'));
+      assert.equal(onDisk.data.items.length, 3);
+      assert.equal(onDisk.data.items[2].name, 'Klow Stack');
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('writeable gate: ingest-only card rejected with explanatory error', () => {
+    const sandbox = createSandbox({ seed: { 'steps.json': INGEST_ONLY } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = call(dispatchToolCall, 'append_row', {
+        id: 'steps',
+        path: '',
+        value: { date: '2026-05-06', count: 9000 },
+      });
+      assert.match(res.error, /not writeable from the webapp/);
+      const onDisk = JSON.parse(fs.readFileSync(path.join(sandbox, 'data', 'steps.json'), 'utf8'));
+      assert.equal(onDisk.data.length, 1, 'on-disk untouched');
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('unknown manifest returns {error}', () => {
+    const sandbox = createSandbox();
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = call(dispatchToolCall, 'append_row', { id: 'ghost', path: '', value: 1 });
+      assert.match(res.error, /unknown manifest/);
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('WRONG_TYPE bubbles with code', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = call(dispatchToolCall, 'append_row', {
+        id: 'peptides',
+        path: 'items[name="BPC-157"].name',
+        value: 'X',
+      });
+      assert.equal(res.code, 'WRONG_TYPE');
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('NO_MATCH bubbles with code; on-disk untouched', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const before = fs.readFileSync(path.join(sandbox, 'data', 'peptides.json'), 'utf8');
+      const res = call(dispatchToolCall, 'append_row', {
+        id: 'peptides',
+        path: 'items[name="DOES_NOT_EXIST"].doses',
+        value: {},
+      });
+      assert.equal(res.code, 'NO_MATCH');
+      const after = fs.readFileSync(path.join(sandbox, 'data', 'peptides.json'), 'utf8');
+      assert.equal(before, after);
+    } finally { cleanupSandbox(sandbox); }
+  });
+});
+
+describe('update_row: dispatch', () => {
+  test('merge-patches a row; persists; recordTouch fires', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const ctx = { touches: [] };
+      const res = JSON.parse(dispatchToolCall(makeToolCall('update_row', {
+        id: 'peptides',
+        path: 'items[name="BPC-157"].doses[scheduledDate="2026-03-25"]',
+        changes: { takenAt: '2026-03-25T03:25:00Z', site: 'belly' },
+      }), ctx));
+      assert.equal(res.ok, true);
+      assert.equal(res.after.takenAt, '2026-03-25T03:25:00Z');
+      assert.equal(res.after.site, 'belly');
+      assert.equal(res.after.scheduledDate, '2026-03-25');
+      assert.deepEqual(ctx.touches, [{ id: 'peptides', flow: 'edit' }]);
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('writeable gate enforced', () => {
+    const sandbox = createSandbox({ seed: { 'steps.json': INGEST_ONLY } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = call(dispatchToolCall, 'update_row', {
+        id: 'steps',
+        path: '[date="2026-05-05"]',
+        changes: { count: 9999 },
+      });
+      assert.match(res.error, /not writeable/);
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('AMBIGUOUS surfaces with code', () => {
+    const dup = {
+      $schema: 'klebb.datafile.v1',
+      meta: { id: 'tags', label: 'T', writeable: { fromWebapp: true, inputs: [] } },
+      data: { rows: [{ tag: 'a', n: 1 }, { tag: 'a', n: 2 }] },
+    };
+    const sandbox = createSandbox({ seed: { 'tags.json': dup } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = call(dispatchToolCall, 'update_row', {
+        id: 'tags',
+        path: 'rows[tag="a"]',
+        changes: { flagged: true },
+      });
+      assert.equal(res.code, 'AMBIGUOUS');
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('rejects non-object changes with WRONG_TYPE', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = call(dispatchToolCall, 'update_row', {
+        id: 'peptides',
+        path: 'items[name="BPC-157"]',
+        changes: null,
+      });
+      assert.equal(res.code, 'WRONG_TYPE');
+    } finally { cleanupSandbox(sandbox); }
+  });
+});
+
+describe('remove_row: dispatch', () => {
+  test('removes a dose by content-addressed path', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const ctx = { touches: [] };
+      const res = JSON.parse(dispatchToolCall(makeToolCall('remove_row', {
+        id: 'peptides',
+        path: 'items[name="BPC-157"].doses[scheduledDate="2026-03-25"]',
+      }), ctx));
+      assert.equal(res.ok, true);
+      assert.equal(res.removed.scheduledDate, '2026-03-25');
+      assert.equal(res.totalAfter, 11);
+      assert.deepEqual(ctx.touches, [{ id: 'peptides', flow: 'edit' }]);
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('writeable gate enforced', () => {
+    const sandbox = createSandbox({ seed: { 'steps.json': INGEST_ONLY } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = call(dispatchToolCall, 'remove_row', {
+        id: 'steps',
+        path: '[date="2026-05-05"]',
+      });
+      assert.match(res.error, /not writeable/);
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('cannot remove a non-array element', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = call(dispatchToolCall, 'remove_row', { id: 'peptides', path: 'items' });
+      assert.equal(res.code, 'WRONG_TYPE');
+    } finally { cleanupSandbox(sandbox); }
+  });
+
+  test('cannot remove the root', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const res = call(dispatchToolCall, 'remove_row', { id: 'peptides', path: '' });
+      assert.equal(res.code, 'WRONG_TYPE');
+    } finally { cleanupSandbox(sandbox); }
+  });
+});
+
+describe('row tools: invalid JSON arguments are caught at the outer parse', () => {
+  test('malformed args return {error}', () => {
+    const sandbox = createSandbox({ seed: { 'peptides.json': PEPTIDES } });
+    try {
+      const { dispatchToolCall } = freshTools(sandbox);
+      const tc = { function: { name: 'append_row', arguments: '{not json' } };
+      const res = JSON.parse(dispatchToolCall(tc));
+      assert.match(res.error, /invalid JSON in tool arguments/);
+    } finally { cleanupSandbox(sandbox); }
+  });
+});


### PR DESCRIPTION
# What changed

Five new tools on the chat agent's `TOOL_DEFS`, each documented
inline with the equality-only path grammar so the model sees it on
every request:

- `read_manifest_meta(id)` — meta + description + schema only.
- `read_manifest_rows(id, path, opts?)` — addressable slice. Long
  arrays auto-truncate to 10 rows with `{truncated, total, window}`;
  `opts.order='desc'` flips the window to the LAST 10 (for "latest
  entry" queries). Long sub-arrays inside an object collapse to
  `{omittedArray, count}`. Tool description spells out that the
  payload is NOT the full data and tells the model to re-fetch by a
  deeper path if it needs the omitted rows.
- `append_row` / `update_row` / `remove_row` — one row at a time.

All three writers enforce `meta.writeable.fromWebapp` before
touching anything. Errors return structured `{error, code, path?,
id?}` payloads with code in `{BAD_PATH, NO_MATCH, AMBIGUOUS,
WRONG_TYPE}` so the model can self-correct without a wholesale
retry.

System prompt updated: row tools added to the bullet list, the
"when to use which write tool" table now points at the row tools
for one-row edits, and a new "prefer row tools over
write_manifest_data" paragraph spells out why (gateway timeouts on
large cards).

# Why

Closes #363. The chat gateway 180 s ceiling has been firing on
large-card edits because `write_manifest_data` round-trips the
entire data block. The peptides card (~67 kB) regularly times out
on what is logically a one-row append. With `append_row`, the same
edit round-trips a single dose object instead of 67 kB.

`read_manifest` was the symmetric problem on the read side: a model
that just wants to know "what items exist" should not have to read
all 294 dose entries. `read_manifest_rows` with auto-summarisation
keeps the response small even when the underlying data isn't.

# How

- Tool descriptions are deliberately verbose. The path grammar lives
  in the description so it's loaded into the model's context every
  request; no inference from training data drift.
- Auto-summarisation is a chat-tool concern (it's about what we
  return to the LLM), not a registry concern. The registry's
  `readRows` is a thin pass-through; the dispatcher applies the
  summarisation pass.
- Existing `read_manifest` and `write_manifest_data` stay as
  fallbacks. No removal: the prompt copy is the only nudge.
- Failure mode shape is `{error, code, path?, id?}`. The `path`
  echo is deliberate: it gives the model exactly enough context to
  fix a typo without re-asking for the card's structure.

# Testing

- [x] `npm test` passes locally — 1206/1206 (3 pre-existing skips,
  unrelated). +26 from this PR.
- [ ] `npm run test:e2e` not run: this surface is exercised through
  the chat widget against a live LLM gateway, not through the
  Playwright suite.
- [x] New regression tests at `tests/chat-tools-rows.test.js` cover:
  - All 5 tools registered in `TOOL_DEFS`.
  - `read_manifest_meta`: returns meta + description + schema, NOT
    data; unknown id yields `{error}`.
  - `read_manifest_rows` summarisation: long arrays truncate to 10
    in both 'asc' and 'desc' windows; short arrays return inline;
    long sub-arrays collapse to `{omittedArray, count}`; short ones
    inline.
  - `read_manifest_rows` errors: `BAD_PATH` and `NO_MATCH` bubble
    with `code` and echo `path` + `id`.
  - `append_row`: persists to disk, fires `recordTouch` for
    embellishment chips, enforces the writeable gate, surfaces
    `WRONG_TYPE` and `NO_MATCH` correctly, leaves on-disk file
    untouched on failure.
  - `update_row`: merge-patches a row, fires `recordTouch`,
    surfaces `AMBIGUOUS` for non-unique paths, rejects non-object
    `changes` with `WRONG_TYPE`, enforces gate.
  - `remove_row`: removes by content-addressed path, fires
    `recordTouch`, rejects non-array elements + root, enforces gate.
  - Outer try/catch: malformed JSON in `arguments` yields
    `{error: 'invalid JSON in tool arguments...'}`.
- [x] Manual QA: not yet exercised against a live gateway (this is
  what the operator will test post-merge against `klebbtest`).
  Will validate by re-running the original "add Klow Stack to
  peptides" prompt that timed out twice on `eddzklebb` previously.

# Checklist

- [x] Conventional-commit subject
- [x] `CHANGELOG.md` updated under `## Unreleased / Added` (this is
  user-visible: the chat agent gains five new tools)
- [x] Docs: tool grammar lives in tool descriptions (loaded into
  the system prompt every request), so no `MANIFEST-SCHEMA.md`
  update needed. The path grammar is a chat-tool concept, not a
  manifest schema concept.
- [x] No personal identifiers
- [x] No secrets

# Breaking changes

None. Pure addition. `read_manifest` and `write_manifest_data` keep
their existing semantics; the prompt simply nudges the model to
prefer the new tools when applicable.

Refs #363, Closes #368.