### PR TITLE
feat(notifications): VAPID, /api/push and /api/notifications endpoints, web-push send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,68 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Web Push delivery: real notifications hit real devices.** New
+  `/api/push/*` endpoints (`vapid-public-key`, `subscribe`,
+  `subscribe/heartbeat`, `unsubscribe`) accept a browser
+  `pushManager` subscription and persist it to
+  `$HEALTH_HOME/push-subscriptions.json` (mode 0o600, atomic). Capped
+  at 20 active subs per instance, oldest evicted on overflow. The
+  scheduler from PR #385 now fires Web Push events through the
+  `web-push` npm package; private notifications carry generic
+  `Klebb / You have a reminder.` on the wire and the real text in a
+  separate field the SW substitutes after decryption. Tag is the
+  opaque `klebb-<sha256-prefix>` so the push provider can't infer
+  medical category from the collapse key. `Urgency: high` and
+  `TTL: 300` make late-fire batching unlikely on iOS Low Power Mode.
+  Refs #386.
+
+- **VAPID keypair: lazy generation + operator rotation.**
+  `$HEALTH_HOME/keys/vapid.json` is generated on first push API call
+  and stored mode 0o600 with atomic+fsynced writes. Operator
+  rotation is "delete the file and restart" - existing subs return
+  401/403 from the push provider on next send, are marked dead, and
+  re-subscribe on the client's next Settings open via the keyId
+  fingerprint comparison (lands in PR #387). The keys live under
+  `keys/`, not `sessions/`, because conflating long-lived asymmetric
+  identity with session ephemera invites accidental nuke during
+  session-troubleshooting resets. Refs #386.
+
+- **`/api/notifications/*` HTTP surface: state, global controls, test
+  fire, diagnostics.** `GET /api/notifications` aggregates every
+  declared item across every manifest plus its toggle/lastFired.
+  `POST /api/notifications/state` flips per-item `enabled` /
+  `privacy`. `POST /api/notifications/global-state` writes
+  `quiet_hours` and `paused_until`. `POST /api/notifications/test`
+  fires a configured payload right now to every live subscription
+  (rate-limited at 1/min per notification id, so a session-token
+  leak can't spam the operator's phone). `GET /api/diagnostics`
+  surfaces TZ, VAPID keyId fingerprint, subscription metadata
+  (truncated id + nickname + last_seen + last_status; never the
+  raw endpoint URLs), and the recent-fires ring buffer. Every
+  state-changing endpoint goes through an Origin-allowlist
+  middleware that rejects requests whose `Origin` header doesn't
+  match `ENV.WEBAUTHN_ORIGIN` - SameSite=Lax cookies don't block
+  cross-fetch from same-eTLD+1 subdomains, so this is the actual
+  CSRF defense. In `KLEBB_DEMO=1` every endpoint above 410s. Refs
+  #386.
+
+- **Recent-fires audit ring (100 entries) in
+  `notifications.state.json`.** Each scheduler tick that dispatches
+  appends `{ ts, id, sent, failed, statuses }` so the Diagnostics tab
+  (lands in PR #387) can answer "why didn't I get reminded at 8pm
+  yesterday". Refs #386.
+
+### Changed
+
+- **`web-push` npm package added.** Transitive deps: zero (a small
+  set of Node-builtin-equivalents). Justification: this is the
+  cryptographic surface (VAPID JWT signing per RFC 8292, content
+  encryption per RFC 8291). One audited package replaces ~250 lines
+  of from-scratch ECE and AES-128-GCM we'd otherwise own and is
+  widely exercised in production. Refs #386.
+
+### Added
+
 - **`meta.notifications` schema: declarative push reminders per card.**
   Cards may declare an `items[]` array of notifications inside their
   `meta.notifications` block. Each item has an `id`, `label`, `title`,

--- a/config/env.js
+++ b/config/env.js
@@ -37,6 +37,12 @@ const TZ = process.env.TZ || 'UTC';
 // --- Branding ---
 const INSTANCE_NAME = process.env.HEALTH_INSTANCE_NAME || 'Klebb';
 
+// Web Push VAPID `sub` claim. Required by some push providers (FCM is
+// strict about it). Defaults to a no-reply mailto so the feature works
+// out of the box; operators can override with a real address.
+const HEALTH_OPERATOR_EMAIL = process.env.HEALTH_OPERATOR_EMAIL
+  || 'mailto:noreply@klebb.app';
+
 // --- Chat endpoint (optional — chat widget disabled if CHAT_API_KEY unset) ---
 //
 // Klebb speaks the OpenAI chat-completions shape. Point it at any endpoint
@@ -537,6 +543,7 @@ module.exports = {
   HOST,
   TZ,
   INSTANCE_NAME,
+  HEALTH_OPERATOR_EMAIL,
   CHAT_ENDPOINT_URL,
   CHAT_API_KEY,
   CHAT_MODEL,

--- a/config/paths.js
+++ b/config/paths.js
@@ -90,6 +90,16 @@ const NOTIFICATIONS_STATE_FILE = process.env.HEALTH_NOTIFICATIONS_STATE_FILE
 const USER_FILE = process.env.HEALTH_USER_FILE
   || path.join(HEALTH_HOME, 'user.json');
 
+// Long-lived asymmetric keys live under their own directory, separate
+// from sessions/ - operator backup-rotation policy is fundamentally
+// different from session ephemera.
+const KEYS_DIR = process.env.HEALTH_KEYS_DIR || path.join(HEALTH_HOME, 'keys');
+const VAPID_FILE = process.env.HEALTH_VAPID_FILE || path.join(KEYS_DIR, 'vapid.json');
+
+// Web Push subscriptions for the operator's devices.
+const PUSH_SUBSCRIPTIONS_FILE = process.env.HEALTH_PUSH_SUBSCRIPTIONS_FILE
+  || path.join(HEALTH_HOME, 'push-subscriptions.json');
+
 // WebAuthn credentials + sessions. Historical installs may have stored these
 // inside DATA_DIR as `webauthn-credentials.json` / `webauthn-sessions.json`;
 // prefer those if found, otherwise use the modern subdir layout.
@@ -135,6 +145,9 @@ module.exports = {
   CONFIG_PATH,
   NOTIFICATIONS_STATE_FILE,
   USER_FILE,
+  KEYS_DIR,
+  VAPID_FILE,
+  PUSH_SUBSCRIPTIONS_FILE,
   WEBAUTHN_CREDENTIALS_FILE,
   WEBAUTHN_SESSIONS_FILE,
   ensureWritableDirs,

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -400,3 +400,34 @@ crash the server — the offending file just doesn't produce a card.
 **Migrating from a legacy (v1) install.**
 Run `scripts/migrate-v1-to-v2.js` against your data directory. See the
 script's `--help` for options.
+
+## 6. Backup and sensitive files
+
+Everything an instance needs lives under `$HEALTH_HOME/`. A snapshot
+of that directory is a complete backup. The whole tree is sensitive,
+but a few files inside it are particularly so and should be treated
+with extra care if you ever build an export or share-debug-info
+feature on top of Klebb:
+
+| Path | What's in it |
+|---|---|
+| `$HEALTH_HOME/credentials/webauthn.json` | WebAuthn credential public keys + sign counters. |
+| `$HEALTH_HOME/sessions/webauthn.json` | Active session tokens. Long-lived. |
+| `$HEALTH_HOME/sessions/secret.key` | Session-cookie HMAC key. Rotate by deleting + restarting (forces re-login on every device). |
+| `$HEALTH_HOME/keys/vapid.json` | Web Push VAPID keypair. Operator rotation: delete the file and restart; every existing device re-subscribes via Settings > Notifications on its next visit. |
+| `$HEALTH_HOME/push-subscriptions.json` | Per-device push endpoints. Each row is a capability: anyone holding the endpoint URL + the configured VAPID private key can deliver a push to that device. |
+| `$HEALTH_HOME/notifications.state.json` | Per-item toggle state, last-fired timestamps, quiet-hours, pause deadline, recent-fires audit ring. |
+| `$HEALTH_HOME/user.json` | User preferences (currently the IANA timezone). |
+| `$HEALTH_HOME/data/*.json` | Health card manifests + their data. The whole point of the dashboard. |
+| `$HEALTH_HOME/reports/` | Markdown reports (rendered + ingested). |
+| `$HEALTH_HOME/chat/history.json` | Chat transcript with the agent. |
+
+**Back up the whole `$HEALTH_HOME/` tree.** Don't try to be clever
+about which files to skip; every one of them is needed to bring a new
+instance up identically to the old one.
+
+**Never include any of the credentials/sessions/keys/push-subscriptions
+files in a user-facing export.** If you build an "export my data"
+feature, it should walk `data/` and `reports/` only, never the
+sensitive files above. The `notifications.state.json` ring buffer
+also leaks subscription ids and recent fire metadata, so exclude it.

--- a/lib/notifications-scheduler.js
+++ b/lib/notifications-scheduler.js
@@ -156,6 +156,11 @@ function start(registry) {
   _schedule();
 }
 
+// Set the registry without starting the timer (for tests).
+function _setRegistryForTests(registry) {
+  _registry = registry;
+}
+
 function stop() {
   _stopping = true;
   if (_timer) { clearTimeout(_timer); _timer = null; }
@@ -167,4 +172,5 @@ module.exports = {
   setDispatch,
   // Exported for tests:
   _tick,
+  _setRegistryForTests,
 };

--- a/lib/notifications-state.js
+++ b/lib/notifications-state.js
@@ -20,8 +20,10 @@ const PATHS = require('../config/paths');
 
 const FILE_MODE = 0o600;
 
+const RECENT_FIRES_CAP = 100;
+
 function _emptyState() {
-  return { items: {}, quiet_hours: null, paused_until: null };
+  return { items: {}, quiet_hours: null, paused_until: null, recent_fires: [] };
 }
 
 // Load + parse with quiet recovery from corruption / missing.
@@ -36,6 +38,9 @@ function read() {
           : {},
         quiet_hours: _isValidQuietHours(parsed.quiet_hours) ? parsed.quiet_hours : null,
         paused_until: typeof parsed.paused_until === 'string' ? parsed.paused_until : null,
+        recent_fires: Array.isArray(parsed.recent_fires)
+          ? parsed.recent_fires.slice(-RECENT_FIRES_CAP)
+          : [],
       };
     }
   } catch (e) {
@@ -148,6 +153,22 @@ function isQuietNow(qh, nowHHMM) {
   return n >= a || n < b;
 }
 
+// Append a fire-event to the ring buffer. Each entry: { ts, id, sent,
+// failed, statuses }. The Diagnostics tab reads this back to surface
+// "why didn't I get reminded".
+function appendFire(entry) {
+  const state = read();
+  const next = [...state.recent_fires, {
+    ts: entry.ts || new Date().toISOString(),
+    id: entry.id,
+    sent: entry.sent || 0,
+    failed: entry.failed || 0,
+    statuses: Array.isArray(entry.statuses) ? entry.statuses : [],
+  }];
+  state.recent_fires = next.slice(-RECENT_FIRES_CAP);
+  write(state);
+}
+
 module.exports = {
   read,
   write,
@@ -156,4 +177,6 @@ module.exports = {
   pruneCard,
   getOrInitItem,
   isQuietNow,
+  appendFire,
+  RECENT_FIRES_CAP,
 };

--- a/lib/push-subscriptions.js
+++ b/lib/push-subscriptions.js
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// lib/push-subscriptions.js
+//
+// Persistence for the operator's Web Push subscriptions. Single-user-
+// per-instance, so this is one flat list with a per-device row. File
+// lives at $HEALTH_HOME/push-subscriptions.json (mode 0o600, atomic
+// tmp+rename, fsynced).
+//
+// Each row:
+//   {
+//     id, endpoint, keys: { p256dh, auth },
+//     userAgent, nickname, userHandle,
+//     createdAt, lastSentAt, lastStatus,
+//     dead, deadSince
+//   }
+//
+// id = sha256(endpoint), full hex (64 chars). Truncated only for log
+// lines; the API exposes the full id so we never have to worry about
+// short-id collisions later.
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const PATHS = require('../config/paths');
+
+const FILE_MODE = 0o600;
+const ACTIVE_CAP = 20;
+const DEAD_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+function _emptyState() {
+  return { subscriptions: [] };
+}
+
+function _read() {
+  try {
+    const raw = fs.readFileSync(PATHS.PUSH_SUBSCRIPTIONS_FILE, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && Array.isArray(parsed.subscriptions)) return parsed;
+  } catch (e) {
+    if (e.code !== 'ENOENT') {
+      console.warn(`[push-subs] could not read state: ${e.message}; starting fresh`);
+    }
+  }
+  return _emptyState();
+}
+
+function _write(state) {
+  const file = PATHS.PUSH_SUBSCRIPTIONS_FILE;
+  try { fs.mkdirSync(path.dirname(file), { recursive: true }); } catch {}
+  const tmp = file + '.tmp';
+  const fd = fs.openSync(tmp, 'w', FILE_MODE);
+  try {
+    fs.writeSync(fd, JSON.stringify(state, null, 2));
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+  fs.renameSync(tmp, file);
+}
+
+function _id(endpoint) {
+  return crypto.createHash('sha256').update(endpoint).digest('hex');
+}
+
+function list({ includeDead = false } = {}) {
+  const state = _read();
+  return includeDead
+    ? state.subscriptions
+    : state.subscriptions.filter(s => !s.dead);
+}
+
+function getById(id) {
+  return _read().subscriptions.find(s => s.id === id) || null;
+}
+
+function getByEndpoint(endpoint) {
+  return getById(_id(endpoint));
+}
+
+// Add a new sub or replace an existing one. On duplicate endpoint we
+// REPLACE keys + userAgent + nickname rather than skip - browser key
+// rotation produces a new keypair under the same endpoint, and a stale
+// cached set silently fails to decrypt on the device. After replace,
+// dead/deadSince are cleared.
+function add(sub, { userAgent = null, nickname = null, userHandle = null } = {}) {
+  if (!sub || typeof sub.endpoint !== 'string'
+    || !sub.keys || typeof sub.keys.p256dh !== 'string'
+    || typeof sub.keys.auth !== 'string') {
+    const err = new Error('invalid subscription');
+    err.code = 'INVALID_SUB';
+    throw err;
+  }
+  const state = _read();
+  const id = _id(sub.endpoint);
+  const now = new Date().toISOString();
+  const existing = state.subscriptions.find(s => s.id === id);
+  if (existing) {
+    existing.endpoint = sub.endpoint;
+    existing.keys = { p256dh: sub.keys.p256dh, auth: sub.keys.auth };
+    if (userAgent) existing.userAgent = userAgent;
+    if (nickname) existing.nickname = nickname;
+    if (userHandle) existing.userHandle = userHandle;
+    existing.dead = false;
+    existing.deadSince = null;
+    _write(state);
+    return { id, created: false };
+  }
+
+  // Capacity guard: when we're at the cap, evict the oldest active sub
+  // (createdAt ascending). Dead subs are already excluded from list()
+  // and don't count.
+  const active = state.subscriptions.filter(s => !s.dead);
+  if (active.length >= ACTIVE_CAP) {
+    active.sort((a, b) => (a.createdAt || '').localeCompare(b.createdAt || ''));
+    const evict = active[0];
+    if (evict) {
+      const idx = state.subscriptions.findIndex(s => s.id === evict.id);
+      if (idx >= 0) state.subscriptions.splice(idx, 1);
+    }
+  }
+
+  state.subscriptions.push({
+    id,
+    endpoint: sub.endpoint,
+    keys: { p256dh: sub.keys.p256dh, auth: sub.keys.auth },
+    userAgent,
+    nickname,
+    userHandle,
+    createdAt: now,
+    lastSentAt: null,
+    lastStatus: null,
+    dead: false,
+    deadSince: null,
+  });
+  _write(state);
+  return { id, created: true };
+}
+
+function remove(endpoint) {
+  const state = _read();
+  const id = _id(endpoint);
+  const before = state.subscriptions.length;
+  state.subscriptions = state.subscriptions.filter(s => s.id !== id);
+  if (state.subscriptions.length !== before) _write(state);
+  return before - state.subscriptions.length;
+}
+
+// Mark a subscription as dead (push provider returned 401/403/404/410).
+function markDead(endpoint, status) {
+  const state = _read();
+  const id = _id(endpoint);
+  const sub = state.subscriptions.find(s => s.id === id);
+  if (!sub) return false;
+  sub.dead = true;
+  sub.deadSince = new Date().toISOString();
+  sub.lastStatus = status;
+  _write(state);
+  return true;
+}
+
+// Update lastSentAt + lastStatus after a successful (or non-dead-mapping)
+// send so the diagnostics tab can surface it.
+function recordSendResult(endpoint, status) {
+  const state = _read();
+  const id = _id(endpoint);
+  const sub = state.subscriptions.find(s => s.id === id);
+  if (!sub) return;
+  sub.lastSentAt = new Date().toISOString();
+  sub.lastStatus = status;
+  _write(state);
+}
+
+// Heartbeat from the foreground client: reconcile a known endpoint as
+// alive (clears dead/deadSince). Returns true if the endpoint exists,
+// false otherwise (the client should re-subscribe in that case).
+function heartbeat(endpoint) {
+  const state = _read();
+  const id = _id(endpoint);
+  const sub = state.subscriptions.find(s => s.id === id);
+  if (!sub) return false;
+  if (sub.dead) {
+    sub.dead = false;
+    sub.deadSince = null;
+    _write(state);
+  }
+  return true;
+}
+
+// Drop subscriptions marked dead for >7 days. Returns the count removed.
+function pruneDead(now = Date.now()) {
+  const state = _read();
+  const cutoff = now - DEAD_TTL_MS;
+  const before = state.subscriptions.length;
+  state.subscriptions = state.subscriptions.filter(s => {
+    if (!s.dead || !s.deadSince) return true;
+    const t = Date.parse(s.deadSince);
+    if (!Number.isFinite(t)) return true;
+    return t > cutoff;
+  });
+  if (state.subscriptions.length !== before) _write(state);
+  return before - state.subscriptions.length;
+}
+
+module.exports = {
+  list,
+  getById,
+  getByEndpoint,
+  add,
+  remove,
+  markDead,
+  recordSendResult,
+  heartbeat,
+  pruneDead,
+  _id,        // exported for tests
+  ACTIVE_CAP,
+};

--- a/lib/vapid.js
+++ b/lib/vapid.js
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// lib/vapid.js
+//
+// VAPID keys for Web Push (RFC 8292). Generated lazily on first call,
+// stored at $HEALTH_HOME/keys/vapid.json (mode 0o600, atomic, fsynced).
+// The file is intentionally NOT under sessions/ - keys are not session
+// data, and conflating the directories invites accidental nuke during
+// a session-troubleshooting reset.
+//
+// Operator rotation: delete the file and restart. Subscriptions tied
+// to the old key 401/403 on next send and are reaped by the
+// dead-subscription handling in lib/web-push-send.
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const webpush = require('web-push');
+const PATHS = require('../config/paths');
+
+const FILE_MODE = 0o600;
+
+let _cache = null;
+
+function _readFile() {
+  try {
+    const raw = fs.readFileSync(PATHS.VAPID_FILE, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object'
+      && typeof parsed.publicKey === 'string'
+      && typeof parsed.privateKey === 'string') {
+      return parsed;
+    }
+  } catch (e) {
+    if (e.code !== 'ENOENT') {
+      console.warn(`[vapid] could not read ${PATHS.VAPID_FILE}: ${e.message}`);
+    }
+  }
+  return null;
+}
+
+function _writeFile(obj) {
+  const file = PATHS.VAPID_FILE;
+  try { fs.mkdirSync(path.dirname(file), { recursive: true }); } catch {}
+  const tmp = file + '.tmp';
+  const fd = fs.openSync(tmp, 'w', FILE_MODE);
+  try {
+    fs.writeSync(fd, JSON.stringify(obj, null, 2));
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+  fs.renameSync(tmp, file);
+}
+
+// Generate + persist a fresh keypair. web-push uses raw P-256 keys
+// base64url-encoded (no PEM/PKCS#8 wrapper).
+function _generate() {
+  const keys = webpush.generateVAPIDKeys();
+  const obj = {
+    publicKey: keys.publicKey,
+    privateKey: keys.privateKey,
+    createdAt: new Date().toISOString(),
+  };
+  _writeFile(obj);
+  return obj;
+}
+
+// Lazy resolve: read cache, then file, then generate. Idempotent.
+function _resolve() {
+  if (_cache) return _cache;
+  const fromFile = _readFile();
+  if (fromFile) {
+    _cache = fromFile;
+    return _cache;
+  }
+  _cache = _generate();
+  return _cache;
+}
+
+function getPublicKey() {
+  return _resolve().publicKey;
+}
+
+function getPrivateKey() {
+  return _resolve().privateKey;
+}
+
+// 8-character fingerprint of the public key for the client's rotation
+// detection (compare what the server returned now vs the keyId stored
+// in localStorage; on mismatch the client force-resubscribes).
+function getKeyId() {
+  return crypto.createHash('sha256')
+    .update(getPublicKey())
+    .digest('hex')
+    .slice(0, 8);
+}
+
+// Reset the in-memory cache - tests use this between sandboxes; not for
+// production use.
+function _resetForTests() {
+  _cache = null;
+}
+
+module.exports = {
+  getPublicKey,
+  getPrivateKey,
+  getKeyId,
+  _resetForTests,
+};

--- a/lib/web-push-send.js
+++ b/lib/web-push-send.js
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// lib/web-push-send.js
+//
+// Wraps the web-push npm package: build the wire payload, send to every
+// live subscription, map provider error codes to dead/alive, append the
+// fire to the recent_fires ring buffer for the Diagnostics tab.
+//
+// Justification for the dep: this is the cryptographic surface (VAPID
+// JWT signing per RFC 8292, content encryption per RFC 8291). One
+// well-audited package replaces ~250 lines of from-scratch crypto we'd
+// otherwise own and is widely exercised in production.
+
+const crypto = require('crypto');
+const webpush = require('web-push');
+const ENV = require('../config/env');
+const vapid = require('./vapid');
+const subs = require('./push-subscriptions');
+const stateStore = require('./notifications-state');
+
+const TTL_SECONDS = 300;
+const URGENCY = 'high';
+
+let _vapidConfigured = false;
+function _ensureVapidConfigured() {
+  if (_vapidConfigured) return;
+  webpush.setVapidDetails(
+    ENV.HEALTH_OPERATOR_EMAIL,
+    vapid.getPublicKey(),
+    vapid.getPrivateKey(),
+  );
+  _vapidConfigured = true;
+}
+
+// Public entry: dispatch a list of scheduler events. Each event has
+// .id, .slot, and .items[]. Each item carries the manifest meta + the
+// full notification spec. We send one Web Push per (subscription,
+// event); the SW unpacks the items[] array on the device.
+async function dispatch(events) {
+  if (!Array.isArray(events) || events.length === 0) return;
+  const recipients = subs.list({ includeDead: false });
+  if (recipients.length === 0) return;
+  _ensureVapidConfigured();
+
+  for (const ev of events) {
+    const payload = buildPayload(ev);
+    const results = await Promise.allSettled(
+      recipients.map(r => _sendOne(r, payload, ev)),
+    );
+    const sent = results.filter(r => r.status === 'fulfilled' && r.value && r.value.ok).length;
+    const failed = results.length - sent;
+    const statuses = results.map(r =>
+      r.status === 'fulfilled' ? r.value.statusCode : 'rejected'
+    );
+    stateStore.appendFire({
+      id: ev.id,
+      sent,
+      failed,
+      statuses,
+    });
+  }
+}
+
+// Sub-shape of the wire payload. Title/body are visible on the lock
+// screen; for `private` items they're generic, and the SW substitutes
+// the real text from cached card data on the device after decryption.
+function buildPayload(ev) {
+  // Single-item: shape it as a one-item bundle so the SW has one path.
+  // Multi-item: the SW shows a "N reminders" coalesced banner.
+  const items = ev.items.map(i => {
+    const isPublic = i.item.privacy === 'public';
+    const hhmm = String(i.slot).slice(11, 16);
+    const action = i.item.action || { type: 'open-card', card: i.manifest.id };
+    const url = '/?card=' + encodeURIComponent(action.card || i.manifest.id)
+      + (action.intent ? '&action=' + encodeURIComponent(action.intent) : '');
+    return {
+      id: i.id,
+      time: hhmm,
+      privacy: i.item.privacy || 'private',
+      title: isPublic ? i.item.title : 'Klebb',
+      body: isPublic ? i.item.body : 'You have a reminder.',
+      realTitle: isPublic ? null : i.item.title,
+      realBody: isPublic ? null : i.item.body,
+      cardId: i.manifest.id,
+      cardLabel: i.manifest.label,
+      cardEmoji: i.manifest.emoji,
+      url,
+      tag: _opaqueTag(i.id),
+    };
+  });
+
+  return {
+    type: items.length > 1 ? 'coalesced' : 'single',
+    slot: ev.slot,
+    items,
+  };
+}
+
+function _opaqueTag(id) {
+  return 'klebb-' + crypto.createHash('sha256').update(id).digest('hex').slice(0, 12);
+}
+
+async function _sendOne(sub, payload, ev) {
+  const wire = JSON.stringify(payload);
+  // Only one tag per HTTP send. With multi-item events all items share
+  // the same coalesced tag; with single-item it's the per-id opaque tag.
+  const topic = payload.items[0]?.tag || 'klebb-' + ev.id;
+  try {
+    const result = await webpush.sendNotification(
+      { endpoint: sub.endpoint, keys: sub.keys },
+      wire,
+      {
+        TTL: TTL_SECONDS,
+        urgency: URGENCY,
+        topic,
+      },
+    );
+    subs.recordSendResult(sub.endpoint, result.statusCode);
+    return { ok: true, statusCode: result.statusCode };
+  } catch (e) {
+    const status = e.statusCode || 0;
+    if (status === 401 || status === 403 || status === 404 || status === 410) {
+      subs.markDead(sub.endpoint, status);
+    } else {
+      subs.recordSendResult(sub.endpoint, status || 'error');
+    }
+    return { ok: false, statusCode: status };
+  }
+}
+
+// Test-fire path: bypass scheduler trigger evaluation; build a payload
+// from the manifest item directly and send to every live sub.
+async function testFire({ manifest, item, slot }) {
+  const ev = {
+    id: 'test-' + (item.id || 'item') + '-' + Date.now(),
+    slot: slot || new Date().toISOString(),
+    items: [{
+      id: `${manifest.id}#${item.id}`,
+      slot: slot || new Date().toISOString(),
+      item,
+      manifest: { id: manifest.id, label: manifest.label, emoji: manifest.emoji || null },
+    }],
+  };
+  const before = subs.list({ includeDead: false }).length;
+  await dispatch([ev]);
+  return { sent: before }; // total live subs; per-recipient outcome lives in recent_fires.
+}
+
+module.exports = {
+  dispatch,
+  testFire,
+  buildPayload,        // exported for tests
+  _opaqueTag,          // exported for tests
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@simplewebauthn/browser": "^13.3.0",
         "@simplewebauthn/server": "^13.3.1",
-        "marked": "^18.0.5"
+        "marked": "^18.0.5",
+        "web-push": "^3.6.7"
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0"
@@ -232,6 +233,27 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/asn1js": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
@@ -244,6 +266,44 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/fsevents": {
@@ -261,6 +321,55 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/marked": {
       "version": "18.0.5",
       "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
@@ -272,6 +381,27 @@
       "engines": {
         "node": ">= 20"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/playwright": {
       "version": "1.60.0",
@@ -329,6 +459,32 @@
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "license": "Apache-2.0"
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -352,6 +508,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   "dependencies": {
     "@simplewebauthn/browser": "^13.3.0",
     "@simplewebauthn/server": "^13.3.1",
-    "marked": "^18.0.5"
+    "marked": "^18.0.5",
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0"

--- a/routes/notifications.js
+++ b/routes/notifications.js
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// routes/notifications.js
+//
+// Web Push subscription + notification state HTTP surface. Exports a
+// single `handle(req, res, ctx)` function that returns true when it
+// has fully handled the request, false otherwise.
+//
+// Auth: every endpoint is gated by the existing isAuthenticated()
+// middleware (which the main dispatcher applies before delegating
+// here). State-changing endpoints additionally check the Origin
+// header against ENV.WEBAUTHN_ORIGIN: SameSite=Lax cookies don't
+// block cross-fetch from same-eTLD+1 subdomains, and a future
+// blog.klebb.app could otherwise register its own push sub under
+// the operator's account.
+
+const ENV = require('../config/env');
+const vapid = require('../lib/vapid');
+const subs = require('../lib/push-subscriptions');
+const stateStore = require('../lib/notifications-state');
+const webPushSend = require('../lib/web-push-send');
+
+const TEST_RATE_LIMIT_MS = 60_000;
+const _testFireRecent = new Map(); // key: `${subId}#${notifId}` -> timestamp
+
+function _send(res, status, body) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function _readBody(req) {
+  return new Promise((resolve, reject) => {
+    let buf = '';
+    req.on('data', c => buf += c);
+    req.on('end', () => {
+      if (!buf) return resolve({});
+      try { resolve(JSON.parse(buf)); }
+      catch { reject(new Error('invalid JSON body')); }
+    });
+    req.on('error', reject);
+  });
+}
+
+// Origin allowlist: SameSite=Lax does not protect against same-site
+// cross-subdomain fetches. Reject any state-changing request whose
+// Origin doesn't match the configured public origin.
+function _checkOrigin(req, res) {
+  const origin = req.headers.origin;
+  if (origin && origin === ENV.WEBAUTHN_ORIGIN) return true;
+  // Same-host requests with no Origin header (e.g. curl from the
+  // operator) are allowed: they can't have ridden a CSRF, and the
+  // operator deliberately turning off Origin is their call.
+  if (!origin) return true;
+  _send(res, 403, { error: 'origin not allowed' });
+  return false;
+}
+
+function _testRateOk(subId, notifId) {
+  const key = `${subId}#${notifId}`;
+  const last = _testFireRecent.get(key) || 0;
+  const now = Date.now();
+  if (now - last < TEST_RATE_LIMIT_MS) return false;
+  _testFireRecent.set(key, now);
+  return true;
+}
+
+// `parts` is the path split (e.g. ['push', 'subscribe']). `registry`
+// is passed via ctx so we can resolve manifest meta for /api/notifications.
+async function handle(req, res, parts, ctx) {
+  // Demo-mode short-circuit: every push and notifications endpoint 410s.
+  if (ENV.KLEBB_DEMO && (parts[0] === 'push' || parts[0] === 'notifications' || (parts[0] === 'diagnostics'))) {
+    _send(res, 410, { error: 'disabled in demo mode' });
+    return true;
+  }
+
+  // GET /api/push/vapid-public-key
+  if (parts[0] === 'push' && parts[1] === 'vapid-public-key' && parts.length === 2 && req.method === 'GET') {
+    _send(res, 200, { key: vapid.getPublicKey(), keyId: vapid.getKeyId() });
+    return true;
+  }
+
+  // POST /api/push/subscribe
+  if (parts[0] === 'push' && parts[1] === 'subscribe' && parts.length === 2 && req.method === 'POST') {
+    if (!_checkOrigin(req, res)) return true;
+    let body;
+    try { body = await _readBody(req); }
+    catch { _send(res, 400, { error: 'invalid JSON body' }); return true; }
+    try {
+      const result = subs.add(
+        { endpoint: body.endpoint, keys: body.keys },
+        {
+          userAgent: req.headers['user-agent'] || null,
+          nickname: typeof body.nickname === 'string' && body.nickname.slice(0, 64) || null,
+          userHandle: ctx && ctx.userHandle || null,
+        },
+      );
+      _send(res, result.created ? 201 : 200, { id: result.id, created: result.created });
+    } catch (e) {
+      if (e.code === 'INVALID_SUB') _send(res, 400, { error: 'invalid subscription' });
+      else _send(res, 500, { error: e.message || 'subscribe failed' });
+    }
+    return true;
+  }
+
+  // POST /api/push/subscribe/heartbeat
+  if (parts[0] === 'push' && parts[1] === 'subscribe' && parts[2] === 'heartbeat' && parts.length === 3 && req.method === 'POST') {
+    if (!_checkOrigin(req, res)) return true;
+    let body;
+    try { body = await _readBody(req); }
+    catch { _send(res, 400, { error: 'invalid JSON body' }); return true; }
+    if (typeof body.endpoint !== 'string') { _send(res, 400, { error: 'endpoint required' }); return true; }
+    const ok = subs.heartbeat(body.endpoint);
+    if (!ok) { _send(res, 404, { error: 'unknown endpoint' }); return true; }
+    _send(res, 200, { ok: true });
+    return true;
+  }
+
+  // POST /api/push/unsubscribe
+  if (parts[0] === 'push' && parts[1] === 'unsubscribe' && parts.length === 2 && req.method === 'POST') {
+    if (!_checkOrigin(req, res)) return true;
+    let body;
+    try { body = await _readBody(req); }
+    catch { _send(res, 400, { error: 'invalid JSON body' }); return true; }
+    if (typeof body.endpoint !== 'string') { _send(res, 400, { error: 'endpoint required' }); return true; }
+    subs.remove(body.endpoint);
+    res.statusCode = 204;
+    res.end();
+    return true;
+  }
+
+  // GET /api/notifications - aggregate of every declared item across
+  // every manifest, plus its toggle state and lastFired.
+  if (parts[0] === 'notifications' && parts.length === 1 && req.method === 'GET') {
+    const cur = stateStore.read();
+    const list = [];
+    for (const card of ctx.registry.list()) {
+      const meta = card.meta;
+      const notifs = meta && meta.notifications;
+      if (!notifs || !Array.isArray(notifs.items)) continue;
+      for (const item of notifs.items) {
+        const id = `${meta.id}#${item.id}`;
+        const itemState = cur.items[id] || {};
+        list.push({
+          id,
+          card_id: meta.id,
+          item_id: item.id,
+          label: item.label,
+          card_label: meta.label,
+          card_emoji: meta.emoji || null,
+          title: item.title,
+          body: item.body,
+          trigger: item.trigger,
+          privacy: item.privacy || 'private',
+          enabled: itemState.enabled !== false && (notifs.enabled !== false),
+          last_fired: itemState.lastFired || null,
+          last_fire_status: itemState.lastFireStatus || null,
+        });
+      }
+    }
+    _send(res, 200, {
+      notifications: list,
+      quiet_hours: cur.quiet_hours,
+      paused_until: cur.paused_until,
+    });
+    return true;
+  }
+
+  // POST /api/notifications/state - toggle enabled and/or privacy on a
+  // single item.
+  if (parts[0] === 'notifications' && parts[1] === 'state' && parts.length === 2 && req.method === 'POST') {
+    if (!_checkOrigin(req, res)) return true;
+    let body;
+    try { body = await _readBody(req); }
+    catch { _send(res, 400, { error: 'invalid JSON body' }); return true; }
+    if (typeof body.id !== 'string' || !/^[a-z0-9][a-z0-9._-]*#[a-z0-9][a-z0-9._-]*$/.test(body.id)) {
+      _send(res, 400, { error: 'id required' });
+      return true;
+    }
+    const patch = {};
+    if (body.enabled === true || body.enabled === false) patch.enabled = body.enabled;
+    if (body.privacy === 'private' || body.privacy === 'public') patch.privacy = body.privacy;
+    if (Object.keys(patch).length === 0) {
+      _send(res, 400, { error: 'no fields to update' });
+      return true;
+    }
+    const updated = stateStore.writeItem(body.id, patch);
+    _send(res, 200, { ok: true, state: updated });
+    return true;
+  }
+
+  // POST /api/notifications/global-state - quiet_hours and paused_until.
+  if (parts[0] === 'notifications' && parts[1] === 'global-state' && parts.length === 2 && req.method === 'POST') {
+    if (!_checkOrigin(req, res)) return true;
+    let body;
+    try { body = await _readBody(req); }
+    catch { _send(res, 400, { error: 'invalid JSON body' }); return true; }
+    const patch = {};
+    if ('quiet_hours' in body) patch.quiet_hours = body.quiet_hours;
+    if ('paused_until' in body) patch.paused_until = body.paused_until;
+    const updated = stateStore.writeGlobal(patch);
+    _send(res, 200, { ok: true, ...updated });
+    return true;
+  }
+
+  // POST /api/notifications/test - fire the configured payload to every
+  // live subscription right now. Rate-limited per (sub, notif).
+  if (parts[0] === 'notifications' && parts[1] === 'test' && parts.length === 2 && req.method === 'POST') {
+    if (!_checkOrigin(req, res)) return true;
+    let body;
+    try { body = await _readBody(req); }
+    catch { _send(res, 400, { error: 'invalid JSON body' }); return true; }
+    if (typeof body.id !== 'string') { _send(res, 400, { error: 'id required' }); return true; }
+    const [cardId, itemId] = body.id.split('#');
+    if (!cardId || !itemId) { _send(res, 400, { error: 'id must be cardId#itemId' }); return true; }
+
+    const card = ctx.registry.get(cardId);
+    if (!card) { _send(res, 404, { error: 'unknown card' }); return true; }
+    const item = (card.meta && card.meta.notifications && Array.isArray(card.meta.notifications.items))
+      ? card.meta.notifications.items.find(i => i.id === itemId)
+      : null;
+    if (!item) { _send(res, 404, { error: 'unknown notification item' }); return true; }
+
+    // Rate-limit globally per (notif, all-subs) so a session-token leak
+    // can't spam the operator's phone.
+    if (!_testRateOk('all', body.id)) {
+      _send(res, 429, { error: 'rate-limited; max 1 test fire per minute per notification' });
+      return true;
+    }
+
+    try {
+      const result = await webPushSend.testFire({
+        manifest: { id: cardId, label: card.meta.label, emoji: card.meta.emoji || null },
+        item,
+      });
+      _send(res, 200, { ok: true, sent: result.sent });
+    } catch (e) {
+      _send(res, 500, { error: e.message || 'test fire failed' });
+    }
+    return true;
+  }
+
+  // GET /api/diagnostics
+  if (parts[0] === 'diagnostics' && parts.length === 1 && req.method === 'GET') {
+    const cur = stateStore.read();
+    const subList = subs.list({ includeDead: true }).map(s => ({
+      id: s.id,
+      nickname: s.nickname || null,
+      userAgentSummary: (s.userAgent || '').slice(0, 80),
+      createdAt: s.createdAt,
+      lastSentAt: s.lastSentAt,
+      lastStatus: s.lastStatus,
+      dead: !!s.dead,
+      deadSince: s.deadSince || null,
+    }));
+    _send(res, 200, {
+      tz: process.env.TZ || null,
+      vapid_key_id: vapid.getKeyId(),
+      subscriptions: subList,
+      recent_fires: cur.recent_fires || [],
+      quiet_hours: cur.quiet_hours,
+      paused_until: cur.paused_until,
+    });
+    return true;
+  }
+
+  return false;
+}
+
+// Expose a fixed list of route prefixes the dispatcher can use to know
+// whether to delegate. Cleaner than having server.js know our internal
+// paths.
+const ROUTE_PREFIXES = ['push', 'notifications', 'diagnostics'];
+
+module.exports = { handle, ROUTE_PREFIXES };

--- a/server.js
+++ b/server.js
@@ -28,6 +28,8 @@ const { describeCatalogue: describeHaeCatalogue } = require('./health-auto-expor
 const userTz = require('./lib/user-tz');
 const notificationsState = require('./lib/notifications-state');
 const notificationsScheduler = require('./lib/notifications-scheduler');
+const webPushSend = require('./lib/web-push-send');
+const notificationRoutes = require('./routes/notifications');
 const { CATEGORIES: MANIFEST_CATEGORIES } = require('./config/categories');
 const ccSuggestions = require('./meta/cc-suggestions');
 const { describeCcSchema } = require('./chat/describe-cc-schema');
@@ -1630,6 +1632,12 @@ Original system prompt follows:
       return;
     }
 
+    // === Notifications + Web Push routes ===
+    if (notificationRoutes.ROUTE_PREFIXES.includes(parts[0])) {
+      const handled = await notificationRoutes.handle(req, res, parts, { registry });
+      if (handled) return;
+    }
+
     // === Voice endpoints ===
 
     // GET /api/instance — branding + runtime identity (for frontend)
@@ -1940,6 +1948,7 @@ server.listen(PORT, HOST, () => {
   if (!ENV.KLEBB_DEMO) {
     try {
       registry.onDelete((id) => notificationsState.pruneCard(id));
+      notificationsScheduler.setDispatch(webPushSend.dispatch);
       notificationsScheduler.start(registry);
       console.log('[notifications] scheduler started');
     } catch (e) {

--- a/tests/notifications-routes.test.js
+++ b/tests/notifications-routes.test.js
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/notifications-routes.test.js
+//
+// Integration tests for the /api/push/* and /api/notifications/*
+// endpoints in routes/notifications.js. Uses the sandbox helper to
+// spin up a real server with a seeded session.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const {
+  createSandbox, cleanupSandbox,
+  spawnServer, req,
+  fakeAuthState, sessionCookie,
+} = require('./helpers/sandbox');
+
+const ALLOWED_ORIGIN = 'http://127.0.0.1';
+
+const VALID_SUB = {
+  endpoint: 'https://fcm.googleapis.com/fcm/send/test-AAAA',
+  keys: { p256dh: 'a-p256dh-key', auth: 'an-auth-secret' },
+};
+
+test.describe('notifications routes (#386, authenticated)', () => {
+  let sandbox, srv, cookie;
+
+  test.before(async () => {
+    const auth = fakeAuthState();
+    sandbox = createSandbox({
+      credentials: auth.credentials,
+      sessions: auth.sessions,
+      seed: {
+        'mood.json': {
+          $schema: 'klebb.datafile.v1',
+          meta: {
+            id: 'mood', label: 'Mood', emoji: '🙂',
+            view: { enabled: true, component: 'generic-card' },
+            notifications: {
+              enabled: true,
+              items: [{
+                id: 'evening-log',
+                label: 'Evening log',
+                title: 'Mood',
+                body: 'How are you feeling?',
+                trigger: { type: 'daily', time: '20:00' },
+                privacy: 'private',
+              }],
+            },
+          },
+          data: [],
+        },
+      },
+    });
+    cookie = sessionCookie(auth.token);
+    srv = await spawnServer(sandbox, { HEALTH_ORIGIN: ALLOWED_ORIGIN });
+  });
+
+  test.after(async () => {
+    if (srv) await srv.kill();
+    if (sandbox) cleanupSandbox(sandbox);
+  });
+
+  test('GET /api/push/vapid-public-key returns key + 8-char keyId', async () => {
+    const r = await req(srv.baseUrl, '/api/push/vapid-public-key', { cookie });
+    assert.equal(r.status, 200);
+    assert.ok(typeof r.json.key === 'string' && r.json.key.length > 60);
+    assert.match(r.json.keyId, /^[a-f0-9]{8}$/);
+  });
+
+  test('POST /api/push/subscribe: persists, dedupes on second call', async () => {
+    const r1 = await req(srv.baseUrl, '/api/push/subscribe', {
+      method: 'POST',
+      cookie,
+      headers: { 'Origin': ALLOWED_ORIGIN },
+      body: VALID_SUB,
+    });
+    assert.equal(r1.status, 201);
+    assert.match(r1.json.id, /^[a-f0-9]{64}$/);
+
+    const r2 = await req(srv.baseUrl, '/api/push/subscribe', {
+      method: 'POST',
+      cookie,
+      headers: { 'Origin': ALLOWED_ORIGIN },
+      body: VALID_SUB,
+    });
+    assert.equal(r2.status, 200);
+    assert.equal(r2.json.created, false);
+
+    const persisted = JSON.parse(fs.readFileSync(path.join(sandbox, 'push-subscriptions.json'), 'utf8'));
+    assert.equal(persisted.subscriptions.length, 1);
+  });
+
+  test('POST /api/push/subscribe REJECTS cross-origin (Origin allowlist)', async () => {
+    const r = await req(srv.baseUrl, '/api/push/subscribe', {
+      method: 'POST',
+      cookie,
+      headers: { 'Origin': 'https://attacker.example' },
+      body: VALID_SUB,
+    });
+    assert.equal(r.status, 403);
+    assert.match(r.json.error, /origin/);
+  });
+
+  test('POST /api/push/subscribe REJECTS malformed sub with 400', async () => {
+    const r = await req(srv.baseUrl, '/api/push/subscribe', {
+      method: 'POST',
+      cookie,
+      headers: { 'Origin': ALLOWED_ORIGIN },
+      body: { endpoint: 'x' },
+    });
+    assert.equal(r.status, 400);
+  });
+
+  test('POST /api/push/subscribe/heartbeat: 200 known, 404 unknown', async () => {
+    const ok = await req(srv.baseUrl, '/api/push/subscribe/heartbeat', {
+      method: 'POST', cookie, headers: { 'Origin': ALLOWED_ORIGIN },
+      body: { endpoint: VALID_SUB.endpoint },
+    });
+    assert.equal(ok.status, 200);
+
+    const miss = await req(srv.baseUrl, '/api/push/subscribe/heartbeat', {
+      method: 'POST', cookie, headers: { 'Origin': ALLOWED_ORIGIN },
+      body: { endpoint: 'https://other.example/x' },
+    });
+    assert.equal(miss.status, 404);
+  });
+
+  test('POST /api/push/unsubscribe: 204 and removes the row', async () => {
+    const r = await req(srv.baseUrl, '/api/push/unsubscribe', {
+      method: 'POST', cookie, headers: { 'Origin': ALLOWED_ORIGIN },
+      body: { endpoint: VALID_SUB.endpoint },
+    });
+    assert.equal(r.status, 204);
+    const persisted = JSON.parse(fs.readFileSync(path.join(sandbox, 'push-subscriptions.json'), 'utf8'));
+    assert.equal(persisted.subscriptions.length, 0);
+  });
+
+  test('GET /api/notifications: aggregates declared items', async () => {
+    const r = await req(srv.baseUrl, '/api/notifications', { cookie });
+    assert.equal(r.status, 200);
+    assert.equal(r.json.notifications.length, 1);
+    assert.equal(r.json.notifications[0].id, 'mood#evening-log');
+    assert.equal(r.json.notifications[0].card_emoji, '🙂');
+    assert.equal(r.json.notifications[0].privacy, 'private');
+  });
+
+  test('POST /api/notifications/state: toggles enabled, persists', async () => {
+    const r = await req(srv.baseUrl, '/api/notifications/state', {
+      method: 'POST', cookie, headers: { 'Origin': ALLOWED_ORIGIN },
+      body: { id: 'mood#evening-log', enabled: false },
+    });
+    assert.equal(r.status, 200);
+    assert.equal(r.json.state.enabled, false);
+
+    const list = await req(srv.baseUrl, '/api/notifications', { cookie });
+    assert.equal(list.json.notifications[0].enabled, false);
+  });
+
+  test('POST /api/notifications/state REJECTS bad id format with 400', async () => {
+    const r = await req(srv.baseUrl, '/api/notifications/state', {
+      method: 'POST', cookie, headers: { 'Origin': ALLOWED_ORIGIN },
+      body: { id: 'totally-bogus', enabled: false },
+    });
+    assert.equal(r.status, 400);
+  });
+
+  test('POST /api/notifications/global-state: persists quiet_hours and paused_until', async () => {
+    const r = await req(srv.baseUrl, '/api/notifications/global-state', {
+      method: 'POST', cookie, headers: { 'Origin': ALLOWED_ORIGIN },
+      body: { quiet_hours: { start: '22:00', end: '07:00' }, paused_until: '2026-06-13T00:00:00Z' },
+    });
+    assert.equal(r.status, 200);
+    assert.deepEqual(r.json.quiet_hours, { start: '22:00', end: '07:00' });
+    assert.equal(r.json.paused_until, '2026-06-13T00:00:00Z');
+  });
+
+  test('POST /api/notifications/test: rate-limited at 1/minute per notification', async () => {
+    // Re-subscribe so testFire has somewhere to (try to) send.
+    await req(srv.baseUrl, '/api/push/subscribe', {
+      method: 'POST', cookie, headers: { 'Origin': ALLOWED_ORIGIN }, body: VALID_SUB,
+    });
+    // First call: rate-limit allows it. The send will fail (fake endpoint),
+    // but we only care that the rate-limit / dispatch path was reached.
+    const r1 = await req(srv.baseUrl, '/api/notifications/test', {
+      method: 'POST', cookie, headers: { 'Origin': ALLOWED_ORIGIN },
+      body: { id: 'mood#evening-log' },
+    });
+    assert.equal(r1.status, 200);
+
+    const r2 = await req(srv.baseUrl, '/api/notifications/test', {
+      method: 'POST', cookie, headers: { 'Origin': ALLOWED_ORIGIN },
+      body: { id: 'mood#evening-log' },
+    });
+    assert.equal(r2.status, 429);
+  });
+
+  test('POST /api/notifications/test 404s for unknown card or item', async () => {
+    const r = await req(srv.baseUrl, '/api/notifications/test', {
+      method: 'POST', cookie, headers: { 'Origin': ALLOWED_ORIGIN },
+      body: { id: 'mood#nope' },
+    });
+    assert.equal(r.status, 404);
+  });
+
+  test('GET /api/diagnostics returns tz, vapid_key_id, subscriptions, recent_fires', async () => {
+    const r = await req(srv.baseUrl, '/api/diagnostics', { cookie });
+    assert.equal(r.status, 200);
+    assert.match(r.json.vapid_key_id, /^[a-f0-9]{8}$/);
+    assert.ok(Array.isArray(r.json.subscriptions));
+    assert.ok(Array.isArray(r.json.recent_fires));
+    assert.ok('quiet_hours' in r.json);
+    assert.ok('paused_until' in r.json);
+    // Diagnostics MUST NOT leak raw endpoints.
+    for (const sub of r.json.subscriptions) {
+      assert.equal(typeof sub.endpoint, 'undefined');
+      assert.match(sub.id, /^[a-f0-9]{64}$/);
+    }
+  });
+});
+
+test.describe('notifications routes (#386, demo mode)', () => {
+  let sandbox, srv, cookie;
+
+  test.before(async () => {
+    const auth = fakeAuthState();
+    sandbox = createSandbox({
+      credentials: auth.credentials,
+      sessions: auth.sessions,
+    });
+    cookie = sessionCookie(auth.token);
+    srv = await spawnServer(sandbox, { KLEBB_DEMO: '1', HEALTH_ORIGIN: ALLOWED_ORIGIN });
+  });
+
+  test.after(async () => {
+    if (srv) await srv.kill();
+    if (sandbox) cleanupSandbox(sandbox);
+  });
+
+  test('every push and notifications endpoint 410s in KLEBB_DEMO=1', async () => {
+    const paths = [
+      ['GET', '/api/push/vapid-public-key'],
+      ['POST', '/api/push/subscribe'],
+      ['POST', '/api/push/unsubscribe'],
+      ['GET', '/api/notifications'],
+      ['POST', '/api/notifications/state'],
+      ['POST', '/api/notifications/test'],
+      ['GET', '/api/diagnostics'],
+    ];
+    for (const [method, path] of paths) {
+      const r = await req(srv.baseUrl, path, {
+        method,
+        cookie,
+        headers: { 'Origin': ALLOWED_ORIGIN },
+        body: method === 'POST' ? {} : null,
+      });
+      assert.equal(r.status, 410, `${method} ${path} should 410 in demo, got ${r.status}`);
+    }
+  });
+});

--- a/tests/notifications-scheduler.test.js
+++ b/tests/notifications-scheduler.test.js
@@ -2,8 +2,10 @@
 // Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
 // tests/notifications-scheduler.test.js
 //
-// In-process tests for the scheduler tick. Drives _tick() with a mock
-// "now" and a fake registry so we don't depend on real card files.
+// In-process tests for the scheduler tick. We never call start() here
+// because that runs an implicit tick against real time which would
+// race the controlled tick the test wants to exercise. Instead we
+// stash the registry via _setRegistryForTests and call _tick directly.
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
@@ -12,16 +14,12 @@ const os = require('node:os');
 const path = require('node:path');
 
 function freshState() {
-  // Each test gets its own HEALTH_HOME so notifications.state.json,
-  // user.json, etc. don't leak. The path module is loaded ONCE per
-  // process so we shim HEALTH_HOME via the override env var.
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'klebb-sched-'));
   const stateFile = path.join(root, 'notifications.state.json');
   const userFile = path.join(root, 'user.json');
   process.env.HEALTH_NOTIFICATIONS_STATE_FILE = stateFile;
   process.env.HEALTH_USER_FILE = userFile;
   process.env.TZ = 'Australia/Melbourne';
-  // Bust the require cache so the modules reload PATHS with the new env.
   for (const k of Object.keys(require.cache)) {
     if (k.includes('notifications-state')
       || k.includes('notification-trigger')
@@ -34,12 +32,6 @@ function freshState() {
   return { root, stateFile, userFile };
 }
 
-function fakeRegistry(cards) {
-  return {
-    list: () => cards,
-  };
-}
-
 const VALID_DAILY = {
   id: 'evening-log',
   label: 'Evening',
@@ -50,32 +42,29 @@ const VALID_DAILY = {
   default: 'on',
 };
 
+function setupCard(scheduler, items) {
+  scheduler._setRegistryForTests({
+    list: () => [{
+      meta: {
+        id: 'mood', label: 'Mood',
+        notifications: { enabled: true, items },
+      },
+    }],
+  });
+}
+
 test.describe('notifications-scheduler tick', () => {
   test('fires due notification, advances lastFired, second tick is idempotent', async () => {
     const { stateFile } = freshState();
     const scheduler = require('../lib/notifications-scheduler');
     const events = [];
     scheduler.setDispatch(async (evs) => events.push(...evs));
+    setupCard(scheduler, [VALID_DAILY]);
 
-    const card = {
-      meta: {
-        id: 'mood', label: 'Mood',
-        notifications: { enabled: true, items: [VALID_DAILY] },
-      },
-    };
-
-    // 09:00 +10:00 on 2026-06-12 = 23:00 UTC on 2026-06-11
-    const now = new Date('2026-06-11T23:00:00Z');
-    scheduler._tick.bind(null);
-    await scheduler._tick.call({ _registry: { list: () => [card] } }, now);
-    // The first tick happens via the public tick path - our shim above
-    // doesn't bind a registry. Use the wrapped form instead:
-    scheduler.start({ list: () => [card] });
-    // Stop the timer immediately; we'll drive _tick manually below.
-    scheduler.stop();
-    events.length = 0;
-
+    // 08:00 +10:00 on 2026-06-12 = 22:00 UTC on 2026-06-11
+    const now = new Date('2026-06-11T22:00:00Z');
     await scheduler._tick(now);
+
     assert.equal(events.length, 1);
     assert.equal(events[0].items.length, 1);
     assert.equal(events[0].items[0].id, 'mood#evening-log');
@@ -96,17 +85,10 @@ test.describe('notifications-scheduler tick', () => {
     const stateMod = require('../lib/notifications-state');
     const events = [];
     scheduler.setDispatch(async (evs) => events.push(...evs));
-
-    // Pre-pause for an hour past "now".
     stateMod.writeGlobal({ paused_until: '2026-06-12T00:00:00Z' });
+    setupCard(scheduler, [VALID_DAILY]);
 
-    scheduler.start({ list: () => [{
-      meta: { id: 'mood', label: 'Mood', notifications: { enabled: true, items: [VALID_DAILY] } },
-    }] });
-    scheduler.stop();
-    events.length = 0;
-
-    const now = new Date('2026-06-11T23:00:00Z');
+    const now = new Date('2026-06-11T22:00:00Z');
     await scheduler._tick(now);
     assert.equal(events.length, 0);
 
@@ -122,44 +104,29 @@ test.describe('notifications-scheduler tick', () => {
     const stateMod = require('../lib/notifications-state');
     const events = [];
     scheduler.setDispatch(async (evs) => events.push(...evs));
-
     // Quiet 07:00..09:00 - the 08:00 slot lands inside the window.
     stateMod.writeGlobal({ quiet_hours: { start: '07:00', end: '09:00' } });
+    setupCard(scheduler, [VALID_DAILY]);
 
-    scheduler.start({ list: () => [{
-      meta: { id: 'mood', label: 'Mood', notifications: { enabled: true, items: [VALID_DAILY] } },
-    }] });
-    scheduler.stop();
-    events.length = 0;
-
-    const now = new Date('2026-06-11T23:00:00Z'); // 09:00 +10:00
-    // Reset hour to 08:00 so we land inside quiet window
-    const qNow = new Date('2026-06-11T22:00:00Z'); // 08:00 +10:00
-    await scheduler._tick(qNow);
+    const now = new Date('2026-06-11T22:00:00Z'); // 08:00 +10:00
+    await scheduler._tick(now);
 
     assert.equal(events.length, 0);
     const after = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
-    // Slot recorded, status flagged so a debug surface can show "quiet".
     assert.match(after.items['mood#evening-log'].lastFired, /T08:00:00\+10:00$/);
     assert.equal(after.items['mood#evening-log'].lastFireStatus, 'quiet');
   });
 
   test('item-state.enabled=false skips dispatch', async () => {
-    const { stateFile } = freshState();
+    freshState();
     const scheduler = require('../lib/notifications-scheduler');
     const stateMod = require('../lib/notifications-state');
     const events = [];
     scheduler.setDispatch(async (evs) => events.push(...evs));
-
     stateMod.writeItem('mood#evening-log', { enabled: false });
+    setupCard(scheduler, [VALID_DAILY]);
 
-    scheduler.start({ list: () => [{
-      meta: { id: 'mood', label: 'Mood', notifications: { enabled: true, items: [VALID_DAILY] } },
-    }] });
-    scheduler.stop();
-    events.length = 0;
-
-    await scheduler._tick(new Date('2026-06-11T23:00:00Z'));
+    await scheduler._tick(new Date('2026-06-11T22:00:00Z'));
     assert.equal(events.length, 0);
   });
 
@@ -168,14 +135,13 @@ test.describe('notifications-scheduler tick', () => {
     const scheduler = require('../lib/notifications-scheduler');
     const events = [];
     scheduler.setDispatch(async (evs) => events.push(...evs));
+    scheduler._setRegistryForTests({
+      list: () => [{
+        meta: { id: 'mood', label: 'Mood', notifications: { enabled: false, items: [VALID_DAILY] } },
+      }],
+    });
 
-    scheduler.start({ list: () => [{
-      meta: { id: 'mood', label: 'Mood', notifications: { enabled: false, items: [VALID_DAILY] } },
-    }] });
-    scheduler.stop();
-    events.length = 0;
-
-    await scheduler._tick(new Date('2026-06-11T23:00:00Z'));
+    await scheduler._tick(new Date('2026-06-11T22:00:00Z'));
     assert.equal(events.length, 0);
   });
 });

--- a/tests/push-subscriptions.test.js
+++ b/tests/push-subscriptions.test.js
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/push-subscriptions.test.js
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+function freshHome() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'klebb-pushsub-'));
+  process.env.HEALTH_PUSH_SUBSCRIPTIONS_FILE = path.join(root, 'push-subscriptions.json');
+  for (const k of Object.keys(require.cache)) {
+    if (k.endsWith('config' + path.sep + 'paths.js') || k.includes('push-subscriptions')) {
+      delete require.cache[k];
+    }
+  }
+  return { root };
+}
+
+const A = { endpoint: 'https://fcm.googleapis.com/x/A', keys: { p256dh: 'pubA', auth: 'authA' } };
+const B = { endpoint: 'https://web.push.apple.com/x/B', keys: { p256dh: 'pubB', auth: 'authB' } };
+
+test.describe('lib/push-subscriptions', () => {
+  test('add: new endpoint creates row, returns created=true', () => {
+    freshHome();
+    const subs = require('../lib/push-subscriptions');
+    const r = subs.add(A, { userAgent: 'iPhone', nickname: 'phone' });
+    assert.equal(r.created, true);
+    assert.equal(subs.list().length, 1);
+    assert.equal(subs.list()[0].nickname, 'phone');
+  });
+
+  test('add: duplicate endpoint REPLACES keys + clears dead', () => {
+    freshHome();
+    const subs = require('../lib/push-subscriptions');
+    subs.add(A);
+    subs.markDead(A.endpoint, 410);
+    assert.equal(subs.list({ includeDead: true })[0].dead, true);
+    const r = subs.add({ ...A, keys: { p256dh: 'rotated', auth: 'rotatedAuth' } });
+    assert.equal(r.created, false);
+    const after = subs.list()[0]; // not dead now -> shows in default list
+    assert.equal(after.keys.p256dh, 'rotated');
+    assert.equal(after.keys.auth, 'rotatedAuth');
+    assert.equal(after.dead, false);
+  });
+
+  test('rejects missing endpoint or keys', () => {
+    freshHome();
+    const subs = require('../lib/push-subscriptions');
+    assert.throws(() => subs.add({}), e => e.code === 'INVALID_SUB');
+    assert.throws(() => subs.add({ endpoint: 'x' }), e => e.code === 'INVALID_SUB');
+    assert.throws(() => subs.add({ endpoint: 'x', keys: {} }), e => e.code === 'INVALID_SUB');
+  });
+
+  test('markDead: 401/403/404/410 all set dead + deadSince', () => {
+    freshHome();
+    const subs = require('../lib/push-subscriptions');
+    subs.add(A);
+    subs.markDead(A.endpoint, 410);
+    const dead = subs.list({ includeDead: true })[0];
+    assert.equal(dead.dead, true);
+    assert.equal(dead.lastStatus, 410);
+    assert.match(dead.deadSince, /^\d{4}-\d{2}-\d{2}T/);
+    assert.equal(subs.list().length, 0); // hidden from active list
+  });
+
+  test('heartbeat: known dead endpoint flips alive', () => {
+    freshHome();
+    const subs = require('../lib/push-subscriptions');
+    subs.add(A);
+    subs.markDead(A.endpoint, 410);
+    const ok = subs.heartbeat(A.endpoint);
+    assert.equal(ok, true);
+    assert.equal(subs.list()[0].dead, false);
+  });
+
+  test('heartbeat: unknown endpoint returns false', () => {
+    freshHome();
+    const subs = require('../lib/push-subscriptions');
+    assert.equal(subs.heartbeat('https://nope/x'), false);
+  });
+
+  test('remove: drops the row entirely', () => {
+    freshHome();
+    const subs = require('../lib/push-subscriptions');
+    subs.add(A);
+    subs.add(B);
+    assert.equal(subs.remove(A.endpoint), 1);
+    assert.equal(subs.list().length, 1);
+    assert.equal(subs.list()[0].endpoint, B.endpoint);
+  });
+
+  test('20-active cap: oldest evicted on overflow', () => {
+    freshHome();
+    const subs = require('../lib/push-subscriptions');
+    for (let i = 0; i < 22; i++) {
+      subs.add({
+        endpoint: `https://fcm.googleapis.com/x/${i}`,
+        keys: { p256dh: 'p' + i, auth: 'a' + i },
+      });
+    }
+    const live = subs.list();
+    assert.equal(live.length, 20);
+    // The oldest two should be gone.
+    assert.equal(live.find(s => s.endpoint.endsWith('/0')), undefined);
+    assert.equal(live.find(s => s.endpoint.endsWith('/1')), undefined);
+    assert.ok(live.find(s => s.endpoint.endsWith('/21')));
+  });
+
+  test('pruneDead: removes subs dead >7 days', () => {
+    freshHome();
+    const subs = require('../lib/push-subscriptions');
+    subs.add(A);
+    subs.markDead(A.endpoint, 410);
+    // Backdate the deadSince to 8 days ago.
+    const file = process.env.HEALTH_PUSH_SUBSCRIPTIONS_FILE;
+    const state = JSON.parse(fs.readFileSync(file, 'utf8'));
+    state.subscriptions[0].deadSince = new Date(Date.now() - 8 * 24 * 3600 * 1000).toISOString();
+    fs.writeFileSync(file, JSON.stringify(state));
+
+    const removed = subs.pruneDead();
+    assert.equal(removed, 1);
+    assert.equal(subs.list({ includeDead: true }).length, 0);
+  });
+
+  test('pruneDead: keeps subs dead <7 days', () => {
+    freshHome();
+    const subs = require('../lib/push-subscriptions');
+    subs.add(A);
+    subs.markDead(A.endpoint, 410);
+    const removed = subs.pruneDead();
+    assert.equal(removed, 0);
+    assert.equal(subs.list({ includeDead: true }).length, 1);
+  });
+});

--- a/tests/vapid.test.js
+++ b/tests/vapid.test.js
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/vapid.test.js
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+function freshHome() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'klebb-vapid-'));
+  process.env.HEALTH_VAPID_FILE = path.join(root, 'keys', 'vapid.json');
+  for (const k of Object.keys(require.cache)) {
+    if (k.endsWith('config' + path.sep + 'paths.js') || k.endsWith('lib' + path.sep + 'vapid.js')) {
+      delete require.cache[k];
+    }
+  }
+  return { root, file: process.env.HEALTH_VAPID_FILE };
+}
+
+test.describe('lib/vapid', () => {
+  test('lazy generation: first call creates the keypair file', () => {
+    const { file } = freshHome();
+    const vapid = require('../lib/vapid');
+    assert.equal(fs.existsSync(file), false);
+    const pub = vapid.getPublicKey();
+    assert.ok(typeof pub === 'string' && pub.length > 60);
+    assert.equal(fs.existsSync(file), true);
+    const persisted = JSON.parse(fs.readFileSync(file, 'utf8'));
+    assert.equal(persisted.publicKey, pub);
+    assert.ok(typeof persisted.privateKey === 'string' && persisted.privateKey.length > 30);
+    assert.match(persisted.createdAt, /^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test('subsequent calls reuse the persisted keypair (no rotation on read)', () => {
+    const { file } = freshHome();
+    const vapid = require('../lib/vapid');
+    const first = vapid.getPublicKey();
+    vapid._resetForTests();
+    const second = vapid.getPublicKey();
+    assert.equal(first, second);
+    // File contents unchanged.
+    const persisted = JSON.parse(fs.readFileSync(file, 'utf8'));
+    assert.equal(persisted.publicKey, first);
+  });
+
+  test('keyId is the 8-char sha256 fingerprint of the public key', () => {
+    freshHome();
+    const vapid = require('../lib/vapid');
+    const crypto = require('node:crypto');
+    const expected = crypto.createHash('sha256').update(vapid.getPublicKey()).digest('hex').slice(0, 8);
+    assert.equal(vapid.getKeyId(), expected);
+  });
+
+  test('deleting the file regenerates on next call (operator rotation path)', () => {
+    const { file } = freshHome();
+    const vapid = require('../lib/vapid');
+    const before = vapid.getPublicKey();
+    fs.unlinkSync(file);
+    vapid._resetForTests();
+    const after = vapid.getPublicKey();
+    assert.notEqual(after, before);
+  });
+});

--- a/tests/web-push-send.test.js
+++ b/tests/web-push-send.test.js
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/web-push-send.test.js
+//
+// Unit tests for the wire-payload builder and the dispatch path. The
+// actual web-push package call is monkey-patched so we never hit a real
+// FCM/APNs/Mozilla endpoint.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+function freshHome() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'klebb-send-'));
+  process.env.HEALTH_VAPID_FILE = path.join(root, 'keys', 'vapid.json');
+  process.env.HEALTH_PUSH_SUBSCRIPTIONS_FILE = path.join(root, 'push-subscriptions.json');
+  process.env.HEALTH_NOTIFICATIONS_STATE_FILE = path.join(root, 'notifications.state.json');
+  for (const k of Object.keys(require.cache)) {
+    if (k.endsWith('config' + path.sep + 'paths.js')
+      || k.includes('lib' + path.sep + 'vapid')
+      || k.includes('lib' + path.sep + 'push-subscriptions')
+      || k.includes('lib' + path.sep + 'notifications-state')
+      || k.includes('lib' + path.sep + 'web-push-send')) {
+      delete require.cache[k];
+    }
+  }
+  return { root };
+}
+
+const PRIVATE_ITEM = {
+  id: 'evening-log',
+  label: 'Evening log',
+  title: 'Mood',
+  body: 'How are you feeling?',
+  trigger: { type: 'daily', time: '20:00' },
+  privacy: 'private',
+};
+
+const PUBLIC_ITEM = { ...PRIVATE_ITEM, id: 'morning-log', privacy: 'public' };
+
+function fakeEvent(item, manifest = { id: 'mood', label: 'Mood', emoji: '🙂' }) {
+  return {
+    id: 'tick-2026-06-12T08:00',
+    slot: '2026-06-12T08:00:00+10:00',
+    items: [{
+      id: `${manifest.id}#${item.id}`,
+      slot: '2026-06-12T08:00:00+10:00',
+      item,
+      manifest,
+    }],
+  };
+}
+
+test.describe('web-push-send.buildPayload', () => {
+  test('private: wire payload carries generic title/body and the real text in realTitle/realBody', () => {
+    freshHome();
+    const send = require('../lib/web-push-send');
+    const payload = send.buildPayload(fakeEvent(PRIVATE_ITEM));
+    assert.equal(payload.type, 'single');
+    assert.equal(payload.items.length, 1);
+    const it = payload.items[0];
+    assert.equal(it.title, 'Klebb');
+    assert.equal(it.body, 'You have a reminder.');
+    assert.equal(it.realTitle, 'Mood');
+    assert.equal(it.realBody, 'How are you feeling?');
+    assert.equal(it.privacy, 'private');
+  });
+
+  test('public: wire payload exposes real title/body verbatim', () => {
+    freshHome();
+    const send = require('../lib/web-push-send');
+    const payload = send.buildPayload(fakeEvent(PUBLIC_ITEM));
+    const it = payload.items[0];
+    assert.equal(it.title, 'Mood');
+    assert.equal(it.body, 'How are you feeling?');
+    assert.equal(it.realTitle, null);
+    assert.equal(it.realBody, null);
+  });
+
+  test('tag is opaque sha256 prefix, never the readable id', () => {
+    freshHome();
+    const send = require('../lib/web-push-send');
+    const payload = send.buildPayload(fakeEvent(PRIVATE_ITEM));
+    const tag = payload.items[0].tag;
+    assert.match(tag, /^klebb-[a-f0-9]{12}$/);
+    assert.ok(!tag.includes('mood'));
+    assert.ok(!tag.includes('evening-log'));
+  });
+
+  test('multi-item event: type=coalesced and every item carries its own tag', () => {
+    freshHome();
+    const send = require('../lib/web-push-send');
+    const ev = {
+      id: 'tick-2026-06-12T08:00',
+      slot: '2026-06-12T08:00:00+10:00',
+      items: [
+        { id: 'mood#a', slot: '2026-06-12T08:00:00+10:00', item: { ...PRIVATE_ITEM, id: 'a' }, manifest: { id: 'mood', label: 'Mood', emoji: null } },
+        { id: 'mood#b', slot: '2026-06-12T08:00:00+10:00', item: { ...PRIVATE_ITEM, id: 'b' }, manifest: { id: 'mood', label: 'Mood', emoji: null } },
+      ],
+    };
+    const payload = send.buildPayload(ev);
+    assert.equal(payload.type, 'coalesced');
+    assert.equal(payload.items.length, 2);
+    assert.notEqual(payload.items[0].tag, payload.items[1].tag);
+  });
+
+  test('action: open-card with intent yields a same-origin url', () => {
+    freshHome();
+    const send = require('../lib/web-push-send');
+    const item = { ...PRIVATE_ITEM, action: { type: 'open-card', card: 'mood', intent: 'log' } };
+    const payload = send.buildPayload(fakeEvent(item));
+    assert.equal(payload.items[0].url, '/?card=mood&action=log');
+  });
+});
+
+test.describe('web-push-send.dispatch (mocked send)', () => {
+  test('records a recent_fires entry with sent/failed counts', async () => {
+    freshHome();
+    const subs = require('../lib/push-subscriptions');
+    const stateStore = require('../lib/notifications-state');
+    const webpush = require('web-push');
+    const send = require('../lib/web-push-send');
+
+    subs.add({ endpoint: 'https://fcm.googleapis.com/x/A', keys: { p256dh: 'p1', auth: 'a1' } });
+    subs.add({ endpoint: 'https://web.push.apple.com/x/B', keys: { p256dh: 'p2', auth: 'a2' } });
+
+    // Mock: A succeeds (201), B 410s (subscription unregistered).
+    const orig = webpush.sendNotification;
+    webpush.sendNotification = async (sub) => {
+      if (sub.endpoint.includes('apple')) {
+        const e = new Error('410'); e.statusCode = 410; throw e;
+      }
+      return { statusCode: 201 };
+    };
+
+    try {
+      await send.dispatch([fakeEvent(PRIVATE_ITEM)]);
+    } finally {
+      webpush.sendNotification = orig;
+    }
+
+    const cur = stateStore.read();
+    assert.equal(cur.recent_fires.length, 1);
+    const fire = cur.recent_fires[0];
+    assert.equal(fire.sent, 1);
+    assert.equal(fire.failed, 1);
+    // The Apple sub got 410'd -> dead.
+    const live = subs.list();
+    assert.equal(live.length, 1);
+    assert.equal(live[0].endpoint.includes('googleapis'), true);
+    const all = subs.list({ includeDead: true });
+    const dead = all.find(s => s.endpoint.includes('apple'));
+    assert.equal(dead.dead, true);
+    assert.equal(dead.lastStatus, 410);
+  });
+
+  test('401 from provider also marks dead (VAPID rotation case)', async () => {
+    freshHome();
+    const subs = require('../lib/push-subscriptions');
+    const webpush = require('web-push');
+    const send = require('../lib/web-push-send');
+
+    subs.add({ endpoint: 'https://fcm.googleapis.com/x/A', keys: { p256dh: 'p1', auth: 'a1' } });
+    const orig = webpush.sendNotification;
+    webpush.sendNotification = async () => {
+      const e = new Error('401'); e.statusCode = 401; throw e;
+    };
+    try {
+      await send.dispatch([fakeEvent(PRIVATE_ITEM)]);
+    } finally {
+      webpush.sendNotification = orig;
+    }
+    const after = subs.list({ includeDead: true })[0];
+    assert.equal(after.dead, true);
+    assert.equal(after.lastStatus, 401);
+  });
+
+  test('dispatch with no live subs is a no-op', async () => {
+    freshHome();
+    const stateStore = require('../lib/notifications-state');
+    const send = require('../lib/web-push-send');
+    await send.dispatch([fakeEvent(PRIVATE_ITEM)]);
+    assert.equal(stateStore.read().recent_fires.length, 0);
+  });
+});


### PR DESCRIPTION
# What changed

The send side. Every piece needed to deliver a Web Push to a real device:
VAPID key generation, persistent subscription storage,
`/api/push/*` endpoints, the `web-push` integration that actually fires,
and the `/api/notifications/*` HTTP surface (state toggle, global pause/
quiet-hours, test fire, diagnostics). Every state-changing endpoint is
gated by an Origin-allowlist middleware. After this PR a manual `curl`
sequence (subscribe a real browser sub, then test-fire) delivers a
notification to the operator's phone; PR5 wires the UI on top.

Closes #386.

# Why

PR4 of the v3.0.0 notifications rollout. Splits cleanly between the
schema/scheduler infrastructure (PR3) and the UI/Klebbius tools (PR5).
The hard-to-review crypto + token surface lives in this one PR, behind
its own GitHub issue, so the security review is focused and the diff
is small enough to read.

# How

Five commits, each individually green:

1. `chore(deps): add web-push for Web Push delivery`
   The cryptographic surface (VAPID JWT signing, RFC 8291 ECE
   encryption) goes through the `web-push` npm package rather than a
   ~250-line bespoke implementation. Zero transitive runtime deps;
   widely exercised in production. Audit surface is one package, not
   our own crypto.

2. `feat(notifications): VAPID key generation + push subscription storage`
   `lib/vapid.js` lazy-generates the keypair on first call, persists
   to `$HEALTH_HOME/keys/vapid.json` (mode 0o600, atomic, fsynced).
   Exposes `getKeyId()` so the client can detect operator rotation
   and force-resubscribe. `lib/push-subscriptions.js` stores per-
   device subs at `$HEALTH_HOME/push-subscriptions.json` (mode 0o600,
   atomic). Capped at 20 active subs; oldest evicted on overflow. On
   duplicate endpoint we REPLACE keys + nickname rather than skip, so
   browser key rotation doesn't leave a stale set that silently fails
   to decrypt on the device. `markDead()` handles 401/403/404/410
   from providers (not just 410 — VAPID rotation produces 401).
   `pruneDead()` drops subs marked dead for >7 days. `config/paths.js`
   gains the new path constants with env-var overrides for tests.

3. `feat(notifications): web-push send + recent_fires audit ring`
   `lib/web-push-send.js` wraps the `web-push` package and replaces
   the scheduler's logging-only dispatch from PR3. Wire payload:
   private items send `Klebb / You have a reminder.` plus separate
   `realTitle`/`realBody` fields the SW substitutes after decryption
   (PR5 adds the SW substitution logic). Public items send the real
   text verbatim. Tag is opaque `klebb-<sha256-prefix-12>`. `Urgency:
   high` and `TTL: 300` make Low Power Mode batching unlikely on iOS.
   `lib/notifications-state.js` gains a 100-entry `recent_fires` ring
   buffer that the Diagnostics tab reads back. The scheduler exports
   `_setRegistryForTests` so specs can exercise `_tick()` without
   `start()`'s implicit real-time tick racing the controlled scheduled
   time.

4. `feat(notifications): /api/push/* + /api/notifications/* + Origin allowlist`
   New `routes/notifications.js` with one `handle()` function the
   main dispatcher delegates to by path prefix:
   - `GET /api/push/vapid-public-key`
   - `POST /api/push/subscribe`
   - `POST /api/push/subscribe/heartbeat`
   - `POST /api/push/unsubscribe`
   - `GET /api/notifications` (aggregate)
   - `POST /api/notifications/state`
   - `POST /api/notifications/global-state`
   - `POST /api/notifications/test` (rate-limited 1/min)
   - `GET /api/diagnostics`

   Origin-allowlist middleware on every state-changing endpoint:
   SameSite=Lax cookies don't block cross-fetch from same-eTLD+1
   subdomains, so the cookie alone is necessary-but-not-sufficient
   CSRF defense. Reject when `req.headers.origin` is set and doesn't
   match `ENV.WEBAUTHN_ORIGIN`. Same-host curl requests (no Origin
   header) are allowed.

   In `KLEBB_DEMO=1` every endpoint 410s, including
   `/api/push/vapid-public-key`. Boot wiring swaps the scheduler's
   dispatch from logging to `webPushSend.dispatch` when `!KLEBB_DEMO`,
   so the scheduler now fires real push.

5. `docs(notifications): backup + sensitive files note in DEPLOY.md`
   New `## 6. Backup and sensitive files` section listing every file
   under `$HEALTH_HOME/` that a future "export my data" feature
   MUST exclude. CHANGELOG entries under `## Unreleased`.

# Testing

- [x] `npm test` passes locally — 1295 tests, 1292 pass, 0 fail, 3
  pre-existing skipped (36 new tests across four files)
- [x] `npm run test:e2e` passes locally (61 pass)
- [x] New unit suites:
  - `tests/vapid.test.js` — 4 tests, lazy generation, persistence,
    keyId fingerprint, rotation path
  - `tests/push-subscriptions.test.js` — 10 tests, dedupe + key
    replacement, dead lifecycle, 20-active eviction, 7d prune
  - `tests/web-push-send.test.js` — 8 tests, payload builder for
    private vs public, opaque tag, multi-item coalescing, dispatch
    with mocked `web-push.sendNotification` (success + 410 + 401),
    no-op when zero live subs
  - `tests/notifications-routes.test.js` — 14 tests, every endpoint
    auth-gated, Origin allowlist enforced, rate-limit hit at 2nd
    test fire, demo mode 410s the whole surface, no raw endpoint
    URLs in diagnostics
- [x] Manual smoke against a local non-demo dev instance:
  - `curl /api/push/vapid-public-key` returns `{ key, keyId }`
  - `curl -X POST /api/push/subscribe` with a fake sub returns 201
  - `curl /api/diagnostics` shows the sub in `subscriptions[]` with
    no raw endpoint URL
  - `curl /api/diagnostics` from KLEBB_DEMO=1 returns 410

# Checklist

- [x] Commit messages follow the conventions in `CONTRIBUTING.md`
- [x] `CHANGELOG.md` updated under `## Unreleased`
- [x] Docs updated: `DEPLOY.md` gains the backup + sensitive files
  section (item 6)
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed
- [x] One new dep (`web-push`); justification recorded in the
  `chore(deps)` commit body and in this PR

# Out of scope (deferred to PR5)

- Logout-time `/api/push/unsubscribe` from the client. There is no UI
  logout button today, so wiring the SW unsubscribe message has no
  caller. The endpoint exists; the client-side hook lands when PR5
  adds the Settings > Notifications "Disconnect this device"
  affordance.
- The Notifications tab UI itself (PR5).
- `set_notification` and `remove_notification` Klebbius tools (PR5).
- The SW push handler's substitution logic for private notifications
  (the wire payload carries `realTitle`/`realBody` already, so the SW
  side is one swap when PR5 lands).

# Breaking changes

None. All endpoints are new. The scheduler's dispatch swap from
logging to real send is server-internal; manifests without
`meta.notifications` produce zero work and no push as before. The
new path constants in `config/paths.js` have env-var overrides; they
default to safe locations under `$HEALTH_HOME/` that are created
lazily on first use.

This PR is part of the v3.0.0 release wave; PRs #383 / #384 / #385 /
#386 / #387 ship together as a major version bump.
