### PR TITLE
fix(server): map validator throws to 422 on POST + PATCH manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
   `schedule.time_of_day` render unchanged. Per-slot adherence breakdown
   columns are deferred to a future change. Fixes #401.
 
+### Fixed
+
+- Manifest validator throws now map to HTTP 422 (not 500) on
+  `POST /api/manifests` and `PATCH /api/manifests/:id`. Specifically
+  the `invalid notifications: ...` and `invalid schedule.time_of_day:
+  ...` prefixes from the strict-mode validators were falling through
+  to the generic 500 handler, so well-behaved clients (the chat agent
+  in particular) misread bad input as a server bug and retried. Closes
+  #404.
+
 ## [3.1.0] - 2026-06-16
 
 ### Added

--- a/MANIFEST-SCHEMA.md
+++ b/MANIFEST-SCHEMA.md
@@ -895,7 +895,8 @@ The canonical schema is:
   chip next to the row (☀️ morning, 🌤️ midday, 🌙 evening, 💤 night).
   Multiple tokens render multiple chips. The presence of the field is
   the toggle; there is no view-config option to hide it. Invalid tokens
-  are dropped at load time and rejected at create / PATCH time, same
+  are dropped at load time and rejected at create / PATCH time (returns
+  422 with the prefix `invalid schedule.time_of_day: ...`), same
   two-stage pattern as `meta.notifications`.
 
 **Migrating old cards:**

--- a/server.js
+++ b/server.js
@@ -660,6 +660,8 @@ const server = http.createServer(async (req, res) => {
           const msg = e.message || 'create failed';
           const status = /^duplicate id/.test(msg) ? 409
             : /^invalid id/.test(msg) ? 422
+            : /^invalid notifications:/.test(msg) ? 422
+            : /^invalid schedule\.time_of_day/.test(msg) ? 422
             : /^(missing |unsupported \$schema)/.test(msg) ? 400
             : 500;
           return sendJSON(res, { error: msg }, status);
@@ -706,7 +708,9 @@ const server = http.createServer(async (req, res) => {
           const msg = e.message || 'patch failed';
           const status = /unknown manifest/.test(msg) ? 404
             : /protected field|patch must be|missing|description must/.test(msg) ? 400
-            : /invalid id/.test(msg) ? 422
+            : /^invalid id/.test(msg) ? 422
+            : /^invalid notifications:/.test(msg) ? 422
+            : /^invalid schedule\.time_of_day/.test(msg) ? 422
             : 500;
           return sendJSON(res, { error: msg }, status);
         }

--- a/tests-e2e/manifest-validation-422.spec.js
+++ b/tests-e2e/manifest-validation-422.spec.js
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests-e2e/manifest-validation-422.spec.js
+// Coverage for #404: notifications + schedule.time_of_day strict-mode
+// validator throws are mapped to HTTP 422 (not 500) on POST /api/manifests
+// and PATCH /api/manifests/:id. The chat agent reads the status code to
+// decide retry vs apologise; 500 means "server bug, retry", 422 means
+// "your input was wrong, here is what".
+
+const { test, expect } = require('./helpers/auth-fixture');
+
+const POST_BAD_TOD = 'iss404-post-bad-tod';
+const POST_MISSING_CARD = 'iss404-post-missing-card';
+const POST_ARRAY_TOD = 'iss404-post-array-tod';
+const POST_BAD_ITEM_TOD = 'iss404-post-bad-item-tod';
+const PATCH_TARGET = 'iss404-patch-target';
+
+async function cleanup(request, baseUrl, id) {
+  await request.delete(`${baseUrl}/api/manifests/${id}`).catch(() => {});
+}
+
+function notifManifest(id, trigger) {
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id,
+      label: id,
+      view: { enabled: true, component: 'list-card' },
+      notifications: {
+        enabled: true,
+        items: [{
+          id: 'n1',
+          label: 'L',
+          title: 'T',
+          body: 'B',
+          trigger,
+        }],
+      },
+    },
+    data: [],
+  };
+}
+
+function scheduleItemManifest(id, items) {
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id,
+      label: id,
+      view: { enabled: true, component: 'list-card' },
+    },
+    data: { items },
+  };
+}
+
+test.describe('#404 POST /api/manifests maps validator throws to 422', () => {
+  test('schedule_due trigger with bad time_of_day token returns 422', async ({ page, sandboxState }) => {
+    const r = await page.request.post(`${sandboxState.baseUrl}/api/manifests`, {
+      data: notifManifest(POST_BAD_TOD, {
+        type: 'schedule_due',
+        card: 'some-card',
+        time_of_day: 'marning',
+        time: '08:00',
+      }),
+    });
+    expect(r.status()).toBe(422);
+    const body = await r.json();
+    expect(body.error).toMatch(/^invalid notifications:/);
+    await cleanup(page.request, sandboxState.baseUrl, POST_BAD_TOD);
+  });
+
+  test('schedule_due trigger missing card returns 422', async ({ page, sandboxState }) => {
+    const r = await page.request.post(`${sandboxState.baseUrl}/api/manifests`, {
+      data: notifManifest(POST_MISSING_CARD, {
+        type: 'schedule_due',
+        time_of_day: 'morning',
+        time: '08:00',
+      }),
+    });
+    expect(r.status()).toBe(422);
+    const body = await r.json();
+    expect(body.error).toMatch(/^invalid notifications:/);
+    await cleanup(page.request, sandboxState.baseUrl, POST_MISSING_CARD);
+  });
+
+  test('schedule_due trigger time_of_day as array (single-token only) returns 422', async ({ page, sandboxState }) => {
+    const r = await page.request.post(`${sandboxState.baseUrl}/api/manifests`, {
+      data: notifManifest(POST_ARRAY_TOD, {
+        type: 'schedule_due',
+        card: 'some-card',
+        time_of_day: ['morning', 'evening'],
+        time: '08:00',
+      }),
+    });
+    expect(r.status()).toBe(422);
+    const body = await r.json();
+    expect(body.error).toMatch(/^invalid notifications:/);
+    await cleanup(page.request, sandboxState.baseUrl, POST_ARRAY_TOD);
+  });
+
+  test('item schedule.time_of_day typo returns 422 with invalid schedule.time_of_day prefix', async ({ page, sandboxState }) => {
+    const r = await page.request.post(`${sandboxState.baseUrl}/api/manifests`, {
+      data: scheduleItemManifest(POST_BAD_ITEM_TOD, [
+        { name: 'Item', schedule: { type: 'daily', time_of_day: 'marning' } },
+      ]),
+    });
+    expect(r.status()).toBe(422);
+    const body = await r.json();
+    expect(body.error).toMatch(/^invalid schedule\.time_of_day/);
+    await cleanup(page.request, sandboxState.baseUrl, POST_BAD_ITEM_TOD);
+  });
+});
+
+test.describe('#404 PATCH /api/manifests/:id maps validator throws to 422', () => {
+  test('PATCH that introduces a malformed notifications block returns 422', async ({ page, sandboxState }) => {
+    const baseUrl = sandboxState.baseUrl;
+    await cleanup(page.request, baseUrl, PATCH_TARGET);
+    const seed = await page.request.post(`${baseUrl}/api/manifests`, {
+      data: {
+        $schema: 'klebb.datafile.v1',
+        meta: {
+          id: PATCH_TARGET,
+          label: 'Patch target',
+          view: { enabled: true, component: 'list-card' },
+        },
+        data: [],
+      },
+    });
+    expect(seed.status()).toBe(201);
+
+    const r = await page.request.patch(`${baseUrl}/api/manifests/${PATCH_TARGET}`, {
+      data: {
+        meta: {
+          notifications: {
+            enabled: true,
+            items: [{
+              id: 'n1',
+              label: 'L',
+              title: 'T',
+              body: 'B',
+              trigger: {
+                type: 'schedule_due',
+                card: PATCH_TARGET,
+                time_of_day: 'marning',
+                time: '08:00',
+              },
+            }],
+          },
+        },
+      },
+    });
+    expect(r.status()).toBe(422);
+    const body = await r.json();
+    expect(body.error).toMatch(/^invalid notifications:/);
+
+    await cleanup(page.request, baseUrl, PATCH_TARGET);
+  });
+});

--- a/tests/api/issue-404.test.js
+++ b/tests/api/issue-404.test.js
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/api/issue-404.test.js
+// Regression seed for #404: notifications + schedule_time_of_day validator
+// throws are mapped to 422 on POST /api/manifests and PATCH /api/manifests/:id.
+// Without the fix these fall through to the generic 500 handler, so any
+// well-behaved client interprets them as a server bug and retries.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const {
+  createSandbox, cleanupSandbox, spawnServer, req, fakeAuthState,
+} = require('../helpers/sandbox');
+
+describe('#404 validator throws map to 422 (POST /api/manifests)', () => {
+  let sandbox, server, auth;
+
+  before(async () => {
+    auth = fakeAuthState('op');
+    sandbox = createSandbox({
+      credentials: auth.credentials,
+      sessions: auth.sessions,
+    });
+    server = await spawnServer(sandbox);
+  });
+  after(async () => {
+    if (server) await server.kill();
+    cleanupSandbox(sandbox);
+  });
+
+  function baseManifest(id, notifTrigger, scheduleItems) {
+    const meta = {
+      id,
+      label: id,
+      view: { enabled: true, component: 'list-card' },
+    };
+    if (notifTrigger) {
+      meta.notifications = {
+        enabled: true,
+        items: [{
+          id: 'n1',
+          label: 'L',
+          title: 'T',
+          body: 'B',
+          trigger: notifTrigger,
+        }],
+      };
+    }
+    return {
+      $schema: 'klebb.datafile.v1',
+      meta,
+      data: scheduleItems ? { items: scheduleItems } : [],
+    };
+  }
+
+  test('schedule_due trigger with bad time_of_day token returns 422 with invalid notifications: prefix', async () => {
+    const res = await req(server.baseUrl, '/api/manifests', {
+      method: 'POST',
+      cookie: auth.cookie,
+      body: baseManifest('issue404-bad-tod', {
+        type: 'schedule_due',
+        card: 'some-card',
+        time_of_day: 'marning',
+        time: '08:00',
+      }),
+    });
+    assert.equal(res.status, 422);
+    assert.match(res.json.error, /^invalid notifications:/);
+  });
+
+  test('schedule_due trigger missing required card field returns 422', async () => {
+    const res = await req(server.baseUrl, '/api/manifests', {
+      method: 'POST',
+      cookie: auth.cookie,
+      body: baseManifest('issue404-missing-card', {
+        type: 'schedule_due',
+        time_of_day: 'morning',
+        time: '08:00',
+      }),
+    });
+    assert.equal(res.status, 422);
+    assert.match(res.json.error, /^invalid notifications:/);
+  });
+
+  test('schedule_due trigger with array time_of_day (single-token only) returns 422', async () => {
+    const res = await req(server.baseUrl, '/api/manifests', {
+      method: 'POST',
+      cookie: auth.cookie,
+      body: baseManifest('issue404-array-tod', {
+        type: 'schedule_due',
+        card: 'some-card',
+        time_of_day: ['morning', 'evening'],
+        time: '08:00',
+      }),
+    });
+    assert.equal(res.status, 422);
+    assert.match(res.json.error, /^invalid notifications:/);
+  });
+
+  test('item schedule.time_of_day with typo returns 422 with invalid schedule.time_of_day prefix', async () => {
+    const res = await req(server.baseUrl, '/api/manifests', {
+      method: 'POST',
+      cookie: auth.cookie,
+      body: baseManifest('issue404-bad-item-tod', null, [
+        { name: 'Item', schedule: { type: 'daily', time_of_day: 'marning' } },
+      ]),
+    });
+    assert.equal(res.status, 422);
+    assert.match(res.json.error, /^invalid schedule\.time_of_day/);
+  });
+});
+
+describe('#404 validator throws map to 422 (PATCH /api/manifests/:id)', () => {
+  let sandbox, server, auth;
+
+  before(async () => {
+    auth = fakeAuthState('op');
+    sandbox = createSandbox({
+      credentials: auth.credentials,
+      sessions: auth.sessions,
+    });
+    server = await spawnServer(sandbox);
+
+    const seed = await req(server.baseUrl, '/api/manifests', {
+      method: 'POST',
+      cookie: auth.cookie,
+      body: {
+        $schema: 'klebb.datafile.v1',
+        meta: {
+          id: 'patch-target',
+          label: 'Patch Target',
+          view: { enabled: true, component: 'list-card' },
+        },
+        data: { items: [{ name: 'Item', schedule: { type: 'daily' } }] },
+      },
+    });
+    assert.equal(seed.status, 201);
+  });
+  after(async () => {
+    if (server) await server.kill();
+    cleanupSandbox(sandbox);
+  });
+
+  test('patching in a malformed notifications block returns 422', async () => {
+    const res = await req(server.baseUrl, '/api/manifests/patch-target', {
+      method: 'PATCH',
+      cookie: auth.cookie,
+      body: {
+        meta: {
+          notifications: {
+            enabled: true,
+            items: [{
+              id: 'n1',
+              label: 'L',
+              title: 'T',
+              body: 'B',
+              trigger: {
+                type: 'schedule_due',
+                card: 'patch-target',
+                time_of_day: 'marning',
+                time: '08:00',
+              },
+            }],
+          },
+        },
+      },
+    });
+    assert.equal(res.status, 422);
+    assert.match(res.json.error, /^invalid notifications:/);
+  });
+
+});


### PR DESCRIPTION
# What changed

Validator throws with the documented `invalid notifications: ...` and `invalid schedule.time_of_day: ...` prefixes now map to HTTP 422 on `POST /api/manifests` and `PATCH /api/manifests/:id`. They previously fell through the regex chain and returned a generic 500.

# Why

Fixes #404.

`manifests/notifications-schema.js:38` throws `invalid notifications: ${msg}` and is documented in that file as a 422-mapping prefix. `manifests/registry.js:43,56,61` throws `invalid schedule.time_of_day on items[N]: ...` from the strict validator added in #397. Neither was wired to the regex chain in `server.js`, so well-behaved clients (the chat agent in particular) read 500 as a transient server bug and retry the same malformed manifest, producing a confusing error trail. 422 plus the validator's actual message is what the schema already promised; this PR catches the gap up.

# How

- Added `^invalid notifications:` and `^invalid schedule\.time_of_day` to the POST `/api/manifests` regex chain (`server.js:660-666`), placed between the existing `invalid id` and `missing |unsupported $schema` arms so prefix specificity is unambiguous.
- Same two patterns added to the PATCH chain (`server.js:706-714`); also tightened the existing `invalid id` PATCH match with a `^` anchor to match the POST chain (no behaviour change, the validator only throws that prefix at the start).
- The `^invalid schedule\.time_of_day` pattern intentionally has no trailing `:` because the actual throw text is `invalid schedule.time_of_day on items[N]: ...`; matching with the `:` would miss it.
- Tightened the existing line in `MANIFEST-SCHEMA.md` (under the `schedule.time_of_day` reference) to spell out the 422 contract for the new prefix; the line for `invalid notifications:` was already accurate.

# A note on PATCH reachability

`patchManifest` in `manifests/registry.js` rejects `data` in the patch body and runs strict validation only on the merged `meta`. The `schedule.time_of_day` validator path lives under `data.items[]`, so the new mapping for that prefix on the PATCH chain is not reachable through any valid request today. The regex is added anyway for symmetry / defence-in-depth so future validator paths inherit the contract by default. Net behaviour change for PATCH is limited to the `invalid notifications:` mapping.

# Testing

- [x] `npm test` passes locally (1354 pass, 0 fail, 3 pre-existing skips).
- [x] `npm run test:e2e` passes locally (73 pass, 0 fail).
- [x] New regression seed at `tests/api/issue-404.test.js`: 5 tests covering bad `time_of_day` token, missing `card`, array-instead-of-token, malformed item-level `time_of_day`, and a PATCH that introduces a bad notifications block.
- [x] New end-to-end coverage at `tests-e2e/manifest-validation-422.spec.js`: same shape at the HTTP boundary, asserting `response.status === 422` and the validator prefix in the body.
- [x] Confirmed all 10 new tests fail on `main` with `actual: 500, expected: 422` and pass on this branch.

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under `## Unreleased`
- [x] Docs updated (`MANIFEST-SCHEMA.md`)
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens

# Breaking changes

None for valid input. Bad input that previously returned 500 now returns 422 with the validator's specific message; that is the documented contract being honoured.