### PR TITLE
fix(chat): don't abort in-flight reply on tab visibility change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Chat widget no longer aborts in-flight replies when the tab is
+  backgrounded.** A defensive `visibilitychange` watcher in
+  `health-chat.js` was calling `AbortController.abort()` on the
+  in-flight `/api/chat` fetch whenever the tab had been hidden for
+  more than three seconds, then pushing a "Tab was backgrounded:
+  reply was lost. Send again." error into the chat. Browsers do not
+  kill in-flight network requests in hidden tabs (they only throttle
+  timers), so the abort was self-inflicted: the fetch would have
+  completed cleanly if left alone. Cheap when chat turns took ~5s,
+  but tool-using turns now legitimately run 30 - 60s and routinely
+  straddle a quick tab switch. The watcher and its error copy are
+  removed entirely; the request rides through visibility changes and
+  the reply lands when the tab comes back. Closes #372.
+
 - **Schedule-card previous-dose hint no longer points at today's dose
   after logging.** When a `checkOffForm` declares `previousDoseFields`
   (the reactions-at-prior-site flow), the form surfaces a "Last:"

--- a/public/js/components/health-chat.js
+++ b/public/js/components/health-chat.js
@@ -605,7 +605,6 @@ class HealthChat extends LitElement {
     this._loadInstance();
     this._loadHistory();
     this._loadStarterChips();
-    this._stallWatcher();
   }
 
   // Produce a short display label for a starter chip. Chip width is
@@ -768,37 +767,6 @@ class HealthChat extends LitElement {
         }
       }
     } catch {}
-  }
-
-  _stallWatcher() {
-    // Only abort an in-flight reply if the tab was actually backgrounded
-    // long enough that the OS likely froze the socket. Brief flickers
-    // (swipe away + swipe back within a second or two) leave the
-    // connection alive and the reply is about to arrive; aborting on
-    // those just loses good replies for no reason.
-    //
-    // iOS Safari and Android Chrome start freezing background tabs
-    // within ~5s. A 3s floor is a safe threshold that catches real
-    // backgrounding while ignoring flickers.
-    let hiddenAt = null;
-    document.addEventListener('visibilitychange', () => {
-      if (document.visibilityState === 'hidden') {
-        hiddenAt = Date.now();
-        return;
-      }
-      const hiddenMs = hiddenAt ? Date.now() - hiddenAt : 0;
-      hiddenAt = null;
-      if (hiddenMs < 3000) return;
-      if (this._loading && this._abortController) {
-        this._abortController.abort();
-        this._abortController = null;
-        this._loading = false;
-        const last = this._messages[this._messages.length - 1];
-        if (last && last.role === 'user') {
-          this._pushError('Tab was backgrounded: reply was lost. Send again.');
-        }
-      }
-    });
   }
 
   // ---------- Message helpers ----------

--- a/tests-e2e/chat-survives-tab-background.spec.js
+++ b/tests-e2e/chat-survives-tab-background.spec.js
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/chat-survives-tab-background.spec.js
+// Regression for #372: a chat reply that's in flight while the tab is
+// backgrounded must NOT be aborted by the widget. Browsers do not kill
+// in-flight network requests in hidden tabs, so the previous defensive
+// AbortController.abort() on a >=3s hidden window was a self-inflicted
+// footgun that lost legitimate tool-using replies.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+test.describe('#372: chat reply survives tab backgrounding', () => {
+  test('visibilitychange while /api/chat is in flight does not abort', async ({ page }) => {
+    // Stall /api/chat for ~6s, then return a normal reply. Long enough
+    // that the test's simulated 4s background window straddles the
+    // in-flight fetch.
+    await page.route('**/api/chat', async (route) => {
+      const req = route.request();
+      if (req.method() !== 'POST') return route.fallback();
+      await new Promise((resolve) => setTimeout(resolve, 6000));
+      try {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ reply: 'reply that survived' }),
+        });
+      } catch {}
+    });
+
+    await page.goto('/');
+    await expect(page.locator('eh-date-view')).toBeVisible();
+
+    const promptModal = page.locator('eh-prompt-modal dialog');
+    await promptModal.waitFor({ state: 'visible', timeout: 3000 }).catch(() => {});
+    if (await promptModal.isVisible().catch(() => false)) {
+      await promptModal.locator('button[aria-label="Dismiss"]').click();
+      await expect(promptModal).not.toBeVisible();
+    }
+
+    await page.getByRole('button', { name: /open chat/i }).click();
+
+    const widget = page.locator('health-chat');
+    const input = widget.locator('.chat-input');
+    await expect(input).toBeVisible();
+
+    await input.fill('long-running tool turn');
+    await input.press('Enter');
+
+    // Textarea is disabled while the request is in flight.
+    await expect(input).toBeDisabled();
+
+    // Simulate the tab going to the background for 4s, then coming
+    // back. Real Chromium tab hiding requires multi-tab orchestration;
+    // the widget keys off document.visibilityState + the
+    // visibilitychange event, so dispatching the event directly
+    // exercises the same code path. 4s is well beyond the previous 3s
+    // self-abort threshold.
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true, get: () => 'hidden',
+      });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    await page.waitForTimeout(4000);
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true, get: () => 'visible',
+      });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    // The reply must still arrive (route resolves at ~6s total).
+    await expect(widget.locator('.msg.assistant'))
+      .toContainText('reply that survived', { timeout: 10_000 });
+
+    // No "tab was backgrounded" or other error bubble.
+    await expect(widget.locator('.msg.error')).toHaveCount(0);
+    await expect(input).toBeEnabled();
+  });
+});


### PR DESCRIPTION
## Summary

The chat widget's `visibilitychange` watcher in `health-chat.js` was
calling `AbortController.abort()` on the in-flight `/api/chat` fetch
once the tab had been hidden for more than three seconds, then pushing
a *Tab was backgrounded: reply was lost. Send again.* error into the
chat. Browsers do not kill in-flight network requests in hidden tabs;
they only throttle timers. So the abort was self-inflicted: the fetch
would have completed cleanly if left alone.

It was a cheap belt-and-braces when chat turns took ~5s. It's a real
footgun now that tool-using turns routinely run 30 - 60s, because a
quick tab switch in the middle of a turn loses a perfectly good reply.

## Why

Surfaced by Phase 3 of #363. Row tools made multi-step turns survive
their first few seconds, which exposed the second-order issue that
those longer turns can't survive a tab switch on the client. Repro
on `eddzklebb` is in #372.

## How

- Drop `_stallWatcher()` and its constructor call.
- Drop the *Tab was backgrounded* error copy along with it.
- Add `tests-e2e/chat-survives-tab-background.spec.js`: stall
  `/api/chat` for 6s, fire a 4s `visibilitychange → hidden → visible`
  window mid-flight, assert the reply still renders and no error
  bubble appears.

The new e2e test was confirmed to fail on `main` (timed out waiting
for the assistant message) and passes on this branch.

## Testing

- [x] `npm test` — 1206 passing, 3 skipped, 0 failed
- [x] `npm run test:e2e` — 58 passing including the new
      `chat-survives-tab-background` regression
- [x] New regression demonstrably fails on `main` first

## Out of scope

Server-side resume across actual tab close + reopen is a richer
feature; #372 explicitly leaves that out.

Closes #372.