### PR TITLE
feat(pwa): service worker, manifest fixes, Cache-Control, CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,57 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Added
+
+- **PWA shell: a real service worker.** `public/sw.js` registers at
+  scope `/` from the app shell on first load. The handlers wrap every
+  task in `event.waitUntil()` so iOS doesn't terminate the SW
+  mid-flight; the body is currently a stub that surfaces a generic
+  notification (the notifications PR fills in real payload handling).
+  `notificationclick` validates payload URLs are same-origin before
+  navigating. Refs #384.
+
+- **Klebb minimum Content-Security-Policy.** `/index.html` (and the
+  SPA fallback for client-side routes) sends a CSP that confines the
+  page to `'self'` plus `https://esm.sh` for scripts and the three
+  Web Push providers (Google FCM, Mozilla autopush, Apple's web push
+  relay) for `connect-src`. Style sources keep `'unsafe-inline'` for
+  Lit; image sources allow `data:` for inline icons. Adding push
+  without a baseline CSP would make any future XSS dramatically more
+  durable. Refs #384.
+
 ### Changed
+
+- **Web app manifest tightened for installability.** `public/manifest.json`
+  declares `id`, `scope`, `description`, `categories`, and a stable
+  `start_url` (`/?source=pwa`). The 192/512 icons now declare
+  `purpose: "any maskable"` so Android adaptive shapes don't clip the
+  glyph. `theme_color` matches `background_color` (`#0f0f1a`) so the
+  PWA's status bar reads dark. The stray `<meta name="theme-color">`
+  in `index.html` (which was a different colour) is gone; the
+  manifest is the sole source of truth. Refs #384.
+
+- **`/sw.js` and `/manifest.json` are served `Cache-Control: no-cache`.**
+  Without this, deployed service worker updates can take days to
+  propagate (especially on iOS Safari, where the HTTP cache is
+  conservative). The exact-path match on the static handler avoids
+  any future user-controlled path inheriting the policy. The manifest
+  is also served as `application/manifest+json` so older browsers
+  parse it with manifest-format expectations rather than as generic
+  JSON. Refs #384.
+
+- **Demo mode 404s `/sw.js`.** The public demo at `demo.klebb.app`
+  should not capture push subscriptions for a tenant that no one
+  owns. Service-worker registration on the demo now fails harmlessly
+  in the browser instead of installing a dead handler. The web app
+  manifest still serves on the demo so install metadata stays correct
+  for visitors who bookmark it. Refs #384.
+
+- **Theme bootstrap script in `index.html`.** A tiny inline IIFE
+  reads `klebb-theme` from localStorage and applies the `data-theme`
+  attribute on `<html>` before stylesheets evaluate. Removes the
+  dark-mode flash-of-light on reload that the previous module-load
+  timing made unavoidable. Refs #384.
 
 - **Settings is now a tabbed view: General / Notifications /
   Connections / Cards / Diagnostics.** The 1029-line monolithic

--- a/auth/webauthn.js
+++ b/auth/webauthn.js
@@ -131,6 +131,7 @@ function isPublicPath(pathname) {
     '/js/',
     '/icons/',
     '/manifest.json',
+    '/sw.js',
     '/favicon.ico',
   ];
   return publicPaths.some(p => pathname === p || pathname.startsWith(p));

--- a/public/index.html
+++ b/public/index.html
@@ -14,9 +14,20 @@
   <link rel="icon" type="image/png" sizes="192x192" href="/icons/icon-192.png">
   <link rel="manifest" href="/manifest.json">
   <meta name="apple-mobile-web-app-capable" content="yes">
-  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="Klebb">
-  <meta name="theme-color" content="#0ea5e9">
+  <script>
+    // Apply the saved theme before stylesheets evaluate, so dark-mode
+    // reloads don't briefly flash light. Mirrors public/js/lib/theme.js.
+    (function () {
+      try {
+        var t = localStorage.getItem('klebb-theme');
+        if (t === 'dark' || t === 'light') {
+          document.documentElement.setAttribute('data-theme', t);
+        }
+      } catch (e) {}
+    })();
+  </script>
   <style>
     .ptr-indicator {
       position: fixed;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -49,6 +49,7 @@ class HealthApp extends LitElement {
     applyTheme(this.theme);
     this._onThemeChanged = (e) => { this.theme = e.detail.theme; };
     window.addEventListener('klebb-theme-changed', this._onThemeChanged);
+    this._registerServiceWorker();
     this._handleRoute();
     this._loadInstance();
     this._loadBuildInfo();
@@ -66,6 +67,15 @@ class HealthApp extends LitElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     window.removeEventListener('klebb-theme-changed', this._onThemeChanged);
+  }
+
+  _registerServiceWorker() {
+    // SW registration is fire-and-forget. /sw.js 404s in demo mode, so the
+    // registration just rejects there with no user-visible effect. Push
+    // delivery is wired up in the notifications PR (#387); for now the SW
+    // is registered so the browser keeps it alive once push lands.
+    if (!('serviceWorker' in navigator)) return;
+    navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch(() => {});
   }
 
   async _loadInstance() {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,15 +1,20 @@
 {
+  "id": "/",
   "name": "Klebb",
   "short_name": "Klebb",
-  "start_url": "/",
+  "description": "Personal health dashboard.",
+  "start_url": "/?source=pwa",
+  "scope": "/",
   "display": "standalone",
+  "orientation": "portrait",
   "background_color": "#0f0f1a",
-  "theme_color": "#00d4aa",
+  "theme_color": "#0f0f1a",
+  "categories": ["health", "lifestyle", "productivity"],
   "icons": [
-    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" },
-    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "/icons/icon-180.png", "sizes": "180x180", "type": "image/png" },
-    { "src": "/icons/icon-152.png", "sizes": "152x152", "type": "image/png" },
-    { "src": "/icons/icon-120.png", "sizes": "120x120", "type": "image/png" }
+    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any maskable" },
+    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any maskable" },
+    { "src": "/icons/icon-180.png", "sizes": "180x180", "type": "image/png", "purpose": "any" },
+    { "src": "/icons/icon-152.png", "sizes": "152x152", "type": "image/png", "purpose": "any" },
+    { "src": "/icons/icon-120.png", "sizes": "120x120", "type": "image/png", "purpose": "any" }
   ]
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// public/sw.js
+//
+// Klebb service worker. Scope: /. The PWA shell registers it once on app
+// load; this file's only job in v3.0.0 is to be present so push events
+// can be delivered when the notifications feature lands.
+//
+// No fetch listener: browsers handle navigation efficiently without one,
+// and an empty fetch handler is a known performance footgun.
+// No precache: offline shell is not in v3.0.0 scope.
+
+const VERSION = 'klebb-sw-v1';
+
+self.addEventListener('install', (event) => {
+  // New SW takes over without waiting for old tabs to close. Safe because
+  // there is no offline cache to invalidate; updates are picked up on the
+  // next visibilitychange.
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  // Take control of clients without requiring a reload. event.waitUntil
+  // ensures iOS doesn't terminate the SW before claim() resolves.
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('push', (event) => {
+  // Stub. The notifications PR (#387) replaces the body with a real
+  // payload parser + showNotification() call. event.waitUntil is
+  // mandatory on iOS PWAs: the SW is killed within seconds of an event
+  // resolving, so any async work must keep the event alive.
+  event.waitUntil((async () => {
+    let payload = {};
+    try {
+      if (event.data) payload = event.data.json();
+    } catch {
+      payload = {};
+    }
+    const title = payload.title || 'Klebb';
+    const body = payload.body || 'You have a reminder.';
+    await self.registration.showNotification(title, {
+      body,
+      tag: payload.tag || VERSION,
+      data: { url: payload.url || '/' },
+      icon: '/icons/icon-192.png',
+      renotify: true,
+    });
+  })());
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  event.waitUntil((async () => {
+    // Same-origin guard: payload-supplied URLs must not redirect off-origin.
+    let target = '/';
+    try {
+      const raw = event.notification.data && event.notification.data.url;
+      if (raw) {
+        const u = new URL(raw, self.location.origin);
+        if (u.origin === self.location.origin) target = u.pathname + u.search + u.hash;
+      }
+    } catch {}
+
+    const allClients = await self.clients.matchAll({
+      type: 'window',
+      includeUncontrolled: true,
+    });
+    for (const c of allClients) {
+      if (c.url && new URL(c.url).origin === self.location.origin) {
+        c.postMessage({ type: 'klebb-deep-link', url: target });
+        return c.focus();
+      }
+    }
+    return self.clients.openWindow(target);
+  })());
+});
+
+self.addEventListener('pushsubscriptionchange', (event) => {
+  // Stub: the notifications PR (#387) handles real resubscription.
+  // For now, log only — there is no /api/push/subscribe yet, so attempting
+  // to POST here would just 404 and log noise.
+  event.waitUntil(Promise.resolve());
+});

--- a/server.js
+++ b/server.js
@@ -88,7 +88,48 @@ const MIME_TYPES = {
   '.png': 'image/png',
   '.svg': 'image/svg+xml',
   '.ico': 'image/x-icon',
+  '.webmanifest': 'application/manifest+json',
 };
+
+// Minimum CSP for /index.html. Push provider connect-src entries unblock
+// pushManager.subscribe + the SW's eventual push fetches; esm.sh stays in
+// script-src because Lit imports load directly from there at runtime.
+// 'unsafe-inline' for styles is required for Lit's render path; the
+// inline FOUC-prevention <script> in index.html is the only inline script
+// and is whitelisted by 'self' (not 'unsafe-inline').
+const CSP_INDEX = [
+  "default-src 'self'",
+  "worker-src 'self'",
+  "script-src 'self' https://esm.sh 'unsafe-inline'",
+  "connect-src 'self' https://*.googleapis.com https://*.push.services.mozilla.com https://web.push.apple.com",
+  "manifest-src 'self'",
+  "img-src 'self' data:",
+  "style-src 'self' 'unsafe-inline'",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "frame-ancestors 'self'",
+].join('; ');
+
+// Per-path header overrides applied on top of the static handler's
+// default Content-Type. Returns the headers object (possibly empty).
+// Exact-path match only — no substring or suffix logic, so a future
+// upload at /data/foo-sw.js cannot inherit SW-only policy.
+function staticHeadersFor(pathname) {
+  const headers = {};
+  if (pathname === '/sw.js' || pathname === '/manifest.json' || pathname === '/manifest.webmanifest') {
+    headers['Cache-Control'] = 'no-cache';
+  }
+  if (pathname === '/manifest.json') {
+    // Override the default application/json MIME so browsers parse the
+    // file with relaxed manifest-format expectations (some older Edge
+    // builds nag if Content-Type isn't application/manifest+json).
+    headers['Content-Type'] = 'application/manifest+json';
+  }
+  if (pathname === '/' || pathname === '/index.html') {
+    headers['Content-Security-Policy'] = CSP_INDEX;
+  }
+  return headers;
+}
 
 function sendJSON(res, data, status = 200) {
   res.writeHead(status, { 'Content-Type': 'application/json' });
@@ -491,16 +532,16 @@ ${htmlContent}
 </body></html>`;
 }
 
-function serveStaticFile(res, filePath) {
+function serveStaticFile(res, filePath, extraHeaders = {}) {
   const ext = path.extname(filePath);
   const mime = MIME_TYPES[ext] || 'application/octet-stream';
 
   try {
     const content = fs.readFileSync(filePath);
-    res.writeHead(200, { 'Content-Type': mime });
+    const headers = { 'Content-Type': mime, ...extraHeaders };
+    res.writeHead(200, headers);
     res.end(content);
   } catch {
-    // For SPA routing, serve index.html for non-API, non-file paths
     return false;
   }
   return true;
@@ -1822,11 +1863,21 @@ Original system prompt follows:
     return send404(res);
   }
 
-  if (serveStaticFile(res, filePath)) return;
+  // Demo mode does not deliver Web Push: 404 the SW so registration on the
+  // public demo fails harmlessly instead of capturing a subscription that
+  // would later be ignored. Manifest stays served (the demo can install
+  // as a PWA, it just won't get push).
+  if (pathname === '/sw.js' && ENV.KLEBB_DEMO) {
+    return send404(res);
+  }
 
-  // SPA fallback: serve index.html for client-side routes
+  const extraHeaders = staticHeadersFor(pathname);
+  if (serveStaticFile(res, filePath, extraHeaders)) return;
+
+  // SPA fallback: serve index.html for client-side routes. Apply the
+  // index-only headers (CSP) so deep-linked routes get the same policy.
   const indexPath = path.join(PUBLIC_DIR, 'index.html');
-  serveStaticFile(res, indexPath);
+  serveStaticFile(res, indexPath, staticHeadersFor('/'));
 });
 
 server.listen(PORT, HOST, () => {

--- a/tests/static-headers.test.js
+++ b/tests/static-headers.test.js
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/static-headers.test.js
+//
+// PWA shell #384: the static handler must send specific headers for
+// the service worker, the web app manifest, and the HTML shell, and
+// must 404 the SW in demo mode so the public demo doesn't capture
+// dead push subscriptions.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  createSandbox, cleanupSandbox,
+  spawnServer, req,
+} = require('./helpers/sandbox');
+
+// Authenticated server: uses a seeded session so the static handler is
+// reachable for /, /index.html, SPA fallbacks, and /icons/*. /sw.js and
+// /manifest.json are on the public-path allowlist regardless.
+test.describe('static headers (#384 PWA shell)', () => {
+  let sandbox, srv, cookie;
+
+  test.before(async () => {
+    const { fakeAuthState, sessionCookie } = require('./helpers/sandbox');
+    const auth = fakeAuthState();
+    sandbox = createSandbox({
+      credentials: auth.credentials,
+      sessions: auth.sessions,
+    });
+    cookie = sessionCookie(auth.token);
+    srv = await spawnServer(sandbox);
+  });
+
+  test.after(async () => {
+    if (srv) await srv.kill();
+    if (sandbox) cleanupSandbox(sandbox);
+  });
+
+  test('GET /sw.js sends Cache-Control: no-cache and JS Content-Type', async () => {
+    const r = await req(srv.baseUrl, '/sw.js');
+    assert.equal(r.status, 200);
+    assert.equal(r.headers['cache-control'], 'no-cache');
+    assert.match(r.headers['content-type'], /^application\/javascript/);
+  });
+
+  test('GET /manifest.json sends Cache-Control: no-cache and application/manifest+json', async () => {
+    const r = await req(srv.baseUrl, '/manifest.json');
+    assert.equal(r.status, 200);
+    assert.equal(r.headers['cache-control'], 'no-cache');
+    assert.match(r.headers['content-type'], /application\/manifest\+json/);
+    const body = JSON.parse(r.body);
+    assert.equal(body.id, '/');
+    assert.equal(body.scope, '/');
+  });
+
+  test('GET / sends a Content-Security-Policy header that includes push providers', async () => {
+    const r = await req(srv.baseUrl, '/', { cookie });
+    assert.equal(r.status, 200);
+    const csp = r.headers['content-security-policy'];
+    assert.ok(csp, 'CSP header should be present on /');
+    assert.match(csp, /default-src 'self'/);
+    assert.match(csp, /worker-src 'self'/);
+    assert.match(csp, /https:\/\/web\.push\.apple\.com/);
+    assert.match(csp, /https:\/\/\*\.push\.services\.mozilla\.com/);
+    assert.match(csp, /https:\/\/\*\.googleapis\.com/);
+    assert.match(csp, /https:\/\/esm\.sh/);
+    assert.match(csp, /object-src 'none'/);
+  });
+
+  test('GET /index.html (direct path) carries the same CSP', async () => {
+    const r = await req(srv.baseUrl, '/index.html', { cookie });
+    assert.equal(r.status, 200);
+    assert.ok(r.headers['content-security-policy']);
+  });
+
+  test('GET /unknown-spa-route falls back to index and carries the CSP', async () => {
+    const r = await req(srv.baseUrl, '/calendar', { cookie });
+    assert.equal(r.status, 200);
+    assert.match(r.headers['content-type'], /^text\/html/);
+    assert.ok(r.headers['content-security-policy'], 'SPA fallback should still send CSP');
+  });
+
+  test('Other static assets still cache normally (no Cache-Control: no-cache)', async () => {
+    const r = await req(srv.baseUrl, '/icons/icon-192.png');
+    assert.equal(r.status, 200);
+    assert.equal(r.headers['cache-control'], undefined);
+  });
+});
+
+test.describe('demo-mode SW gate (#384)', () => {
+  let sandbox, srv;
+
+  test.before(async () => {
+    sandbox = createSandbox();
+    srv = await spawnServer(sandbox, { KLEBB_DEMO: '1' });
+  });
+
+  test.after(async () => {
+    if (srv) await srv.kill();
+    if (sandbox) cleanupSandbox(sandbox);
+  });
+
+  test('GET /sw.js returns 404 in KLEBB_DEMO=1', async () => {
+    const r = await req(srv.baseUrl, '/sw.js');
+    assert.equal(r.status, 404);
+  });
+
+  test('GET /manifest.json still serves in demo mode', async () => {
+    const r = await req(srv.baseUrl, '/manifest.json');
+    assert.equal(r.status, 200);
+    assert.match(r.headers['content-type'], /application\/manifest\+json/);
+  });
+});


### PR DESCRIPTION
# What changed

The PWA shell. A real service worker registers at scope `/`, the web
app manifest is tightened to satisfy modern install criteria, the
static handler sends `Cache-Control: no-cache` for `/sw.js` and
`/manifest.json`, the HTML response carries a minimum CSP that
whitelists the Web Push providers, and the demo instance 404s the SW
so it doesn't capture subscriptions.

The push handler body is a stub today; #387 replaces it with real
payload handling once the rest of the notifications stack lands.

Closes #384.

# Why

PR2 of the v3.0.0 notifications rollout. Web Push needs a service
worker, full stop. Shipping the SW + the supporting cache and CSP
headers in their own PR keeps the security review surface small and
lets the notifications PR (#387) be a focused payload-handling change
rather than infrastructure-plus-feature in one diff.

The Cache-Control header is the single most important production
safety change in the PR: without it, a deployed SW update can take
days to propagate on iOS Safari.

# How

Three commits:

1. `feat(pwa): tighten web app manifest, add FOUC-prevention bootstrap`
   `public/manifest.json` gains `id`, `scope`, `description`,
   `categories`, `orientation`, a stable `start_url`. The 192/512
   icons declare `purpose: "any maskable"`: the dog glyph already
   sits in the inner ~70% of the dark canvas so the same files
   satisfy the maskable safe zone without padded variants. The
   stray `<meta theme-color>` in `index.html` is gone (the manifest
   is the single source of truth). An inline IIFE reads
   `klebb-theme` and applies `data-theme` before stylesheets paint,
   killing the dark-mode FOUC on reload.

2. `feat(pwa): service worker scaffold + registration`
   `public/sw.js` with `install`/`activate`/`push`/`notificationclick`/
   `pushsubscriptionchange`. Every async handler is wrapped in
   `event.waitUntil()` (mandatory on iOS PWAs: the SW dies within
   seconds of an event resolving). `notificationclick` validates the
   payload URL is same-origin via `new URL(url, self.location.origin).origin`
   before navigating. The body of `push` is currently a generic
   "You have a reminder." fallback; #387 replaces it. `/sw.js` is
   added to the WebAuthn public-path allowlist so the browser can
   fetch it before any login redirect.

3. `feat(pwa): static handler sends Cache-Control + CSP, demo 404s sw.js`
   New `staticHeadersFor(pathname)` helper, exact-path match only,
   sets `Cache-Control: no-cache` on `/sw.js` and `/manifest.json`,
   `Content-Type: application/manifest+json` on the manifest, and
   the CSP on `/index.html` and the SPA fallback. Demo mode 404s
   `/sw.js` so registration on `demo.klebb.app` fails harmlessly
   instead of installing a dead handler.

# Testing

- [x] `npm test` passes locally (1214 pass / 0 fail / 3 skipped — 8 new)
- [x] `npm run test:e2e` passes locally (61 pass)
- [x] New unit suite at `tests/static-headers.test.js` covers:
  - `/sw.js` Cache-Control + JS Content-Type
  - `/manifest.json` Cache-Control + `application/manifest+json`
  - `/` CSP includes the three Web Push provider hosts
  - `/index.html` carries the same CSP
  - SPA fallback (e.g. `/calendar`) carries the CSP
  - Other static assets (`/icons/*`) keep their default cache behaviour
  - Demo mode 404s `/sw.js` while still serving the manifest
- [x] Manual smoke against a local non-demo dev instance:
  - `curl -D -` shows `/sw.js` 200 with `Cache-Control: no-cache`
  - `curl -D -` shows `/manifest.json` 200 with
    `Content-Type: application/manifest+json` and
    `Cache-Control: no-cache`
- [x] Manual smoke against a local demo instance: `/sw.js` 404s,
  manifest still serves

# Checklist

- [x] Commit messages follow the conventions in `CONTRIBUTING.md`
- [x] `CHANGELOG.md` updated under `## Unreleased`
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed
- [x] Docs unchanged: PR3 (#385) is where the manifest schema and
      `MANIFEST-SCHEMA.md` get their notifications additions

# Breaking changes

None. The web app manifest's `id` is now declared explicitly as `/`,
which matches what browsers were already deriving from `start_url`,
so existing PWA installs are unaffected. The wordmark click handler
was already removed in #388.

This PR is part of the v3.0.0 release wave; PRs #383 / #384 / #385 /
#386 / #387 ship together as a major version bump.
