### PR TITLE
fix(ui): make Settings > Cards Reorder button actually reorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Changed
+
+- **Settings > Cards: Reorder is now a top-of-page section that takes
+  you to Today.** The old inline button shared a flex row with the
+  filter input and the on/off summary, which clipped its right edge
+  on iPhone 13 mini. More importantly, the button silently did
+  nothing on `/settings` because reorder mode lives on the Today
+  view: dispatching the old `klebb-enter-reorder-mode` event went
+  unheard with no Today renderer mounted. The button now sits in its
+  own labelled section above the filter row, with a short blurb
+  explaining the navigation, and tapping it sets a one-shot
+  sessionStorage flag and routes to `/`. The Today view consumes the
+  flag once cards have loaded, drops into reorder mode, and the
+  existing Done button keeps the user on Today. Hidden when fewer
+  than 2 cards exist or in demo mode. Fixes #395.
+
 ## [3.0.4] - 2026-06-12
 
 ### Fixed

--- a/public/js/components/eh-settings-cards.js
+++ b/public/js/components/eh-settings-cards.js
@@ -107,7 +107,11 @@ export class EhSettingsCards extends LitElement {
   }
 
   _enterReorderMode() {
-    window.dispatchEvent(new CustomEvent('klebb-enter-reorder-mode'));
+    // Reorder is a visual task that happens on the Today page. Set a
+    // one-shot flag so the view renderer flips into reorder mode as
+    // soon as it mounts on / and finishes its first card fetch.
+    try { sessionStorage.setItem('klebb-pending-reorder', '1'); } catch {}
+    window.dispatchEvent(new CustomEvent('navigate', { detail: { path: '/' } }));
   }
 
   static styles = css`
@@ -154,21 +158,45 @@ export class EhSettingsCards extends LitElement {
       color: var(--text-secondary);
       white-space: nowrap;
     }
+    .reorder-section {
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: var(--bg-card);
+      padding: 12px 14px;
+      margin-bottom: 14px;
+    }
+    .reorder-title {
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--text-primary);
+      margin-bottom: 4px;
+    }
+    .reorder-blurb {
+      font-size: 12px;
+      color: var(--text-secondary);
+      line-height: 1.5;
+      margin-bottom: 10px;
+    }
     .reorder-btn {
       font: inherit;
-      font-size: 12px;
+      font-size: 13px;
       font-weight: 600;
-      padding: 6px 10px;
-      border-radius: 6px;
+      padding: 10px 14px;
+      border-radius: 8px;
       border: 1px solid var(--border);
-      background: var(--bg-card);
+      background: var(--bg-muted, rgba(255,255,255,0.04));
       color: var(--text-primary);
       cursor: pointer;
-      white-space: nowrap;
+      width: 100%;
+      text-align: center;
     }
     .reorder-btn:hover {
       border-color: var(--accent);
       color: var(--accent);
+    }
+    .reorder-btn:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
     }
     .card {
       display: flex;
@@ -286,6 +314,20 @@ export class EhSettingsCards extends LitElement {
         `}
       </div>
 
+      ${!this._demo && totalAll >= 2 ? html`
+        <section class="reorder-section">
+          <div class="reorder-title">⋮⋮ Reorder cards on Today</div>
+          <div class="reorder-blurb">
+            Tapping below takes you to the Today page so you can drag your
+            cards into a new order. Tap <strong>Done</strong> on the
+            reorder bar there when you're finished.
+          </div>
+          <button class="reorder-btn" @click=${this._enterReorderMode}>
+            Reorder cards on Today
+          </button>
+        </section>
+      ` : ''}
+
       ${totalAll > 0 ? html`
         <div class="controls">
           <input
@@ -297,9 +339,6 @@ export class EhSettingsCards extends LitElement {
             aria-label="Filter cards"
           />
           <span class="count-summary">${enabled} on · ${disabled} off</span>
-          ${this._demo ? '' : html`
-            <button class="reorder-btn" @click=${this._enterReorderMode}>⋮⋮ Reorder</button>
-          `}
         </div>
       ` : ''}
 

--- a/public/js/components/eh-view-renderer.js
+++ b/public/js/components/eh-view-renderer.js
@@ -312,11 +312,25 @@ export class EhViewRenderer extends LitElement {
           }
         } catch {}
       }
+      this._consumePendingReorder();
     } catch (e) {
       this._error = e.message || 'fetch failed';
     } finally {
       this._loading = false;
     }
+  }
+
+  // Settings > Cards "Reorder" sets sessionStorage 'klebb-pending-reorder'
+  // before navigating to /. Consume it once the cards land, but only on
+  // the live Today view — never on Trends, Reports, or a past-day view.
+  _consumePendingReorder() {
+    if (this.view !== 'view' || this.dateMode !== 'today') return;
+    let pending = false;
+    try {
+      pending = sessionStorage.getItem('klebb-pending-reorder') === '1';
+      if (pending) sessionStorage.removeItem('klebb-pending-reorder');
+    } catch {}
+    if (pending) this._enterReorderMode();
   }
 
   _renderCard(card) {

--- a/tests-e2e/settings-tabs.spec.js
+++ b/tests-e2e/settings-tabs.spec.js
@@ -74,7 +74,7 @@ test.describe('#383: tabbed settings shell', () => {
     await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
   });
 
-  test('Cards tab Reorder button dispatches klebb-enter-reorder-mode', async ({ page }) => {
+  test('Cards tab Reorder button navigates to Today and enters reorder mode (#395)', async ({ page }) => {
     await page.goto('/settings');
     await expect(page.locator('eh-settings-view')).toBeVisible();
 
@@ -82,17 +82,17 @@ test.describe('#383: tabbed settings shell', () => {
     const reorderBtn = page.locator('eh-settings-cards .reorder-btn');
     await expect(reorderBtn).toBeVisible();
 
-    // Listen for the event before clicking.
-    await page.evaluate(() => {
-      window.__lastReorderEvent = null;
-      window.addEventListener('klebb-enter-reorder-mode', () => {
-        window.__lastReorderEvent = Date.now();
-      });
-    });
-
     await reorderBtn.click();
 
-    const fired = await page.evaluate(() => window.__lastReorderEvent);
-    expect(fired).toBeTruthy();
+    // URL flips to / and the Today renderer drops into reorder mode.
+    await expect(page).toHaveURL(/\/$/);
+    const reorderBar = page.locator('eh-view-renderer').first().locator('.reorder-bar');
+    await expect(reorderBar).toBeVisible();
+    await expect(reorderBar.locator('.reorder-bar-done')).toBeVisible();
+
+    // The one-shot flag is consumed, so a fresh reload of / does NOT
+    // re-enter reorder mode.
+    await page.goto('/');
+    await expect(page.locator('eh-view-renderer').first().locator('.reorder-bar')).toHaveCount(0);
   });
 });


### PR DESCRIPTION
# What changed

Reorder lives in its own section at the top of Settings > Cards now,
with copy that tells the user the button takes them to the Today
page. Tapping it routes to `/` and the Today view drops into reorder
mode automatically. The existing Done button on the reorder bar
keeps the user on Today.

# Why

Fixes #395.

Two reports rolled into one: tapping Reorder in Settings > Cards
silently did nothing, and the button's right edge was clipped
off-screen on the iPhone 13 mini. Both were caused by the same
placement: the button sat in the same flex row as the filter input
and the on/off summary, where it dispatched a window event nobody on
`/settings` was listening for.

# How

Settings > Cards: replaced the inline button with a top-of-page
section. The handler sets `sessionStorage['klebb-pending-reorder'] =
'1'` and dispatches the existing `navigate` window event to route to
`/`. The new section is hidden when fewer than 2 cards exist (reorder
is meaningless) and in demo mode (locked anyway).

`eh-view-renderer`: after a successful card fetch, consume the flag
once. Gated on `view === 'view'` AND `dateMode === 'today'` so it
never accidentally fires on Trends, Reports, or a past-day view.
Renderer's existing `klebb-enter-reorder-mode` listener is left in
place — cheap, and useful if any future caller wants to trigger
reorder while already on Today.

The reorder bar's existing Done button at
`eh-view-renderer.js:_exitReorderMode` already exits in place
without navigating, so "Done stays on Today" works without any
change.

# Testing

- [x] `npm test` passes locally (1305 pass / 0 fail / 3 pre-existing
      skips)
- [x] `npx playwright test tests-e2e/settings-tabs.spec.js` passes
      (3/3)
- [x] Updated the existing e2e to assert the new contract: click
      navigates to `/`, the reorder bar appears in `eh-view-renderer`,
      and a fresh reload of `/` does NOT re-enter reorder mode
      (one-shot flag is consumed)
- [ ] Manual QA on iPhone 13 mini width: open Settings > Cards, tap
      the new button, verify navigation + reorder bar; tap Done,
      verify staying on Today; verify button is no longer clipped

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [x] No docs/schema changes needed
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens

# Breaking changes

None. The `klebb-enter-reorder-mode` window event still exists and
still works for anyone listening; the Settings button just no longer
relies on it.