### PR TITLE
test(ingest): poll the .error sidecar instead of the moved file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Ingest tests no longer race the `.error` sidecar write on Node
+  22.** Two end-to-end ingest tests (`unsupported extension lands in
+  _failed/` and `audio drop without FISH_AUDIO_API_KEY`) were
+  polling for the moved file in `_failed/` and then immediately
+  reading the sibling `.error` sidecar. The pipeline writes those in
+  two steps (rename, then a separate `writeFileSync`), and Node 22's
+  fs scheduler in CI occasionally landed the rename before the
+  sidecar write completed. Both tests now poll for the sidecar
+  itself (the LAST artefact written) with non-empty content, then
+  assert the moved file is also present. Removes intermittent
+  ENOENT failures on the Node 22 CI job. Closes #377.
+
 - **Chat widget no longer aborts in-flight replies when the tab is
   backgrounded.** A defensive `visibilitychange` watcher in
   `health-chat.js` was calling `AbortController.abort()` on the

--- a/tests/ingest.test.js
+++ b/tests/ingest.test.js
@@ -285,14 +285,21 @@ describe('ingest pipeline: end-to-end via spawnServer', () => {
     const src = path.join(inbox, 'evil.docx');
     fs.writeFileSync(src, 'binary doom');
 
-    const moved = await waitFor(() => {
-      return fs.existsSync(path.join(failed, 'evil.docx')) ? true : null;
-    });
-    assert.ok(moved, 'evil.docx never moved to _failed/');
-
+    // Poll the sidecar (the LAST artefact the pipeline writes), not the
+    // moved file (the first). The pipeline does renameSync then a
+    // separate writeFileSync for the .error; on Node 22 in CI the second
+    // write occasionally lags the rename, so polling for the moved file
+    // and then immediately reading the sidecar raced (#377).
     const errFile = path.join(failed, 'evil.docx.error');
-    assert.ok(fs.existsSync(errFile), 'no sibling .error written');
-    const errBody = fs.readFileSync(errFile, 'utf8');
+    const errBody = await waitFor(() => {
+      try {
+        const body = fs.readFileSync(errFile, 'utf8');
+        return body.length > 0 ? body : null;
+      } catch { return null; }
+    });
+    assert.ok(errBody, 'no sibling .error written for evil.docx');
+    assert.ok(fs.existsSync(path.join(failed, 'evil.docx')),
+      'source file never moved to _failed/');
     assert.match(errBody, /unsupported format/);
   });
 
@@ -302,12 +309,18 @@ describe('ingest pipeline: end-to-end via spawnServer', () => {
     const src = path.join(inbox, 'voice-note.mp3');
     fs.writeFileSync(src, 'not really mp3 bytes; ffmpeg+ASR will not run');
 
-    const moved = await waitFor(() => {
-      return fs.existsSync(path.join(failed, 'voice-note.mp3')) ? true : null;
+    // See note in 'unsupported extension' above: poll the sidecar, not
+    // the moved file.
+    const errFile = path.join(failed, 'voice-note.mp3.error');
+    const errBody = await waitFor(() => {
+      try {
+        const body = fs.readFileSync(errFile, 'utf8');
+        return body.length > 0 ? body : null;
+      } catch { return null; }
     });
-    assert.ok(moved, 'voice-note.mp3 never moved to _failed/');
-
-    const errBody = fs.readFileSync(path.join(failed, 'voice-note.mp3.error'), 'utf8');
+    assert.ok(errBody, 'no sibling .error written for voice-note.mp3');
+    assert.ok(fs.existsSync(path.join(failed, 'voice-note.mp3')),
+      'source file never moved to _failed/');
     assert.match(errBody, /audio ingest disabled|FISH_AUDIO_API_KEY/);
   });
 });


### PR DESCRIPTION
## Summary

The two ingest tests at `tests/ingest.test.js:282` (unsupported
extension) and `tests/ingest.test.js:299` (audio drop without
`FISH_AUDIO_API_KEY`) were:

1. Dropping a file into the sandbox inbox.
2. Polling for it to appear in `_failed/`.
3. Immediately `readFileSync`-ing the sibling `.error` sidecar.

The pipeline writes those in **two** steps: `renameSync` into
`_failed/`, then a separate `writeFileSync` of the `.error` body.
On Node 22 in CI, the second write occasionally lagged the first
just enough that step 3 raced step 2's writeFileSync, and the
test got `ENOENT: ... voice-note.mp3.error`.

## Why

#377: flaky on the Node 22 CI job, passed on Node 20 in the same
run, passed on a re-run. Re-runs are how flakes turn into ignored
failures over time.

## How

Switch the `waitFor` predicate to poll the `.error` sidecar
itself with non-empty content (it's the LAST artefact the pipeline
writes). Then assert the moved source file is also present, since
the rename necessarily preceded the write. No read-before-write
window remains.

I could not reproduce locally on Node 24 (30/30 green); the flake is
specific to Node 22's fs scheduling in the CI Linux runner. The fix
is structural: poll for the last write, not the first.

## Testing

- [x] `npm test` — 1206 pass, 3 skipped, 0 fail
- [x] 30x loop of the audio test on Node 24 locally — 30/30 green
- [ ] Confirmed on Node 22 in CI — see this PR's matrix run

## Out of scope

The `_waitUntilStable` step in `ingest/pipeline.js` still has the
two-write pattern; not changing the production code, only the test's
read pattern. If we ever want a deterministic "ingest pipeline idle"
barrier exposed for tests, that's a separate piece of work.

Fixes #377.