### PR TITLE
schedule-card: top action bar above prev-dose context, fix right-align

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Schedule-card check-off form: top action bar now sits above the
+  prev-dose context, and both bars right-align as intended.** The
+  Cancel / Log dose pair at the top of the popped-out form
+  previously rendered below "How does the last injection site look?",
+  and both bars rendered left-aligned despite their CSS asking for
+  the right. Two bugs: (1) the prev-dose context (`Last: ...` panel
+  + prompt) was rendered by `eh-schedule-card` outside the form, so
+  the form's top action bar slotted in below it. Moved into the form
+  via a new `.headerSlot` Lit-template prop on `eh-input-form`,
+  sitting between the top action bar and the inputs. Order is now:
+  top actions, prev-dose context, divider + new-dose chips, bottom
+  actions. (2) An orphan CSS brace inside `eh-input-form`'s
+  stylesheet (`color: var(--text-inverse, white); }` with no matching
+  opener, left over from an earlier stepper-input batch) was causing
+  the browser's CSS parser to drop the `.actions { justify-content:
+  flex-end; ... }` rule on the floor. Removed the dead three lines;
+  both action bars now sit at the right edge of the form. Closes #375.
+
 ### Added
 
 - **Row-level chat tools.** The chat agent gains five new tools that
@@ -42,18 +62,6 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Internal
 
-- **Sharper system-prompt copy on which read tool to default to.**
-  Live-test of the new row tools (#369) on a real instance showed
-  the model still calling `read_manifest` (full-fat, returns the
-  whole data block) for pre-write inspection instead of
-  `read_manifest_meta` (meta + description + schema only). The
-  prompt now states `read_manifest_meta` is the DEFAULT pre-write
-  call (~95% case), `read_manifest_rows` is the DEFAULT data-
-  inspection call, and `read_manifest` is the LAST RESORT only when
-  the user explicitly asked for everything AND no row-path could
-  give the same answer. The "Read before write" rule is restated to
-  call out which read to default to for which inspection. No code
-  changes outside `config/env.js`. Closes #373.
 - **Manifest path parser + resolver.** New pure module
   `manifests/path.js` providing `parsePath()` and `resolvePath()`
   for an equality-only path language (`segment.segment[k=v]`,

--- a/public/js/components/eh-input-form.js
+++ b/public/js/components/eh-input-form.js
@@ -45,6 +45,14 @@
 // Schedule-card's check-off form sets this to "both" so the user can
 // confirm with a second tap right under their thumb without scrolling
 // past chip rows when they're skipping the metadata fields. See #370.
+//
+// .headerSlot (optional, property only): a Lit template rendered
+// between the top action bar and the first input. Used by schedule-
+// card to host its prev-dose context block ("Last: 4d ago / How does
+// the last injection site look?") between the two so the top action
+// bar sits at the very top of the popped-out form, above the prev-
+// dose context. Has no effect when actions-position is "bottom".
+// See #375.
 
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
 
@@ -87,6 +95,12 @@ export class EhInputForm extends LitElement {
     // second tap right under their thumb (no scroll past chip rows
     // when they're not logging metadata) — see #370.
     actionsPosition: { type: String, attribute: 'actions-position' },
+    // Lit template, set as a property (no `attribute` form). Rendered
+    // between the top action bar and the first input. Used by
+    // schedule-card to host its prev-dose context inside the form so
+    // the top action bar can sit above it. Default `null` = nothing
+    // rendered. See #375.
+    headerSlot: { attribute: false },
     busy: { type: Boolean },
     _state: { state: true },
     _error: { state: true },
@@ -104,6 +118,7 @@ export class EhInputForm extends LitElement {
     this.submitLabel = 'Save';
     this.cancelLabel = 'Cancel';
     this.actionsPosition = 'bottom';
+    this.headerSlot = null;
     this.busy = false;
     this._state = {};
     this._error = null;
@@ -634,8 +649,6 @@ export class EhInputForm extends LitElement {
     @media (prefers-reduced-motion: reduce) {
       .stepper-btn { transition: none; }
     }
-      color: var(--text-inverse, white);
-    }
     .actions {
       display: flex;
       gap: 8px;
@@ -645,6 +658,36 @@ export class EhInputForm extends LitElement {
     .actions.actions-top {
       margin-top: 0;
       margin-bottom: 2px;
+    }
+
+    /* Header slot: used by schedule-card to host its prev-dose
+       context block ("Last: 4d ago / How does the last injection site
+       look?") between the top action bar and the inputs. The
+       prev-dose-* rules below are duplicated from eh-schedule-card's
+       own stylesheet because shadow DOM scoping doesn't let host
+       styles reach into here. Keep in sync if either evolves. See #375. */
+    .header-slot { margin-bottom: 10px; }
+    .header-slot .prev-dose {
+      background: var(--bg-input, rgba(0,0,0,0.04));
+      padding: 10px 12px;
+      border-radius: 8px;
+    }
+    .header-slot .prev-dose-line {
+      font-size: 13px;
+      color: var(--text-secondary);
+    }
+    .header-slot .prev-dose-label {
+      font-weight: 600;
+      margin-right: 4px;
+    }
+    .header-slot .prev-dose-summary {
+      color: var(--text-primary);
+      font-weight: 600;
+    }
+    .header-slot .prev-dose-prompt {
+      font-size: 12px;
+      color: var(--text-muted, var(--text-secondary));
+      margin-top: 4px;
     }
     .btn {
       padding: 7px 14px;
@@ -720,6 +763,7 @@ export class EhInputForm extends LitElement {
     return html`
       <form @submit=${this._onSubmit}>
         ${showTop ? this._renderActions('top') : ''}
+        ${this.headerSlot ? html`<div class="header-slot">${this.headerSlot}</div>` : ''}
         ${this.inputs.map(input => html`
           <div class="field ${input.type === 'checkbox' ? 'checkbox' : ''}">
             ${input.label ? html`<label for="in-${input.key}">${input.label}${input.required ? ' *' : ''}</label>` : ''}

--- a/public/js/components/eh-schedule-card.js
+++ b/public/js/components/eh-schedule-card.js
@@ -297,33 +297,10 @@ export class EhScheduleCard extends EhBaseCard {
         border-radius: 8px;
         background: var(--bg-card);
       }
-      /* Previous-dose section (#359). The panel marks "this is about
-         a different dose than the one being logged". The reactions
-         chips render outside the panel in normal styling, then a
-         form-divider separates them from the new-dose fields. */
-      .prev-dose {
-        background: var(--bg-input, rgba(0,0,0,0.04));
-        padding: 10px 12px;
-        border-radius: 8px;
-        margin-bottom: 10px;
-      }
-      .prev-dose-line {
-        font-size: 13px;
-        color: var(--text-secondary);
-      }
-      .prev-dose-label {
-        font-weight: 600;
-        margin-right: 4px;
-      }
-      .prev-dose-summary {
-        color: var(--text-primary);
-        font-weight: 600;
-      }
-      .prev-dose-prompt {
-        font-size: 12px;
-        color: var(--text-muted, var(--text-secondary));
-        margin-top: 4px;
-      }
+      /* Previous-dose section (#359, #375). The panel-and-prompt
+         markup is now hosted inside <eh-input-form> via its
+         headerSlot prop, so the .prev-dose* styles live there. The
+         schedule-card keeps no styling for those classes. */
       .form-error {
         color: #ff4466;
         font-size: 12px;
@@ -668,23 +645,30 @@ export class EhScheduleCard extends EhBaseCard {
       ? (cfg.currentDosePrompt || 'This dose')
       : '';
 
+    // The prev-dose context block ("Last: 4d ago / How does the last
+    // injection site look?") is hosted INSIDE the form via headerSlot
+    // so the top action bar (which the form renders) sits visually
+    // above it: the user pops the form, sees Cancel / Log dose at the
+    // very top, then the prompt, then the chips. See #375.
+    const prevDoseSlot = showPrevContext ? html`
+      <div class="prev-dose">
+        <div class="prev-dose-line">
+          <span class="prev-dose-label">Last:</span>
+          <span class="prev-dose-summary">${ago}${summary ? ' · ' + summary : ''}</span>
+        </div>
+        ${cfg.previousDosePrompt ? html`
+          <div class="prev-dose-prompt">${cfg.previousDosePrompt}</div>
+        ` : ''}
+      </div>
+    ` : null;
+
     return html`
       <div class="checkoff-form">
-        ${showPrevContext ? html`
-          <div class="prev-dose">
-            <div class="prev-dose-line">
-              <span class="prev-dose-label">Last:</span>
-              <span class="prev-dose-summary">${ago}${summary ? ' · ' + summary : ''}</span>
-            </div>
-            ${cfg.previousDosePrompt ? html`
-              <div class="prev-dose-prompt">${cfg.previousDosePrompt}</div>
-            ` : ''}
-          </div>
-        ` : ''}
         <eh-input-form
           .inputs=${visibleInputs}
           .values=${formValues}
           .date=${this.date}
+          .headerSlot=${prevDoseSlot}
           submit-label=${opts.offSchedule ? 'Log off-schedule dose' : 'Log dose'}
           cancel-label="Cancel"
           actions-position="both"

--- a/tests-e2e/schedule-card-checkoff-form.spec.js
+++ b/tests-e2e/schedule-card-checkoff-form.spec.js
@@ -561,3 +561,79 @@ test.describe('#361: new-dose section is labelled by currentDosePrompt', () => {
     await cleanup(page.request, sandboxState.baseUrl, CARD_ID);
   });
 });
+
+test.describe('#375: top action bar sits above the prev-dose context', () => {
+  test('top actions render before .prev-dose, both action bars right-aligned', async ({ page, sandboxState }) => {
+    const m = manifest();
+    await seed(page.request, sandboxState.baseUrl, m);
+
+    await page.goto('/');
+    const card = page.locator(`[data-card-id="${CARD_ID}"] eh-schedule-card`);
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    await card.locator('.checkbox').first().click();
+    const innerForm = card.locator('.checkoff-form eh-input-form');
+    await expect(innerForm).toBeVisible();
+
+    // Walk the form's shadow DOM and capture the rendered top-level
+    // structure. Expected order: top actions, header-slot (prev-dose
+    // context), inputs (chip rows + divider + heading), bottom actions.
+    const order = await innerForm.evaluate(root => {
+      const sr = root.shadowRoot;
+      if (!sr) return [];
+      const formEl = sr.querySelector('form');
+      if (!formEl) return [];
+      const tags = [];
+      for (const child of formEl.children) {
+        if (child.classList.contains('actions-top')) tags.push('actions-top');
+        else if (child.classList.contains('actions-bottom')) tags.push('actions-bottom');
+        else if (child.classList.contains('header-slot')) tags.push('header-slot');
+        else if (child.classList.contains('field')) tags.push('field');
+        else if (child.tagName === 'HR') tags.push('divider');
+        else if (child.classList.contains('form-section-label')) tags.push('heading');
+        else tags.push(child.tagName.toLowerCase());
+      }
+      return tags;
+    });
+    // Top actions FIRST, then header-slot (prev-dose), then fields,
+    // then bottom actions LAST.
+    expect(order[0]).toBe('actions-top');
+    expect(order[1]).toBe('header-slot');
+    expect(order[order.length - 1]).toBe('actions-bottom');
+    // The header-slot must come before any field.
+    const firstFieldIdx = order.indexOf('field');
+    const headerSlotIdx = order.indexOf('header-slot');
+    expect(headerSlotIdx).toBeLessThan(firstFieldIdx);
+
+    // Both action bars render right-aligned (justify-content: flex-end
+    // resolves to "flex-end" computed). Pre-#375 the rule was being
+    // dropped due to an orphan CSS brace earlier in the stylesheet.
+    const justifies = await innerForm.evaluate(root => {
+      const sr = root.shadowRoot;
+      if (!sr) return null;
+      const top = sr.querySelector('.actions-top');
+      const bot = sr.querySelector('.actions-bottom');
+      return {
+        top: top ? getComputedStyle(top).justifyContent : null,
+        bot: bot ? getComputedStyle(bot).justifyContent : null,
+      };
+    });
+    expect(justifies.top).toBe('flex-end');
+    expect(justifies.bot).toBe('flex-end');
+
+    // The prev-dose markup is now inside eh-input-form's shadow (via
+    // headerSlot), not in the schedule-card's shadow as before. Sanity-
+    // check the .prev-dose block is still visible and correctly styled.
+    const prevDoseBg = await innerForm.evaluate(root => {
+      const sr = root.shadowRoot;
+      if (!sr) return null;
+      const el = sr.querySelector('.header-slot .prev-dose');
+      return el ? getComputedStyle(el).backgroundColor : null;
+    });
+    expect(prevDoseBg).not.toBe(null);
+    expect(prevDoseBg).not.toBe('rgba(0, 0, 0, 0)');
+    expect(prevDoseBg).not.toBe('transparent');
+
+    await cleanup(page.request, sandboxState.baseUrl, CARD_ID);
+  });
+});


### PR DESCRIPTION
# What changed

Refinement of #371 in two parts:

1. Top action bar moved above the prev-dose context block (the
   \"Last: 4d ago / How does the last injection site look?\" panel).
   Tap to open the form, tap Log dose at the top: zero scroll.
2. Removed an orphan CSS brace in `eh-input-form`'s stylesheet that
   was silently dropping the `.actions { justify-content: flex-end; }`
   rule. Both action bars now sit at the right edge of the form.

# Why

User feedback after #371 shipped: the top buttons sat below \"How
does the last injection site look?\" because the prev-dose markup
was rendered by the host (eh-schedule-card) above the form, and the
form's top action bar slotted in below it. The intended one-tap-to-
log motion still required the eye to drop past the prompt.

Right-alignment was a separate bug uncovered by the same review.
The CSS rule `.actions { ... justify-content: flex-end; ... }`
existed pre-#371 but had been silently dropped by a parser-recovery
error since the stepper-input batch a1886a1 (orphan
`color: var(--text-inverse, white); }` block with no opening
selector).

# How

**Layout (#375 part 1)**
- `eh-input-form.js`: new `.headerSlot` Lit-template property,
  rendered between the top action bar and the inputs.
  CSS for `.prev-dose*` ported into eh-input-form's stylesheet,
  scoped under `.header-slot` so it only applies when the slot is in
  use.
- `eh-schedule-card.js`: prev-dose markup is now passed as the form's
  `.headerSlot` value instead of rendered above the form. The
  card's own `.prev-dose*` CSS rules are removed (now-dead, the
  markup no longer lives in this shadow root).

**CSS bug (#375 part 2)**
- `eh-input-form.js`: removed three dead lines between the
  `prefers-reduced-motion` `@media` and the `.actions` rule:
  ```
        color: var(--text-inverse, white);
      }
  ```
  No selector preceded those lines; the browser's CSS parser was
  recovering at the next `}` and dropping `.actions { ... }` on the
  floor.

**Tests (#375 part 3)**
- New e2e spec under `#375: top action bar sits above the prev-dose
  context` asserts:
  - DOM order in the form shadow: top-actions, header-slot,
    field(s), bottom-actions.
  - Both `.actions-top` and `.actions-bottom` compute to
    `justify-content: flex-end`.
  - The `.header-slot .prev-dose` block has a non-transparent
    background (i.e. styles ported correctly).
- The existing 8 e2e specs from this file still pass unchanged
  (Playwright's locator pierces shadow roots, so `.prev-dose-summary`
  etc. still resolve from outside).

# Testing

- [x] `npm test` passes locally: 1206 of 1206, 3 pre-existing skips.
- [x] `npx playwright test tests-e2e/schedule-card-checkoff-form.spec.js`
  passes: 9 of 9 (8 existing + 1 new for #375).
- [x] Manual QA: not yet on a real device. Will eyeball on
  klebbtest after merge to confirm the visual alignment matches the
  spec's computed-style assertions, but the spec encodes the same
  expectation.
- [x] No regression risk to other consumers of `eh-input-form`
  (mood, journal, etc.): they don't pass `.headerSlot`, so the new
  prop defaults to null and nothing renders.

# Checklist

- [x] Conventional-commit subject
- [x] CHANGELOG.md entry under \`## Unreleased / Fixed\`
- [x] Docs: not updated. The `.headerSlot` prop is internal API; only
  consumer is eh-schedule-card.
- [x] No personal identifiers
- [x] No secrets

# Breaking changes

None for users. For component consumers: `eh-input-form` adds a new
optional `.headerSlot` property (defaults to null). Existing
consumers that don't set it get the same render they got before.

# Related

Refs #370, #371. Closes #375.