### PR TITLE
feat(schedule-card): render check-off form actions at top and bottom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
   that previously rewrote ~67 kB of JSON now round-trips a single
   dose. Closes #363.
 
+### Changed
+
+- **Schedule-card check-off form: actions render at top and bottom.**
+  Tapping a scheduled item's ✓ now shows Cancel / Log dose bars both
+  above and below the inputs, so the common "tick a dose without
+  logging the site" path is two thumb-adjacent taps with no scrolling
+  past the chip rows. The bottom bar stays for users who do fill the
+  fields. Driven by a new `actions-position` prop on `eh-input-form`
+  (`bottom` (default) / `top` / `both`); other cards using the form
+  are unchanged. Closes #370.
+
 ### Internal
 
 - **Manifest path parser + resolver.** New pure module

--- a/public/js/components/eh-input-form.js
+++ b/public/js/components/eh-input-form.js
@@ -40,6 +40,11 @@
 // heading rendered immediately after the divider, labelling the
 // section that begins on the divider's far side. Used by schedule-
 // card to anchor the new-dose section (e.g. "This injection").
+//
+// actions-position (optional): "bottom" (default), "top", or "both".
+// Schedule-card's check-off form sets this to "both" so the user can
+// confirm with a second tap right under their thumb without scrolling
+// past chip rows when they're skipping the metadata fields. See #370.
 
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
 
@@ -75,6 +80,13 @@ export class EhInputForm extends LitElement {
     dividerLabel: { type: String, attribute: 'divider-label' },
     submitLabel: { type: String, attribute: 'submit-label' },
     cancelLabel: { type: String, attribute: 'cancel-label' },
+    // Where the Cancel / Submit bar renders. "bottom" (default) keeps
+    // the original layout; "top" moves it above the inputs; "both"
+    // renders identical bars at top and bottom. Schedule-card's
+    // check-off form uses "both" so the user can confirm with a
+    // second tap right under their thumb (no scroll past chip rows
+    // when they're not logging metadata) — see #370.
+    actionsPosition: { type: String, attribute: 'actions-position' },
     busy: { type: Boolean },
     _state: { state: true },
     _error: { state: true },
@@ -91,6 +103,7 @@ export class EhInputForm extends LitElement {
     this.dividerLabel = null;
     this.submitLabel = 'Save';
     this.cancelLabel = 'Cancel';
+    this.actionsPosition = 'bottom';
     this.busy = false;
     this._state = {};
     this._error = null;
@@ -629,6 +642,10 @@ export class EhInputForm extends LitElement {
       justify-content: flex-end;
       margin-top: 6px;
     }
+    .actions.actions-top {
+      margin-top: 0;
+      margin-bottom: 2px;
+    }
     .btn {
       padding: 7px 14px;
       border-radius: 6px;
@@ -684,12 +701,25 @@ export class EhInputForm extends LitElement {
     }
   `;
 
+  _renderActions(position) {
+    return html`
+      <div class="actions actions-${position}">
+        <button type="button" class="btn ghost" ?disabled=${this.busy} @click=${this._onCancel}>${this.cancelLabel}</button>
+        <button type="submit" class="btn primary" ?disabled=${this.busy || !this._isValid()}>${this.busy ? 'Saving…' : this.submitLabel}</button>
+      </div>
+    `;
+  }
+
   render() {
     if (!Array.isArray(this.inputs) || this.inputs.length === 0) {
       return html`<em>No inputs defined for this card.</em>`;
     }
+    const pos = this.actionsPosition;
+    const showTop = pos === 'top' || pos === 'both';
+    const showBottom = pos !== 'top';
     return html`
       <form @submit=${this._onSubmit}>
+        ${showTop ? this._renderActions('top') : ''}
         ${this.inputs.map(input => html`
           <div class="field ${input.type === 'checkbox' ? 'checkbox' : ''}">
             ${input.label ? html`<label for="in-${input.key}">${input.label}${input.required ? ' *' : ''}</label>` : ''}
@@ -703,10 +733,7 @@ export class EhInputForm extends LitElement {
             ` : ''}
         `)}
         ${this._error ? html`<div class="error">${this._error}</div>` : ''}
-        <div class="actions">
-          <button type="button" class="btn ghost" ?disabled=${this.busy} @click=${this._onCancel}>${this.cancelLabel}</button>
-          <button type="submit" class="btn primary" ?disabled=${this.busy || !this._isValid()}>${this.busy ? 'Saving…' : this.submitLabel}</button>
-        </div>
+        ${showBottom ? this._renderActions('bottom') : ''}
       </form>
     `;
   }

--- a/public/js/components/eh-schedule-card.js
+++ b/public/js/components/eh-schedule-card.js
@@ -687,6 +687,7 @@ export class EhScheduleCard extends EhBaseCard {
           .date=${this.date}
           submit-label=${opts.offSchedule ? 'Log off-schedule dose' : 'Log dose'}
           cancel-label="Cancel"
+          actions-position="both"
           divider-after-key=${dividerAfterKey}
           divider-label=${dividerLabel}
           @eh-submit=${onSubmit}

--- a/tests-e2e/schedule-card-checkoff-form.spec.js
+++ b/tests-e2e/schedule-card-checkoff-form.spec.js
@@ -141,7 +141,7 @@ test.describe('#345: schedule-card check-off form with per-dose metadata', () =>
     await chipRows.nth(3).locator('.chip', { hasText: 'upper' }).click();
 
     // Submit.
-    await innerForm.getByRole('button', { name: /log dose/i }).click();
+    await innerForm.getByRole('button', { name: /log dose/i }).first().click();
 
     // Form should collapse.
     await expect(form).toHaveCount(0);
@@ -191,7 +191,7 @@ test.describe('#345: schedule-card check-off form with per-dose metadata', () =>
 
     // Tap a chip then cancel.
     await form.locator('.chip', { hasText: 'bruised' }).click();
-    await form.getByRole('button', { name: /cancel/i }).click();
+    await form.getByRole('button', { name: /cancel/i }).first().click();
     await expect(form).toHaveCount(0);
 
     // Data file unchanged: still one dose, no reactions on it.
@@ -223,7 +223,7 @@ test.describe('#354: schedule-card surfaces logged per-dose metadata + edit on r
     await chipRows.nth(1).locator('.chip', { hasText: 'left' }).click();
     await chipRows.nth(2).locator('.chip', { hasText: 'thigh' }).click();
     await chipRows.nth(3).locator('.chip', { hasText: 'upper' }).click();
-    await innerForm.getByRole('button', { name: /log dose/i }).click();
+    await innerForm.getByRole('button', { name: /log dose/i }).first().click();
     await expect(form).toHaveCount(0);
 
     // The card should now show a summary line carrying the new-dose
@@ -254,7 +254,7 @@ test.describe('#354: schedule-card surfaces logged per-dose metadata + edit on r
     await chipRows.nth(1).locator('.chip', { hasText: 'left' }).click();
     await chipRows.nth(2).locator('.chip', { hasText: 'thigh' }).click();
     await chipRows.nth(3).locator('.chip', { hasText: 'upper' }).click();
-    await innerForm.getByRole('button', { name: /log dose/i }).click();
+    await innerForm.getByRole('button', { name: /log dose/i }).first().click();
     await expect(form).toHaveCount(0);
 
     // Re-tap the now-checked checkbox to UNTICK first (immediate save,
@@ -277,7 +277,7 @@ test.describe('#354: schedule-card surfaces logged per-dose metadata + edit on r
     // Edit: clear `left` (tap to deselect), pick `right` instead.
     await chipRows.nth(1).locator('.chip.selected', { hasText: 'left' }).click();
     await chipRows.nth(1).locator('.chip', { hasText: 'right' }).click();
-    await innerForm.getByRole('button', { name: /log dose/i }).click();
+    await innerForm.getByRole('button', { name: /log dose/i }).first().click();
 
     // The data file should reflect the edit, not stack a second dose.
     const res = await page.request.get(`${sandboxState.baseUrl}/api/manifests/${CARD_ID}/data`);
@@ -440,6 +440,47 @@ test.describe('#359: previous-dose section is visually separated from new-dose f
     expect(headingIdx).toBe(dividerIdx + 1);
     expect(cleaned[headingIdx]).toBe('heading:This dose');
     expect(sideIdx).toBe(headingIdx + 1);
+
+    await cleanup(page.request, sandboxState.baseUrl, CARD_ID);
+  });
+});
+
+test.describe('#370: check-off form actions render at top and bottom', () => {
+  test('both action bars render, and the top Log dose submits', async ({ page, sandboxState }) => {
+    const m = manifest();
+    await seed(page.request, sandboxState.baseUrl, m);
+
+    await page.goto('/');
+    const card = page.locator(`[data-card-id="${CARD_ID}"] eh-schedule-card`);
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    await card.locator('.checkbox').first().click();
+    const innerForm = card.locator('.checkoff-form eh-input-form');
+    await expect(innerForm).toBeVisible();
+
+    // Both action bars present in the shadow root, in DOM order
+    // top → inputs → bottom.
+    const positions = await innerForm.evaluate(root => {
+      const sr = root.shadowRoot;
+      if (!sr) return [];
+      return Array.from(sr.querySelectorAll('.actions')).map(el => {
+        if (el.classList.contains('actions-top')) return 'top';
+        if (el.classList.contains('actions-bottom')) return 'bottom';
+        return 'unknown';
+      });
+    });
+    expect(positions).toEqual(['top', 'bottom']);
+
+    // Submit by tapping the TOP Log dose button (no scrolling past chips).
+    await innerForm.getByRole('button', { name: /log dose/i }).first().click();
+    await expect(card.locator('.checkoff-form')).toHaveCount(0);
+
+    // Round-trip — today's dose should be on disk with takenAt set.
+    const res = await page.request.get(`${sandboxState.baseUrl}/api/manifests/${CARD_ID}/data`);
+    const body = await res.json();
+    const todays = body.data.items[0].doses.find(d => d.scheduledDate === todayISO());
+    expect(todays).toBeTruthy();
+    expect(todays.takenAt).toBeTruthy();
 
     await cleanup(page.request, sandboxState.baseUrl, CARD_ID);
   });


### PR DESCRIPTION
## Summary

When a scheduled item's tick opens the per-dose-metadata form (the injection-site / reactions UI from #345), Cancel and Log dose render above *and* below the inputs. Tapping the row tick and then immediately tapping Log dose at the top of the form is now zero-scroll, thumb-adjacent.

## Why

The common path is "tick a dose, don't bother recording the site this time" — and today that path makes the user scroll past several chip rows to reach the bottom action bar. The user wanted tap-and-tap-again. Top+bottom action bars give that without giving up the natural end-of-form Save position for users who do fill the fields.

I considered four options (full discussion in #370):

- **Top + bottom (this PR).** No scroll either way.
- Top only. Forces a scroll back up after filling fields.
- Sticky bottom. Layout-fragile inside a card-in-a-page tree.
- Tick-to-confirm on the row icon. Overloads the tick state, and chips render below the row anyway so the eye still has to drop down.

## How

- `public/js/components/eh-input-form.js`:
  - New `actions-position` prop: `"bottom"` (default) | `"top"` | `"both"`.
  - Extracted `_renderActions(position)` helper; render() emits the appropriate combination.
  - `.actions-top` gets a tighter top/bottom margin so it sits flush above the first field.
- `public/js/components/eh-schedule-card.js`:
  - The check-off form's `<eh-input-form>` sets `actions-position="both"`. One-line change.

Other consumers of `eh-input-form` (mood, journal, etc.) don't pass the prop, so they keep their current bottom-only layout.

## Testing

- [x] `npm test` — 1206 pass, 0 fail, 3 skipped.
- [x] `npx playwright test tests-e2e/schedule-card-checkoff-form.spec.js` — 8 specs, all pass.
- [x] New spec under `#370` asserts:
  - Both `.actions-top` and `.actions-bottom` render, in DOM order top → inputs → bottom.
  - Tapping the *top* Log dose button submits and writes `takenAt` to disk.
- [x] Existing specs that selected the action buttons by accessible name now use `.first()` (since two buttons match) — the click target is the top bar, which exercises the new path.

## Out of scope

- Other cards that use `eh-input-form`. They render in modal/expanded contexts where the bottom-only convention works fine; opt-in keeps the change scoped.
- A sticky-action variant. Could be added later under the same prop (`"sticky"`) if the top+bottom approach turns out not to be enough on very long forms.

Closes #370