### PR TITLE
fix(schedule-card): skip same-day dose when resolving previous dose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Schedule-card previous-dose hint no longer points at today's dose
+  after logging.** When a `checkOffForm` declares `previousDoseFields`
+  (the reactions-at-prior-site flow), the form surfaces a "Last:"
+  context line summarising the most recent dose, and merges any
+  `previousDoseFields` payload values back onto that same dose. Both
+  lookups walked backwards through `item.doses` to find the most
+  recent entry with `takenAt` set. After the user logged today's dose
+  and re-opened the form to fill in the prior-site reaction, that
+  walk landed on today's entry instead of the one before it: the hint
+  showed today's location, and the reaction got stamped onto today's
+  dose. Both call sites (`_findPreviousDose` and the inline walk-back
+  in `_submitCheckOffForm`) now skip any dose whose `scheduledDate`
+  matches the currently-viewed date. Closes #378.
+
 ## [2.4.0] - 2026-06-10
 
 ### Fixed

--- a/public/js/components/eh-schedule-card.js
+++ b/public/js/components/eh-schedule-card.js
@@ -398,12 +398,15 @@ export class EhScheduleCard extends EhBaseCard {
   }
 
   // The most recent dose with a takenAt timestamp set, OR null. Walks
-  // backwards to skip scheduled-but-untaken entries (takenAt: null).
+  // backwards to skip scheduled-but-untaken entries (takenAt: null) and
+  // any dose for the currently-viewed date — when the user logs today
+  // and re-opens the form to fill in the previous-dose reaction, the
+  // "previous" dose is the one before today, not today itself.
   _findPreviousDose(item) {
     if (!Array.isArray(item.doses)) return null;
     for (let i = item.doses.length - 1; i >= 0; i--) {
       const d = item.doses[i];
-      if (d && d.takenAt) return { dose: d, index: i };
+      if (d && d.takenAt && d.scheduledDate !== this.date) return { dose: d, index: i };
     }
     return null;
   }
@@ -537,7 +540,8 @@ export class EhScheduleCard extends EhBaseCard {
     const doses = Array.isArray(item.doses) ? [...item.doses] : [];
     let prev = null;
     for (let i = doses.length - 1; i >= 0; i--) {
-      if (doses[i] && doses[i].takenAt) { prev = { dose: doses[i], index: i }; break; }
+      const d = doses[i];
+      if (d && d.takenAt && d.scheduledDate !== this.date) { prev = { dose: d, index: i }; break; }
     }
     if (prev && formCfg.previousDoseFields.length > 0) {
       const merged = { ...prev.dose };

--- a/tests-e2e/schedule-card-checkoff-form.spec.js
+++ b/tests-e2e/schedule-card-checkoff-form.spec.js
@@ -562,6 +562,121 @@ test.describe('#361: new-dose section is labelled by currentDosePrompt', () => {
   });
 });
 
+test.describe('#378: previous-dose hint skips a same-day dose', () => {
+  test('after logging today, re-opening the form still shows the PRIOR dose', async ({ page, sandboxState }) => {
+    // Seed two doses: a prior one 3 days ago at "right belly upper",
+    // AND today's already logged at "left thigh upper" (takenAt set).
+    // The previous-dose hint must point at the 3-days-ago entry, not
+    // at today's entry. Without the fix, _findPreviousDose walks back
+    // and stops at today, so the hint reads "left thigh upper" and
+    // the reaction-merge target becomes today's dose.
+    const today = todayISO();
+    const priorDate = shiftDays(today, -3);
+    const startDate = shiftDays(today, -10);
+    const m = {
+      $schema: 'klebb.datafile.v1',
+      meta: {
+        id: CARD_ID,
+        label: '#378 prev-dose skip-today (e2e)',
+        emoji: '💉',
+        order: 9203,
+        category: 'protocols',
+        view: {
+          enabled: true,
+          component: 'schedule-card',
+          checkOffForm: {
+            currentDoseFields: ['site_side', 'site_region', 'site_position'],
+            previousDoseFields: ['reactions'],
+          },
+        },
+        writeable: {
+          fromWebapp: true, todayAllowed: true, pastAllowed: true, futureAllowed: false,
+          inputs: [
+            { key: 'site_side',     label: 'Side',     type: 'chips',
+              options: ['left', 'right', 'centre'] },
+            { key: 'site_region',   label: 'Region',   type: 'chips',
+              options: ['belly', 'flank', 'thigh', 'delt'] },
+            { key: 'site_position', label: 'Position', type: 'chips',
+              options: ['upper', 'middle', 'lower'] },
+            { key: 'reactions',     label: 'Reactions', type: 'chips-multi',
+              options: ['none', 'bruised', 'red', 'swollen', 'itchy'] },
+          ],
+        },
+      },
+      description: 'Previous-dose hint must skip a same-day dose entry (#378).',
+      data: {
+        items: [
+          {
+            name: 'TestPeptide-378',
+            schedule: { type: 'daily', start_date: startDate, cycle_weeks: 4 },
+            doses: [
+              {
+                scheduledDate: priorDate,
+                takenAt: `${priorDate}T08:00:00Z`,
+                site_side: 'right', site_region: 'belly', site_position: 'upper',
+              },
+              {
+                scheduledDate: today,
+                takenAt: `${today}T08:00:00Z`,
+                site_side: 'left', site_region: 'thigh', site_position: 'upper',
+              },
+            ],
+          },
+        ],
+      },
+    };
+    await seed(page.request, sandboxState.baseUrl, m);
+
+    await page.goto('/');
+    const card = page.locator(`[data-card-id="${CARD_ID}"] eh-schedule-card`);
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    // Untick → re-tick to expand the form for the existing today entry.
+    await card.locator('.checkbox').first().click(); // untick (clears takenAt, persists)
+    await card.locator('.checkbox').first().click(); // re-tick → opens form
+
+    const form = card.locator('.checkoff-form');
+    await expect(form).toBeVisible();
+
+    // The prev-dose context line must reflect the PRIOR dose (3 days
+    // ago, "right belly upper"), NOT today's logged site
+    // ("left thigh upper").
+    const innerForm = form.locator('eh-input-form');
+    const prevSummaryText = await innerForm.evaluate(root => {
+      const sr = root.shadowRoot;
+      if (!sr) return null;
+      const el = sr.querySelector('.header-slot .prev-dose-summary');
+      return el ? el.textContent.trim() : null;
+    });
+    expect(prevSummaryText).toContain('right belly upper');
+    expect(prevSummaryText).not.toContain('left thigh upper');
+
+    // Pick a reactions chip — it should merge onto the PRIOR dose,
+    // not today's. (The merge target is the same lookup; both call
+    // sites must skip same-day.)
+    const chipRows = innerForm.locator('.chip-row');
+    await chipRows.nth(0).locator('.chip', { hasText: 'bruised' }).click();
+    // Resubmit (today's site fields are already prefilled).
+    await innerForm.getByRole('button', { name: /log dose/i }).first().click();
+    await expect(form).toHaveCount(0);
+
+    // Round-trip: the prior dose (3 days ago) should now carry
+    // reactions:["bruised"]. Today's dose must NOT.
+    const res = await page.request.get(`${sandboxState.baseUrl}/api/manifests/${CARD_ID}/data`);
+    const body = await res.json();
+    const doses = body.data.items[0].doses;
+    const prior = doses.find(d => d.scheduledDate === priorDate);
+    const todays = doses.find(d => d.scheduledDate === today);
+    expect(prior).toBeTruthy();
+    expect(todays).toBeTruthy();
+    expect(Array.isArray(prior.reactions)).toBe(true);
+    expect(prior.reactions).toContain('bruised');
+    expect(todays.reactions).toBeUndefined();
+
+    await cleanup(page.request, sandboxState.baseUrl, CARD_ID);
+  });
+});
+
 test.describe('#375: top action bar sits above the prev-dose context', () => {
   test('top actions render before .prev-dose, both action bars right-aligned', async ({ page, sandboxState }) => {
     const m = manifest();


### PR DESCRIPTION
## Summary

The schedule-card check-off form's previous-dose lookup picked up today's dose once it had been logged, so re-opening the form to fill in the previous-site reaction showed today's location and merged the reaction onto today's entry instead of the prior one.

Fixes #378.

## Why

The form has two coupled fields: this dose's location (current) and the reaction at the *previous* injection site. The previous-site hint is computed from `item.doses` by walking backwards to the most recent entry with `takenAt` set. Once today is logged, that walk stops at today, so the hint reads today's location and the reaction-merge target becomes today's dose. The two should refer to different doses.

## How

Both call sites in `public/js/components/eh-schedule-card.js` now skip any dose whose `scheduledDate` matches the currently-viewed date:

- `_findPreviousDose` (drives the displayed "Last:" hint).
- The inline walk-back in `_submitCheckOffForm` (drives the merge target for `previousDoseFields` payload values).

The lookup is otherwise unchanged: still walks backwards, still requires `takenAt` set.

## Testing checklist

- [x] `npm test` — 1206 / 1206 pass, no new skips.
- [x] New e2e spec under `tests-e2e/schedule-card-checkoff-form.spec.js` (`#378: previous-dose hint skips a same-day dose`): seeds a prior dose 3 days ago and today's dose already logged, opens the form, asserts the prev-dose summary names the prior site (not today's) and that submitting `reactions: ['bruised']` merges onto the prior dose entry, leaving today's `reactions` undefined.
- [x] Hygiene scan clean.
- [ ] CI green on Node 20 + 22 matrix.
- [ ] Manual verification on a live instance — operator's call.