### PR TITLE
refactor(schedule): move schedule lib to repo root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Changed
 
+- **Schedule resolution helpers moved from `public/js/lib/schedule.js`
+  to `lib/schedule.js`** so the server can consume them too. The file
+  stays a single ESM source; the browser still fetches it via
+  `/lib/schedule.js` through a precise carve-out in the static handler
+  (no general `/lib/*` window). Pure relocation, no behaviour change.
+  Unblocks the upcoming `schedule_due` notification trigger (#397),
+  which needs `isScheduledOnDate` + `effectiveCycles` server-side
+  every minute. Fixes #396.
+
 - **Settings > Cards: Reorder is now a top-of-page section that takes
   you to Today.** The old inline button shared a flex row with the
   filter input and the on/off summary, which clipped its right edge

--- a/auth/webauthn.js
+++ b/auth/webauthn.js
@@ -134,6 +134,10 @@ function isPublicPath(pathname) {
     '/sw.js',
     '/favicon.ico',
   ];
+  // Exact-path public files. Kept separate from the prefix list so adding
+  // an entry here cannot accidentally open a directory window.
+  const publicExact = ['/lib/schedule.js'];
+  if (publicExact.includes(pathname)) return true;
   return publicPaths.some(p => pathname === p || pathname.startsWith(p));
 }
 

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
-// public/js/lib/schedule.js
+// lib/schedule.js
 // Pure functions evaluating whether a scheduled item is "on" for a given date.
-// Shared by eh-checklist-card, eh-schedule-timeline, eh-calendar-view etc.
+// Shared between the browser (eh-checklist-card, eh-schedule-timeline,
+// eh-schedule-card, eh-adherence-report, eh-prompt-modal, prompt-queue) and
+// the server (notification scheduler). Stays ESM; CJS callers consume via
+// dynamic import().
 
 const DAY_NAMES_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 

--- a/public/js/components/eh-adherence-report.js
+++ b/public/js/components/eh-adherence-report.js
@@ -18,7 +18,7 @@
 
 import { html, css } from 'https://esm.sh/lit@3';
 import { EhBaseCard } from './eh-base-card.js';
-import { isScheduledOnDate, enumerateDates } from '../lib/schedule.js';
+import { isScheduledOnDate, enumerateDates } from '../../../lib/schedule.js';
 import { registerRenderer } from '../renderer-registry.js';
 
 function todayStr() {

--- a/public/js/components/eh-checklist-card.js
+++ b/public/js/components/eh-checklist-card.js
@@ -11,7 +11,7 @@
 import { html, css } from 'https://esm.sh/lit@3';
 import { EhBaseCard } from './eh-base-card.js';
 import { registerRenderer } from '../renderer-registry.js';
-import { isScheduledOnDate } from '../lib/schedule.js';
+import { isScheduledOnDate } from '../../../lib/schedule.js';
 
 export class EhChecklistCard extends EhBaseCard {
   static styles = [

--- a/public/js/components/eh-prompt-modal.js
+++ b/public/js/components/eh-prompt-modal.js
@@ -38,7 +38,7 @@
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
 import { localToday } from '../lib/date-util.js';
 import { errorFromResponse } from '../lib/save-error.js';
-import { isScheduledOnDate } from '../lib/schedule.js';
+import { isScheduledOnDate } from '../../../lib/schedule.js';
 import './eh-input-form.js';
 
 export class EhPromptModal extends LitElement {

--- a/public/js/components/eh-schedule-card.js
+++ b/public/js/components/eh-schedule-card.js
@@ -18,7 +18,7 @@
 
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
 import { EhBaseCard } from './eh-base-card.js';
-import { isScheduledOnDate, effectiveCycles } from '../lib/schedule.js';
+import { isScheduledOnDate, effectiveCycles } from '../../../lib/schedule.js';
 import { registerRenderer } from '../renderer-registry.js';
 import './eh-input-form.js';
 

--- a/public/js/components/eh-schedule-timeline.js
+++ b/public/js/components/eh-schedule-timeline.js
@@ -20,7 +20,7 @@
 
 import { html, css } from 'https://esm.sh/lit@3';
 import { EhBaseCard } from './eh-base-card.js';
-import { isScheduledOnDate, enumerateDates } from '../lib/schedule.js';
+import { isScheduledOnDate, enumerateDates } from '../../../lib/schedule.js';
 import { registerRenderer } from '../renderer-registry.js';
 
 function todayStr() {

--- a/public/js/lib/prompt-queue.js
+++ b/public/js/lib/prompt-queue.js
@@ -19,7 +19,7 @@
 //     eh-prompt-modal.
 
 import { localToday } from './date-util.js';
-import { isScheduledOnDate } from './schedule.js';
+import { isScheduledOnDate } from '../../../lib/schedule.js';
 
 const STORAGE_PREFIX = 'klebb-prompt-shown-';
 

--- a/server.js
+++ b/server.js
@@ -1887,6 +1887,15 @@ Original system prompt follows:
     return;
   }
 
+  // schedule.js lives at the repo root so the server (CJS) and the
+  // browser can share one source file. Exact-path carve-out: only this
+  // file is served from outside PUBLIC_DIR; no general /lib/* window.
+  if (pathname === '/lib/schedule.js') {
+    const schedulePath = path.join(__dirname, 'lib', 'schedule.js');
+    if (serveStaticFile(res, schedulePath)) return;
+    return send404(res);
+  }
+
   // Static file serving
   let filePath = path.join(PUBLIC_DIR, pathname === '/' ? 'index.html' : pathname);
 

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
 // tests/schedule.test.js
-// Unit tests for public/js/lib/schedule.js — the canonical + legacy
-// schedule evaluation rules.
+// Unit tests for lib/schedule.js: the canonical + legacy schedule
+// evaluation rules.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { isScheduledOnDate, enumerateDates, effectiveCycles } from '../public/js/lib/schedule.js';
+import { isScheduledOnDate, enumerateDates, effectiveCycles } from '../lib/schedule.js';
 
 // --- Canonical schema tests ---
 


### PR DESCRIPTION
# What changed

Relocated `public/js/lib/schedule.js` to `lib/schedule.js` so the
server can consume it. The file stays a single ESM source. Browser
callers updated to a relative import (`../../../lib/schedule.js`)
that resolves to `/lib/schedule.js` in the URL space; a precise
exact-path carve-out in the static handler serves it from the new
location with the standard JS MIME type.

Files touched: 1 rename, 10 edits.

- `public/js/lib/schedule.js` → `lib/schedule.js`
- 5 components + `prompt-queue.js`: import path updated
- `tests/schedule.test.js`: import path updated
- `server.js`: exact-path static carve-out for `/lib/schedule.js`
- `auth/webauthn.js`: `/lib/schedule.js` added to public paths
  (exact-match list, separate from the prefix list, so this cannot
  accidentally widen into a `/lib/*` window)
- `CHANGELOG.md`: entry under Unreleased

# Why

Fixes #396. The upcoming `schedule_due` notification trigger (#397)
needs `isScheduledOnDate` + `effectiveCycles` every minute on the
server. The two viable shapes were duplicate-on-server or relocate;
duplication guarantees drift, so the relocation lands first as its
own PR.

# How

- Single source file, ESM. CJS callers (the notification scheduler
  in #397) consume via dynamic `import()`; verified the import
  resolves cleanly from a one-shot CJS sanity script before deleting
  it.
- Browser path stays `/lib/schedule.js`. Two surgical changes to
  reach the new on-disk location: the static handler intercepts the
  exact path and serves from `__dirname/lib/schedule.js`; the auth
  gate exempts the exact path so unauthenticated bootstraps still
  resolve the module (matches how `/js/` is handled today).
- Imports use a relative path (`../../../lib/schedule.js`) rather
  than absolute `/lib/schedule.js` so the same string resolves in
  both Node ESM (filesystem-relative) and browser ESM (URL-relative
  to repo root). Absolute `/lib/...` worked in the browser but broke
  Node's loader for `tests/prompt-queue.test.js`.
- The server's `/lib/notifications-scheduler.js` (and siblings) stay
  inaccessible: the carve-out is exact-match, not prefix.

# Testing

- [x] `npm test` passes locally: 1308 total, 1305 pass, 3 skipped
      (ffmpeg unrelated), 0 fail.
- [x] `npm run test:e2e` passes locally: 65/65 chromium specs.
- [x] Manual: booted `node server.js` on port 10889 and confirmed
      `GET /lib/schedule.js` returns 200 + correct body + correct
      MIME, while `GET /lib/notifications-scheduler.js` still
      returns the auth-gate 302.
- [x] No new test added: pure file relocation, existing
      `tests/schedule.test.js` already covers the helpers and was
      re-pointed at the new path.

# Checklist

- [x] Commit messages follow the conventions in `CONTRIBUTING.md`
- [x] `CHANGELOG.md` updated under `## Unreleased`
- [x] Docs updated where relevant (`MANIFEST-SCHEMA.md` already
      referenced the lib by short name; no further doc churn needed)
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Breaking changes

None. Internal reorganisation only; no manifest-author surface
changes, no schema changes, no env-var changes.