### PR TITLE
chore(readme): use a static license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Klebb
 
 [![tests](https://github.com/Aristocles/klebb/actions/workflows/test.yml/badge.svg)](https://github.com/Aristocles/klebb/actions/workflows/test.yml)
-[![license](https://img.shields.io/github/license/Aristocles/klebb.svg)](./LICENSE)
+[![license](https://img.shields.io/badge/license-AGPL--3.0--only-blue.svg)](./LICENSE)
 [![node](https://img.shields.io/badge/node-%3E%3D20-brightgreen.svg)](https://nodejs.org/)
 
 <p align="center">


### PR DESCRIPTION
## Summary

Replace the dynamic shields.io license badge with a static one.

## Why

The dynamic badge (`img.shields.io/github/license/...`) queries
GitHub's API via shields.io's token pool. When that pool is
exhausted or rate-limited, the badge renders \"Unable to select next
GitHub token from pool\" on the repo landing page — exactly what
showed up today.

The licence isn't going to change without a deliberate decision, so
the dynamic lookup buys nothing. A static badge is served from
shields.io's CDN with no upstream API call.

## How

One-line change in README.md:

```
- [![license](https://img.shields.io/github/license/Aristocles/klebb.svg)](./LICENSE)
+ [![license](https://img.shields.io/badge/license-AGPL--3.0--only-blue.svg)](./LICENSE)
```

## Testing

- [x] Doc-only change. README-only.