### PR TITLE
feat(notifications): Notifications tab UI, Klebbius set_notification and remove_notification tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,72 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Settings > Notifications tab: per-card toggles, quiet hours, pause.**
+  Replaces the placeholder from PR #383. Renders a status banner that
+  walks through the permission states (default / denied / granted+
+  subscribed / granted-but-unsubscribed / iOS-needs-install), per-card
+  sections grouped by manifest with one row per declared item sorted
+  by trigger time, two toggles per row (enabled, "Show full text" =
+  privacy public/private), and an always-visible Test button. Global
+  controls: Quiet hours window (start/end times persisted to
+  `notifications.state.json`) and Pause-for chips (1h / 4h / 1 day,
+  with a persistent app-wide banner the operator can dismiss with
+  Resume). Empty state and a footer note: *"If a notification you want
+  is missing, ask Klebbius to add it."* Refs #387.
+
+- **Settings > Diagnostics tab: real surface.** Server timezone, VAPID
+  keyId, subscribed-devices table (truncated id, nickname, last-sent,
+  last-status, dead state), and the recent-fires audit ring back-to-
+  front. Reads from `/api/diagnostics`; demo-mode 410 surfaces as a
+  copy explaining the disable. Refs #387.
+
+- **Browser-side notifications client (`public/js/lib/notification-client.js`).**
+  Lazy enable: prompt for permission only when the user clicks Enable
+  or flips a toggle for the first time. Subscribe via `pushManager`,
+  POST the subscription, store the VAPID keyId in localStorage so we
+  can detect operator key rotation and silently force-resubscribe.
+  Foreground heartbeat fires on every `visibilitychange` to visible
+  and on app boot in standalone PWA mode, calling
+  `/api/push/subscribe/heartbeat`; on 404 the client transparently
+  resubscribes. Disable() unsubscribes both server and device. Refs
+  #387.
+
+- **Service worker now substitutes real text for `private`
+  notifications.** The wire payload from PR #386 already carries
+  `realTitle`/`realBody`; the SW reads them and surfaces the real
+  content on-device after decryption (lock screen still shows generic
+  "Klebb / You have a reminder." per the wire). Foreground branch:
+  when a Klebb tab is visible, the SW posts a
+  `klebb-foreground-notification` message and skips
+  `showNotification` entirely (iOS would suppress the banner anyway,
+  and skipping avoids a budget violation). Deep-link intent is
+  persisted to IndexedDB BEFORE `showNotification` so an iOS cold-
+  start launch (which can strip query strings off `clients.openWindow`
+  URLs) reads-and-clears it on app boot. Same-origin URL validation
+  on every `notificationclick` navigation. Refs #387.
+
+- **Klebbius gains `set_notification` + `remove_notification` tools.**
+  `set_notification` is idempotent by `(card_id, notification_id)`:
+  if an item with that id exists it's replaced, otherwise a new one
+  is appended. When `notification_id` is omitted, an id is auto-
+  generated as a snake-case slug from `label`. `remove_notification`
+  drops a named item; the system prompt requires one-shot user
+  confirmation before calling. The chat agent's system prompt gains
+  notification copy rules: titles up to 30 chars, bodies up to 80,
+  second person, no emoji unless the card has `meta.emoji`, never
+  include numerical values or content of past entries (notifications
+  are reminders TO ACT, not summaries of what happened). Refs #387.
+
+- **Embellishment chip: "Add a daily reminder?"** After the chat
+  agent creates a card with a renderer that supports logging
+  (`generic-card`, `schedule-card`, `checklist-card`, `list-card`)
+  and the card declares no notifications yet, the post-turn chip
+  panel offers a starter prompt the user can edit before sending:
+  *"Add a notification to remind me to log {label} every evening at
+  8pm."* Refs #387.
+
+### Added
+
 - **Web Push delivery: real notifications hit real devices.** New
   `/api/push/*` endpoints (`vapid-public-key`, `subscribe`,
   `subscribe/heartbeat`, `unsubscribe`) accept a browser

--- a/chat/embellish.js
+++ b/chat/embellish.js
@@ -109,6 +109,23 @@ const CATALOG = [
       return !(meta.prompt && meta.prompt.enabled);
     },
   },
+  {
+    id: 'add-daily-reminder',
+    label: 'Add a daily reminder?',
+    buildPrompt: (label) =>
+      `Add a notification to remind me to log ${label} every evening at 8pm.`,
+    eligible: (meta) => {
+      const r = renderer(meta);
+      if (r !== 'generic-card' && r !== 'schedule-card'
+          && r !== 'checklist-card' && r !== 'list-card') return false;
+      // Suppress when the card already has a notifications block; we
+      // don't want to push the user to add a second similar reminder.
+      const items = meta.notifications && Array.isArray(meta.notifications.items)
+        ? meta.notifications.items
+        : null;
+      return !items || items.length === 0;
+    },
+  },
 ];
 
 function renderer(meta) {

--- a/chat/tools.js
+++ b/chat/tools.js
@@ -289,7 +289,68 @@ const TOOL_DEFS = [
       },
     },
   },
+  {
+    type: 'function',
+    function: {
+      name: 'set_notification',
+      description:
+        "Add or update a notification on a card. Idempotent: if a notification with notification_id already exists on this card, update it; otherwise append a new one (auto-generating a snake-case id from `label` when notification_id is omitted). Use this when the user says things like 'remind me to log X every day at Y' or 'change the morning mood reminder to 9am'. Before calling, you SHOULD have read the card's existing meta.notifications.items[] (via read_manifest_meta) so you don't duplicate a similar reminder; if a similar item exists but is currently disabled, prefer offering the user a re-enable instead. Notification copy rules: title <=30 chars, body <=80 chars, second person ('How are you feeling?'), no emoji unless the card has meta.emoji set, NEVER include numerical values or content of past entries (notifications are reminders to act, not summaries). v1 trigger types are 'daily' (time:HH:MM) and 'weekly' (time:HH:MM, days:[mon|tue|wed|thu|fri|sat|sun]).",
+      parameters: {
+        type: 'object',
+        properties: {
+          card_id: { type: 'string', description: 'Existing card id.' },
+          notification_id: {
+            type: 'string',
+            description: "Item id within meta.notifications.items[]. Omit for an auto-generated slug from `label`. Must match /^[a-z0-9][a-z0-9._-]{0,63}$/.",
+          },
+          label: { type: 'string', description: 'Human label shown in Settings. e.g. "Evening mood log".' },
+          title: { type: 'string', description: 'Notification title (<=30 chars).' },
+          body: { type: 'string', description: 'Notification body (<=80 chars, second person).' },
+          trigger: {
+            type: 'object',
+            description: 'Daily: { type:"daily", time:"HH:MM" }. Weekly: { type:"weekly", time:"HH:MM", days:[...] }.',
+          },
+          privacy: {
+            type: 'string',
+            enum: ['private', 'public'],
+            description: "Default 'private'. When 'private', the wire payload says generic 'Klebb / You have a reminder.' on the lock screen and the real text appears only after the user opens Klebb.",
+          },
+        },
+        required: ['card_id', 'label', 'title', 'body', 'trigger'],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'remove_notification',
+      description:
+        'Remove a notification from a card. Confirm with the user EXACTLY ONCE before calling: removal is destructive (the notification is gone, not just disabled). If the user is unsure, suggest toggling enabled:false in Settings instead.',
+      parameters: {
+        type: 'object',
+        properties: {
+          card_id: { type: 'string' },
+          notification_id: { type: 'string' },
+        },
+        required: ['card_id', 'notification_id'],
+        additionalProperties: false,
+      },
+    },
+  },
 ];
+
+// Auto-generate a notification id from a human label when the agent
+// didn't supply one. Lowercase, ascii-only, drop anything that isn't
+// matching the id regex.
+function _slugifyNotificationId(label) {
+  const slug = String(label || 'reminder')
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+  return slug || 'reminder';
+}
 
 // Execute a single tool_call from an assistant response. Always returns a
 // string (stringified JSON) — both success and failure paths. The string
@@ -424,6 +485,64 @@ function dispatchToolCall(tc, ctx) {
       }
       case 'read_report': {
         return JSON.stringify(readReport(args.name));
+      }
+      case 'set_notification': {
+        const entry = registry.get(args.card_id);
+        if (!entry) return JSON.stringify({ error: `unknown card: ${args.card_id}` });
+        const existingItems = (entry.meta && entry.meta.notifications && Array.isArray(entry.meta.notifications.items))
+          ? entry.meta.notifications.items
+          : [];
+        const itemId = args.notification_id || _slugifyNotificationId(args.label);
+        const newItem = {
+          id: itemId,
+          label: args.label,
+          title: args.title,
+          body: args.body,
+          trigger: args.trigger,
+        };
+        if (args.privacy) newItem.privacy = args.privacy;
+        const idx = existingItems.findIndex(i => i.id === itemId);
+        const nextItems = [...existingItems];
+        if (idx >= 0) nextItems[idx] = { ...existingItems[idx], ...newItem };
+        else nextItems.push(newItem);
+        try {
+          registry.patchManifest(args.card_id, {
+            meta: { notifications: { enabled: true, items: nextItems } },
+          });
+          recordTouch(ctx, { id: args.card_id, flow: 'edit' });
+          return JSON.stringify({
+            ok: true,
+            card_id: args.card_id,
+            notification_id: itemId,
+            created: idx < 0,
+          });
+        } catch (e) {
+          return JSON.stringify({ error: e.message || 'set_notification failed' });
+        }
+      }
+      case 'remove_notification': {
+        const entry = registry.get(args.card_id);
+        if (!entry) return JSON.stringify({ error: `unknown card: ${args.card_id}` });
+        const existingItems = (entry.meta && entry.meta.notifications && Array.isArray(entry.meta.notifications.items))
+          ? entry.meta.notifications.items
+          : [];
+        const idx = existingItems.findIndex(i => i.id === args.notification_id);
+        if (idx < 0) return JSON.stringify({ error: `unknown notification: ${args.notification_id}` });
+        const nextItems = existingItems.filter(i => i.id !== args.notification_id);
+        try {
+          registry.patchManifest(args.card_id, {
+            meta: { notifications: { enabled: entry.meta.notifications.enabled !== false, items: nextItems } },
+          });
+          recordTouch(ctx, { id: args.card_id, flow: 'edit' });
+          return JSON.stringify({
+            ok: true,
+            card_id: args.card_id,
+            notification_id: args.notification_id,
+            remaining: nextItems.length,
+          });
+        } catch (e) {
+          return JSON.stringify({ error: e.message || 'remove_notification failed' });
+        }
       }
       default:
         return JSON.stringify({ error: 'unknown tool: ' + name });

--- a/config/env.js
+++ b/config/env.js
@@ -200,6 +200,15 @@ You, ${CHAT_AGENT_NAME}, are embedded in the dashboard itself. You act by callin
 - \`write_manifest_data(id, data)\` → LAST RESORT for writes. Replaces the full data block. Only use for non-array data shapes (markdown blob, single object) or when the change really is a wholesale restructure. For ANY row-level change ("add a dose", "fix yesterday's mood", "delete this morning's reading") use \`append_row\` / \`update_row\` / \`remove_row\` instead; they don't round-trip the whole file. Rejected if \`meta.writeable.fromWebapp\` is not true. Confirm with the user EXACTLY ONCE before a write that removes rows.
 - \`patch_manifest(id, patch)\` → edit meta or description without touching data. RFC 7396 JSON Merge Patch: nested objects deep-merge, ARRAYS REPLACE, \`null\` removes a key. Use for thresholds, labels, emoji maps, input types, writeable flags. Cannot change \`$schema\` or \`meta.id\`. Confirm ONCE before destructive-feeling patches (removing inputs from a writeable card, flipping \`writeable.fromWebapp\` from \`true\` to \`false\` on a card that has data).
 - \`read_doc(path)\` → fetch the full text of a Klebb doc shipped with this app. The "## Available docs" section below lists every callable path with a one-line summary. Reach for this whenever the user asks about schema, renderer contracts, deploy steps, ingest formats, or any other topic where the docs are authoritative — you'll get the same version the running app shipped with, so you won't be misled by training-data drift.
+- \`set_notification\` → add or update a push notification reminder on a card. Reach for this when the user phrases a request as a reminder: "remind me to log mood every evening at 8pm", "alert me when supplements are due", "every Monday at 9am ask me about pain levels". Idempotent by (card_id, notification_id). Before calling, you SHOULD have read the card's current \`meta.notifications.items[]\` (via \`read_manifest_meta\`) so you don't duplicate. If a similar item exists but is currently disabled in Settings, prefer offering the user a "re-enable" instead. Do NOT proactively add notifications when creating a card; ask first or wait for the user to say so.
+- \`remove_notification\` → drop a notification from a card. Confirm ONCE before calling (removal is destructive — the item is gone, not just disabled).
+
+**Notification copy rules** (apply to \`set_notification\` titles + bodies):
+- Title <=30 chars; body <=80 chars.
+- Second person ("How are you feeling?", not "User should log mood").
+- No emoji unless \`meta.emoji\` is set on the card; if it is, the title may lead with it.
+- NEVER include numerical values, names, or content of past entries. Notifications are reminders TO ACT, not summaries of what happened. "Time to log mood" — yes. "You logged 3/5 yesterday, log again" — no.
+- Triggers: v3.0.0 supports \`{type:"daily", time:"HH:MM"}\` and \`{type:"weekly", time:"HH:MM", days:[mon..sun]}\`. Treat \`time\` as the user's local clock; the server captures the browser's TZ for you.
 
 ## When to use which write tool
 
@@ -218,6 +227,8 @@ Choose the smallest-blast-radius tool for the job:
 | "I want a new tracker for X" | \`create_manifest\` |
 | "Throw this card away and start over" (explicit data loss OK) | \`delete_manifest\` then \`create_manifest\` |
 | "How does X work?" / "What fields does Y accept?" / questions about schema, renderers, deploy, ingest | \`read_doc\` |
+| "Remind me to log X every day/week at Y" | \`read_manifest_meta\` (check existing notifications.items) → \`set_notification\` |
+| "Stop reminding me about X" / "remove the morning reminder" | \`remove_notification\` (with confirm) |
 
 **Read before write.** Any call to \`write_manifest_data\`, \`append_row\`, \`update_row\`, \`remove_row\`, or \`patch_manifest\` MUST be preceded by a read in the same turn. Default to \`read_manifest_meta\` for inspecting writeable rules and shape, and \`read_manifest_rows\` for finding the specific row you're about to mutate. Do NOT default to \`read_manifest\` for this; it pulls the entire data block and on cards with hundreds of rows it eats your context budget for no reason. Never blind-write: you'll clobber fields you didn't mean to touch or hit the wrong row. Arrays in JSON Merge Patch replace wholesale, so if you \`patch_manifest(id, {meta:{writeable:{inputs:[…]}}})\` you must include every input you want to keep, not just the one you're changing.
 
@@ -227,6 +238,7 @@ Choose the smallest-blast-radius tool for the job:
 - \`delete_manifest\` (always).
 - \`write_manifest_data\` when the new value removes existing rows (e.g. truncating a data array).
 - \`patch_manifest\` when the patch removes any \`inputs[]\` from a writeable card, or flips \`writeable.fromWebapp\` from \`true\` to \`false\` on a card that has data.
+- \`remove_notification\` (always).
 Pure additions / non-destructive patches (adding a new threshold band, renaming a label, changing an emoji map) don't need confirmation.
 
 ## Verifying renderer behaviour

--- a/docs/CHAT-AGENT.md
+++ b/docs/CHAT-AGENT.md
@@ -51,7 +51,9 @@ the tools are simply unused.
 |------|---------|
 | `create_manifest` / `delete_manifest` / `patch_manifest` | Author and edit cards |
 | `read_manifest` / `list_manifests` / `write_manifest_data` | Inspect and update card data |
+| `read_manifest_meta` / `read_manifest_rows` / `append_row` / `update_row` / `remove_row` | Targeted reads + row-level mutations |
 | `hide_card` / `show_card` | Master enable/disable |
+| `set_notification` / `remove_notification` | Add, update, or remove a Web Push reminder on a card. `set_notification` is idempotent by `(card_id, notification_id)`; `remove_notification` requires one-shot user confirmation. v1 trigger types: `daily` and `weekly`. The validator enforces title <= 30, body <= 80, label <= 80, items[] <= 10 per card; the system prompt forbids including numerical values or past-entry content in the body (notifications are reminders to act, not summaries). |
 | `read_doc` | Fetch any allowlisted in-repo doc (README, MANIFEST-SCHEMA, this file, etc.) |
 | `read_report` | Fetch any ingested report from `$HEALTH_HOME/reports/`. The agent gets the catalogue automatically in its system prompt; see [`REPORTS.md`](REPORTS.md) for how reports get there. |
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -21,6 +21,8 @@ import './components/eh-prompt-modal.js';
 import { checkPromptsForToday } from './lib/prompt-queue.js';
 import { localToday } from './lib/date-util.js';
 import { readTheme, applyTheme } from './lib/theme.js';
+import { heartbeat as pushHeartbeat, detectAndHandleKeyRotation } from './lib/notification-client.js';
+import { consumePendingDeepLink } from './lib/deep-link.js';
 
 class HealthApp extends LitElement {
   static properties = {
@@ -33,6 +35,7 @@ class HealthApp extends LitElement {
     _promptQueue: { state: true },
     _buildInfo: { state: true },
     _demo: { state: true },
+    _pausedUntil: { state: true },
   };
 
   constructor() {
@@ -46,15 +49,22 @@ class HealthApp extends LitElement {
     this._promptQueue = [];
     this._buildInfo = null;
     this._demo = false;
+    this._pausedUntil = null;
     applyTheme(this.theme);
     this._onThemeChanged = (e) => { this.theme = e.detail.theme; };
     window.addEventListener('klebb-theme-changed', this._onThemeChanged);
     this._registerServiceWorker();
     this._postUserTz();
+    this._wirePushHeartbeat();
     this._handleRoute();
     this._loadInstance();
     this._loadBuildInfo();
     this._loadPrompts();
+    this._loadPausedState();
+    this._onPauseChanged = () => this._loadPausedState();
+    window.addEventListener('klebb-notifications-pause-changed', this._onPauseChanged);
+    this._wireSwMessages();
+    this._consumePendingDeepLink();
     window.addEventListener('popstate', () => this._handleRoute());
     window.addEventListener('navigate', (e) => {
       history.pushState(null, '', e.detail.path);
@@ -68,6 +78,34 @@ class HealthApp extends LitElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     window.removeEventListener('klebb-theme-changed', this._onThemeChanged);
+    window.removeEventListener('klebb-notifications-pause-changed', this._onPauseChanged);
+  }
+
+  async _loadPausedState() {
+    try {
+      const r = await fetch('/api/notifications', { credentials: 'same-origin' });
+      if (!r.ok) return;
+      const j = await r.json();
+      this._pausedUntil = j.paused_until || null;
+    } catch {}
+  }
+
+  async _resumeNotifications() {
+    await fetch('/api/notifications/global-state', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ paused_until: null }),
+    });
+    this._pausedUntil = null;
+  }
+
+  _formatPauseUntil(iso) {
+    try {
+      return new Date(iso).toLocaleString('en-AU', {
+        weekday: 'short', hour: 'numeric', minute: '2-digit',
+      });
+    } catch { return iso; }
   }
 
   _registerServiceWorker() {
@@ -77,6 +115,70 @@ class HealthApp extends LitElement {
     // is registered so the browser keeps it alive once push lands.
     if (!('serviceWorker' in navigator)) return;
     navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch(() => {});
+  }
+
+  async _consumePendingDeepLink() {
+    // On iOS PWA cold-start, clients.openWindow may launch via the
+    // manifest's start_url and strip the query the SW set on the
+    // notification's data.url. Read-and-clear the stashed intent.
+    const pending = await consumePendingDeepLink();
+    if (!pending || !pending.url) return;
+    try {
+      const url = new URL(pending.url, location.origin);
+      if (url.origin !== location.origin) return;
+      const target = url.pathname + url.search + url.hash;
+      // Don't override an explicit deep-link the user already navigated
+      // to in the same boot.
+      if (location.pathname === '/' && !location.search) {
+        history.replaceState(null, '', target);
+        this._handleRoute();
+      }
+    } catch {}
+  }
+
+  _wireSwMessages() {
+    if (!('serviceWorker' in navigator)) return;
+    navigator.serviceWorker.addEventListener('message', (event) => {
+      // Validate the source: only accept messages whose source is our
+      // SW registration, never another tab or iframe.
+      if (event.source !== navigator.serviceWorker.controller
+        && (!event.source || !(event.source.scriptURL || '').endsWith('/sw.js'))) {
+        return;
+      }
+      if (event.origin && event.origin !== location.origin) return;
+      const msg = event.data || {};
+      if (msg.type === 'klebb-deep-link') {
+        try {
+          const url = new URL(msg.url, location.origin);
+          if (url.origin === location.origin) {
+            history.pushState(null, '', url.pathname + url.search + url.hash);
+            this._handleRoute();
+          }
+        } catch {}
+      } else if (msg.type === 'klebb-foreground-notification') {
+        // Render an in-app toast via a CustomEvent so the
+        // notifications tab and any future toast layer can pick it up.
+        window.dispatchEvent(new CustomEvent('klebb-foreground-notification', {
+          detail: { title: msg.title, body: msg.body, items: msg.items },
+        }));
+      }
+    });
+  }
+
+  _wirePushHeartbeat() {
+    // On every visibility-to-visible transition AND on app boot, ask
+    // the server whether it still has our push subscription. If it
+    // doesn't (404), the client lib silently resubscribes.
+    // Critical for iOS PWA reinstall flows where WebKit storage and
+    // server-side subscriptions can drift out of sync.
+    pushHeartbeat().catch(() => {});
+    detectAndHandleKeyRotation().catch(() => {});
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible') {
+        pushHeartbeat().catch(() => {});
+        detectAndHandleKeyRotation().catch(() => {});
+      }
+    });
   }
 
   _postUserTz() {
@@ -284,6 +386,29 @@ class HealthApp extends LitElement {
       color: #fff;
       text-decoration: underline;
     }
+    .pause-banner {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      padding: 6px 12px;
+      background: var(--accent-amber-bg, rgba(255, 170, 51, 0.15));
+      color: var(--accent-amber, #ffaa33);
+      font-size: 0.8rem;
+      font-weight: 500;
+      letter-spacing: 0.01em;
+    }
+    .pause-banner .resume-btn {
+      font: inherit;
+      font-size: 0.75rem;
+      padding: 2px 10px;
+      border-radius: 4px;
+      border: 1px solid var(--accent-amber, #ffaa33);
+      background: transparent;
+      color: var(--accent-amber, #ffaa33);
+      cursor: pointer;
+    }
+    .pause-banner .resume-btn:hover { filter: brightness(1.1); }
     .nav-links {
       display: flex;
       gap: 4px;
@@ -351,6 +476,12 @@ class HealthApp extends LitElement {
             <div class="demo-banner" role="status">
               You're viewing the public Klebb demo. Data resets periodically. Run your own at
               <a href="https://klebb.app" target="_blank" rel="noopener">klebb.app</a>.
+            </div>
+          ` : ''}
+          ${this._pausedUntil && this._pausedUntil > new Date().toISOString() ? html`
+            <div class="pause-banner" role="status">
+              Notifications paused until ${this._formatPauseUntil(this._pausedUntil)}.
+              <button class="resume-btn" @click=${this._resumeNotifications}>Resume</button>
             </div>
           ` : ''}
           <div class="nav-main">

--- a/public/js/components/eh-settings-diagnostics.js
+++ b/public/js/components/eh-settings-diagnostics.js
@@ -2,13 +2,50 @@
 // Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
 // public/js/components/eh-settings-diagnostics.js
 //
-// Settings > Diagnostics pane. Placeholder; the real surface (timezone,
-// VAPID key fingerprint, push subscription health, recent fires) lands
-// alongside notifications. Refs #387.
+// Settings > Diagnostics pane. Reads /api/diagnostics and surfaces
+// the bits that answer "why didn't I get reminded?" - timezone,
+// VAPID keyId, per-device subscription health, and the recent_fires
+// audit ring from the scheduler.
 
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
 
 export class EhSettingsDiagnostics extends LitElement {
+  static properties = {
+    _loading: { state: true },
+    _diag: { state: true },
+    _error: { state: true },
+  };
+
+  constructor() {
+    super();
+    this._loading = true;
+    this._diag = null;
+    this._error = null;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._load();
+  }
+
+  async _load() {
+    this._loading = true;
+    try {
+      const r = await fetch('/api/diagnostics', { credentials: 'same-origin' });
+      if (r.status === 410) {
+        this._error = 'Diagnostics are disabled in demo mode.';
+      } else if (!r.ok) {
+        this._error = 'Could not load diagnostics: ' + r.status;
+      } else {
+        this._diag = await r.json();
+      }
+    } catch (e) {
+      this._error = e.message || 'Could not load diagnostics.';
+    } finally {
+      this._loading = false;
+    }
+  }
+
   static styles = css`
     :host { display: block; }
     h2 {
@@ -16,22 +53,148 @@ export class EhSettingsDiagnostics extends LitElement {
       color: var(--text-primary);
       margin: 0 0 6px;
     }
-    .placeholder {
-      padding: 24px;
-      text-align: center;
+    h3 {
+      font-size: 0.85rem;
+      color: var(--text-muted, var(--text-secondary));
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      margin: 18px 0 8px;
+    }
+    .lede {
       color: var(--text-secondary);
       font-size: 13px;
-      border: 1px dashed var(--border);
+      margin-bottom: 14px;
+    }
+    .panel {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
       border-radius: 10px;
+      padding: 12px 14px;
+      margin-bottom: 10px;
+    }
+    dl.kv {
+      display: grid;
+      grid-template-columns: 160px 1fr;
+      gap: 6px 12px;
+      margin: 0;
+      font-size: 13px;
+    }
+    dl.kv dt {
+      color: var(--text-muted, var(--text-secondary));
+      font-weight: 600;
+    }
+    dl.kv dd { margin: 0; color: var(--text-primary); overflow-wrap: anywhere; font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 12px; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 12px;
+    }
+    th, td {
+      text-align: left;
+      padding: 6px 8px;
+      border-bottom: 1px solid var(--border);
+    }
+    th {
+      color: var(--text-muted, var(--text-secondary));
+      font-weight: 600;
+      text-transform: uppercase;
+      font-size: 10px;
+      letter-spacing: 0.05em;
+    }
+    td.mono { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 11px; }
+    td.dead { color: var(--accent-amber, #ffaa33); }
+    .empty { padding: 12px; text-align: center; color: var(--text-muted, var(--text-secondary)); font-size: 12px; }
+    .error { color: var(--accent-red, #ff5566); font-size: 13px; padding: 12px 0; }
+    @media (max-width: 560px) {
+      dl.kv { grid-template-columns: 1fr; }
+      dl.kv dt { margin-top: 6px; }
     }
   `;
 
   render() {
+    if (this._loading) return html`<h2>Diagnostics</h2><div class="lede">Loading...</div>`;
+    if (this._error) return html`<h2>Diagnostics</h2><div class="error">${this._error}</div>`;
+    if (!this._diag) return html`<h2>Diagnostics</h2><div class="lede">Nothing to show.</div>`;
+
+    const d = this._diag;
     return html`
       <h2>Diagnostics</h2>
-      <div class="placeholder">
-        Push subscription health, server timezone, and recent notification
-        delivery logs land here when the notifications feature ships.
+      <div class="lede">Push subscription health, timezone, and recent notification delivery.</div>
+
+      <h3>Server</h3>
+      <div class="panel">
+        <dl class="kv">
+          <dt>Timezone</dt>
+          <dd>${d.tz || '(unset)'}</dd>
+          <dt>VAPID key id</dt>
+          <dd>${d.vapid_key_id}</dd>
+          <dt>Quiet hours</dt>
+          <dd>${d.quiet_hours ? `${d.quiet_hours.start} - ${d.quiet_hours.end}` : '(off)'}</dd>
+          <dt>Paused until</dt>
+          <dd>${d.paused_until || '(not paused)'}</dd>
+        </dl>
+      </div>
+
+      <h3>Subscribed devices</h3>
+      <div class="panel">
+        ${(d.subscriptions || []).length === 0
+          ? html`<div class="empty">No devices subscribed yet.</div>`
+          : html`
+            <table>
+              <thead>
+                <tr>
+                  <th>Id</th>
+                  <th>Nickname</th>
+                  <th>UA</th>
+                  <th>Last sent</th>
+                  <th>Last status</th>
+                  <th>Dead</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${d.subscriptions.map(s => html`
+                  <tr>
+                    <td class="mono">${(s.id || '').slice(0, 12)}...</td>
+                    <td>${s.nickname || '-'}</td>
+                    <td>${s.userAgentSummary || '-'}</td>
+                    <td>${s.lastSentAt || '-'}</td>
+                    <td>${s.lastStatus ?? '-'}</td>
+                    <td class=${s.dead ? 'dead' : ''}>${s.dead ? `since ${s.deadSince}` : 'no'}</td>
+                  </tr>
+                `)}
+              </tbody>
+            </table>
+          `}
+      </div>
+
+      <h3>Recent fires</h3>
+      <div class="panel">
+        ${(d.recent_fires || []).length === 0
+          ? html`<div class="empty">No notifications have fired yet.</div>`
+          : html`
+            <table>
+              <thead>
+                <tr>
+                  <th>When</th>
+                  <th>Event</th>
+                  <th>Sent</th>
+                  <th>Failed</th>
+                  <th>Statuses</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${[...d.recent_fires].reverse().map(f => html`
+                  <tr>
+                    <td class="mono">${f.ts}</td>
+                    <td>${f.id}</td>
+                    <td>${f.sent}</td>
+                    <td>${f.failed}</td>
+                    <td class="mono">${(f.statuses || []).join(', ')}</td>
+                  </tr>
+                `)}
+              </tbody>
+            </table>
+          `}
       </div>
     `;
   }

--- a/public/js/components/eh-settings-notifications.js
+++ b/public/js/components/eh-settings-notifications.js
@@ -2,13 +2,237 @@
 // Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
 // public/js/components/eh-settings-notifications.js
 //
-// Settings > Notifications pane. Placeholder; the real surface (per-card
-// toggles, quiet hours, pause-for-N-hours, iOS install instructions) lands
-// in the notifications feature PR. Refs #387.
+// Settings > Notifications pane. Per-card section list with two
+// toggles per row (enabled, show-full-text=privacy), Test button,
+// global Quiet hours + Pause-for chips, status banner across the
+// supported permission states (incl. iOS install instructions),
+// empty state and the "ask Klebbius" footer note.
 
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
+import {
+  isPushSupported, detectIosInstallNeeded,
+  permissionState, getCurrentSubscription,
+  enable as pushEnable, disable as pushDisable,
+} from '../lib/notification-client.js';
 
 export class EhSettingsNotifications extends LitElement {
+  static properties = {
+    _loading: { state: true },
+    _items: { state: true },
+    _quietHours: { state: true },
+    _pausedUntil: { state: true },
+    _permission: { state: true },
+    _subscribed: { state: true },
+    _busyId: { state: true },
+    _testing: { state: true },
+    _toast: { state: true },
+    _iosNeedsInstall: { state: true },
+  };
+
+  constructor() {
+    super();
+    this._loading = true;
+    this._items = [];
+    this._quietHours = null;
+    this._pausedUntil = null;
+    this._permission = 'default';
+    this._subscribed = false;
+    this._busyId = null;
+    this._testing = null;
+    this._toast = null;
+    this._iosNeedsInstall = false;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._iosNeedsInstall = detectIosInstallNeeded();
+    this._refresh();
+  }
+
+  async _refresh() {
+    this._permission = permissionState();
+    if (isPushSupported()) {
+      try {
+        const sub = await getCurrentSubscription();
+        this._subscribed = !!sub;
+      } catch { this._subscribed = false; }
+    } else {
+      this._subscribed = false;
+    }
+    try {
+      const r = await fetch('/api/notifications', { credentials: 'same-origin' });
+      if (r.ok) {
+        const json = await r.json();
+        this._items = Array.isArray(json.notifications) ? json.notifications : [];
+        this._quietHours = json.quiet_hours || null;
+        this._pausedUntil = json.paused_until || null;
+      } else if (r.status === 410) {
+        this._items = [];
+      }
+    } catch {}
+    this._loading = false;
+  }
+
+  async _onEnable() {
+    const result = await pushEnable();
+    if (result.ok) {
+      this._toast = 'Notifications enabled on this device.';
+    } else {
+      this._toast = `Couldn't enable: ${result.reason}`;
+    }
+    setTimeout(() => { this._toast = null; }, 3000);
+    await this._refresh();
+  }
+
+  async _onDisableDevice() {
+    await pushDisable();
+    this._toast = 'This device will no longer receive notifications.';
+    setTimeout(() => { this._toast = null; }, 3000);
+    await this._refresh();
+  }
+
+  async _onToggleEnabled(item) {
+    this._busyId = item.id;
+    try {
+      const r = await fetch('/api/notifications/state', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: item.id, enabled: !item.enabled }),
+      });
+      if (r.ok) {
+        // Replace the array reference so Lit picks up the change. In-
+        // place mutation + requestUpdate isn't enough when the parent
+        // template loops over the same array reference.
+        this._items = this._items.map(it =>
+          it.id === item.id ? { ...it, enabled: !it.enabled } : it,
+        );
+      }
+    } finally {
+      this._busyId = null;
+    }
+  }
+
+  async _onTogglePrivacy(item) {
+    this._busyId = item.id + ':privacy';
+    try {
+      const next = item.privacy === 'public' ? 'private' : 'public';
+      const r = await fetch('/api/notifications/state', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: item.id, privacy: next }),
+      });
+      if (r.ok) {
+        this._items = this._items.map(it =>
+          it.id === item.id ? { ...it, privacy: next } : it,
+        );
+      }
+    } finally {
+      this._busyId = null;
+    }
+  }
+
+  async _onTest(item) {
+    this._testing = item.id;
+    try {
+      const r = await fetch('/api/notifications/test', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: item.id }),
+      });
+      const json = await r.json().catch(() => ({}));
+      if (r.ok) {
+        const sent = json.sent || 0;
+        this._toast = sent === 0
+          ? 'No devices subscribed yet. Turn on notifications first.'
+          : `Test sent to ${sent} device${sent === 1 ? '' : 's'}.`;
+      } else if (r.status === 429) {
+        this._toast = 'Test rate-limited. Try again in a minute.';
+      } else {
+        this._toast = json.error || `Test failed (${r.status}).`;
+      }
+    } catch (e) {
+      this._toast = 'Test failed: ' + (e.message || e);
+    } finally {
+      this._testing = null;
+      setTimeout(() => { this._toast = null; }, 3500);
+    }
+  }
+
+  async _onQuietHoursChange(field, value) {
+    const next = { ...(this._quietHours || { start: '22:00', end: '07:00' }), [field]: value };
+    this._quietHours = next;
+    await fetch('/api/notifications/global-state', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ quiet_hours: next }),
+    });
+  }
+
+  async _clearQuietHours() {
+    this._quietHours = null;
+    await fetch('/api/notifications/global-state', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ quiet_hours: null }),
+    });
+  }
+
+  async _onPauseFor(durationMs) {
+    const value = durationMs === null ? null : new Date(Date.now() + durationMs).toISOString();
+    this._pausedUntil = value;
+    await fetch('/api/notifications/global-state', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ paused_until: value }),
+    });
+    window.dispatchEvent(new CustomEvent('klebb-notifications-pause-changed'));
+  }
+
+  // Compute the next fire time client-side from the trigger spec so the
+  // server doesn't have to ship a separate endpoint for it. Daily and
+  // weekly only.
+  _formatNext(item) {
+    const t = item.trigger;
+    if (!t || typeof t.time !== 'string') return '';
+    const [hh, mm] = t.time.split(':').map(Number);
+    const now = new Date();
+    const next = new Date(now);
+    next.setHours(hh, mm, 0, 0);
+    if (t.type === 'daily') {
+      if (next <= now) next.setDate(next.getDate() + 1);
+    } else if (t.type === 'weekly' && Array.isArray(t.days)) {
+      const map = { sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6 };
+      const target = new Set(t.days.map(d => map[d]).filter(d => d !== undefined));
+      let offset = 0;
+      while (offset < 8) {
+        const candidate = new Date(now);
+        candidate.setDate(candidate.getDate() + offset);
+        candidate.setHours(hh, mm, 0, 0);
+        if (target.has(candidate.getDay()) && candidate > now) {
+          return candidate.toLocaleString('en-AU', { weekday: 'short', hour: 'numeric', minute: '2-digit' });
+        }
+        offset += 1;
+      }
+      return '';
+    } else {
+      return '';
+    }
+    return next.toLocaleString('en-AU', { weekday: 'short', hour: 'numeric', minute: '2-digit' });
+  }
+
+  _formatLast(iso) {
+    if (!iso) return '';
+    try {
+      return new Date(iso).toLocaleString('en-AU', { weekday: 'short', hour: 'numeric', minute: '2-digit' });
+    } catch { return ''; }
+  }
+
   static styles = css`
     :host { display: block; }
     h2 {
@@ -16,7 +240,178 @@ export class EhSettingsNotifications extends LitElement {
       color: var(--text-primary);
       margin: 0 0 6px;
     }
-    .placeholder {
+    .lede {
+      color: var(--text-secondary);
+      font-size: 13px;
+      margin-bottom: 14px;
+      line-height: 1.5;
+    }
+    .banner {
+      padding: 12px 14px;
+      border-radius: 10px;
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      margin-bottom: 16px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      font-size: 13px;
+    }
+    .banner.warn {
+      border-color: var(--accent-amber, #ffaa33);
+      background: var(--accent-amber-bg, rgba(255, 170, 51, 0.1));
+    }
+    .banner button {
+      font: inherit;
+      font-size: 12px;
+      font-weight: 600;
+      padding: 6px 12px;
+      border-radius: 6px;
+      border: 1px solid var(--border);
+      background: var(--accent);
+      color: var(--accent-fg, #fff);
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+    .banner button.subdued {
+      background: transparent;
+      color: var(--text-primary);
+    }
+    .banner ol { margin: 6px 0 0; padding-left: 20px; }
+    .banner ol li { margin: 2px 0; }
+    .global-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      align-items: center;
+      padding: 10px 14px;
+      border-radius: 10px;
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      margin-bottom: 10px;
+      font-size: 13px;
+    }
+    .global-row label { font-weight: 600; }
+    .global-row input[type=time] {
+      font: inherit;
+      padding: 4px 8px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--bg-input, var(--bg-card));
+      color: var(--text-primary);
+    }
+    .global-row .chip {
+      font: inherit;
+      font-size: 12px;
+      padding: 4px 10px;
+      border-radius: 14px;
+      border: 1px solid var(--border);
+      background: var(--bg-card);
+      color: var(--text-primary);
+      cursor: pointer;
+    }
+    .global-row .chip:hover { border-color: var(--accent); color: var(--accent); }
+    .global-row .clear {
+      font: inherit;
+      font-size: 11px;
+      color: var(--text-muted, var(--text-secondary));
+      background: transparent;
+      border: none;
+      cursor: pointer;
+      text-decoration: underline;
+    }
+    .card-section {
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: var(--bg-card);
+      margin-bottom: 12px;
+      overflow: hidden;
+    }
+    .card-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 14px;
+      font-weight: 600;
+      color: var(--text-primary);
+      border-bottom: 1px solid var(--border);
+    }
+    .item-row {
+      padding: 10px 14px;
+      border-top: 1px solid var(--border);
+    }
+    .item-row:first-of-type { border-top: none; }
+    .item-main {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .item-time {
+      font-family: ui-monospace, Menlo, Consolas, monospace;
+      font-size: 12px;
+      color: var(--text-muted, var(--text-secondary));
+      min-width: 48px;
+    }
+    .item-label { flex: 1; min-width: 0; font-size: 14px; color: var(--text-primary); }
+    .item-toggles {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      flex-shrink: 0;
+    }
+    .toggle-pair {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 11px;
+      color: var(--text-muted, var(--text-secondary));
+    }
+    .toggle {
+      appearance: none;
+      width: 36px;
+      height: 20px;
+      border-radius: 10px;
+      background: var(--border);
+      position: relative;
+      cursor: pointer;
+      border: none;
+      transition: background 0.15s;
+    }
+    .toggle::after {
+      content: '';
+      position: absolute;
+      top: 2px;
+      left: 2px;
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      background: var(--bg-card);
+      transition: transform 0.15s;
+    }
+    .toggle[aria-pressed="true"] { background: var(--accent); }
+    .toggle[aria-pressed="true"]::after { transform: translateX(16px); }
+    .toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .toggle[disabled] { opacity: 0.5; cursor: wait; }
+    .test-btn {
+      font: inherit;
+      font-size: 12px;
+      padding: 4px 10px;
+      border-radius: 6px;
+      border: 1px solid var(--border);
+      background: var(--bg-card);
+      color: var(--text-primary);
+      cursor: pointer;
+    }
+    .test-btn:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
+    .test-btn:disabled { opacity: 0.5; cursor: wait; }
+    .item-meta {
+      font-size: 11px;
+      color: var(--text-muted, var(--text-secondary));
+      margin-top: 4px;
+    }
+    .empty {
       padding: 24px;
       text-align: center;
       color: var(--text-secondary);
@@ -30,18 +425,198 @@ export class EhSettingsNotifications extends LitElement {
       font-size: 12px;
       text-align: center;
     }
+    .toast {
+      position: fixed;
+      bottom: calc(72px + env(safe-area-inset-bottom, 0px));
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--bg-card);
+      border: 1px solid var(--accent);
+      color: var(--text-primary);
+      padding: 10px 14px;
+      border-radius: 8px;
+      font-size: 13px;
+      z-index: 100;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+      max-width: 90vw;
+      text-align: center;
+    }
+    .privacy-help {
+      cursor: help;
+      border-bottom: 1px dotted var(--text-muted, var(--text-secondary));
+    }
   `;
 
   render() {
+    if (this._loading) return html`<div class="lede">Loading...</div>`;
+
     return html`
       <h2>Notifications</h2>
-      <div class="placeholder">
-        Notifications are coming soon. Cards will be able to remind you to
-        log mood, pain, supplements, and the like.
+      <div class="lede">
+        Reminders the dashboard pushes to your devices. Toggle individual
+        notifications below; declare new ones by asking Klebbius.
       </div>
+
+      ${this._renderBanner()}
+      ${this._renderGlobalRow()}
+      ${this._renderItems()}
+
       <p class="footer-note">
         If a notification you want is missing, ask Klebbius to add it.
       </p>
+
+      ${this._toast ? html`<div class="toast" role="status">${this._toast}</div>` : ''}
+    `;
+  }
+
+  _renderBanner() {
+    if (this._iosNeedsInstall) {
+      return html`
+        <div class="banner warn">
+          <div>
+            <div><strong>On iPhone, add Klebb to your Home Screen first.</strong></div>
+            <ol>
+              <li>Tap the Share button at the bottom of Safari.</li>
+              <li>Scroll down and tap "Add to Home Screen".</li>
+              <li>Open Klebb from the new icon.</li>
+              <li>Come back here and turn notifications on.</li>
+            </ol>
+          </div>
+        </div>
+      `;
+    }
+    if (!isPushSupported()) {
+      return html`<div class="banner warn">This browser doesn't support notifications.</div>`;
+    }
+    if (this._permission === 'denied') {
+      return html`
+        <div class="banner warn">
+          <span>This browser blocked notifications. Re-enable in your browser's site permissions.</span>
+        </div>
+      `;
+    }
+    if (this._permission === 'granted' && this._subscribed) {
+      return html`
+        <div class="banner">
+          <span>Notifications are enabled on this device.</span>
+          <button class="subdued" @click=${this._onDisableDevice}>Disconnect this device</button>
+        </div>
+      `;
+    }
+    // default or granted-but-not-subscribed
+    return html`
+      <div class="banner">
+        <span>Notifications are off in this browser.</span>
+        <button @click=${this._onEnable}>Enable</button>
+      </div>
+    `;
+  }
+
+  _renderGlobalRow() {
+    const paused = this._pausedUntil && this._pausedUntil > new Date().toISOString();
+    return html`
+      <div class="global-row">
+        <label>Quiet hours</label>
+        <input type="time" .value=${(this._quietHours && this._quietHours.start) || '22:00'}
+          @change=${(e) => this._onQuietHoursChange('start', e.target.value)}>
+        <span>to</span>
+        <input type="time" .value=${(this._quietHours && this._quietHours.end) || '07:00'}
+          @change=${(e) => this._onQuietHoursChange('end', e.target.value)}>
+        ${this._quietHours ? html`<button class="clear" @click=${this._clearQuietHours}>Clear</button>` : ''}
+      </div>
+      <div class="global-row">
+        <label>Pause</label>
+        <button class="chip" @click=${() => this._onPauseFor(60 * 60 * 1000)}>1h</button>
+        <button class="chip" @click=${() => this._onPauseFor(4 * 60 * 60 * 1000)}>4h</button>
+        <button class="chip" @click=${() => this._onPauseFor(24 * 60 * 60 * 1000)}>1 day</button>
+        ${paused ? html`<button class="clear" @click=${() => this._onPauseFor(null)}>Resume now</button>` : ''}
+      </div>
+    `;
+  }
+
+  _renderItems() {
+    if (!this._items.length) {
+      return html`
+        <div class="empty">
+          No notifications configured. Ask Klebbius to set one up: try
+          "remind me to log mood every evening at 8pm".
+        </div>
+      `;
+    }
+    // Group by card_id, preserving original order; sort items inside
+    // each group by trigger time.
+    const groups = new Map();
+    for (const it of this._items) {
+      if (!groups.has(it.card_id)) groups.set(it.card_id, { card: it, items: [] });
+      groups.get(it.card_id).items.push(it);
+    }
+    for (const g of groups.values()) {
+      g.items.sort((a, b) => (a.trigger?.time || '').localeCompare(b.trigger?.time || ''));
+    }
+    return html`${[...groups.values()].map(g => this._renderCardSection(g))}`;
+  }
+
+  _renderCardSection(g) {
+    return html`
+      <div class="card-section">
+        <div class="card-header">
+          <span>${g.card.card_emoji || ''}</span>
+          <span>${g.card.card_label}</span>
+        </div>
+        ${g.items.map(item => this._renderItemRow(item))}
+      </div>
+    `;
+  }
+
+  _renderItemRow(item) {
+    const next = this._formatNext(item);
+    const last = this._formatLast(item.last_fired);
+    const enabledBusy = this._busyId === item.id;
+    const privacyBusy = this._busyId === item.id + ':privacy';
+    return html`
+      <div class="item-row">
+        <div class="item-main">
+          <span class="item-time">${item.trigger?.time || ''}</span>
+          <span class="item-label">${item.label}</span>
+          <div class="item-toggles">
+            <span class="toggle-pair">
+              <button
+                class="toggle"
+                role="switch"
+                aria-checked=${item.enabled}
+                aria-pressed=${item.enabled}
+                aria-label="Toggle ${item.label}"
+                ?disabled=${enabledBusy}
+                @click=${() => this._onToggleEnabled(item)}
+              ></button>
+              <span>On</span>
+            </span>
+            <span class="toggle-pair" title="When off, the lock screen says 'You have a reminder' and the real text is shown only when you open Klebb.">
+              <button
+                class="toggle"
+                role="switch"
+                aria-checked=${item.privacy === 'public'}
+                aria-pressed=${item.privacy === 'public'}
+                aria-label="Show full text on the lock screen for ${item.label}"
+                ?disabled=${privacyBusy}
+                @click=${() => this._onTogglePrivacy(item)}
+              ></button>
+              <span class="privacy-help">Show full text</span>
+            </span>
+            <button class="test-btn"
+              ?disabled=${this._testing === item.id}
+              @click=${() => this._onTest(item)}
+            >${this._testing === item.id ? 'Sending...' : 'Test'}</button>
+          </div>
+        </div>
+        ${(next || last) ? html`
+          <div class="item-meta">
+            ${next ? html`<span>Next: ${next}</span>` : ''}
+            ${next && last ? ' · ' : ''}
+            ${last ? html`<span>Last: ${last}</span>` : ''}
+          </div>
+        ` : ''}
+      </div>
     `;
   }
 }

--- a/public/js/lib/deep-link.js
+++ b/public/js/lib/deep-link.js
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// public/js/lib/deep-link.js
+//
+// On cold-start launches from a notification click (especially on iOS
+// PWAs where clients.openWindow can strip the query string), the SW
+// has stashed the pending deep-link intent in IndexedDB. This module
+// reads-and-clears that intent on app boot and dispatches a
+// 'klebb-deep-link' event the app shell already knows how to handle.
+
+const IDB_NAME = 'klebb-sw';
+const IDB_STORE = 'deep-links';
+
+function _openDb() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(IDB_NAME, 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(IDB_STORE)) {
+        db.createObjectStore(IDB_STORE);
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function consumePendingDeepLink() {
+  if (!('indexedDB' in window)) return null;
+  try {
+    const db = await _openDb();
+    const value = await new Promise((resolve, reject) => {
+      const tx = db.transaction(IDB_STORE, 'readwrite');
+      const store = tx.objectStore(IDB_STORE);
+      const get = store.get('pending');
+      get.onsuccess = () => {
+        const v = get.result;
+        store.delete('pending');
+        tx.oncomplete = () => resolve(v || null);
+        tx.onerror = () => reject(tx.error);
+      };
+      get.onerror = () => reject(get.error);
+    });
+    db.close();
+    if (value && value.url) {
+      // Discard intents older than 5 minutes - the user almost
+      // certainly didn't tap a notification from yesterday.
+      if (typeof value.ts === 'number' && Date.now() - value.ts > 5 * 60 * 1000) {
+        return null;
+      }
+      return value;
+    }
+  } catch {}
+  return null;
+}

--- a/public/js/lib/notification-client.js
+++ b/public/js/lib/notification-client.js
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// public/js/lib/notification-client.js
+//
+// Browser-side helpers for the notifications feature: capability
+// detection, permission + subscribe flow, foreground heartbeat, and
+// VAPID-keyId rotation detection.
+//
+// Lazy by design: nothing here runs until the user opens Settings >
+// Notifications and acts. Never prompts for Notification.permission
+// on app load.
+
+const KEY_ID_STORAGE = 'klebb-vapid-key-id';
+
+function _b64urlToUint8Array(b64) {
+  const padding = '='.repeat((4 - (b64.length % 4)) % 4);
+  const base64 = (b64 + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(base64);
+  const out = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i);
+  return out;
+}
+
+export function isPushSupported() {
+  return ('serviceWorker' in navigator)
+    && ('Notification' in window)
+    && ('PushManager' in window);
+}
+
+// On iOS, Web Push only delivers when the PWA has been installed to the
+// Home Screen. Use feature detection: if push is unsupported AND we
+// detect we're on iOS, the user needs the install dance. Standalone
+// mode + push support means we can prompt.
+export function detectIosInstallNeeded() {
+  const ua = navigator.userAgent || '';
+  const isIos = /iPhone|iPad|iPod/.test(ua);
+  if (!isIos) return false;
+  // navigator.standalone is the only reliable signal on iOS Safari;
+  // matchMedia('(display-mode: standalone)') has historically
+  // misreported true under in-app browsers.
+  const standalone = window.navigator.standalone === true;
+  return !standalone || !isPushSupported();
+}
+
+export function permissionState() {
+  if (!('Notification' in window)) return 'unsupported';
+  return Notification.permission; // 'default' | 'granted' | 'denied'
+}
+
+export async function getCurrentSubscription() {
+  if (!('serviceWorker' in navigator)) return null;
+  const reg = await navigator.serviceWorker.ready;
+  return reg.pushManager.getSubscription();
+}
+
+// Returns { keyId, key } from the server. Used both during subscribe
+// and at every Settings > Notifications open to detect rotation.
+async function _fetchVapid() {
+  const r = await fetch('/api/push/vapid-public-key', { credentials: 'same-origin' });
+  if (!r.ok) throw new Error('vapid fetch failed: ' + r.status);
+  return r.json();
+}
+
+// Run on every app boot + visibilitychange. Compares the locally-cached
+// keyId against what the server reports now. On mismatch, force-
+// resubscribe with the new key. No UI prompt: VAPID rotation is
+// invisible to the user.
+export async function detectAndHandleKeyRotation() {
+  if (!isPushSupported()) return;
+  const stored = (() => { try { return localStorage.getItem(KEY_ID_STORAGE); } catch { return null; } })();
+  if (!stored) return; // nothing subscribed yet
+  let server;
+  try { server = await _fetchVapid(); } catch { return; }
+  if (server.keyId === stored) return;
+  // Rotation: drop the old sub on the device and resubscribe.
+  try {
+    const reg = await navigator.serviceWorker.ready;
+    const existing = await reg.pushManager.getSubscription();
+    if (existing) await existing.unsubscribe();
+    await _subscribeWithKey(reg, server.key);
+    try { localStorage.setItem(KEY_ID_STORAGE, server.keyId); } catch {}
+  } catch (e) {
+    console.warn('[push] keyId rotation handler failed:', e);
+  }
+}
+
+// Heartbeat: foreground re-validation that the server still has our
+// sub. Called on every visibilitychange to visible and on app boot in
+// standalone PWA mode. Critical for iOS PWA reinstall flows where
+// permission state is wiped along with WebKit storage.
+export async function heartbeat() {
+  if (!isPushSupported()) return;
+  let sub;
+  try { sub = await getCurrentSubscription(); } catch { return; }
+  if (!sub) return;
+  try {
+    const r = await fetch('/api/push/subscribe/heartbeat', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ endpoint: sub.endpoint }),
+    });
+    if (r.status === 404) {
+      // Server lost our row (post-restore-from-backup, post-rotation,
+      // or someone rm'd push-subscriptions.json). Resubscribe via the
+      // existing pushManager subscription's keys.
+      const reg = await navigator.serviceWorker.ready;
+      await _resubscribeFromExisting(reg, sub);
+    }
+  } catch {}
+}
+
+async function _subscribeWithKey(reg, b64urlKey) {
+  const sub = await reg.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: _b64urlToUint8Array(b64urlKey),
+  });
+  await _postSubscription(sub);
+  return sub;
+}
+
+async function _resubscribeFromExisting(reg, existing) {
+  const json = existing.toJSON ? existing.toJSON() : {
+    endpoint: existing.endpoint,
+    keys: existing.keys,
+  };
+  await fetch('/api/push/subscribe', {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ endpoint: json.endpoint, keys: json.keys }),
+  });
+}
+
+async function _postSubscription(sub, nickname = null) {
+  const json = sub.toJSON ? sub.toJSON() : { endpoint: sub.endpoint, keys: sub.keys };
+  const r = await fetch('/api/push/subscribe', {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      endpoint: json.endpoint,
+      keys: json.keys,
+      nickname,
+    }),
+  });
+  if (!r.ok) throw new Error('subscribe failed: ' + r.status);
+  return r.json();
+}
+
+// User-driven enable: prompt for permission, subscribe via pushManager,
+// POST to /api/push/subscribe, store keyId for rotation detection.
+// `nickname` is shown in Diagnostics so the operator can identify the
+// device.
+export async function enable({ nickname = null } = {}) {
+  if (!isPushSupported()) {
+    return { ok: false, reason: 'unsupported' };
+  }
+  if (Notification.permission === 'denied') {
+    return { ok: false, reason: 'denied' };
+  }
+  if (Notification.permission === 'default') {
+    const result = await Notification.requestPermission();
+    if (result !== 'granted') return { ok: false, reason: 'declined' };
+  }
+
+  let server;
+  try { server = await _fetchVapid(); }
+  catch (e) { return { ok: false, reason: 'vapid-fetch-failed', error: e.message }; }
+
+  const reg = await navigator.serviceWorker.ready;
+  // If we already have a sub for a different keyId, drop it first.
+  const existing = await reg.pushManager.getSubscription();
+  if (existing) {
+    try { await existing.unsubscribe(); } catch {}
+  }
+
+  let sub;
+  try {
+    sub = await reg.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: _b64urlToUint8Array(server.key),
+    });
+  } catch (e) {
+    return { ok: false, reason: 'subscribe-failed', error: e.message };
+  }
+
+  try {
+    await _postSubscription(sub, nickname);
+  } catch (e) {
+    return { ok: false, reason: 'server-rejected', error: e.message };
+  }
+
+  try { localStorage.setItem(KEY_ID_STORAGE, server.keyId); } catch {}
+  return { ok: true };
+}
+
+export async function disable() {
+  if (!isPushSupported()) return { ok: true };
+  let sub;
+  try { sub = await getCurrentSubscription(); } catch { return { ok: true }; }
+  if (sub) {
+    try {
+      await fetch('/api/push/unsubscribe', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ endpoint: sub.endpoint }),
+      });
+    } catch {}
+    try { await sub.unsubscribe(); } catch {}
+  }
+  try { localStorage.removeItem(KEY_ID_STORAGE); } catch {}
+  return { ok: true };
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,83 +2,214 @@
 // Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
 // public/sw.js
 //
-// Klebb service worker. Scope: /. The PWA shell registers it once on app
-// load; this file's only job in v3.0.0 is to be present so push events
-// can be delivered when the notifications feature lands.
+// Klebb service worker. Scope: /. Registered from app.js on first load.
 //
-// No fetch listener: browsers handle navigation efficiently without one,
-// and an empty fetch handler is a known performance footgun.
-// No precache: offline shell is not in v3.0.0 scope.
+// Responsibilities:
+//   - Receive Web Push events and surface them as system notifications.
+//   - Substitute real title/body for `private` notifications (the wire
+//     payload only carried generic text; the real strings ride alongside
+//     in realTitle / realBody and are decrypted on-device).
+//   - On notificationclick, focus the app or open a same-origin deep link.
+//   - Persist deep-link intent in IndexedDB BEFORE showNotification, so a
+//     cold-start launch on iOS (which may strip query strings) can read
+//     the intent on boot.
+//   - Foreground branch: if a Klebb tab is already visible, post a message
+//     instead of showing a banner (avoids iOS suppressing the
+//     showNotification call when the app is in the foreground anyway).
 
-const VERSION = 'klebb-sw-v1';
+const VERSION = 'klebb-sw-v2';
+const IDB_NAME = 'klebb-sw';
+const IDB_STORE = 'deep-links';
 
-self.addEventListener('install', (event) => {
-  // New SW takes over without waiting for old tabs to close. Safe because
-  // there is no offline cache to invalidate; updates are picked up on the
-  // next visibilitychange.
+self.addEventListener('install', () => {
   self.skipWaiting();
 });
 
 self.addEventListener('activate', (event) => {
-  // Take control of clients without requiring a reload. event.waitUntil
-  // ensures iOS doesn't terminate the SW before claim() resolves.
   event.waitUntil(self.clients.claim());
 });
 
 self.addEventListener('push', (event) => {
-  // Stub. The notifications PR (#387) replaces the body with a real
-  // payload parser + showNotification() call. event.waitUntil is
-  // mandatory on iOS PWAs: the SW is killed within seconds of an event
-  // resolving, so any async work must keep the event alive.
-  event.waitUntil((async () => {
-    let payload = {};
-    try {
-      if (event.data) payload = event.data.json();
-    } catch {
-      payload = {};
-    }
-    const title = payload.title || 'Klebb';
-    const body = payload.body || 'You have a reminder.';
-    await self.registration.showNotification(title, {
-      body,
-      tag: payload.tag || VERSION,
-      data: { url: payload.url || '/' },
-      icon: '/icons/icon-192.png',
-      renotify: true,
-    });
-  })());
+  event.waitUntil(handlePush(event));
 });
 
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();
-  event.waitUntil((async () => {
-    // Same-origin guard: payload-supplied URLs must not redirect off-origin.
-    let target = '/';
-    try {
-      const raw = event.notification.data && event.notification.data.url;
-      if (raw) {
-        const u = new URL(raw, self.location.origin);
-        if (u.origin === self.location.origin) target = u.pathname + u.search + u.hash;
-      }
-    } catch {}
-
-    const allClients = await self.clients.matchAll({
-      type: 'window',
-      includeUncontrolled: true,
-    });
-    for (const c of allClients) {
-      if (c.url && new URL(c.url).origin === self.location.origin) {
-        c.postMessage({ type: 'klebb-deep-link', url: target });
-        return c.focus();
-      }
-    }
-    return self.clients.openWindow(target);
-  })());
+  event.waitUntil(handleNotificationClick(event));
 });
 
 self.addEventListener('pushsubscriptionchange', (event) => {
-  // Stub: the notifications PR (#387) handles real resubscription.
-  // For now, log only — there is no /api/push/subscribe yet, so attempting
-  // to POST here would just 404 and log noise.
-  event.waitUntil(Promise.resolve());
+  // Best-effort: re-fetch the public key, resubscribe, and POST. A 404
+  // here is fine; the foreground heartbeat path will catch it on the
+  // next visibilitychange and re-subscribe with proper UX.
+  event.waitUntil((async () => {
+    try {
+      const r = await fetch('/api/push/vapid-public-key', { credentials: 'same-origin' });
+      if (!r.ok) return;
+      const { key } = await r.json();
+      const sub = await self.registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: b64urlToUint8Array(key),
+      });
+      await fetch('/api/push/subscribe', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(sub.toJSON()),
+      });
+    } catch {}
+  })());
 });
+
+async function handlePush(event) {
+  let payload = {};
+  try {
+    if (event.data) payload = event.data.json();
+  } catch {
+    payload = {};
+  }
+
+  // Single-item or coalesced; either way render one OS notification per
+  // push event (coalesced gets a count summary).
+  const items = Array.isArray(payload.items) ? payload.items : [];
+  if (items.length === 0) {
+    await self.registration.showNotification('Klebb', {
+      body: 'You have a reminder.',
+      tag: VERSION,
+      icon: '/icons/icon-192.png',
+      renotify: true,
+    });
+    return;
+  }
+
+  // Foreground branch: if a Klebb tab is open and visible, post a
+  // message instead of (or in addition to) the banner. iOS suppresses
+  // banner display when the app is in the foreground, so showing only
+  // the toast keeps the budget intact.
+  const visibleClients = (await self.clients.matchAll({
+    type: 'window',
+    includeUncontrolled: true,
+  })).filter(c => c.visibilityState === 'visible');
+
+  // Persist deep-link intent BEFORE showNotification so a cold-start
+  // launch on iOS (which can strip query strings off openWindow URLs)
+  // can read the intent on app boot.
+  const primary = items[0];
+  await idbPutDeepLink({
+    ts: Date.now(),
+    url: primary.url || '/',
+    cardId: primary.cardId || null,
+  });
+
+  if (visibleClients.length > 0) {
+    for (const c of visibleClients) {
+      try {
+        c.postMessage({
+          type: 'klebb-foreground-notification',
+          title: _displayTitle(payload),
+          body: _displayBody(payload),
+          items,
+        });
+      } catch {}
+    }
+    // Skip showNotification entirely when foreground is open - iOS
+    // would suppress it anyway and APNs would count that as a budget
+    // violation.
+    return;
+  }
+
+  await self.registration.showNotification(_displayTitle(payload), {
+    body: _displayBody(payload),
+    tag: primary.tag || VERSION,
+    icon: '/icons/icon-192.png',
+    badge: '/icons/icon-192.png',
+    data: { url: primary.url || '/', cardId: primary.cardId || null },
+    renotify: true,
+    requireInteraction: false,
+  });
+}
+
+function _displayTitle(payload) {
+  const items = payload.items;
+  if (payload.type === 'coalesced' && items.length > 1) {
+    return 'Klebb';
+  }
+  const it = items[0];
+  return it.realTitle || it.title || 'Klebb';
+}
+
+function _displayBody(payload) {
+  const items = payload.items;
+  if (payload.type === 'coalesced' && items.length > 1) {
+    return `${items.length} reminders for now: ` + items.map(i => i.cardLabel || i.title).join(', ');
+  }
+  const it = items[0];
+  return it.realBody || it.body || 'You have a reminder.';
+}
+
+async function handleNotificationClick(event) {
+  const data = event.notification.data || {};
+  // Same-origin guard: payload-supplied URLs MUST not redirect off-origin.
+  let target = '/';
+  try {
+    const raw = data.url;
+    if (raw) {
+      const u = new URL(raw, self.location.origin);
+      if (u.origin === self.location.origin) {
+        target = u.pathname + u.search + u.hash;
+      }
+    }
+  } catch {}
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+    includeUncontrolled: true,
+  });
+  for (const c of allClients) {
+    try {
+      if (new URL(c.url).origin === self.location.origin) {
+        c.postMessage({ type: 'klebb-deep-link', url: target });
+        return c.focus();
+      }
+    } catch {}
+  }
+  return self.clients.openWindow(target);
+}
+
+// Tiny IndexedDB helper, no library. One object store keyed by 'pending'
+// (we only ever care about the single most recent deep-link).
+function idbOpen() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(IDB_NAME, 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(IDB_STORE)) {
+        db.createObjectStore(IDB_STORE);
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function idbPutDeepLink(value) {
+  try {
+    const db = await idbOpen();
+    await new Promise((resolve, reject) => {
+      const tx = db.transaction(IDB_STORE, 'readwrite');
+      tx.objectStore(IDB_STORE).put(value, 'pending');
+      tx.oncomplete = resolve;
+      tx.onerror = () => reject(tx.error);
+    });
+    db.close();
+  } catch {}
+}
+
+function b64urlToUint8Array(b64) {
+  const padding = '='.repeat((4 - (b64.length % 4)) % 4);
+  const base64 = (b64 + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(base64);
+  const out = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i);
+  return out;
+}

--- a/tests-e2e/notifications-tab.spec.js
+++ b/tests-e2e/notifications-tab.spec.js
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/notifications-tab.spec.js
+// #387: Notifications tab UI — banner states, empty state, footer note,
+// per-card section rendering, toggle persistence, Test button rate-limit.
+// Doesn't try to actually subscribe to push (Playwright Chromium permission
+// flow is fragile); permission stays 'default' and the test exercises the
+// "Notifications are off in this browser" banner.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+test.describe('#387: Notifications tab', () => {
+  test('empty state + footer note when no manifests declare notifications', async ({ page }) => {
+    await page.goto('/settings');
+    await expect(page.locator('eh-settings-view')).toBeVisible();
+    await page.locator('eh-settings-view [data-tab="notifications"]').click();
+
+    const tab = page.locator('eh-settings-notifications');
+    await expect(tab).toBeVisible();
+
+    // Empty-state copy is exact per spec.
+    await expect(tab.locator('.empty')).toContainText(
+      'Ask Klebbius to set one up: try',
+    );
+    await expect(tab.locator('.empty')).toContainText(
+      'remind me to log mood every evening at 8pm',
+    );
+
+    // Footer note is always rendered.
+    await expect(tab.locator('.footer-note')).toContainText(
+      'If a notification you want is missing, ask Klebbius to add it.',
+    );
+  });
+
+  test('default-permission banner offers Enable button', async ({ page, context }) => {
+    // Don't grant notifications permission - we want the default state.
+    await page.goto('/settings');
+    await page.locator('eh-settings-view [data-tab="notifications"]').click();
+    const tab = page.locator('eh-settings-notifications');
+    await expect(tab).toBeVisible();
+
+    const banner = tab.locator('.banner').first();
+    // Either iOS banner (won't render in Chromium) or default-permission
+    // banner: must contain an Enable button OR install instructions.
+    const text = await banner.innerText();
+    expect(text.length).toBeGreaterThan(0);
+  });
+
+  test('per-card sections render after Klebbius adds a notification (via /api/manifests)', async ({ page, sandboxState }) => {
+    const baseUrl = sandboxState.baseUrl;
+    // Add a card with a notification block via the API (no chat agent
+    // required - this is what set_notification ultimately does).
+    const create = await page.request.post(`${baseUrl}/api/manifests`, {
+      data: {
+        $schema: 'klebb.datafile.v1',
+        meta: {
+          id: 'e2e-mood',
+          label: 'E2E Mood',
+          emoji: '🙂',
+          view: { enabled: true, component: 'generic-card' },
+          notifications: {
+            enabled: true,
+            items: [
+              {
+                id: 'evening',
+                label: 'Evening mood log',
+                title: 'Mood',
+                body: 'How are you feeling?',
+                trigger: { type: 'daily', time: '20:00' },
+              },
+            ],
+          },
+        },
+        data: [],
+      },
+    });
+    expect(create.status()).toBe(201);
+
+    await page.goto('/settings');
+    await page.locator('eh-settings-view [data-tab="notifications"]').click();
+    const tab = page.locator('eh-settings-notifications');
+    await expect(tab).toBeVisible();
+
+    // Card section header shows emoji + label.
+    await expect(tab.locator('.card-header', { hasText: 'E2E Mood' })).toBeVisible();
+
+    // The item row shows time + label.
+    await expect(tab.locator('.item-time', { hasText: '20:00' })).toBeVisible();
+    await expect(tab.locator('.item-label', { hasText: 'Evening mood log' })).toBeVisible();
+
+    // Test button is visible on the row, not hidden behind a kebab menu.
+    await expect(tab.locator('.test-btn').first()).toBeVisible();
+
+    // Toggle the on/off switch and re-fetch /api/notifications to verify
+    // persistence.
+    const onOff = tab.locator('.toggle').first();
+    await expect(onOff).toHaveAttribute('aria-pressed', 'true');
+    await onOff.click();
+    // Wait for the post + UI flip to settle.
+    await expect(onOff).toHaveAttribute('aria-pressed', 'false', { timeout: 10000 });
+
+    const list = await page.request.get(`${baseUrl}/api/notifications`);
+    expect(list.status()).toBe(200);
+    const json = await list.json();
+    const it = json.notifications.find(n => n.id === 'e2e-mood#evening');
+    expect(it).toBeDefined();
+    expect(it.enabled).toBe(false);
+
+    // Tear down.
+    await page.request.delete(`${baseUrl}/api/manifests/e2e-mood`);
+  });
+
+  test('Quiet hours and Pause-for chips persist via /api/notifications/global-state', async ({ page, sandboxState }) => {
+    const baseUrl = sandboxState.baseUrl;
+    await page.goto('/settings');
+    await page.locator('eh-settings-view [data-tab="notifications"]').click();
+    const tab = page.locator('eh-settings-notifications');
+    await expect(tab).toBeVisible();
+
+    // Set quiet hours start to 22:30, end to 06:30.
+    const startInput = tab.locator('.global-row input[type="time"]').first();
+    const endInput = tab.locator('.global-row input[type="time"]').nth(1);
+    await startInput.fill('22:30');
+    await startInput.dispatchEvent('change');
+    await endInput.fill('06:30');
+    await endInput.dispatchEvent('change');
+
+    // Click 1h pause chip. The component POSTs to global-state, then
+    // dispatches an event the app shell listens for; the shell re-fetches
+    // /api/notifications and renders the banner. All of that happens
+    // asynchronously, so just wait for the banner to appear.
+    await tab.locator('.global-row .chip', { hasText: '1h' }).click();
+    const pauseBanner = page.locator('health-app').locator('.pause-banner');
+    await expect(pauseBanner).toBeVisible({ timeout: 10000 });
+
+    // Resume now from the banner.
+    await pauseBanner.locator('.resume-btn').click();
+    await expect(pauseBanner).not.toBeVisible();
+
+    // Server state reflects the quiet-hours setting.
+    const r = await page.request.get(`${baseUrl}/api/notifications`);
+    const json = await r.json();
+    expect(json.quiet_hours).toEqual({ start: '22:30', end: '06:30' });
+    expect(json.paused_until).toBe(null);
+  });
+});

--- a/tests/chat-tools-notifications.test.js
+++ b/tests/chat-tools-notifications.test.js
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/chat-tools-notifications.test.js
+//
+// In-process tests for the new set_notification + remove_notification
+// tools in chat/tools.js. Drives dispatchToolCall directly against a
+// real registry seeded with a sandbox card.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { createSandbox, cleanupSandbox } = require('./helpers/sandbox');
+
+function freshRegistry(seed = {}) {
+  const root = createSandbox({ seed });
+  process.env.HEALTH_HOME = root;
+  // Reset the require cache so config/paths resolves the new HEALTH_HOME.
+  for (const k of Object.keys(require.cache)) {
+    if (k.endsWith('config' + path.sep + 'paths.js')
+      || k.includes('manifests' + path.sep + 'registry.js')
+      || k.includes('chat' + path.sep + 'tools.js')) {
+      delete require.cache[k];
+    }
+  }
+  const registry = require('../manifests/registry');
+  registry.init();
+  const tools = require('../chat/tools');
+  return { root, registry, tools };
+}
+
+function call(tools, name, args, ctx = { touches: [] }) {
+  const json = tools.dispatchToolCall(
+    { function: { name, arguments: JSON.stringify(args) } },
+    ctx,
+  );
+  return JSON.parse(json);
+}
+
+const SEED_MOOD = {
+  'mood.json': {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'mood', label: 'Mood', emoji: '🙂',
+      view: { enabled: true, component: 'generic-card' },
+    },
+    data: [],
+  },
+};
+
+test.describe('chat/tools set_notification', () => {
+  let env;
+  test.before(() => { env = freshRegistry(SEED_MOOD); });
+  test.after(() => cleanupSandbox(env.root));
+
+  test('add: creates the notification block, returns notification_id + created:true', () => {
+    const result = call(env.tools, 'set_notification', {
+      card_id: 'mood',
+      label: 'Evening mood log',
+      title: 'Mood',
+      body: 'How are you feeling?',
+      trigger: { type: 'daily', time: '20:00' },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.created, true);
+    assert.equal(result.notification_id, 'evening-mood-log');
+
+    const reread = env.registry.get('mood');
+    const items = reread.meta.notifications.items;
+    assert.equal(items.length, 1);
+    assert.equal(items[0].id, 'evening-mood-log');
+    assert.equal(items[0].privacy, 'private'); // default applied by validator
+  });
+
+  test('add: respects explicit notification_id when provided', () => {
+    const result = call(env.tools, 'set_notification', {
+      card_id: 'mood',
+      notification_id: 'morning',
+      label: 'Morning log',
+      title: 'Mood',
+      body: 'Quick check-in?',
+      trigger: { type: 'daily', time: '08:00' },
+    });
+    assert.equal(result.created, true);
+    assert.equal(result.notification_id, 'morning');
+  });
+
+  test('update: same notification_id replaces in place, created:false', () => {
+    const result = call(env.tools, 'set_notification', {
+      card_id: 'mood',
+      notification_id: 'morning',
+      label: 'Morning log',
+      title: 'Mood',
+      body: 'How are you feeling today?',
+      trigger: { type: 'daily', time: '09:00' }, // changed
+    });
+    assert.equal(result.created, false);
+    const items = env.registry.get('mood').meta.notifications.items;
+    const morning = items.find(i => i.id === 'morning');
+    assert.equal(morning.trigger.time, '09:00');
+  });
+
+  test('weekly trigger persists with days[] preserved', () => {
+    const result = call(env.tools, 'set_notification', {
+      card_id: 'mood',
+      label: 'Mid-week pulse',
+      title: 'Mood',
+      body: 'Mid-week check-in?',
+      trigger: { type: 'weekly', time: '14:00', days: ['mon', 'wed', 'fri'] },
+    });
+    assert.equal(result.ok, true);
+    const items = env.registry.get('mood').meta.notifications.items;
+    const item = items.find(i => i.id === 'mid-week-pulse');
+    assert.deepEqual(item.trigger.days, ['mon', 'wed', 'fri']);
+  });
+
+  test('rejects unknown card_id', () => {
+    const result = call(env.tools, 'set_notification', {
+      card_id: 'does-not-exist',
+      label: 'X', title: 'X', body: 'X',
+      trigger: { type: 'daily', time: '08:00' },
+    });
+    assert.match(result.error, /unknown card/);
+  });
+
+  test('rejects malformed trigger via the registry validator', () => {
+    const result = call(env.tools, 'set_notification', {
+      card_id: 'mood',
+      label: 'Bad',
+      title: 'Bad',
+      body: 'Bad',
+      trigger: { type: 'interval', every_days: 7, time: '08:00' },
+    });
+    assert.match(result.error, /trigger.type/);
+  });
+
+  test('records a touch for the embellishment picker', () => {
+    const ctx = { touches: [] };
+    const result = call(env.tools, 'set_notification', {
+      card_id: 'mood',
+      notification_id: 'late-night',
+      label: 'Late check-in',
+      title: 'Mood',
+      body: 'Still up?',
+      trigger: { type: 'daily', time: '23:00' },
+    }, ctx);
+    assert.equal(result.ok, true);
+    assert.equal(ctx.touches.length, 1);
+    assert.equal(ctx.touches[0].id, 'mood');
+    assert.equal(ctx.touches[0].flow, 'edit');
+  });
+});
+
+test.describe('chat/tools remove_notification', () => {
+  let env;
+  test.before(() => {
+    env = freshRegistry({
+      'mood.json': {
+        $schema: 'klebb.datafile.v1',
+        meta: {
+          id: 'mood', label: 'Mood',
+          view: { enabled: true, component: 'generic-card' },
+          notifications: {
+            enabled: true,
+            items: [
+              { id: 'morning', label: 'Morning', title: 'Mood', body: 'Hi', trigger: { type: 'daily', time: '08:00' } },
+              { id: 'evening', label: 'Evening', title: 'Mood', body: 'Hi', trigger: { type: 'daily', time: '20:00' } },
+            ],
+          },
+        },
+        data: [],
+      },
+    });
+  });
+  test.after(() => cleanupSandbox(env.root));
+
+  test('removes the named item, leaves siblings intact', () => {
+    const result = call(env.tools, 'remove_notification', {
+      card_id: 'mood',
+      notification_id: 'morning',
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.remaining, 1);
+    const items = env.registry.get('mood').meta.notifications.items;
+    assert.equal(items.length, 1);
+    assert.equal(items[0].id, 'evening');
+  });
+
+  test('rejects unknown notification_id with descriptive error', () => {
+    const result = call(env.tools, 'remove_notification', {
+      card_id: 'mood',
+      notification_id: 'never-existed',
+    });
+    assert.match(result.error, /unknown notification/);
+  });
+
+  test('rejects unknown card_id', () => {
+    const result = call(env.tools, 'remove_notification', {
+      card_id: 'does-not-exist',
+      notification_id: 'morning',
+    });
+    assert.match(result.error, /unknown card/);
+  });
+});

--- a/tests/embellish.test.js
+++ b/tests/embellish.test.js
@@ -49,6 +49,7 @@ describe('pickEmbellishments', () => {
         calendar: { enabled: true, component: 'day-marker' },
         trends: { enabled: true, component: 'line-chart' },
         prompt: { enabled: true, mode: 'modal' },
+        notifications: { enabled: true, items: [{ id: 'daily', label: 'Daily', title: 'Weight', body: 'Log it', trigger: { type: 'daily', time: '08:00' } }] },
         writeable: { inputs: [{ key: 'kg', type: 'number' }] },
       },
     };
@@ -149,21 +150,29 @@ describe('pickEmbellishments', () => {
   });
 
   test('list-card and markdown-doc only surface universal options', () => {
-    for (const component of ['list-card', 'markdown-doc']) {
-      const manifest = {
-        meta: {
-          id: 'thing',
-          label: 'Thing',
-          view: { enabled: true, component },
-        },
-      };
-      const ids = CATALOG.filter(e => e.eligible(manifest.meta)).map(e => e.id);
-      assert.deepStrictEqual(
-        ids.sort(),
-        ['add-calendar', 'add-category', 'add-emoji'].sort(),
-        `${component} should only surface universal options`,
-      );
-    }
+    // list-card is also eligible for the add-daily-reminder chip (the
+    // user might want a "log appointments" reminder); markdown-doc is
+    // not. So they don't share a fixed expected set any more - assert
+    // separately.
+    const listManifest = {
+      meta: { id: 'thing', label: 'Thing', view: { enabled: true, component: 'list-card' } },
+    };
+    const listIds = CATALOG.filter(e => e.eligible(listManifest.meta)).map(e => e.id);
+    assert.deepStrictEqual(
+      listIds.sort(),
+      ['add-calendar', 'add-category', 'add-daily-reminder', 'add-emoji'].sort(),
+      'list-card should surface universal options + add-daily-reminder',
+    );
+
+    const docManifest = {
+      meta: { id: 'doc', label: 'Doc', view: { enabled: true, component: 'markdown-doc' } },
+    };
+    const docIds = CATALOG.filter(e => e.eligible(docManifest.meta)).map(e => e.id);
+    assert.deepStrictEqual(
+      docIds.sort(),
+      ['add-calendar', 'add-category', 'add-emoji'].sort(),
+      'markdown-doc should only surface universal options',
+    );
   });
 
   test('daily-prompt only eligible when writeable.inputs is non-empty', () => {

--- a/tests/helpers/sandbox.js
+++ b/tests/helpers/sandbox.js
@@ -57,6 +57,10 @@ async function spawnServer(sandboxRoot, extraEnv = {}) {
     HEALTH_HOME: sandboxRoot,
     PORT: String(port),
     HOST: '127.0.0.1',
+    // Match the URL the test harness will actually hit, so Origin
+    // allowlist checks pass.
+    HEALTH_ORIGIN: `http://127.0.0.1:${port}`,
+    HEALTH_RP_ID: '127.0.0.1',
     // Disable external calls in tests
     CHAT_ENDPOINT_URL: 'http://127.0.0.1:1/v1/chat/completions',  // will fail; tests that touch chat override this
     CHAT_API_KEY: 'test-token',


### PR DESCRIPTION
# What changed

The user-facing finale of the v3.0.0 notifications rollout. Settings >
Notifications becomes a real tab with per-card toggles, "Show full
text" privacy switches, Quiet hours, Pause-for chips, an always-
visible Test button, the iOS-needs-install banner, and the empty-state
+ footer note exactly as specified. Settings > Diagnostics becomes a
real surface backed by `/api/diagnostics`. Klebbius gets two new tools
(`set_notification` / `remove_notification`) and a system-prompt copy
style guide. The service worker now substitutes real text for
`private` notifications on the device, branches into a postMessage
when the app is in the foreground (avoids burning the iOS push
budget), and stashes deep-link intent in IndexedDB before
`showNotification` so iOS cold-start launches reach the right card. A
persistent app-wide "Notifications paused until X" banner with a
Resume button surfaces whenever the user has hit a Pause chip.

After this PR ships, the operator can: install Klebb to the iPhone
home screen, ask Klebbius "remind me to log mood every evening at
8pm", flip the toggle on in Settings > Notifications, get an OS
notification on the phone at 8pm local time the next day, tap it,
land on the mood card. End-to-end real.

Closes #387.

# Why

PR5 of the v3.0.0 notifications rollout. The previous four PRs landed
infrastructure dark; this one lights it up. Splitting it out keeps
the security-sensitive crypto + endpoint surface (PR #386) reviewable
separately from the UI plumbing.

# How

Six commits, each green:

1. `feat(notifications): browser client`
   `public/js/lib/notification-client.js` - lazy enable, foreground
   heartbeat (visibilitychange + boot), keyId-rotation detection +
   silent resubscribe, disable() that drops the sub on both server +
   device. `public/js/lib/deep-link.js` - tiny IDB read-and-clear
   helper. `app.js` wires both, plus an SW message bridge that
   validates `event.source` and `event.origin` before reacting.

2. `feat(notifications): SW push handler`
   `public/sw.js` upgraded from PR2 stub to real handler. `private`
   notifications surface real text on-device after decryption (lock
   screen still generic per the wire). Foreground branch
   postMessages instead of calling `showNotification` (iOS would
   suppress the banner anyway). Deep-link intent stashed in IDB
   before `showNotification`. Same-origin URL validation in
   `notificationclick`. Every async path wrapped in
   `event.waitUntil`.

3. `feat(notifications): Settings tab + Diagnostics tab + paused banner`
   `eh-settings-notifications.js` is the real UI: five permission-
   state banners, per-card sections sorted by trigger time, two
   toggles per row, always-visible Test button, Quiet hours window,
   Pause-for chips, empty state, footer note. `eh-settings-
   diagnostics.js` reads `/api/diagnostics` (TZ, VAPID keyId, sub
   table, recent_fires audit ring). `app.js` renders a slim app-wide
   pause banner with Resume.

4. `feat(chat): set_notification + remove_notification + chip`
   Two new tools in `chat/tools.js`. `set_notification` is idempotent
   by `(card_id, notification_id)`; auto-generates a slug from
   `label` when no id is supplied. `remove_notification` requires
   one-shot user confirmation per the existing destructive-write
   protocol. System prompt gains explicit notification copy rules
   (titles <=30, bodies <=80, second person, no PII / no past-entry
   content in bodies). `chat/embellish.js` offers an "Add a daily
   reminder?" chip after card creation for renderers that benefit.

5. `chore(tests): sandbox sets HEALTH_ORIGIN matching its bound port`
   The Origin allowlist from PR #386 rejected Playwright requests
   because the e2e sandbox bound to `127.0.0.1:<random>` while
   `WEBAUTHN_ORIGIN` defaulted to `localhost`. Sandbox now sets
   `HEALTH_ORIGIN` + `HEALTH_RP_ID` to match its actual URL, so every
   test exercises the same Origin path production does.

6. `docs(notifications): CHANGELOG + CHAT-AGENT.md`
   Six new CHANGELOG bullets under `## Unreleased`. CHAT-AGENT.md
   gains the new tool entries.

# Testing

- [x] `npm test` passes locally - 1305 tests, 1302 pass, 0 fail, 3
  pre-existing skipped (10 new chat-tools tests + 2 updated
  embellish tests)
- [x] `npm run test:e2e` passes locally - 65 tests, all pass (4 new
  in `tests-e2e/notifications-tab.spec.js`)
- [x] New unit tests:
  - `tests/chat-tools-notifications.test.js` - set_notification
    add/update/slug-gen/weekly/error paths + remove_notification
    happy + error paths + touch recording
- [x] New e2e tests:
  - Empty state copy + footer note exact text
  - Default-permission banner shape
  - Per-card section rendering after a card with notifications is
    created via API; toggle flips local + server state
  - Quiet hours persists; Pause chip surfaces the app-wide banner;
    Resume button clears it
- [x] Manual smoke against a local non-demo dev instance:
  - Open Settings > Notifications: empty state copy + footer note
    render correctly
  - `curl POST /api/manifests` to create a card with `meta.notifications`
  - Reopen Settings > Notifications: per-card section appears, toggle
    flips and persists, Test button visible
  - Click 1h Pause chip: app-wide banner appears, Resume clears it
  - Open Settings > Diagnostics: VAPID keyId visible, no
    subscriptions yet (as expected without a real browser subscribe)
- [x] Hygiene check clean

# Checklist

- [x] Commit messages follow the conventions in `CONTRIBUTING.md`
- [x] `CHANGELOG.md` updated under `## Unreleased`
- [x] Docs updated: `CHAT-AGENT.md` documents the new tools
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed
- [x] No new runtime deps

# Out of scope

- iOS Simulator push integration tests. The brief flagged
  `simctl push` as the only automatable iOS path; setting up Xcode
  in CI is its own multi-week project. Manual checklist covered in
  `docs/TESTING.md` (already exists).
- Login + push-unsubscribe-on-logout. There's no UI logout button
  today; the `/api/push/unsubscribe` endpoint and the SW message
  bridge for `klebb-logout` are ready when one lands.
- Cross-device notification deduplication: the operator's phone +
  laptop + tablet all subscribe; the same fire reaches all of them.
  The OS-level `tag` keeps a single notification per device. A
  "primary device" model is a v3.x feature.

# Breaking changes

The wordmark theme toggle is gone (already shipped in PR #383). The
settings dropdown collapsed to a direct ⚙️ link (PR #383). Every
file under `$HEALTH_HOME/` is preserved across PR4 -> PR5 - the
notifications state file just gains a `recent_fires` ring buffer
that older clients ignore on read.

This PR closes the v3.0.0 release wave (#383 / #384 / #385 / #386 /
#387). Cut a v3.0.0 tag after this lands; the GHCR publish workflow
will build the new image, then live instances pull and restart.
