### PR TITLE
feat(notifications): meta.notifications schema, validator, scheduler skeleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,46 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **`meta.notifications` schema: declarative push reminders per card.**
+  Cards may declare an `items[]` array of notifications inside their
+  `meta.notifications` block. Each item has an `id`, `label`, `title`,
+  `body`, a `trigger` (v3.0.0 supports `daily` and `weekly` types),
+  and optional `action`, `privacy`, and `default` fields. Validator
+  is lenient at load (drops bad items silently so a malformed sidecar
+  can't wedge the registry) and strict at create / PATCH (returns 422
+  with an `invalid notifications: ...` prefix). Caps: 10 items per
+  manifest, 50 active items per instance. Documented in
+  `MANIFEST-SCHEMA.md`. Refs #385.
+
+- **In-process notifications scheduler.** A self-rescheduling
+  `setTimeout` lands on the start of each minute, walks the registry,
+  evaluates triggers, and dispatches due notifications. Idempotent:
+  `lastFired` stores the slot ISO (not the wall-clock fire time) so a
+  restart inside the minute doesn't refire. Coalesces same-minute
+  fires into a single dispatch event. Honours global `paused_until`
+  (skips and does not advance `lastFired`, so the most recent missed
+  slot fires when paused expires) and `quiet_hours` (advances
+  `lastFired` but skips the dispatch). The dispatch path is
+  logging-only in this PR; the Web Push send arrives in #386.
+  Started at server boot when `!KLEBB_DEMO`; stopped on SIGTERM /
+  SIGINT. Refs #385.
+
+- **Per-instance runtime state file at
+  `$HEALTH_HOME/notifications.state.json`.** Mode `0o600`, atomic
+  tmp+rename writes with `fsync`. Stores per-item enabled/lastFired,
+  global quiet hours, and the global pause deadline. Created lazily
+  on first toggle. The registry's new `onDelete` hook prunes orphan
+  entries when a card is deleted. Refs #385.
+
+- **User-timezone capture for the scheduler.** New `POST /api/user/tz`
+  endpoint validates against `Intl.supportedValuesOf('timeZone')` and
+  persists to `$HEALTH_HOME/user.json` (mode `0o600`, atomic). The
+  client sends the browser's `Intl.DateTimeFormat().resolvedOptions().timeZone`
+  on each session boot, idempotently (skipped when unchanged since
+  last post). The scheduler reads the user's TZ first and falls back
+  to `process.env.TZ`, so reminders fire in the user's local time
+  even when they travel. Refs #385.
+
 - **PWA shell: a real service worker.** `public/sw.js` registers at
   scope `/` from the app shell on first load. The handlers wrap every
   task in `event.waitUntil()` so iOS doesn't terminate the SW

--- a/MANIFEST-SCHEMA.md
+++ b/MANIFEST-SCHEMA.md
@@ -120,6 +120,87 @@ in `meta.order` ascending. Shown-today state is tracked in
 Dismissing still marks as shown. See `docs/CARDS.md` for the full
 behaviour notes.
 
+### Push notifications (`meta.notifications`)
+
+Declares Web Push reminders the dashboard delivers to the user's
+devices. Each item is a single notification with a recurring trigger,
+a label that surfaces in Settings, and a title + body for the OS
+banner. Unlike `meta.prompt` (in-app modal, fires when the user opens
+the app), notifications fire on a schedule whether the app is open or
+not - they're how the dashboard reminds the user to log mood, take a
+supplement, log a pain level, etc.
+
+```json
+"meta": {
+  "notifications": {
+    "enabled": true,
+    "items": [
+      {
+        "id": "evening-log",
+        "label": "Evening mood log",
+        "title": "Mood",
+        "body": "How are you feeling?",
+        "trigger": { "type": "daily", "time": "20:00" },
+        "action": { "type": "open-card", "card": "mood", "intent": "log" },
+        "privacy": "private",
+        "default": "on"
+      }
+    ]
+  }
+}
+```
+
+**Field rules:**
+
+- `enabled` (bool, default `true`): card-level kill switch. `false`
+  silences every item even if individually toggled on.
+- `items[]`: array of notification declarations. Capped at 10 per
+  manifest. Each item has:
+  - `id` — required, matches `^[a-z0-9][a-z0-9._-]{0,63}$`, unique
+    within the manifest's `items[]`. Globally unique runtime id is
+    `${meta.id}#${item.id}`.
+  - `label` — required, up to 80 chars. The string Settings shows.
+  - `title` — required, up to 30 chars. The notification title.
+  - `body` — required, up to 80 chars. The notification body.
+    Placeholders `{label}` (the card's `meta.label`) and `{emoji}`
+    (the card's `meta.emoji`) substitute on render.
+  - `trigger` — required object. v3.0.0 supports two types:
+    - `{ type: "daily", time: "HH:MM" }` — fires every day at the
+      configured local time.
+    - `{ type: "weekly", days: ["mon","wed","fri"], time: "HH:MM" }`
+      — fires on listed weekdays at the configured local time.
+    `interval`, `last_logged`, and `schedule_due` arrive in v3.1.
+  - `action` — optional, default `{ type: "open-card", card: meta.id }`.
+    Only `type: "open-card"` is supported. `intent` is one of
+    `"view" | "log"`.
+  - `privacy` — `"private"` (default) or `"public"`. When private,
+    the wire payload carries a generic title/body and the real text
+    is substituted on the device after decryption, so the lock
+    screen shows "Klebb: You have a reminder." instead of the real
+    string. The user can flip a per-notification toggle in Settings
+    to override.
+  - `default` — `"on"` (default) or `"off"`. Initial enabled state
+    the first time the user sees the toggle. Subsequent state is
+    user-controlled.
+
+**Local time:** triggers evaluate against the user's IANA timezone
+captured by the browser on each session boot (stored in
+`$HEALTH_HOME/user.json`). The server's `process.env.TZ` is the
+fallback when the browser hasn't reported one yet. This is what
+makes "remind me at 20:00" still mean 20:00 local when the user
+travels.
+
+**Validation:** lenient at load (a malformed item is dropped silently
+so a bad sidecar can't wedge the registry), strict at create / PATCH
+(returns 422 with the prefix `invalid notifications: ...`).
+
+**State separation:** the manifest declares which notifications
+exist. Whether the user has flipped a given one off, when each last
+fired, and the global quiet-hours / pause controls all live in
+`$HEALTH_HOME/notifications.state.json`, an opaque sidecar that the
+manifest registry doesn't watch. So the manifest stays clean and
+grep-able, and runtime state stays out of authored config.
+
 ### Ingest subscription (`meta.ingest`)
 
 Opts a manifest into receiving data from an external ingest source. Today

--- a/config/paths.js
+++ b/config/paths.js
@@ -79,6 +79,17 @@ const CHAT_DIR = process.env.HEALTH_CHAT_DIR || path.join(HEALTH_HOME, 'chat');
 const CHAT_HISTORY_FILE = path.join(CHAT_DIR, 'history.json');
 const CONFIG_PATH = process.env.HEALTH_CONFIG_PATH || path.join(HEALTH_HOME, 'config.json');
 
+// Per-instance runtime state for notifications. Decoupled from manifests
+// so the per-card meta block stays clean (config) and last-fired / toggle
+// state lives in this opaque sidecar (runtime). Created lazily.
+const NOTIFICATIONS_STATE_FILE = process.env.HEALTH_NOTIFICATIONS_STATE_FILE
+  || path.join(HEALTH_HOME, 'notifications.state.json');
+
+// Per-instance user preferences (timezone today; future: device nicknames).
+// Single-user-per-instance, so this is one file - not a per-user store.
+const USER_FILE = process.env.HEALTH_USER_FILE
+  || path.join(HEALTH_HOME, 'user.json');
+
 // WebAuthn credentials + sessions. Historical installs may have stored these
 // inside DATA_DIR as `webauthn-credentials.json` / `webauthn-sessions.json`;
 // prefer those if found, otherwise use the modern subdir layout.
@@ -122,6 +133,8 @@ module.exports = {
   CHAT_DIR,
   CHAT_HISTORY_FILE,
   CONFIG_PATH,
+  NOTIFICATIONS_STATE_FILE,
+  USER_FILE,
   WEBAUTHN_CREDENTIALS_FILE,
   WEBAUTHN_SESSIONS_FILE,
   ensureWritableDirs,

--- a/lib/notification-trigger.js
+++ b/lib/notification-trigger.js
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// lib/notification-trigger.js
+//
+// Pure trigger-evaluation helpers. Given a trigger spec, a "now" instant,
+// and a user-configured IANA timezone, compute the previous and next fire
+// slots for the trigger.
+//
+// v3.0.0 supports two trigger types: daily and weekly. Other types are
+// deferred to v3.1.
+//
+// The slots returned are ISO 8601 strings in the user's TZ (e.g.
+// "2026-06-11T20:00:00+10:00"). The scheduler compares them as strings -
+// equality is sufficient for "have we fired this slot yet" because two
+// computations of the same slot in the same TZ always yield byte-equal
+// strings.
+
+const WEEKDAY_INDEX = {
+  // Map IANA short weekday strings to day-of-week integers.
+  // Date#getDay() is 0=Sun..6=Sat; we use that ordering.
+  sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6,
+};
+
+function _parseHHMM(time) {
+  const m = /^([01]\d|2[0-3]):([0-5]\d)$/.exec(time);
+  if (!m) return null;
+  return { h: Number(m[1]), m: Number(m[2]) };
+}
+
+// Given a UTC instant and a TZ, return the wall-clock components in that TZ.
+// Uses Intl.DateTimeFormat under the hood; correct across DST transitions.
+function _wallClockIn(instant, tz) {
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: tz,
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit',
+    hour12: false,
+    weekday: 'short',
+  });
+  const parts = fmt.formatToParts(instant);
+  const get = (k) => parts.find(p => p.type === k)?.value;
+  return {
+    year: Number(get('year')),
+    month: Number(get('month')),
+    day: Number(get('day')),
+    hour: Number(get('hour') === '24' ? '0' : get('hour')),
+    minute: Number(get('minute')),
+    second: Number(get('second')),
+    weekday: get('weekday').toLowerCase().slice(0, 3),
+  };
+}
+
+// Given wall-clock components in a TZ, return the UTC instant whose
+// projection into that TZ matches. Handles DST: searches by binary-iterating
+// the offset until the projection matches the requested wall-clock.
+function _wallClockToInstant(year, month, day, hour, minute, tz) {
+  // Start with a UTC guess (TZ is unknown offset; project to find it).
+  // Walk in two passes: project guess back to wall-clock, compute the
+  // offset, then re-anchor. Two passes converge for any IANA TZ that
+  // doesn't change offset twice in <24h.
+  let guess = Date.UTC(year, month - 1, day, hour, minute, 0);
+  for (let pass = 0; pass < 3; pass++) {
+    const wc = _wallClockIn(new Date(guess), tz);
+    const target = Date.UTC(year, month - 1, day, hour, minute, 0);
+    const got = Date.UTC(wc.year, wc.month - 1, wc.day, wc.hour, wc.minute, 0);
+    const drift = got - target;
+    if (drift === 0) return new Date(guess);
+    guess -= drift;
+  }
+  return new Date(guess);
+}
+
+// Format an instant as an ISO string in the given TZ, including offset.
+function _formatIso(instant, tz) {
+  const wc = _wallClockIn(instant, tz);
+  // Compute the offset from the wall-clock vs the UTC instant.
+  const wcUtc = Date.UTC(wc.year, wc.month - 1, wc.day, wc.hour, wc.minute, wc.second);
+  const offsetMin = Math.round((wcUtc - instant.getTime()) / 60000);
+  const sign = offsetMin >= 0 ? '+' : '-';
+  const a = Math.abs(offsetMin);
+  const oh = String(Math.floor(a / 60)).padStart(2, '0');
+  const om = String(a % 60).padStart(2, '0');
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${wc.year}-${pad(wc.month)}-${pad(wc.day)}T${pad(wc.hour)}:${pad(wc.minute)}:${pad(wc.second)}${sign}${oh}:${om}`;
+}
+
+// daily: most recent and next instant of HH:MM in the user's TZ.
+function _evalDaily(trigger, now, tz) {
+  const t = _parseHHMM(trigger.time);
+  if (!t) return null;
+  const wc = _wallClockIn(now, tz);
+
+  const todayInstant = _wallClockToInstant(wc.year, wc.month, wc.day, t.h, t.m, tz);
+  if (todayInstant.getTime() <= now.getTime()) {
+    // Today's slot has already passed (or is right now). Next is tomorrow.
+    const tomorrow = new Date(now.getTime() + 24 * 3600 * 1000);
+    const twc = _wallClockIn(tomorrow, tz);
+    const nextInstant = _wallClockToInstant(twc.year, twc.month, twc.day, t.h, t.m, tz);
+    return {
+      prev: _formatIso(todayInstant, tz),
+      next: _formatIso(nextInstant, tz),
+    };
+  }
+  // Today's slot hasn't fired yet. Previous is yesterday at HH:MM.
+  const yesterday = new Date(now.getTime() - 24 * 3600 * 1000);
+  const ywc = _wallClockIn(yesterday, tz);
+  const prevInstant = _wallClockToInstant(ywc.year, ywc.month, ywc.day, t.h, t.m, tz);
+  return {
+    prev: _formatIso(prevInstant, tz),
+    next: _formatIso(todayInstant, tz),
+  };
+}
+
+function _evalWeekly(trigger, now, tz) {
+  const t = _parseHHMM(trigger.time);
+  if (!t) return null;
+  const days = (trigger.days || []).filter(d => d in WEEKDAY_INDEX);
+  if (days.length === 0) return null;
+  const dowSet = new Set(days.map(d => WEEKDAY_INDEX[d]));
+
+  const wc = _wallClockIn(now, tz);
+  const todayDow = WEEKDAY_INDEX[wc.weekday] ?? 0;
+
+  // Find the next eligible slot at or after now.
+  let nextInstant = null;
+  for (let offset = 0; offset < 8; offset++) {
+    const candidateDow = (todayDow + offset) % 7;
+    if (!dowSet.has(candidateDow)) continue;
+    const future = new Date(now.getTime() + offset * 24 * 3600 * 1000);
+    const fwc = _wallClockIn(future, tz);
+    const inst = _wallClockToInstant(fwc.year, fwc.month, fwc.day, t.h, t.m, tz);
+    if (inst.getTime() > now.getTime()) {
+      nextInstant = inst;
+      break;
+    }
+  }
+
+  // Find the most recent eligible slot before now.
+  let prevInstant = null;
+  for (let offset = 0; offset < 8; offset++) {
+    const candidateDow = (todayDow + 7 - offset) % 7;
+    if (!dowSet.has(candidateDow)) continue;
+    const past = new Date(now.getTime() - offset * 24 * 3600 * 1000);
+    const pwc = _wallClockIn(past, tz);
+    const inst = _wallClockToInstant(pwc.year, pwc.month, pwc.day, t.h, t.m, tz);
+    if (inst.getTime() <= now.getTime()) {
+      prevInstant = inst;
+      break;
+    }
+  }
+
+  if (!nextInstant || !prevInstant) return null;
+  return {
+    prev: _formatIso(prevInstant, tz),
+    next: _formatIso(nextInstant, tz),
+  };
+}
+
+// Evaluate a trigger: returns { prev, next } as ISO strings, or null if
+// the trigger type is unknown / the spec is malformed (the validator
+// should have caught the latter, so null here is the load-time-lenient
+// recovery path).
+function evaluate(trigger, now, tz) {
+  if (!trigger || !tz) return null;
+  if (trigger.type === 'daily') return _evalDaily(trigger, now, tz);
+  if (trigger.type === 'weekly') return _evalWeekly(trigger, now, tz);
+  return null;
+}
+
+module.exports = {
+  evaluate,
+  // Exported for tests:
+  _parseHHMM,
+  _wallClockIn,
+  _wallClockToInstant,
+  _formatIso,
+};

--- a/lib/notifications-scheduler.js
+++ b/lib/notifications-scheduler.js
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// lib/notifications-scheduler.js
+//
+// In-process scheduler that walks the manifest registry once per minute,
+// evaluates triggers, and fires due notifications. v3.0.0 wires this up
+// to logging only (no push send); the notifications-send PR (#386)
+// replaces _dispatch() with the real send path.
+//
+// Idempotency: lastFired stores the SLOT instant (the prevFire ISO from
+// the trigger evaluator), not the wall-clock fire time. So a server
+// restart at 08:00:30 sees lastFired=2026-06-12T08:00:00... and skips,
+// rather than refiring 30s later.
+//
+// Coalescing: if multiple items fire in the same minute they are bundled
+// into one logical dispatch event. The send-side PR uses this to send
+// one collapsed Web Push instead of N separate notifications.
+
+const trigger = require('./notification-trigger');
+const state = require('./notifications-state');
+const userTz = require('./user-tz');
+
+const TICK_MS = 60_000;
+const ITEMS_CAP = 50;
+
+let _registry = null;
+let _timer = null;
+let _stopping = false;
+let _dispatch = _logDispatch;
+
+// Default dispatch: log what would be sent. PR #386 swaps this for the
+// real Web Push send path via setDispatch().
+function _logDispatch(events) {
+  for (const ev of events) {
+    console.log(`[notifications] would-fire id=${ev.id} slot=${ev.slot} items=${ev.items.length}`);
+  }
+}
+
+// Replace the dispatch function. Called by the boot wiring in PR4 once
+// the send module exists.
+function setDispatch(fn) {
+  _dispatch = typeof fn === 'function' ? fn : _logDispatch;
+}
+
+// Self-rescheduling timer that lands close to the start of each minute.
+// setInterval would drift under event-loop pressure; setTimeout +
+// next-minute alignment keeps fires deterministic.
+function _schedule() {
+  if (_stopping) return;
+  const now = Date.now();
+  const ms = now % 60_000;
+  const delay = ms === 0 ? TICK_MS : (TICK_MS - ms);
+  _timer = setTimeout(async () => {
+    try { await _tick(new Date()); } catch (e) {
+      console.warn(`[notifications-scheduler] tick error: ${e.message}`);
+    }
+    _schedule();
+  }, delay);
+  if (typeof _timer.unref === 'function') _timer.unref();
+}
+
+// Format Date#now in the user TZ as HH:MM (used for quiet-hours
+// inside-window check).
+function _hhmmIn(now, tz) {
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: tz, hour: '2-digit', minute: '2-digit', hour12: false,
+  });
+  const parts = fmt.formatToParts(now);
+  const h = parts.find(p => p.type === 'hour').value;
+  const m = parts.find(p => p.type === 'minute').value;
+  return `${h === '24' ? '00' : h}:${m}`;
+}
+
+// Single tick: evaluate every notification across every manifest, write
+// any state changes once, and dispatch the coalesced events.
+async function _tick(now) {
+  if (!_registry) return;
+  const tz = userTz.readUserTz();
+  const cur = state.read();
+
+  // Global pause short-circuits everything: do NOT advance lastFired so
+  // when paused expires, the next tick fires the most recent missed slot.
+  if (cur.paused_until && cur.paused_until > now.toISOString()) {
+    return;
+  }
+
+  const due = [];
+  let mutated = false;
+  let activeCount = 0;
+
+  for (const card of _registry.list()) {
+    const meta = card.meta;
+    const notifs = meta && meta.notifications;
+    if (!notifs || notifs.enabled === false) continue;
+    const items = Array.isArray(notifs.items) ? notifs.items : [];
+    for (const item of items) {
+      const id = `${meta.id}#${item.id}`;
+      const itemState = state.getOrInitItem(cur, id, (item.default || 'on') !== 'off');
+      if (itemState.enabled === false) continue;
+      if (++activeCount > ITEMS_CAP) {
+        console.warn(`[notifications-scheduler] active-item cap (${ITEMS_CAP}) reached; skipping further items this tick`);
+        break;
+      }
+
+      const slots = trigger.evaluate(item.trigger, now, tz);
+      if (!slots) continue;
+
+      const slotMs = new Date(slots.prev).getTime();
+      // Only fire when the slot is in the past (or now-ish) AND we
+      // haven't already recorded firing for it. The slot string equality
+      // is what makes this idempotent across restarts.
+      if (slotMs > now.getTime()) continue;
+      if (itemState.lastFired === slots.prev) continue;
+
+      // Quiet hours: record the slot as fired (so we don't replay a
+      // backlog when the window ends), but skip the dispatch.
+      const inQuiet = state.isQuietNow(cur.quiet_hours, _hhmmIn(now, tz));
+      itemState.lastFired = slots.prev;
+      itemState.lastFireStatus = inQuiet ? 'quiet' : 'pending';
+      mutated = true;
+      if (inQuiet) continue;
+
+      due.push({
+        id,
+        slot: slots.prev,
+        item,
+        manifest: { id: meta.id, label: meta.label, emoji: meta.emoji || null },
+      });
+    }
+    if (activeCount > ITEMS_CAP) break;
+  }
+
+  if (mutated) state.write(cur);
+
+  if (due.length === 0) return;
+
+  // Coalesce same-minute fires (currently every fire shares the tick's
+  // wall-clock minute, so coalescing means one event per item bundle).
+  // The dispatch contract is: an array of events, each with .items, even
+  // when the items array has length 1.
+  const events = [{
+    id: 'tick-' + now.toISOString().slice(0, 16),
+    slot: due[0].slot,
+    items: due,
+  }];
+  await _dispatch(events);
+}
+
+function start(registry) {
+  if (_timer) return;
+  _registry = registry;
+  _stopping = false;
+  // Fire on boot so a notification due during a restart window catches up
+  // within ~1 second instead of waiting up to 60s.
+  _tick(new Date()).catch(() => {});
+  _schedule();
+}
+
+function stop() {
+  _stopping = true;
+  if (_timer) { clearTimeout(_timer); _timer = null; }
+}
+
+module.exports = {
+  start,
+  stop,
+  setDispatch,
+  // Exported for tests:
+  _tick,
+};

--- a/lib/notifications-state.js
+++ b/lib/notifications-state.js
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// lib/notifications-state.js
+//
+// Runtime state for notifications. Lives at $HEALTH_HOME/notifications.state.json
+// (mode 0o600, atomic tmp+rename, fsynced). Stores:
+//   - per-item enabled flag and lastFired (the slot the scheduler last
+//     dispatched for, NOT the wall-clock time it fired - that lets the
+//     idempotency check survive restarts inside the same minute);
+//   - global quiet_hours window (off-hours where the slot is recorded as
+//     fired but no push is sent);
+//   - global paused_until (whole-feature mute up to a deadline).
+//
+// The file is created lazily on the first toggle: instances that never
+// open Settings > Notifications never gain a state file.
+
+const fs = require('fs');
+const path = require('path');
+const PATHS = require('../config/paths');
+
+const FILE_MODE = 0o600;
+
+function _emptyState() {
+  return { items: {}, quiet_hours: null, paused_until: null };
+}
+
+// Load + parse with quiet recovery from corruption / missing.
+function read() {
+  try {
+    const raw = fs.readFileSync(PATHS.NOTIFICATIONS_STATE_FILE, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return {
+        items: parsed.items && typeof parsed.items === 'object' && !Array.isArray(parsed.items)
+          ? parsed.items
+          : {},
+        quiet_hours: _isValidQuietHours(parsed.quiet_hours) ? parsed.quiet_hours : null,
+        paused_until: typeof parsed.paused_until === 'string' ? parsed.paused_until : null,
+      };
+    }
+  } catch (e) {
+    if (e.code !== 'ENOENT') {
+      console.warn(`[notifications-state] could not read state: ${e.message}; starting fresh`);
+    }
+  }
+  return _emptyState();
+}
+
+function _isValidQuietHours(qh) {
+  if (qh === null || qh === undefined) return false;
+  if (typeof qh !== 'object' || Array.isArray(qh)) return false;
+  return /^([01]\d|2[0-3]):[0-5]\d$/.test(qh.start) && /^([01]\d|2[0-3]):[0-5]\d$/.test(qh.end);
+}
+
+// Write + fsync atomically. Caller passes the full new state object.
+function write(state) {
+  const file = PATHS.NOTIFICATIONS_STATE_FILE;
+  // Ensure the parent directory exists. Lazy creation: HEALTH_HOME itself
+  // is bootstrap territory, but a fresh install may not yet have it.
+  try { fs.mkdirSync(path.dirname(file), { recursive: true }); } catch {}
+  const tmp = file + '.tmp';
+  const fd = fs.openSync(tmp, 'w', FILE_MODE);
+  try {
+    fs.writeSync(fd, JSON.stringify(state, null, 2));
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+  fs.renameSync(tmp, file);
+}
+
+// Return the per-item state, initialising it from the manifest's declared
+// `default` if not yet known. Does NOT persist; caller decides when to
+// write the merged state back.
+function getOrInitItem(state, id, defaultOn = true) {
+  if (state.items[id]) return state.items[id];
+  const created = {
+    enabled: defaultOn !== false,
+    lastFired: null,
+    lastFireStatus: null,
+  };
+  state.items[id] = created;
+  return created;
+}
+
+// Patch a single item's state. Reads, merges, writes atomically.
+function writeItem(id, patch) {
+  const state = read();
+  const current = state.items[id] || { enabled: true, lastFired: null, lastFireStatus: null };
+  state.items[id] = { ...current, ...patch };
+  write(state);
+  return state.items[id];
+}
+
+// Patch the global controls (quiet_hours, paused_until). Pass null to
+// clear an entry.
+function writeGlobal(patch) {
+  const state = read();
+  if ('quiet_hours' in patch) {
+    state.quiet_hours = patch.quiet_hours === null
+      ? null
+      : (_isValidQuietHours(patch.quiet_hours) ? { start: patch.quiet_hours.start, end: patch.quiet_hours.end } : state.quiet_hours);
+  }
+  if ('paused_until' in patch) {
+    state.paused_until = patch.paused_until === null ? null : String(patch.paused_until);
+  }
+  write(state);
+  return { quiet_hours: state.quiet_hours, paused_until: state.paused_until };
+}
+
+// Drop every items[] key whose runtime id starts with `${cardId}#`.
+// Called from the registry's onDelete hook so a deleted card doesn't
+// leave orphan toggle state behind. No-op when the file doesn't exist
+// yet (the common case on a fresh instance).
+function pruneCard(cardId) {
+  let state;
+  try {
+    state = read();
+  } catch {
+    return 0;
+  }
+  if (!fs.existsSync(PATHS.NOTIFICATIONS_STATE_FILE)) return 0;
+  const prefix = cardId + '#';
+  let removed = 0;
+  for (const k of Object.keys(state.items)) {
+    if (k.startsWith(prefix)) {
+      delete state.items[k];
+      removed += 1;
+    }
+  }
+  if (removed > 0) write(state);
+  return removed;
+}
+
+// Inside-quiet-hours check at a given instant. Returns boolean.
+// `qh` is { start, end } in "HH:MM" - both in the user's TZ.
+// Wall clock is computed once by the caller via lib/notification-trigger
+// and passed in as `nowHHMM`; this keeps the function pure.
+function isQuietNow(qh, nowHHMM) {
+  if (!qh || typeof qh.start !== 'string' || typeof qh.end !== 'string') return false;
+  const a = qh.start, b = qh.end, n = nowHHMM;
+  if (a === b) return false; // Empty window.
+  if (a < b) {
+    // Same-day window, e.g. 13:00..17:00.
+    return n >= a && n < b;
+  }
+  // Crosses midnight, e.g. 22:00..07:00.
+  return n >= a || n < b;
+}
+
+module.exports = {
+  read,
+  write,
+  writeItem,
+  writeGlobal,
+  pruneCard,
+  getOrInitItem,
+  isQuietNow,
+};

--- a/lib/user-tz.js
+++ b/lib/user-tz.js
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// lib/user-tz.js
+//
+// Per-instance user preferences. Today this is just the user's IANA
+// timezone, captured by the browser on each session and used by the
+// scheduler so reminders fire in the user's local time, not the server's.
+//
+// Single-user-per-instance: this is one file, not a per-user store.
+// $HEALTH_HOME/user.json, mode 0o600, atomic tmp+rename, fsynced.
+
+const fs = require('fs');
+const path = require('path');
+const PATHS = require('../config/paths');
+
+const FILE_MODE = 0o600;
+
+// IANA timezones change rarely but Intl.supportedValuesOf is the canonical
+// source. Cache the snapshot at module load to avoid the per-request cost.
+const SUPPORTED_TZS = (() => {
+  try {
+    if (typeof Intl.supportedValuesOf === 'function') {
+      return new Set(Intl.supportedValuesOf('timeZone'));
+    }
+  } catch {}
+  return null; // Older Node: skip strict membership check, fall back to format probe.
+})();
+
+function _isValidTz(tz) {
+  if (typeof tz !== 'string' || !tz || tz.length > 64) return false;
+  if (SUPPORTED_TZS) return SUPPORTED_TZS.has(tz);
+  // Fallback: try to construct an Intl.DateTimeFormat - throws on invalid.
+  try {
+    new Intl.DateTimeFormat('en-CA', { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function _readFile() {
+  try {
+    const raw = fs.readFileSync(PATHS.USER_FILE, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed;
+  } catch (e) {
+    if (e.code !== 'ENOENT') {
+      console.warn(`[user-tz] could not read ${PATHS.USER_FILE}: ${e.message}`);
+    }
+  }
+  return {};
+}
+
+function _writeFile(obj) {
+  const file = PATHS.USER_FILE;
+  try { fs.mkdirSync(path.dirname(file), { recursive: true }); } catch {}
+  const tmp = file + '.tmp';
+  const fd = fs.openSync(tmp, 'w', FILE_MODE);
+  try {
+    fs.writeSync(fd, JSON.stringify(obj, null, 2));
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+  fs.renameSync(tmp, file);
+}
+
+// Resolve the active TZ: client-supplied if known, else process.env.TZ
+// (which Node already honours for Date math), else 'UTC' as a final
+// safety net.
+function readUserTz() {
+  const stored = _readFile().tz;
+  if (typeof stored === 'string' && stored) return stored;
+  return process.env.TZ || 'UTC';
+}
+
+// Persist a new TZ if (a) it parses, (b) it differs from the current
+// stored value. Returns { tz, changed }.
+function writeUserTz(tz) {
+  if (!_isValidTz(tz)) {
+    const err = new Error('invalid tz');
+    err.code = 'INVALID_TZ';
+    throw err;
+  }
+  const obj = _readFile();
+  if (obj.tz === tz) return { tz, changed: false };
+  obj.tz = tz;
+  _writeFile(obj);
+  return { tz, changed: true };
+}
+
+module.exports = {
+  readUserTz,
+  writeUserTz,
+  _isValidTz, // exposed for the API handler error mapping + tests
+};

--- a/manifests/notifications-schema.js
+++ b/manifests/notifications-schema.js
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// manifests/notifications-schema.js
+//
+// Validator for meta.notifications. Mirrors the existing two-stage pattern
+// in manifests/registry.js: lenient at load (drop bad items silently,
+// return cleaned), strict at create + PATCH (throw with a prefix the HTTP
+// handler maps to a status code).
+//
+// Strict-mode error prefixes (handler maps these):
+//   "invalid notifications: ..."  -> 422
+//
+// v1 supports two trigger types only: daily and weekly. interval,
+// last_logged, and schedule_due are deferred.
+
+const ITEM_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+const TIME_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
+const WEEKDAYS = new Set(['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']);
+const TRIGGER_TYPES_V1 = new Set(['daily', 'weekly']);
+
+const TITLE_MAX = 30;
+const BODY_MAX = 80;
+const LABEL_MAX = 80;
+const ITEMS_MAX = 10;
+const ID_MAX = 64;
+
+const PRIVACY_VALUES = new Set(['private', 'public']);
+const DEFAULT_VALUES = new Set(['on', 'off']);
+const ACTION_INTENTS = new Set(['view', 'log']);
+const CARD_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+
+function isPlainObject(v) {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function fail(strict, msg) {
+  if (strict) throw new Error(`invalid notifications: ${msg}`);
+}
+
+// Validate one item. Returns the item (possibly with optional fields
+// normalised) or null if invalid. In strict mode, throws on the first
+// failure. In lenient mode, returns null for the caller to drop.
+function validateItem(item, strict, seenIds) {
+  if (!isPlainObject(item)) {
+    fail(strict, 'each items[] entry must be an object');
+    return null;
+  }
+
+  const id = item.id;
+  if (typeof id !== 'string' || !ITEM_ID_PATTERN.test(id) || id.length > ID_MAX) {
+    fail(strict, `item.id missing or invalid (must match ^[a-z0-9][a-z0-9._-]{0,63}$)`);
+    return null;
+  }
+  if (seenIds.has(id)) {
+    fail(strict, `duplicate item.id "${id}" within meta.notifications.items[]`);
+    return null;
+  }
+  seenIds.add(id);
+
+  if (typeof item.label !== 'string' || !item.label || item.label.length > LABEL_MAX) {
+    fail(strict, `item ${id}: label must be a non-empty string up to ${LABEL_MAX} chars`);
+    return null;
+  }
+  if (typeof item.title !== 'string' || !item.title || item.title.length > TITLE_MAX) {
+    fail(strict, `item ${id}: title must be a non-empty string up to ${TITLE_MAX} chars`);
+    return null;
+  }
+  if (typeof item.body !== 'string' || !item.body || item.body.length > BODY_MAX) {
+    fail(strict, `item ${id}: body must be a non-empty string up to ${BODY_MAX} chars`);
+    return null;
+  }
+
+  const trig = item.trigger;
+  if (!isPlainObject(trig) || !TRIGGER_TYPES_V1.has(trig.type)) {
+    fail(strict, `item ${id}: trigger.type must be "daily" or "weekly" (other types arrive in v3.1)`);
+    return null;
+  }
+  if (typeof trig.time !== 'string' || !TIME_PATTERN.test(trig.time)) {
+    fail(strict, `item ${id}: trigger.time must match HH:MM (24-hour)`);
+    return null;
+  }
+  if (trig.type === 'weekly') {
+    if (!Array.isArray(trig.days) || trig.days.length === 0) {
+      fail(strict, `item ${id}: weekly trigger requires non-empty days[]`);
+      return null;
+    }
+    const seen = new Set();
+    for (const d of trig.days) {
+      if (typeof d !== 'string' || !WEEKDAYS.has(d) || seen.has(d)) {
+        fail(strict, `item ${id}: weekly trigger.days entries must be unique and one of mon|tue|wed|thu|fri|sat|sun`);
+        return null;
+      }
+      seen.add(d);
+    }
+  }
+
+  // action: optional. When present, must be the open-card shape.
+  let action = item.action;
+  if (action !== undefined) {
+    if (!isPlainObject(action) || action.type !== 'open-card') {
+      fail(strict, `item ${id}: action.type must be "open-card"`);
+      return null;
+    }
+    if (action.card !== undefined && (typeof action.card !== 'string' || !CARD_ID_PATTERN.test(action.card))) {
+      fail(strict, `item ${id}: action.card must match ^[a-z0-9][a-z0-9._-]{0,63}$`);
+      return null;
+    }
+    if (action.intent !== undefined && !ACTION_INTENTS.has(action.intent)) {
+      fail(strict, `item ${id}: action.intent must be "view" or "log"`);
+      return null;
+    }
+  }
+
+  if (item.privacy !== undefined && !PRIVACY_VALUES.has(item.privacy)) {
+    fail(strict, `item ${id}: privacy must be "private" or "public"`);
+    return null;
+  }
+  if (item.default !== undefined && !DEFAULT_VALUES.has(item.default)) {
+    fail(strict, `item ${id}: default must be "on" or "off"`);
+    return null;
+  }
+
+  // Normalise: surface the defaults so downstream code never has to repeat them.
+  return {
+    id,
+    label: item.label,
+    title: item.title,
+    body: item.body,
+    trigger: trig.type === 'daily'
+      ? { type: 'daily', time: trig.time }
+      : { type: 'weekly', time: trig.time, days: [...trig.days] },
+    action: action ? { ...action } : undefined,
+    privacy: item.privacy || 'private',
+    default: item.default || 'on',
+  };
+}
+
+// Validate the meta.notifications block on a manifest object.
+// In lenient mode (strict=false), invalid items are dropped silently and
+// the function returns a cleaned block (or undefined if the whole block is
+// the wrong shape).
+// In strict mode (strict=true), the first failure throws with the
+// "invalid notifications: ..." prefix.
+function validateNotifications(notifications, { strict = false } = {}) {
+  if (notifications === undefined || notifications === null) {
+    return undefined;
+  }
+  if (!isPlainObject(notifications)) {
+    fail(strict, 'meta.notifications must be an object');
+    return undefined;
+  }
+
+  const enabled = notifications.enabled === false ? false : true;
+
+  const rawItems = notifications.items;
+  if (rawItems === undefined) {
+    return { enabled, items: [] };
+  }
+  if (!Array.isArray(rawItems)) {
+    fail(strict, 'meta.notifications.items must be an array');
+    return { enabled, items: [] };
+  }
+  if (rawItems.length > ITEMS_MAX) {
+    fail(strict, `meta.notifications.items length exceeds the cap of ${ITEMS_MAX}`);
+    // Lenient: keep the first N and drop the rest.
+  }
+
+  const cleaned = [];
+  const seenIds = new Set();
+  const limit = strict ? rawItems.length : Math.min(rawItems.length, ITEMS_MAX);
+  for (let i = 0; i < limit; i++) {
+    const out = validateItem(rawItems[i], strict, seenIds);
+    if (out) cleaned.push(out);
+  }
+
+  return { enabled, items: cleaned };
+}
+
+module.exports = {
+  validateNotifications,
+  // Exported for use in tests + future trigger/scheduler modules.
+  ITEMS_MAX,
+  TITLE_MAX,
+  BODY_MAX,
+  LABEL_MAX,
+  ITEM_ID_PATTERN,
+  TIME_PATTERN,
+  WEEKDAYS: [...WEEKDAYS],
+  TRIGGER_TYPES_V1: [...TRIGGER_TYPES_V1],
+};

--- a/manifests/registry.js
+++ b/manifests/registry.js
@@ -19,6 +19,7 @@ const { mergePatch, isPlainObject } = require('./merge-patch');
 const { parsePath, resolvePath } = require('./path');
 
 const { isValidCategory } = require('../config/categories');
+const { validateNotifications } = require('./notifications-schema');
 
 const SUPPORTED_SCHEMAS = ['klebb.datafile.v1'];
 const RESERVED_DIR_PREFIX = '_';
@@ -34,6 +35,13 @@ const RESERVED_IDS = new Set([
 let _entries = new Map();   // id -> { meta, description, schema, data, source, version }
 let _errors = [];           // [{file, error}]
 let _watcher = null;
+const _deleteHooks = [];    // (id) => void; called after a manifest is deleted
+
+// Register a callback to fire after deleteManifest succeeds. Used by
+// notifications-state to prune sidecar entries for a removed card.
+function onDelete(fn) {
+  if (typeof fn === 'function') _deleteHooks.push(fn);
+}
 
 // Backup files created by scripts/migrate-* and scripts/reingest-hae
 // land beside the canonical manifest with a timestamped suffix before
@@ -75,7 +83,7 @@ function _scanDir(dir) {
 // names, length). Load-time validation is lenient about id format so legacy
 // files keep loading; the create path sets strictId:true.
 function validateManifestShape(parsed, opts = {}) {
-  const { strictId = false } = opts;
+  const { strictId = false, strictNotifications = strictId } = opts;
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     throw new Error('missing $schema');
   }
@@ -110,6 +118,18 @@ function validateManifestShape(parsed, opts = {}) {
   if (parsed.meta.category !== undefined && !isValidCategory(parsed.meta.category)) {
     delete parsed.meta.category;
   }
+
+  // meta.notifications is optional. Lenient at load (drop bad items),
+  // strict at create/PATCH (throw "invalid notifications: ...").
+  if (parsed.meta.notifications !== undefined) {
+    const cleaned = validateNotifications(parsed.meta.notifications, { strict: strictNotifications });
+    if (cleaned === undefined) {
+      delete parsed.meta.notifications;
+    } else {
+      parsed.meta.notifications = cleaned;
+    }
+  }
+
   return parsed;
 }
 
@@ -697,8 +717,10 @@ function patchManifest(id, patch) {
   const merged = _buildEntryEnvelope(stagedEntry);
 
   // Re-validate. strictId:false so we don't reject legacy ids that already
-  // loaded; we already blocked id changes above.
-  validateManifestShape(merged, { strictId: false });
+  // loaded; we already blocked id changes above. Notifications get strict
+  // validation though - the agent shouldn't be able to patch in malformed
+  // items lenient-mode just because the manifest's id is grandfathered.
+  validateManifestShape(merged, { strictId: false, strictNotifications: true });
 
   _persistEnvelope(entry, merged);
   entry.meta = merged.meta;
@@ -721,6 +743,11 @@ function deleteManifest(id) {
     }
   }
   _entries.delete(id);
+  for (const fn of _deleteHooks) {
+    try { fn(id); } catch (e) {
+      console.warn(`[registry] onDelete hook error for ${id}: ${e.message}`);
+    }
+  }
   return { id, removed: entry.source };
 }
 
@@ -744,4 +771,5 @@ module.exports = {
   patchManifest,
   deleteManifest,
   validateManifestShape,
+  onDelete,
 };

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -50,6 +50,7 @@ class HealthApp extends LitElement {
     this._onThemeChanged = (e) => { this.theme = e.detail.theme; };
     window.addEventListener('klebb-theme-changed', this._onThemeChanged);
     this._registerServiceWorker();
+    this._postUserTz();
     this._handleRoute();
     this._loadInstance();
     this._loadBuildInfo();
@@ -76,6 +77,31 @@ class HealthApp extends LitElement {
     // is registered so the browser keeps it alive once push lands.
     if (!('serviceWorker' in navigator)) return;
     navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch(() => {});
+  }
+
+  _postUserTz() {
+    // Tell the server which IANA timezone the browser is in, so the
+    // notifications scheduler fires reminders in the user's local time
+    // when they travel rather than in the server's TZ.
+    //
+    // Fire-and-forget; quiet on failure (the scheduler falls back to
+    // process.env.TZ on the server). Idempotent: skip the round-trip
+    // when the value hasn't changed since last boot.
+    let tz = null;
+    try { tz = Intl.DateTimeFormat().resolvedOptions().timeZone; } catch {}
+    if (!tz) return;
+    try {
+      if (localStorage.getItem('klebb-tz-last-posted') === tz) return;
+    } catch {}
+    fetch('/api/user/tz', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tz }),
+    }).then(r => {
+      if (r.ok) {
+        try { localStorage.setItem('klebb-tz-last-posted', tz); } catch {}
+      }
+    }).catch(() => {});
   }
 
   async _loadInstance() {

--- a/server.js
+++ b/server.js
@@ -25,6 +25,9 @@ const haeDiagnostics = require('./health-auto-export/diagnostics');
 const haeDiscoveries = require('./health-auto-export/discoveries');
 const haeTokenStore = require('./health-auto-export/token-store');
 const { describeCatalogue: describeHaeCatalogue } = require('./health-auto-export/describe');
+const userTz = require('./lib/user-tz');
+const notificationsState = require('./lib/notifications-state');
+const notificationsScheduler = require('./lib/notifications-scheduler');
 const { CATEGORIES: MANIFEST_CATEGORIES } = require('./config/categories');
 const ccSuggestions = require('./meta/cc-suggestions');
 const { describeCcSchema } = require('./chat/describe-cc-schema');
@@ -1641,6 +1644,27 @@ Original system prompt follows:
       });
     }
 
+    // POST /api/user/tz — capture the user's IANA timezone for the
+    // notifications scheduler. The browser posts this on every session
+    // boot; the server only writes when the value changed.
+    if (parts[0] === 'user' && parts[1] === 'tz' && parts.length === 2 && req.method === 'POST') {
+      let body = '';
+      req.on('data', c => body += c);
+      req.on('end', () => {
+        let parsed;
+        try { parsed = JSON.parse(body || '{}'); }
+        catch { return sendJSON(res, { error: 'invalid JSON body' }, 400); }
+        try {
+          const result = userTz.writeUserTz(parsed.tz);
+          return sendJSON(res, { ok: true, tz: result.tz, changed: result.changed });
+        } catch (e) {
+          if (e.code === 'INVALID_TZ') return sendJSON(res, { error: 'invalid tz' }, 400);
+          return sendJSON(res, { error: e.message || 'tz write failed' }, 500);
+        }
+      });
+      return;
+    }
+
     // Voice is disabled in demo mode. Every /api/voice/* path returns 503
     // before falling through to the real handlers below.
     if (ENV.KLEBB_DEMO && parts[0] === 'voice') {
@@ -1908,4 +1932,27 @@ server.listen(PORT, HOST, () => {
   } catch (e) {
     console.warn('[ingest] watcher init failed:', e.message);
   }
+
+  // Notifications scheduler: 1-minute tick, evaluates triggers, fires
+  // due notifications. Disabled in demo mode (the demo doesn't deliver
+  // push). The dispatch path is logging-only in v3.0.0; PR #386 wires
+  // up the real Web Push send.
+  if (!ENV.KLEBB_DEMO) {
+    try {
+      registry.onDelete((id) => notificationsState.pruneCard(id));
+      notificationsScheduler.start(registry);
+      console.log('[notifications] scheduler started');
+    } catch (e) {
+      console.warn('[notifications] scheduler init failed:', e.message);
+    }
+  }
 });
+
+// Graceful shutdown: stop the scheduler so the test harness's SIGTERM
+// doesn't leave a stray timer keeping the process alive.
+function _shutdown() {
+  try { notificationsScheduler.stop(); } catch {}
+  process.exit(0);
+}
+process.on('SIGTERM', _shutdown);
+process.on('SIGINT', _shutdown);

--- a/tests/notifications-scheduler.test.js
+++ b/tests/notifications-scheduler.test.js
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/notifications-scheduler.test.js
+//
+// In-process tests for the scheduler tick. Drives _tick() with a mock
+// "now" and a fake registry so we don't depend on real card files.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+function freshState() {
+  // Each test gets its own HEALTH_HOME so notifications.state.json,
+  // user.json, etc. don't leak. The path module is loaded ONCE per
+  // process so we shim HEALTH_HOME via the override env var.
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'klebb-sched-'));
+  const stateFile = path.join(root, 'notifications.state.json');
+  const userFile = path.join(root, 'user.json');
+  process.env.HEALTH_NOTIFICATIONS_STATE_FILE = stateFile;
+  process.env.HEALTH_USER_FILE = userFile;
+  process.env.TZ = 'Australia/Melbourne';
+  // Bust the require cache so the modules reload PATHS with the new env.
+  for (const k of Object.keys(require.cache)) {
+    if (k.includes('notifications-state')
+      || k.includes('notification-trigger')
+      || k.includes('notifications-scheduler')
+      || k.includes('user-tz')
+      || k.endsWith('config' + path.sep + 'paths.js')) {
+      delete require.cache[k];
+    }
+  }
+  return { root, stateFile, userFile };
+}
+
+function fakeRegistry(cards) {
+  return {
+    list: () => cards,
+  };
+}
+
+const VALID_DAILY = {
+  id: 'evening-log',
+  label: 'Evening',
+  title: 'Mood',
+  body: 'How are you feeling?',
+  trigger: { type: 'daily', time: '08:00' },
+  privacy: 'private',
+  default: 'on',
+};
+
+test.describe('notifications-scheduler tick', () => {
+  test('fires due notification, advances lastFired, second tick is idempotent', async () => {
+    const { stateFile } = freshState();
+    const scheduler = require('../lib/notifications-scheduler');
+    const events = [];
+    scheduler.setDispatch(async (evs) => events.push(...evs));
+
+    const card = {
+      meta: {
+        id: 'mood', label: 'Mood',
+        notifications: { enabled: true, items: [VALID_DAILY] },
+      },
+    };
+
+    // 09:00 +10:00 on 2026-06-12 = 23:00 UTC on 2026-06-11
+    const now = new Date('2026-06-11T23:00:00Z');
+    scheduler._tick.bind(null);
+    await scheduler._tick.call({ _registry: { list: () => [card] } }, now);
+    // The first tick happens via the public tick path - our shim above
+    // doesn't bind a registry. Use the wrapped form instead:
+    scheduler.start({ list: () => [card] });
+    // Stop the timer immediately; we'll drive _tick manually below.
+    scheduler.stop();
+    events.length = 0;
+
+    await scheduler._tick(now);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].items.length, 1);
+    assert.equal(events[0].items[0].id, 'mood#evening-log');
+
+    const persisted = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+    assert.match(persisted.items['mood#evening-log'].lastFired, /T08:00:00\+10:00$/);
+    assert.equal(persisted.items['mood#evening-log'].lastFireStatus, 'pending');
+
+    // Second tick at the same instant: no new dispatch.
+    events.length = 0;
+    await scheduler._tick(now);
+    assert.equal(events.length, 0);
+  });
+
+  test('paused_until short-circuits the tick (does not advance lastFired)', async () => {
+    const { stateFile } = freshState();
+    const scheduler = require('../lib/notifications-scheduler');
+    const stateMod = require('../lib/notifications-state');
+    const events = [];
+    scheduler.setDispatch(async (evs) => events.push(...evs));
+
+    // Pre-pause for an hour past "now".
+    stateMod.writeGlobal({ paused_until: '2026-06-12T00:00:00Z' });
+
+    scheduler.start({ list: () => [{
+      meta: { id: 'mood', label: 'Mood', notifications: { enabled: true, items: [VALID_DAILY] } },
+    }] });
+    scheduler.stop();
+    events.length = 0;
+
+    const now = new Date('2026-06-11T23:00:00Z');
+    await scheduler._tick(now);
+    assert.equal(events.length, 0);
+
+    // Critical: lastFired must NOT have advanced - so when paused
+    // expires the next tick can still fire the missed slot.
+    const after = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+    assert.equal(after.items['mood#evening-log']?.lastFired, undefined);
+  });
+
+  test('quiet_hours: tick records lastFired but skips dispatch', async () => {
+    const { stateFile } = freshState();
+    const scheduler = require('../lib/notifications-scheduler');
+    const stateMod = require('../lib/notifications-state');
+    const events = [];
+    scheduler.setDispatch(async (evs) => events.push(...evs));
+
+    // Quiet 07:00..09:00 - the 08:00 slot lands inside the window.
+    stateMod.writeGlobal({ quiet_hours: { start: '07:00', end: '09:00' } });
+
+    scheduler.start({ list: () => [{
+      meta: { id: 'mood', label: 'Mood', notifications: { enabled: true, items: [VALID_DAILY] } },
+    }] });
+    scheduler.stop();
+    events.length = 0;
+
+    const now = new Date('2026-06-11T23:00:00Z'); // 09:00 +10:00
+    // Reset hour to 08:00 so we land inside quiet window
+    const qNow = new Date('2026-06-11T22:00:00Z'); // 08:00 +10:00
+    await scheduler._tick(qNow);
+
+    assert.equal(events.length, 0);
+    const after = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+    // Slot recorded, status flagged so a debug surface can show "quiet".
+    assert.match(after.items['mood#evening-log'].lastFired, /T08:00:00\+10:00$/);
+    assert.equal(after.items['mood#evening-log'].lastFireStatus, 'quiet');
+  });
+
+  test('item-state.enabled=false skips dispatch', async () => {
+    const { stateFile } = freshState();
+    const scheduler = require('../lib/notifications-scheduler');
+    const stateMod = require('../lib/notifications-state');
+    const events = [];
+    scheduler.setDispatch(async (evs) => events.push(...evs));
+
+    stateMod.writeItem('mood#evening-log', { enabled: false });
+
+    scheduler.start({ list: () => [{
+      meta: { id: 'mood', label: 'Mood', notifications: { enabled: true, items: [VALID_DAILY] } },
+    }] });
+    scheduler.stop();
+    events.length = 0;
+
+    await scheduler._tick(new Date('2026-06-11T23:00:00Z'));
+    assert.equal(events.length, 0);
+  });
+
+  test('manifest-level enabled=false skips every item', async () => {
+    freshState();
+    const scheduler = require('../lib/notifications-scheduler');
+    const events = [];
+    scheduler.setDispatch(async (evs) => events.push(...evs));
+
+    scheduler.start({ list: () => [{
+      meta: { id: 'mood', label: 'Mood', notifications: { enabled: false, items: [VALID_DAILY] } },
+    }] });
+    scheduler.stop();
+    events.length = 0;
+
+    await scheduler._tick(new Date('2026-06-11T23:00:00Z'));
+    assert.equal(events.length, 0);
+  });
+});

--- a/tests/notifications-schema.test.js
+++ b/tests/notifications-schema.test.js
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/notifications-schema.test.js
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { validateNotifications } = require('../manifests/notifications-schema');
+
+const VALID_ITEM = {
+  id: 'evening-log',
+  label: 'Evening mood log',
+  title: 'Mood',
+  body: 'How are you feeling?',
+  trigger: { type: 'daily', time: '20:00' },
+};
+
+test.describe('validateNotifications: lenient mode (load-time)', () => {
+  test('returns undefined for null/undefined input', () => {
+    assert.equal(validateNotifications(null), undefined);
+    assert.equal(validateNotifications(undefined), undefined);
+  });
+
+  test('drops bad items silently and returns the cleaned block', () => {
+    const out = validateNotifications({
+      enabled: true,
+      items: [
+        VALID_ITEM,
+        { id: '!!bad-id', label: 'x', title: 'x', body: 'x', trigger: { type: 'daily', time: '08:00' } },
+        { id: 'no-trigger', label: 'x', title: 'x', body: 'x' },
+      ],
+    });
+    assert.equal(out.items.length, 1);
+    assert.equal(out.items[0].id, 'evening-log');
+  });
+
+  test('caps items[] at 10 silently', () => {
+    const items = [];
+    for (let i = 0; i < 15; i++) {
+      items.push({ ...VALID_ITEM, id: `item-${i}` });
+    }
+    const out = validateNotifications({ items });
+    assert.equal(out.items.length, 10);
+  });
+
+  test('treats unknown trigger types as malformed (drops)', () => {
+    const out = validateNotifications({
+      items: [
+        { ...VALID_ITEM, trigger: { type: 'interval', every_days: 7, time: '08:00' } },
+      ],
+    });
+    assert.equal(out.items.length, 0);
+  });
+
+  test('normalises defaults: privacy=private, default=on, items[] always present', () => {
+    const out = validateNotifications({ items: [VALID_ITEM] });
+    assert.equal(out.enabled, true);
+    assert.equal(out.items[0].privacy, 'private');
+    assert.equal(out.items[0].default, 'on');
+  });
+
+  test('respects enabled:false', () => {
+    const out = validateNotifications({ enabled: false, items: [VALID_ITEM] });
+    assert.equal(out.enabled, false);
+  });
+});
+
+test.describe('validateNotifications: strict mode (create / PATCH)', () => {
+  function expectFail(input, msgRe) {
+    assert.throws(
+      () => validateNotifications(input, { strict: true }),
+      e => msgRe.test(e.message),
+    );
+  }
+
+  test('rejects non-object', () => {
+    expectFail([], /must be an object/);
+    expectFail('x', /must be an object/);
+  });
+
+  test('rejects items.length > 10', () => {
+    const items = [];
+    for (let i = 0; i < 11; i++) items.push({ ...VALID_ITEM, id: `item-${i}` });
+    expectFail({ items }, /exceeds the cap/);
+  });
+
+  test('rejects malformed id', () => {
+    expectFail({ items: [{ ...VALID_ITEM, id: 'BAD' }] }, /item.id missing or invalid/);
+    expectFail({ items: [{ ...VALID_ITEM, id: '-startswithdash' }] }, /item.id missing or invalid/);
+  });
+
+  test('rejects duplicate ids', () => {
+    expectFail({
+      items: [VALID_ITEM, { ...VALID_ITEM }],
+    }, /duplicate item.id/);
+  });
+
+  test('rejects missing required strings', () => {
+    expectFail({ items: [{ ...VALID_ITEM, label: '' }] }, /label must be/);
+    expectFail({ items: [{ ...VALID_ITEM, title: undefined }] }, /title must be/);
+    expectFail({ items: [{ ...VALID_ITEM, body: 123 }] }, /body must be/);
+  });
+
+  test('rejects oversize strings', () => {
+    expectFail({ items: [{ ...VALID_ITEM, title: 'x'.repeat(31) }] }, /title must be/);
+    expectFail({ items: [{ ...VALID_ITEM, body: 'x'.repeat(81) }] }, /body must be/);
+    expectFail({ items: [{ ...VALID_ITEM, label: 'x'.repeat(81) }] }, /label must be/);
+  });
+
+  test('rejects bad trigger types and times', () => {
+    expectFail({ items: [{ ...VALID_ITEM, trigger: { type: 'interval', time: '08:00' } }] }, /trigger.type/);
+    expectFail({ items: [{ ...VALID_ITEM, trigger: { type: 'daily', time: '8:00' } }] }, /trigger.time/);
+    expectFail({ items: [{ ...VALID_ITEM, trigger: { type: 'daily', time: '24:00' } }] }, /trigger.time/);
+  });
+
+  test('rejects weekly without days[] or with bad day strings', () => {
+    expectFail({ items: [{ ...VALID_ITEM, trigger: { type: 'weekly', time: '20:00' } }] }, /days/);
+    expectFail({ items: [{ ...VALID_ITEM, trigger: { type: 'weekly', time: '20:00', days: [] } }] }, /days/);
+    expectFail({ items: [{ ...VALID_ITEM, trigger: { type: 'weekly', time: '20:00', days: ['mon', 'mon'] } }] }, /days/);
+    expectFail({ items: [{ ...VALID_ITEM, trigger: { type: 'weekly', time: '20:00', days: ['monday'] } }] }, /days/);
+  });
+
+  test('rejects malformed action', () => {
+    expectFail({ items: [{ ...VALID_ITEM, action: { type: 'navigate' } }] }, /action.type/);
+    expectFail({ items: [{ ...VALID_ITEM, action: { type: 'open-card', intent: 'log-now' } }] }, /action.intent/);
+    expectFail({ items: [{ ...VALID_ITEM, action: { type: 'open-card', card: 'BAD!' } }] }, /action.card/);
+  });
+
+  test('rejects bad privacy / default values', () => {
+    expectFail({ items: [{ ...VALID_ITEM, privacy: 'opaque' }] }, /privacy must be/);
+    expectFail({ items: [{ ...VALID_ITEM, default: 'maybe' }] }, /default must be/);
+  });
+
+  test('accepts the canonical happy path', () => {
+    const out = validateNotifications({
+      enabled: true,
+      items: [
+        VALID_ITEM,
+        {
+          id: 'mw-mood',
+          label: 'Mon/Wed/Fri',
+          title: 'Mood',
+          body: 'How are you feeling?',
+          trigger: { type: 'weekly', time: '08:00', days: ['mon', 'wed', 'fri'] },
+          privacy: 'public',
+          default: 'off',
+        },
+      ],
+    }, { strict: true });
+    assert.equal(out.items.length, 2);
+    assert.equal(out.items[1].privacy, 'public');
+    assert.equal(out.items[1].default, 'off');
+    assert.deepEqual(out.items[1].trigger.days, ['mon', 'wed', 'fri']);
+  });
+});

--- a/tests/notifications-state-prune.test.js
+++ b/tests/notifications-state-prune.test.js
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/notifications-state-prune.test.js
+//
+// Verifies the registry's onDelete hook prunes orphan items[] entries
+// from notifications.state.json when a card is deleted.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+function freshState() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'klebb-prune-'));
+  const stateFile = path.join(root, 'notifications.state.json');
+  process.env.HEALTH_NOTIFICATIONS_STATE_FILE = stateFile;
+  // Reset the require cache so PATHS picks up the override.
+  for (const k of Object.keys(require.cache)) {
+    if (k.endsWith('config' + path.sep + 'paths.js') || k.includes('notifications-state')) {
+      delete require.cache[k];
+    }
+  }
+  return { root, stateFile };
+}
+
+test.describe('notifications-state.pruneCard', () => {
+  test('removes only the keys whose runtime id starts with `${cardId}#`', () => {
+    const { stateFile } = freshState();
+    const stateMod = require('../lib/notifications-state');
+
+    stateMod.writeItem('mood#evening-log', { enabled: true, lastFired: 'a' });
+    stateMod.writeItem('mood#morning-log', { enabled: false, lastFired: 'b' });
+    stateMod.writeItem('weight#daily', { enabled: true, lastFired: 'c' });
+
+    const removed = stateMod.pruneCard('mood');
+    assert.equal(removed, 2);
+
+    const remaining = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+    assert.deepEqual(Object.keys(remaining.items), ['weight#daily']);
+  });
+
+  test('returns 0 when no matching keys exist', () => {
+    freshState();
+    const stateMod = require('../lib/notifications-state');
+    stateMod.writeItem('weight#daily', { enabled: true });
+    assert.equal(stateMod.pruneCard('mood'), 0);
+  });
+
+  test('returns 0 when the state file does not exist yet', () => {
+    freshState();
+    const stateMod = require('../lib/notifications-state');
+    assert.equal(stateMod.pruneCard('mood'), 0);
+  });
+});

--- a/tests/notifications-trigger.test.js
+++ b/tests/notifications-trigger.test.js
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/notifications-trigger.test.js
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const trigger = require('../lib/notification-trigger');
+
+const TZ = 'Australia/Melbourne';
+
+test.describe('notification-trigger: daily', () => {
+  test('mid-afternoon: prev = today 08:00, next = tomorrow 08:00', () => {
+    // 2026-06-12T15:00:00+10:00 (winter in AEST, UTC+10)
+    const now = new Date('2026-06-12T05:00:00Z');
+    const out = trigger.evaluate({ type: 'daily', time: '08:00' }, now, TZ);
+    assert.match(out.prev, /^2026-06-12T08:00:00\+10:00$/);
+    assert.match(out.next, /^2026-06-13T08:00:00\+10:00$/);
+  });
+
+  test('before today\'s slot: prev = yesterday, next = today', () => {
+    // 2026-06-12T05:00:00+10:00 = 2026-06-11T19:00:00Z
+    const now = new Date('2026-06-11T19:00:00Z');
+    const out = trigger.evaluate({ type: 'daily', time: '08:00' }, now, TZ);
+    assert.match(out.prev, /^2026-06-11T08:00:00\+10:00$/);
+    assert.match(out.next, /^2026-06-12T08:00:00\+10:00$/);
+  });
+
+  test('exactly at the slot: counts as fired (prev=today, next=tomorrow)', () => {
+    // 2026-06-12T08:00:00+10:00 = 2026-06-11T22:00:00Z
+    const now = new Date('2026-06-11T22:00:00Z');
+    const out = trigger.evaluate({ type: 'daily', time: '08:00' }, now, TZ);
+    assert.match(out.prev, /^2026-06-12T08:00:00\+10:00$/);
+    assert.match(out.next, /^2026-06-13T08:00:00\+10:00$/);
+  });
+});
+
+test.describe('notification-trigger: daily across DST', () => {
+  // Australia/Melbourne ends AEDT on 2026-04-05 03:00 (clocks roll
+  // back from +11 to +10) and starts AEDT on 2026-10-04 02:00 (clocks
+  // jump from +10 to +11). A correct evaluator yields HH:MM in local
+  // wall-clock terms even across these boundaries.
+
+  test('autumn DST boundary (AEDT ends 2026-04-05): 08:00 stays 08:00', () => {
+    // 09:00 AEDT/+11 on 2026-04-05 = 22:00 UTC the day before
+    const now = new Date('2026-04-04T22:00:00Z');
+    const out = trigger.evaluate({ type: 'daily', time: '08:00' }, now, TZ);
+    // After the rollback the offset is +10
+    assert.match(out.next, /T08:00:00\+10:00$/);
+  });
+
+  test('spring DST boundary (AEDT starts 2026-10-04): 08:00 stays 08:00', () => {
+    // 06:00 AEST/+10 on 2026-10-04 = 20:00 UTC the day before
+    const now = new Date('2026-10-03T20:00:00Z');
+    const out = trigger.evaluate({ type: 'daily', time: '08:00' }, now, TZ);
+    // After the jump-forward the offset is +11
+    assert.match(out.next, /T08:00:00\+11:00$/);
+  });
+});
+
+test.describe('notification-trigger: weekly', () => {
+  test('Mon/Wed/Fri 08:00 from a Wed afternoon: prev = today, next = Friday', () => {
+    // 2026-06-10 is a Wednesday. 15:00 local = 05:00 UTC.
+    const now = new Date('2026-06-10T05:00:00Z');
+    const out = trigger.evaluate(
+      { type: 'weekly', time: '08:00', days: ['mon', 'wed', 'fri'] },
+      now, TZ,
+    );
+    assert.match(out.prev, /^2026-06-10T08:00:00\+10:00$/);
+    assert.match(out.next, /^2026-06-12T08:00:00\+10:00$/);
+  });
+
+  test('Sun-only trigger from a Wed: prev = last Sunday, next = next Sunday', () => {
+    const now = new Date('2026-06-10T05:00:00Z'); // Wed 15:00 +10
+    const out = trigger.evaluate(
+      { type: 'weekly', time: '09:00', days: ['sun'] },
+      now, TZ,
+    );
+    assert.match(out.prev, /^2026-06-07T09:00:00\+10:00$/);
+    assert.match(out.next, /^2026-06-14T09:00:00\+10:00$/);
+  });
+
+  test('returns null when days[] is empty', () => {
+    const now = new Date('2026-06-10T05:00:00Z');
+    const out = trigger.evaluate(
+      { type: 'weekly', time: '08:00', days: [] },
+      now, TZ,
+    );
+    assert.equal(out, null);
+  });
+});
+
+test.describe('notification-trigger: malformed input', () => {
+  test('returns null for unknown trigger type', () => {
+    const out = trigger.evaluate({ type: 'interval', time: '08:00' }, new Date(), TZ);
+    assert.equal(out, null);
+  });
+
+  test('returns null for malformed time', () => {
+    const out = trigger.evaluate({ type: 'daily', time: '8am' }, new Date(), TZ);
+    assert.equal(out, null);
+  });
+
+  test('returns null when tz is missing', () => {
+    const out = trigger.evaluate({ type: 'daily', time: '08:00' }, new Date(), null);
+    assert.equal(out, null);
+  });
+});

--- a/tests/user-tz.test.js
+++ b/tests/user-tz.test.js
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/user-tz.test.js
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const {
+  createSandbox, cleanupSandbox,
+  spawnServer, req,
+  fakeAuthState, sessionCookie,
+} = require('./helpers/sandbox');
+
+test.describe('POST /api/user/tz', () => {
+  let sandbox, srv, cookie;
+
+  test.before(async () => {
+    const auth = fakeAuthState();
+    sandbox = createSandbox({ credentials: auth.credentials, sessions: auth.sessions });
+    cookie = sessionCookie(auth.token);
+    srv = await spawnServer(sandbox, { KLEBB_DEMO: '1' });
+  });
+
+  test.after(async () => {
+    if (srv) await srv.kill();
+    if (sandbox) cleanupSandbox(sandbox);
+  });
+
+  test('valid IANA tz: persists to user.json and returns changed=true', async () => {
+    const r = await req(srv.baseUrl, '/api/user/tz', {
+      method: 'POST',
+      cookie,
+      body: { tz: 'Australia/Melbourne' },
+    });
+    assert.equal(r.status, 200);
+    assert.equal(r.json.ok, true);
+    assert.equal(r.json.tz, 'Australia/Melbourne');
+    assert.equal(r.json.changed, true);
+
+    const fileContents = JSON.parse(fs.readFileSync(path.join(sandbox, 'user.json'), 'utf8'));
+    assert.equal(fileContents.tz, 'Australia/Melbourne');
+  });
+
+  test('repeated POST with same tz: changed=false, no rewrite', async () => {
+    const r = await req(srv.baseUrl, '/api/user/tz', {
+      method: 'POST',
+      cookie,
+      body: { tz: 'Australia/Melbourne' },
+    });
+    assert.equal(r.status, 200);
+    assert.equal(r.json.changed, false);
+  });
+
+  test('different tz: persists and returns changed=true', async () => {
+    const r = await req(srv.baseUrl, '/api/user/tz', {
+      method: 'POST',
+      cookie,
+      body: { tz: 'America/New_York' },
+    });
+    assert.equal(r.status, 200);
+    assert.equal(r.json.changed, true);
+    const fileContents = JSON.parse(fs.readFileSync(path.join(sandbox, 'user.json'), 'utf8'));
+    assert.equal(fileContents.tz, 'America/New_York');
+  });
+
+  test('rejects malformed tz with 400', async () => {
+    const r = await req(srv.baseUrl, '/api/user/tz', {
+      method: 'POST',
+      cookie,
+      body: { tz: 'Mars/Olympus' },
+    });
+    assert.equal(r.status, 400);
+    assert.equal(r.json.error, 'invalid tz');
+  });
+
+  test('rejects missing tz with 400', async () => {
+    const r = await req(srv.baseUrl, '/api/user/tz', {
+      method: 'POST',
+      cookie,
+      body: {},
+    });
+    assert.equal(r.status, 400);
+  });
+
+  test('unauthenticated request returns 302/401 (auth gate, not endpoint reachable)', async () => {
+    const r = await req(srv.baseUrl, '/api/user/tz', {
+      method: 'POST',
+      body: { tz: 'Australia/Melbourne' },
+    });
+    // The gate returns 302 to /login.html in normal mode and 401 in
+    // demo for /api/* paths. Either way, 200 would be a regression.
+    assert.notEqual(r.status, 200);
+  });
+});


### PR DESCRIPTION
# What changed

The notifications backbone. `meta.notifications` is now a schema-validated
block on every card. A 1-minute scheduler walks the registry, evaluates
each item's trigger in the user's IANA timezone, and dispatches due
notifications via a swappable function. State (per-item enabled, last
fired, quiet hours, pause-until) lives in
`$HEALTH_HOME/notifications.state.json`, a sidecar separate from the
manifest. The browser captures its timezone on each session boot so
reminders fire in local time even when the operator travels.

The dispatch function is logging-only in this PR — PR4 (#386) wires it
to the real Web Push send. After this PR you can already declare
`meta.notifications` on a manifest, hit `/api/user/tz`, and watch the
scheduler log "would-fire" lines for due items.

Closes #385.

# Why

PR3 of the v3.0.0 notifications rollout. Splits the schema +
infrastructure (this PR) from the cryptographic surface (PR4) and the
UI / chat tool (PR5). After this lands the scheduler runs on every
non-demo instance, but no push is delivered until PR4. That keeps the
security review of PR4 (VAPID, RFC 8291, web-push dep) focused on the
crypto and the routes, not infrastructure plumbing.

# How

Five commits, each individually green:

1. `feat(notifications): meta.notifications schema + validator`
   `manifests/notifications-schema.js` exposes
   `validateNotifications()`. Two-stage like `meta.category`: lenient at
   load (drops malformed items so a bad sidecar can't wedge the
   registry), strict at create + PATCH (returns 422 with prefix
   `invalid notifications: ...`). v3.0.0 supports `daily` and `weekly`
   triggers only. Caps: 10 items per manifest, 50 active per instance.
   Wired into `validateManifestShape` after the category check.
   `patchManifest` passes `strictNotifications:true` so the agent can't
   sneak past validation by relying on lenient-at-load. Adds an
   `onDelete` callback registry so the state-file pruner can hook in
   without the registry knowing about lib/.

2. `feat(notifications): trigger evaluator + runtime state file`
   `lib/notification-trigger.js`: pure `evaluate(trigger, now, tz)` that
   returns `{ prev, next }` ISO strings in the user's IANA timezone.
   Uses `Intl.DateTimeFormat` to extract local wall-clock components, so
   "08:00 daily" stays at 08:00 local across DST transitions in
   `Australia/Melbourne` (and anywhere else). `lib/notifications-state.js`
   reads/writes `$HEALTH_HOME/notifications.state.json` (mode 0o600,
   atomic tmp+rename, fsynced). `pruneCard()` drops orphan items[] keys
   when a card is deleted. `config/paths.js` gains the
   `NOTIFICATIONS_STATE_FILE` and `USER_FILE` constants with
   `HEALTH_NOTIFICATIONS_STATE_FILE` / `HEALTH_USER_FILE` env-var
   overrides used by tests.

3. `feat(notifications): user-timezone capture for travel`
   `lib/user-tz.js` + `POST /api/user/tz`. The browser sends
   `Intl.DateTimeFormat().resolvedOptions().timeZone` on every session
   boot, idempotently (a `klebb-tz-last-posted` localStorage cache skips
   the round-trip when unchanged). Server validates against
   `Intl.supportedValuesOf('timeZone')`, persists to `$HEALTH_HOME/user.json`.
   The scheduler reads the user's TZ first and falls back to
   `process.env.TZ`.

4. `feat(notifications): scheduler tick + boot wiring + /api/user/tz route`
   `lib/notifications-scheduler.js` — self-rescheduling `setTimeout`
   that lands close to the start of each minute. Walks the registry,
   evaluates triggers, fires due notifications via a swappable dispatch
   function. Idempotent: `lastFired` stores the slot ISO, not the
   wall-clock fire time, so a restart inside the minute doesn't refire.
   Coalesces same-minute fires into one dispatch event (PR4 uses this to
   collapse N reminders into one Web Push). Honours `paused_until`
   (skips, doesn't advance `lastFired`, so the most recent missed slot
   fires when paused expires) and `quiet_hours` (advances `lastFired`
   but skips dispatch). Active-item count capped at 50. Started at
   server boot when `!KLEBB_DEMO`; `SIGTERM`/`SIGINT` stop it.

5. `docs(notifications): document meta.notifications + CHANGELOG`
   `MANIFEST-SCHEMA.md` gains a "Push notifications" section between
   `meta.prompt` and `meta.ingest`. CHANGELOG entries under
   `## Unreleased`.

# Testing

- [x] `npm test` passes locally — 1259 tests, 1256 pass, 0 fail, 3
  pre-existing skipped (42 new tests across five files)
- [x] `npm run test:e2e` passes locally (61 pass)
- [x] New unit suites:
  - `tests/notifications-schema.test.js` — 17 tests, every reject case
    in strict mode + lenient cleanup behaviour + happy path
  - `tests/notifications-trigger.test.js` — 11 tests, daily + weekly
    + DST boundaries (autumn 2026-04-05 and spring 2026-10-04 in
    `Australia/Melbourne`)
  - `tests/notifications-scheduler.test.js` — 5 tests, due-fire +
    idempotency + paused_until + quiet_hours + per-item disable +
    manifest-level disable
  - `tests/user-tz.test.js` — 6 tests, valid persist + idempotent
    no-rewrite + invalid 400 + auth gate
  - `tests/notifications-state-prune.test.js` — 3 tests, prefix-only
    prune + no-state-file edge case
- [x] Manual smoke against a local non-demo dev instance:
  - Start the server with a manifest that declares
    `meta.notifications.items[]`, scheduler logs `[notifications]
    scheduler started`
  - `curl -X POST /api/user/tz -d '{"tz":"Australia/Melbourne"}'`
    returns `{ ok: true, changed: true }`; second identical call
    returns `changed: false`

# Checklist

- [x] Commit messages follow the conventions in `CONTRIBUTING.md`
- [x] `CHANGELOG.md` updated under `## Unreleased`
- [x] Docs updated: `MANIFEST-SCHEMA.md` documents the new block
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Breaking changes

None. `meta.notifications` is optional; manifests without it produce
zero notifications and zero work in the scheduler tick. The state file
is created lazily on first toggle; instances that never open Settings >
Notifications never gain it. The scheduler runs everywhere
non-demo from this PR forward, but its dispatch path is
logging-only — no push is delivered until #386.

This PR is part of the v3.0.0 release wave; PRs #383 / #384 / #385 /
#386 / #387 ship together as a major version bump.
