### PR TITLE
feat(renderers): time-of-day chips in trends + adherence views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Added
+
+- **Time-of-day chips in Trends + Reports.** The same `schedule.time_of_day`
+  chip (☀️ / 🌤️ / 🌙 / 💤) that the schedule-card and checklist-card
+  surface now also renders next to the item label in `eh-schedule-timeline`
+  cycle headers and `eh-adherence-report` cycle rows. Items without
+  `schedule.time_of_day` render unchanged. Per-slot adherence breakdown
+  columns are deferred to a future change. Fixes #401.
+
 ## [3.1.0] - 2026-06-16
 
 ### Added

--- a/chat/docs.js
+++ b/chat/docs.js
@@ -68,7 +68,7 @@ const DOC_INDEX = [
   { kind: 'source', path: 'public/js/components/eh-prompt-modal.js',
     summary: 'prompt-modal — daily "log this now" full-screen modal. mode:"modal" routes through meta.writeable.inputs (same shape as eh-input-form). mode:"checklist" hardcodes per-item dose / takenDates writes. Once-per-day localStorage gate (klebb-prompt-shown-{cardId}-{YYYY-MM-DD}).' },
   { kind: 'source', path: 'public/js/components/eh-schedule-timeline.js',
-    summary: 'schedule-timeline renderer (read-only). Dot-grid per-cycle adherence. Dot states: solid accent (taken), solid red (missed), hollow grey (rest), solid amber (off-schedule), accent ring (today), dim hollow (future). One row per cycle (NOT per item).' },
+    summary: 'schedule-timeline renderer (read-only). Dot-grid per-cycle adherence. Dot states: solid accent (taken), solid red (missed), hollow grey (rest), solid amber (off-schedule), accent ring (today), dim hollow (future). One row per cycle (NOT per item). Renders a time-of-day chip (☀️/🌤️/🌙/💤) next to the item label in each cycle header when `schedule.time_of_day` is set, via the same shared helper as schedule-card.' },
   { kind: 'source', path: 'public/js/components/eh-cc-suggestion-card.js',
     summary: 'cc-suggestion-card — pinned suggestion surface. Fires when ≥3 enabled atomic cards share a meta.category. Read-only; "Ask klebbius" seeds a chat prompt that negotiates a combination-card manifest. Server-side clustering in meta/cc-suggestions.js.' },
   { kind: 'source', path: 'public/js/components/eh-hae-discovery-card.js',

--- a/docs/CARDS.md
+++ b/docs/CARDS.md
@@ -1112,6 +1112,13 @@ Read-only in those views.
 - `meta.schedule` (single card-level cadence) OR `data.items[]` and
   per-item `schedule` / `doses[]`.
 - `meta.reports.windowDays`, `.showPast`, `.showFuture`.
+- Per-item `schedule.time_of_day` (single token or array, drawn from
+  `morning | midday | evening | night`): when set, the renderer
+  paints a sun/sky/moon/zzz emoji chip next to the item label in
+  each cycle header (☀️ morning, 🌤️ midday, 🌙 evening, 💤 night).
+  Same shared helper as `schedule-card`, so the dot-grid view picks
+  up the chip on the same code path. Items without the field render
+  unchanged.
 
 **Writes:**
 - None.
@@ -1136,6 +1143,13 @@ Used in `meta.reports.component`. Read-only.
 - `data.items[].doses[]` and per-item `schedule` / `cycles[]` for the
   expected-vs-taken calculation.
 - `meta.reports.showCompliance`, `.showInventory`.
+- Per-item `schedule.time_of_day` (single token or array, drawn from
+  `morning | midday | evening | night`): when set, the renderer
+  paints a sun/sky/moon/zzz emoji chip next to the item name in
+  each cycle row (☀️ morning, 🌤️ midday, 🌙 evening, 💤 night).
+  Same shared helper as `schedule-card`. Items without the field
+  render unchanged. Per-slot adherence breakdown columns are not in
+  scope for this renderer yet.
 
 **Writes:**
 - None.

--- a/public/js/components/eh-adherence-report.js
+++ b/public/js/components/eh-adherence-report.js
@@ -20,6 +20,7 @@ import { html, css } from 'https://esm.sh/lit@3';
 import { EhBaseCard } from './eh-base-card.js';
 import { isScheduledOnDate, enumerateDates } from '../../../lib/schedule.js';
 import { registerRenderer } from '../renderer-registry.js';
+import { chipsFor as todChipsFor } from '../lib/time-of-day.esm.js';
 
 function todayStr() {
   const d = new Date();
@@ -188,6 +189,15 @@ export class EhAdherenceReport extends EhBaseCard {
         text-overflow: ellipsis;
         white-space: nowrap;
       }
+      .tod-chip {
+        display: inline-block;
+        margin-left: 6px;
+        font-size: 14px;
+        line-height: 1;
+        vertical-align: middle;
+        user-select: none;
+      }
+      .tod-chip + .tod-chip { margin-left: 2px; }
       .cycle-badge {
         font-size: 10px;
         font-weight: 600;
@@ -339,10 +349,11 @@ export class EhAdherenceReport extends EhBaseCard {
     const isFuture = stats.cycleIsFuture;
     const pastCount = stats.scheduled - stats.upcoming;
 
+    const todChips = todChipsFor(item.schedule?.time_of_day);
     return html`
       <div class="cycle-row ${isActive ? 'active' : ''} ${isFuture ? 'future' : ''}">
         <div class="cycle-head">
-          <span class="cycle-name">${item.name}${cycle.cycle_number ? ' · Cycle ' + cycle.cycle_number : ''}</span>
+          <span class="cycle-name">${item.name}${cycle.cycle_number ? ' · Cycle ' + cycle.cycle_number : ''}${todChips.map(c => html`<span class="tod-chip" aria-label=${c.label} title=${c.label}>${c.emoji}</span>`)}</span>
           <span class="cycle-badge ${cycle.status}">${cycle.status}</span>
         </div>
         <div class="cycle-dates">

--- a/public/js/components/eh-schedule-timeline.js
+++ b/public/js/components/eh-schedule-timeline.js
@@ -22,6 +22,7 @@ import { html, css } from 'https://esm.sh/lit@3';
 import { EhBaseCard } from './eh-base-card.js';
 import { isScheduledOnDate, enumerateDates } from '../../../lib/schedule.js';
 import { registerRenderer } from '../renderer-registry.js';
+import { chipsFor as todChipsFor } from '../lib/time-of-day.esm.js';
 
 function todayStr() {
   const d = new Date();
@@ -166,6 +167,15 @@ export class EhScheduleTimeline extends EhBaseCard {
         font-weight: 700;
         color: var(--text-primary);
       }
+      .tod-chip {
+        display: inline-block;
+        margin-left: 6px;
+        font-size: 14px;
+        line-height: 1;
+        vertical-align: middle;
+        user-select: none;
+      }
+      .tod-chip + .tod-chip { margin-left: 2px; }
       .cycle-badge {
         font-size: 9px;
         font-weight: 600;
@@ -315,10 +325,11 @@ export class EhScheduleTimeline extends EhBaseCard {
   _renderCycleBlock(item, cycle, vocab = DEFAULT_VOCAB) {
     const dots = buildDotArray(item, cycle, vocab);
     const summary = cycleSummary(dots);
+    const todChips = todChipsFor(item.schedule?.time_of_day);
     return html`
       <div class="cycle-block">
         <div class="cycle-head">
-          <span class="cycle-name">${item.short_name || item.name}${cycle.cycle_number ? ' · C' + cycle.cycle_number : ''}</span>
+          <span class="cycle-name">${item.short_name || item.name}${cycle.cycle_number ? ' · C' + cycle.cycle_number : ''}${todChips.map(c => html`<span class="tod-chip" aria-label=${c.label} title=${c.label}>${c.emoji}</span>`)}</span>
           <span class="cycle-badge ${cycle.status}">${cycle.status}</span>
           <span class="cycle-dates">${fmtDate(cycle.start_date)} → ${fmtDate(cycle.end_date)}</span>
         </div>

--- a/tests-e2e/time-of-day-chips-trends-reports.spec.js
+++ b/tests-e2e/time-of-day-chips-trends-reports.spec.js
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/time-of-day-chips-trends-reports.spec.js
+// Coverage for #401: time-of-day chips on the historical views,
+// eh-schedule-timeline (Trends) and eh-adherence-report (Reports).
+// Items with schedule.time_of_day get the canonical .tod-chip; items
+// without it render with no chip.
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+const CARD_ID = 'tod-chips-trends-reports-e2e';
+
+function todayISO() {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function shiftDays(iso, delta) {
+  const [y, m, d] = iso.split('-').map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  dt.setUTCDate(dt.getUTCDate() + delta);
+  const yy = dt.getUTCFullYear();
+  const mm = String(dt.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(dt.getUTCDate()).padStart(2, '0');
+  return `${yy}-${mm}-${dd}`;
+}
+
+function activeCycle(today) {
+  return [{
+    type: 'on',
+    status: 'active',
+    cycle_number: 1,
+    start: shiftDays(today, -5),
+    end: shiftDays(today, 25),
+    start_date: shiftDays(today, -5),
+    end_date: shiftDays(today, 25),
+  }];
+}
+
+function manifestForViews(today) {
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: CARD_ID,
+      label: 'Time-of-day historical chips (e2e)',
+      emoji: '💉',
+      order: 9710,
+      category: 'protocols',
+      view: { enabled: true, component: 'schedule-card' },
+      trends: { enabled: true, component: 'schedule-timeline', itemsPath: 'items' },
+      reports: { enabled: true, component: 'adherence-report' },
+      writeable: { fromWebapp: true, todayAllowed: true, pastAllowed: true, futureAllowed: false },
+    },
+    description: 'Time-of-day chip rendering on historical views (#401).',
+    data: {
+      items: [
+        {
+          name: 'Morning-only',
+          short_name: 'Morning-only',
+          schedule: { type: 'daily', time_of_day: 'morning' },
+          cycles: activeCycle(today),
+        },
+        {
+          // Manifest order [evening, morning] exercises the canonical
+          // slot-order sort: morning chip must appear FIRST regardless.
+          name: 'Twice-daily',
+          short_name: 'Twice-daily',
+          schedule: { type: 'daily', time_of_day: ['evening', 'morning'] },
+          cycles: activeCycle(today),
+        },
+        {
+          name: 'No-tod',
+          short_name: 'No-tod',
+          schedule: { type: 'daily' },
+          cycles: activeCycle(today),
+        },
+      ],
+    },
+  };
+}
+
+async function seed(request, baseUrl, m) {
+  await request.delete(`${baseUrl}/api/manifests/${m.meta.id}`).catch(() => {});
+  const r = await request.post(`${baseUrl}/api/manifests`, { data: m });
+  expect([201, 409]).toContain(r.status());
+}
+
+async function cleanup(request, baseUrl, id) {
+  await request.delete(`${baseUrl}/api/manifests/${id}`).catch(() => {});
+}
+
+function harvestChipsByCycleName(rendererTag) {
+  return async (root) => {
+    const sr = root.shadowRoot;
+    if (!sr) return null;
+    const blocks = Array.from(sr.querySelectorAll('.cycle-block, .cycle-row'));
+    return blocks.map((block) => {
+      const nameEl = block.querySelector('.cycle-name');
+      const name = nameEl ? (nameEl.textContent || '').trim() : '';
+      const chips = Array.from(block.querySelectorAll('.tod-chip')).map((c) => ({
+        emoji: c.textContent.trim(),
+        label: c.getAttribute('aria-label'),
+        title: c.getAttribute('title'),
+      }));
+      return { name, chips };
+    });
+  };
+}
+
+test.describe('#401: time-of-day chips on Trends (eh-schedule-timeline)', () => {
+  test('renders chips for items with time_of_day, none for items without', async ({ page, sandboxState }) => {
+    const today = todayISO();
+    const m = manifestForViews(today);
+    await seed(page.request, sandboxState.baseUrl, m);
+
+    await page.goto('/trends');
+    await expect(page.locator('eh-trends-view')).toBeVisible({ timeout: 10_000 });
+
+    const card = page.locator(`[data-card-id="${CARD_ID}"] eh-schedule-timeline`);
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    const rows = await card.evaluate(harvestChipsByCycleName('eh-schedule-timeline'));
+    expect(rows).not.toBeNull();
+
+    // One cycle per item, three items.
+    expect(rows.length).toBe(3);
+
+    const morningOnly = rows.find((r) => r.name.startsWith('Morning-only'));
+    const twiceDaily = rows.find((r) => r.name.startsWith('Twice-daily'));
+    const noTod = rows.find((r) => r.name.startsWith('No-tod'));
+
+    expect(morningOnly).toBeTruthy();
+    expect(morningOnly.chips).toEqual([
+      { emoji: '☀️', label: 'Morning', title: 'Morning' },
+    ]);
+
+    expect(twiceDaily).toBeTruthy();
+    // Manifest array is ['evening', 'morning']; chipsFor sorts to canonical
+    // slot order so morning comes first.
+    expect(twiceDaily.chips.length).toBe(2);
+    expect(twiceDaily.chips[0]).toEqual({ emoji: '☀️', label: 'Morning', title: 'Morning' });
+    expect(twiceDaily.chips[1]).toEqual({ emoji: '🌙', label: 'Evening', title: 'Evening' });
+
+    expect(noTod).toBeTruthy();
+    expect(noTod.chips).toEqual([]);
+
+    await cleanup(page.request, sandboxState.baseUrl, CARD_ID);
+  });
+});
+
+test.describe('#401: time-of-day chips on Reports (eh-adherence-report)', () => {
+  test('renders chips for items with time_of_day, none for items without', async ({ page, sandboxState }) => {
+    const today = todayISO();
+    const m = manifestForViews(today);
+    await seed(page.request, sandboxState.baseUrl, m);
+
+    await page.goto('/reports');
+    await expect(page.locator('eh-reports-view')).toBeVisible({ timeout: 10_000 });
+
+    const card = page.locator(`[data-card-id="${CARD_ID}"] eh-adherence-report`);
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    const rows = await card.evaluate(harvestChipsByCycleName('eh-adherence-report'));
+    expect(rows).not.toBeNull();
+
+    // One cycle per item, three items.
+    expect(rows.length).toBe(3);
+
+    const morningOnly = rows.find((r) => r.name.startsWith('Morning-only'));
+    const twiceDaily = rows.find((r) => r.name.startsWith('Twice-daily'));
+    const noTod = rows.find((r) => r.name.startsWith('No-tod'));
+
+    expect(morningOnly).toBeTruthy();
+    expect(morningOnly.chips).toEqual([
+      { emoji: '☀️', label: 'Morning', title: 'Morning' },
+    ]);
+
+    expect(twiceDaily).toBeTruthy();
+    expect(twiceDaily.chips.length).toBe(2);
+    expect(twiceDaily.chips[0]).toEqual({ emoji: '☀️', label: 'Morning', title: 'Morning' });
+    expect(twiceDaily.chips[1]).toEqual({ emoji: '🌙', label: 'Evening', title: 'Evening' });
+
+    expect(noTod).toBeTruthy();
+    expect(noTod.chips).toEqual([]);
+
+    await cleanup(page.request, sandboxState.baseUrl, CARD_ID);
+  });
+});

--- a/tests/time-of-day-renderer-coverage.test.js
+++ b/tests/time-of-day-renderer-coverage.test.js
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/time-of-day-renderer-coverage.test.js
+// Static coverage check: each renderer that surfaces time-of-day must
+// import the shared chipsFor helper and emit the canonical .tod-chip
+// markup. Lit components can't be exercised in Node (esm.sh imports),
+// so this layer guards against accidental drift like a duplicated
+// emoji map or a dropped chip render. The DOM-level assertion lives
+// in the e2e suite.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const COMPONENTS = path.join(__dirname, '..', 'public', 'js', 'components');
+
+const RENDERERS = [
+  'eh-schedule-card.js',
+  'eh-checklist-card.js',
+  'eh-schedule-timeline.js',
+  'eh-adherence-report.js',
+];
+
+describe('time-of-day chip renderer coverage', () => {
+  for (const file of RENDERERS) {
+    describe(file, () => {
+      const src = fs.readFileSync(path.join(COMPONENTS, file), 'utf8');
+
+      test('imports chipsFor from the shared ESM helper', () => {
+        assert.match(
+          src,
+          /import\s*\{[^}]*chipsFor[^}]*\}\s*from\s*['"]\.\.\/lib\/time-of-day\.esm\.js['"]/,
+          'chip projection must come from public/js/lib/time-of-day.esm.js',
+        );
+      });
+
+      test('does not duplicate the emoji map', () => {
+        assert.doesNotMatch(src, /['"]morning['"]\s*:\s*['"]☀️['"]/, 'inline emoji map duplicates time-of-day.esm.js');
+        assert.doesNotMatch(src, /['"]midday['"]\s*:\s*['"]🌤️['"]/, 'inline emoji map duplicates time-of-day.esm.js');
+      });
+
+      test('emits the canonical .tod-chip markup with aria-label and title', () => {
+        assert.match(src, /class="tod-chip"/, 'renderer must emit a .tod-chip element');
+        assert.match(src, /aria-label=\$\{c\.label\}/, 'chip must expose label as aria-label');
+        assert.match(src, /title=\$\{c\.label\}/, 'chip must expose label as title');
+      });
+
+      test('reads time_of_day off the schedule item', () => {
+        // Renderers alias the import as todChipsFor; both call shapes
+        // count.
+        assert.match(
+          src,
+          /(?:tod)?[Cc]hipsFor\([^)]*\.schedule\?\.time_of_day\)/,
+          'renderer must source chips from item.schedule.time_of_day',
+        );
+      });
+    });
+  }
+});


### PR DESCRIPTION
# What changed

Surface the `schedule.time_of_day` chip set (☀️ morning, 🌤️ midday, 🌙 evening, 💤 night) in the two historical surfaces that previously did not show it: `eh-schedule-timeline` cycle headers and `eh-adherence-report` cycle rows. The same shared `chipsFor` helper that `schedule-card` and `checklist-card` already consume drives all four renderers, so canonical slot order is preserved without a duplicated emoji map.

# Why

Fixes #401.

Once dose timing became part of the schedule vocabulary in #397, the historical views were misleading without it. Adherence-by-time-of-day is a real question (am I missing my evening doses more than my morning doses?), and the timeline dot grid + adherence report had no way to express which slot a dose belonged to. Pure visual addition; no schema change.

# How

- `eh-schedule-timeline.js` and `eh-adherence-report.js` import `chipsFor` from `public/js/lib/time-of-day.esm.js` and project the chip array next to the existing item-name / cycle-name span in the cycle header / cycle row.
- Identical `.tod-chip` CSS rule used in `eh-schedule-card.js` and `eh-checklist-card.js` is mirrored verbatim in both renderers, so the visual shape (font size, gap, vertical alignment) is consistent across all four.
- Items without `schedule.time_of_day` render unchanged: `chipsFor` returns an empty array and Lit renders nothing.
- `chat/docs.js` `DOC_INDEX` summary for `eh-schedule-timeline` is extended at the headline level so Klebbius can answer "why is there a sun next to my vitamin?" questions correctly. `eh-adherence-report` has no `DOC_INDEX` entry today; intentionally not added to keep scope tight.
- `docs/CARDS.md` Renderer behaviour entries for both renderers gain a `schedule.time_of_day` reads-line and a note that the per-slot adherence breakdown column is deferred.

# Testing

- [x] `npm test` passes locally (1368 pass, 0 fail, 3 pre-existing skips).
- [x] `npm run test:e2e` passes locally (70 pass, 0 fail).
- [x] New static-source coverage tests in `tests/time-of-day-renderer-coverage.test.js` lock in the canonical chip wiring (correct helper import, no duplicate emoji map, canonical `.tod-chip` markup, reads `item.schedule.time_of_day`) across all four chip-rendering renderers, so future drift is caught regardless of which renderer is touched.
- [x] New end-to-end test in `tests-e2e/time-of-day-chips-trends-reports.spec.js` seeds a manifest with three items (single-token, array-out-of-canonical-order, no `time_of_day`), navigates to Trends and Reports, and asserts chip emojis + aria-labels + slot-order canonicalisation, plus absence of chips on the no-tod row.

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under `## Unreleased`
- [x] Docs updated (`docs/CARDS.md`, `chat/docs.js`)
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens

# Breaking changes

None. Pure visual addition; items without `schedule.time_of_day` render exactly as before.

# Out of scope (noted as v2)

Per-slot adherence breakdown column in `eh-adherence-report` (e.g. percent-by-slot grid). Out of scope here per the issue spec; can land as a follow-up.