### PR TITLE
chore(server): rename lib/schedule.js to .mjs to silence Node warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
   `schedule.time_of_day` render unchanged. Per-slot adherence breakdown
   columns are deferred to a future change. Fixes #401.
 
+### Changed
+
+- Silenced the `MODULE_TYPELESS_PACKAGE_JSON` warning on boot by
+  renaming `lib/schedule.js` to `lib/schedule.mjs`. Pure rename, no
+  behaviour change. Fixes #405.
+
 ### Fixed
 
 - Manifest validator throws now map to HTTP 422 (not 500) on

--- a/MANIFEST-SCHEMA.md
+++ b/MANIFEST-SCHEMA.md
@@ -908,7 +908,7 @@ unification:
 node scripts/migrate-schedule-vocabulary.js /path/to/your/health/data
 ```
 
-Legacy keys supported transparently by `lib/schedule.js` (no migration
+Legacy keys supported transparently by `lib/schedule.mjs` (no migration
 required, but recommended for new work):
 
 | Legacy | Canonical |

--- a/auth/webauthn.js
+++ b/auth/webauthn.js
@@ -136,7 +136,7 @@ function isPublicPath(pathname) {
   ];
   // Exact-path public files. Kept separate from the prefix list so adding
   // an entry here cannot accidentally open a directory window.
-  const publicExact = ['/lib/schedule.js'];
+  const publicExact = ['/lib/schedule.mjs'];
   if (publicExact.includes(pathname)) return true;
   return publicPaths.some(p => pathname === p || pathname.startsWith(p));
 }

--- a/lib/notifications-scheduler.js
+++ b/lib/notifications-scheduler.js
@@ -29,14 +29,14 @@ let _timer = null;
 let _stopping = false;
 let _dispatch = _logDispatch;
 
-// schedule.js is ESM; this module is CJS. Cache the dynamic import so
+// schedule.mjs is ESM; this module is CJS. Cache the dynamic import so
 // the cost is paid once at first need. Returns a thenable on first call,
 // the resolved module on every subsequent call.
 let _scheduleLib = null;
 let _scheduleLibPromise = null;
 async function _loadScheduleLib() {
   if (_scheduleLib) return _scheduleLib;
-  if (!_scheduleLibPromise) _scheduleLibPromise = import('./schedule.js');
+  if (!_scheduleLibPromise) _scheduleLibPromise = import('./schedule.mjs');
   _scheduleLib = await _scheduleLibPromise;
   return _scheduleLib;
 }

--- a/lib/schedule.mjs
+++ b/lib/schedule.mjs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
-// lib/schedule.js
+// lib/schedule.mjs
 // Pure functions evaluating whether a scheduled item is "on" for a given date.
 // Shared between the browser (eh-checklist-card, eh-schedule-timeline,
 // eh-schedule-card, eh-adherence-report, eh-prompt-modal, prompt-queue) and

--- a/public/js/components/eh-adherence-report.js
+++ b/public/js/components/eh-adherence-report.js
@@ -18,7 +18,7 @@
 
 import { html, css } from 'https://esm.sh/lit@3';
 import { EhBaseCard } from './eh-base-card.js';
-import { isScheduledOnDate, enumerateDates } from '../../../lib/schedule.js';
+import { isScheduledOnDate, enumerateDates } from '../../../lib/schedule.mjs';
 import { registerRenderer } from '../renderer-registry.js';
 import { chipsFor as todChipsFor } from '../lib/time-of-day.esm.js';
 

--- a/public/js/components/eh-checklist-card.js
+++ b/public/js/components/eh-checklist-card.js
@@ -11,7 +11,7 @@
 import { html, css } from 'https://esm.sh/lit@3';
 import { EhBaseCard } from './eh-base-card.js';
 import { registerRenderer } from '../renderer-registry.js';
-import { isScheduledOnDate } from '../../../lib/schedule.js';
+import { isScheduledOnDate } from '../../../lib/schedule.mjs';
 import { chipsFor as todChipsFor } from '../lib/time-of-day.esm.js';
 
 export class EhChecklistCard extends EhBaseCard {

--- a/public/js/components/eh-prompt-modal.js
+++ b/public/js/components/eh-prompt-modal.js
@@ -38,7 +38,7 @@
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
 import { localToday } from '../lib/date-util.js';
 import { errorFromResponse } from '../lib/save-error.js';
-import { isScheduledOnDate } from '../../../lib/schedule.js';
+import { isScheduledOnDate } from '../../../lib/schedule.mjs';
 import './eh-input-form.js';
 
 export class EhPromptModal extends LitElement {

--- a/public/js/components/eh-schedule-card.js
+++ b/public/js/components/eh-schedule-card.js
@@ -18,7 +18,7 @@
 
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
 import { EhBaseCard } from './eh-base-card.js';
-import { isScheduledOnDate, effectiveCycles } from '../../../lib/schedule.js';
+import { isScheduledOnDate, effectiveCycles } from '../../../lib/schedule.mjs';
 import { registerRenderer } from '../renderer-registry.js';
 import { chipsFor as todChipsFor } from '../lib/time-of-day.esm.js';
 import './eh-input-form.js';

--- a/public/js/components/eh-schedule-timeline.js
+++ b/public/js/components/eh-schedule-timeline.js
@@ -20,7 +20,7 @@
 
 import { html, css } from 'https://esm.sh/lit@3';
 import { EhBaseCard } from './eh-base-card.js';
-import { isScheduledOnDate, enumerateDates } from '../../../lib/schedule.js';
+import { isScheduledOnDate, enumerateDates } from '../../../lib/schedule.mjs';
 import { registerRenderer } from '../renderer-registry.js';
 import { chipsFor as todChipsFor } from '../lib/time-of-day.esm.js';
 

--- a/public/js/lib/prompt-queue.js
+++ b/public/js/lib/prompt-queue.js
@@ -19,7 +19,7 @@
 //     eh-prompt-modal.
 
 import { localToday } from './date-util.js';
-import { isScheduledOnDate } from '../../../lib/schedule.js';
+import { isScheduledOnDate } from '../../../lib/schedule.mjs';
 
 const STORAGE_PREFIX = 'klebb-prompt-shown-';
 

--- a/server.js
+++ b/server.js
@@ -89,6 +89,7 @@ const MIME_TYPES = {
   '.html': 'text/html',
   '.css': 'text/css',
   '.js': 'application/javascript',
+  '.mjs': 'application/javascript',
   '.json': 'application/json',
   '.png': 'image/png',
   '.svg': 'image/svg+xml',
@@ -1891,11 +1892,11 @@ Original system prompt follows:
     return;
   }
 
-  // schedule.js lives at the repo root so the server (CJS) and the
+  // schedule.mjs lives at the repo root so the server (CJS) and the
   // browser can share one source file. Exact-path carve-out: only this
   // file is served from outside PUBLIC_DIR; no general /lib/* window.
-  if (pathname === '/lib/schedule.js') {
-    const schedulePath = path.join(__dirname, 'lib', 'schedule.js');
+  if (pathname === '/lib/schedule.mjs') {
+    const schedulePath = path.join(__dirname, 'lib', 'schedule.mjs');
     if (serveStaticFile(res, schedulePath)) return;
     return send404(res);
   }

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
 // tests/schedule.test.js
-// Unit tests for lib/schedule.js: the canonical + legacy schedule
+// Unit tests for lib/schedule.mjs: the canonical + legacy schedule
 // evaluation rules.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { isScheduledOnDate, enumerateDates, effectiveCycles } from '../lib/schedule.js';
+import { isScheduledOnDate, enumerateDates, effectiveCycles } from '../lib/schedule.mjs';
 
 // --- Canonical schema tests ---
 


### PR DESCRIPTION
# What changed

Renamed `lib/schedule.js` to `lib/schedule.mjs` and updated all importers. Pure rename otherwise, no behaviour change for users.

# Why

Fixes #405.

`lib/schedule.js` is ESM source; the server-side notifications scheduler (`lib/notifications-scheduler.js`) is CJS and consumes the helpers via `await import('./schedule.js')`. Without an explicit module-type marker, Node 20+ reparses the file as ESM after a failed CJS-parse and emits this on stderr at first import per process:

```
(node:N) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///.../lib/schedule.js is not specified and it doesn't parse as CommonJS.
Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
```

Functionally harmless, cosmetic only. The performance overhead is one sub-millisecond reparse at startup; the real cost is that a new operator reading their first `docker logs` reasonably wonders if their setup is broken. Stderr noise is bad first-impression material before the public flip.

# How

Option 1 from the issue: rename the file. The other two options were rejected (a `lib/schedule/package.json` containing `{"type":"module"}` is uglier on disk; flipping the entire repo to ESM via root `package.json` has a massive blast radius across hundreds of CJS source files).

Importers updated:
- Static-serve carve-out in `server.js` (path-string + comment).
- Public-path allow-list in `auth/webauthn.js` (`publicExact` array).
- Dynamic import in `lib/notifications-scheduler.js` (the import string + adjacent comment).
- Browser-component imports: `eh-adherence-report.js`, `eh-checklist-card.js`, `eh-prompt-modal.js`, `eh-schedule-card.js`, `eh-schedule-timeline.js`, plus `public/js/lib/prompt-queue.js`. The relative-path style established in #402 is preserved (`../../../lib/schedule.mjs` from components); only the extension changed.
- Test import in `tests/schedule.test.js`.
- One prose code-pointer in `MANIFEST-SCHEMA.md`.

# Required scope addition: `.mjs` MIME type

The first end-to-end test run on the renamed module failed 63/68: browsers refused to import `/lib/schedule.mjs` because the server's `MIME_TYPES` table had no entry for `.mjs`, so the file was served as `application/octet-stream` and the SPA never mounted. Fix: added `'.mjs': 'application/javascript'` to the `MIME_TYPES` map at the top of `server.js`. This is a separate map from the static-serve allow-list, so the carve-out remains exact and the public-surface footprint is unchanged. Strictly speaking this deviates from "pure rename, no behaviour change", but the rename is non-functional in browsers without it.

# Testing

- [x] `npm test` passes locally (1352 pass, 0 fail, 3 pre-existing skips).
- [x] `npm run test:e2e` passes locally (68 pass, 0 fail) after the MIME fix.
- [x] Cold boot of `node server.js` against a fresh `HEALTH_HOME` produces no `MODULE_TYPELESS_PACKAGE_JSON` warning. Verified directly by forcing the dynamic import on `main` (warning) vs this branch (no warning).
- [x] Exhaustive grep for the old extension across the repo: zero stale code/import references; remaining hits are pre-existing history mentions in `CHANGELOG.md` (intentionally left alone) and an unrelated JSON filename string in `scripts/migrate-schedule-vocabulary.js`.

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under `## Unreleased`
- [x] Docs updated (`MANIFEST-SCHEMA.md` code-pointer)
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens

# Breaking changes

None for any user-facing path. Anyone consuming `lib/schedule.js` via the public-served URL `/lib/schedule.js` would now need `/lib/schedule.mjs`, but no external code depends on that URL today (the carve-out exists strictly so the bundled browser components can share the source).