### PR TITLE
fix(chat): refuse fast when no tool fits the request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Chat agent fails fast when no tool fits.** When the user asks for
+  something that no available tool can carry out (reorder rows, merge
+  cards, etc.), the model used to fudge it through the closest tool
+  (typically `write_manifest_data` regenerating the whole data block).
+  On a card with a 75 KB data block that generation routinely ran
+  past the 180s gateway ceiling, the request died with `gateway_timeout`,
+  and the user saw three minutes of dead air per attempt. The system
+  prompt now carries an explicit "When no tool fits" section that
+  steers the model to a fast plain-language refusal instead. As a
+  belt-and-braces backstop, `runAgentLoop` enforces a soft per-iter
+  budget (`CHAT_ITER_TIMEOUT_MS`, default 60000ms): if any single
+  gateway iteration runs past it, the agent loop aborts and replies
+  with the standard refusal copy at HTTP 200, not 504. Closes #399.
+
 ## [3.2.0] - 2026-06-16
 
 ### Added

--- a/config/env.js
+++ b/config/env.js
@@ -133,6 +133,21 @@ function getSessionSecret() {
 // --- Feature flags ---
 const DEBUG_LOG = process.env.HEALTH_DEBUG === '1';
 
+// Soft per-iter cap on the chat agent loop's gateway calls. The transport
+// already enforces a 180s hard ceiling (see callGateway), but a single
+// iteration that runs that long is almost always the model fudging an
+// over-large generation through the wrong tool ("write_manifest_data" on a
+// 75 KB data block to do a trivial reorder, etc.). A tighter per-iter
+// budget lets us return a fast refusal instead of leaving the user staring
+// at a 3-minute spinner. Set to 0 to disable (fall back to the 180s ceiling).
+const CHAT_ITER_TIMEOUT_MS = (() => {
+  const raw = process.env.CHAT_ITER_TIMEOUT_MS;
+  if (raw === undefined || raw === '') return 60000;
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) return 60000;
+  return n;
+})();
+
 // --- Demo mode ---
 // When KLEBB_DEMO=1, the server runs as a public no-credentials demo:
 //   - The login page shows a single "Enter the demo" button that calls
@@ -240,6 +255,25 @@ Choose the smallest-blast-radius tool for the job:
 - \`patch_manifest\` when the patch removes any \`inputs[]\` from a writeable card, or flips \`writeable.fromWebapp\` from \`true\` to \`false\` on a card that has data.
 - \`remove_notification\` (always).
 Pure additions / non-destructive patches (adding a new threshold band, renaming a label, changing an emoji map) don't need confirmation.
+
+## When no tool fits the request
+
+If the user's request can't be carried out by ANY tool listed above in a reasonable single generation, refuse fast. Do NOT try to fudge it through the closest-looking tool. Forcing a wholesale-rewrite tool (\`write_manifest_data\`, \`patch_manifest\`) to do a small mutation it wasn't designed for is the failure mode this rule exists to prevent: the generation runs long enough to time out the gateway and the user just sees dead air.
+
+The refusal applies whenever any of these are true:
+- The intent is "row-level" (reorder, sort, deduplicate, bulk-edit-by-predicate) but no tool above carries it out at row-level, so the only tool that could is \`write_manifest_data\`, AND the card's data block is large (more than a few rows or anything larger than a few KB).
+- The intent needs a primitive that simply doesn't exist (cross-card joins, transactional multi-card edits, free-form scripting, importing arbitrary external data).
+- The intent needs a tool I genuinely don't have (sending email, scheduling external calendar events, reading the user's filesystem outside \`read_doc\` / \`read_report\`).
+
+Refusal copy template (1-2 short sentences):
+
+> I can't do that in one step right now: <one-line reason>. <Optional: name the closest workaround the user CAN do, or what tool would be needed.>
+
+Examples:
+- "I can't reorder rows in one step right now: there's no reorder primitive, and the only tool that could do it would have to rewrite the whole data block (which times out on cards this size). You can re-order this card by editing the manifest file directly for now."
+- "I can't merge two cards in one call: there's no cross-card transaction tool. I can copy rows from one to the other if you read them out yourself first."
+
+Pick refusal over a heroic tool call. A 5-second "I can't do that" beats a 180-second timeout every time. Do NOT pad the refusal with apologies, "as an AI" disclaimers, or suggestions to contact support.
 
 ## Verifying renderer behaviour
 
@@ -566,6 +600,7 @@ module.exports = {
   WEBAUTHN_ORIGIN,
   getSessionSecret,
   DEBUG_LOG,
+  CHAT_ITER_TIMEOUT_MS,
   KLEBB_DEMO,
   DEMO_USER_ID,
   HEALTH_SYSTEM_PROMPT,

--- a/docs/CHAT-AGENT.md
+++ b/docs/CHAT-AGENT.md
@@ -57,6 +57,45 @@ the tools are simply unused.
 | `read_doc` | Fetch any allowlisted in-repo doc (README, MANIFEST-SCHEMA, this file, etc.) |
 | `read_report` | Fetch any ingested report from `$HEALTH_HOME/reports/`. The agent gets the catalogue automatically in its system prompt; see [`REPORTS.md`](REPORTS.md) for how reports get there. |
 
+### Refusal when no tool fits
+
+The system prompt explicitly tells the model to refuse fast when the
+user's request can't be carried out by any of the available tools in a
+single generation. This is the answer to "the model tried to fudge a
+reorder through `write_manifest_data`, the gateway timed out at 180s,
+the user saw three minutes of dead air".
+
+The standard refusal copy is one or two short sentences:
+
+> I can't do that in one step right now: \<one-line reason\>. \<Optional:
+> name the closest workaround the user CAN do, or what tool would be needed.\>
+
+Examples:
+
+- "I can't reorder rows in one step right now: there's no reorder
+  primitive, and the only tool that could do it would have to rewrite
+  the whole data block (which times out on cards this size). You can
+  re-order this card by editing the manifest file directly for now."
+- "I can't merge two cards in one call: there's no cross-card
+  transaction tool. I can copy rows from one to the other if you read
+  them out yourself first."
+
+Any future tool addition should keep the refusal pattern and tighten
+it: when a new primitive lands (e.g. `reorder_rows`), the refusal text
+for that intent stops applying and the agent should reach for the new
+tool instead.
+
+### Belt-and-braces: per-iter gateway budget
+
+The transport layer's per-hop ceiling is a hard 180s and intentionally
+matches the client. On top of that, `runAgentLoop` enforces a soft
+per-iteration budget via `CHAT_ITER_TIMEOUT_MS` (default `60000`). If a
+single iteration runs past the soft cap, the agent loop aborts the
+in-flight gateway call, returns the standard refusal copy with HTTP
+200, and emits `[chat:<id>] iter=N gw=<ms>ms iter_timeout` in debug
+logs. Set `CHAT_ITER_TIMEOUT_MS=0` to disable and fall back to the
+180s ceiling.
+
 ### Legacy env vars
 
 Older deploys used `CHAT_GATEWAY_HOST` + `CHAT_GATEWAY_PORT` +

--- a/server.js
+++ b/server.js
@@ -42,6 +42,10 @@ const CHAT_ENDPOINT_URL = ENV.CHAT_ENDPOINT_URL;
 const CHAT_API_KEY = ENV.CHAT_API_KEY;
 const CHAT_MODEL = ENV.CHAT_MODEL;
 const DEBUG_LOG = ENV.DEBUG_LOG;
+const CHAT_ITER_TIMEOUT_MS = ENV.CHAT_ITER_TIMEOUT_MS;
+const GATEWAY_HARD_TIMEOUT_MS = 180000;
+const NO_TOOL_FITS_REFUSAL =
+  "I can't do that in one step right now: it doesn't fit any of the tools I have, and the workaround would have to rewrite the whole card (which times out on cards this size). If you tell me which slice of the card you want changed, I can usually do that with a row-level edit.";
 
 // Forensic logging for the chat agent loop. Off by default; flip on with
 // HEALTH_DEBUG=1. Emits structural facts only (durations, counts, tool
@@ -300,7 +304,7 @@ function extractJsonReply(raw) {
 //   'gateway_parse: <msg>'        -> 500
 // Preserves the existing transport options (no keep-alive, self-signed TLS
 // tolerated, 180s per-hop timeout).
-function callGateway({ messages, tools }) {
+function callGateway({ messages, tools, timeoutMs }) {
   return new Promise((resolve, reject) => {
     if (!CHAT_ENDPOINT) return reject(new Error('gateway_unavailable: CHAT_ENDPOINT_URL not set'));
     const body = { model: CHAT_MODEL, messages };
@@ -332,9 +336,13 @@ function callGateway({ messages, tools }) {
       });
     });
     proxyReq.on('error', (e) => reject(new Error('gateway_unavailable: ' + e.message)));
-    proxyReq.setTimeout(180000, () => {
+    const effectiveTimeout = (typeof timeoutMs === 'number' && timeoutMs > 0)
+      ? Math.min(timeoutMs, GATEWAY_HARD_TIMEOUT_MS)
+      : GATEWAY_HARD_TIMEOUT_MS;
+    const isSoftCap = effectiveTimeout < GATEWAY_HARD_TIMEOUT_MS;
+    proxyReq.setTimeout(effectiveTimeout, () => {
       proxyReq.destroy();
-      reject(new Error('gateway_timeout'));
+      reject(new Error(isSoftCap ? 'gateway_iter_timeout' : 'gateway_timeout'));
     });
     proxyReq.write(payload);
     proxyReq.end();
@@ -355,7 +363,23 @@ async function runAgentLoop({ systemPrompt, userMessages, reqId = '-' }) {
   let lastAssistantText = '';
   for (let i = 0; i < MAX_ITERS; i++) {
     const gwStart = Date.now();
-    const gw = await callGateway({ messages, tools: TOOL_DEFS });
+    let gw;
+    try {
+      gw = await callGateway({ messages, tools: TOOL_DEFS, timeoutMs: CHAT_ITER_TIMEOUT_MS });
+    } catch (e) {
+      if (e && e.message === 'gateway_iter_timeout') {
+        const gwMs = Date.now() - gwStart;
+        chatLog(reqId, `iter=${i} gw=${gwMs}ms iter_timeout`);
+        return {
+          finalText: NO_TOOL_FITS_REFUSAL,
+          cappedOut: false,
+          iterTimedOut: true,
+          ctx,
+          iters: i + 1,
+        };
+      }
+      throw e;
+    }
     const gwMs = Date.now() - gwStart;
     const choice = gw.choices?.[0];
     const msg = choice?.message || {};
@@ -401,7 +425,7 @@ async function runAgentLoop({ systemPrompt, userMessages, reqId = '-' }) {
   }
   return {
     finalText: lastAssistantText ||
-      "I wasn't able to finish that in one turn — please re-ask or be more specific.",
+      "I wasn't able to finish that in one turn. Please re-ask or be more specific.",
     cappedOut: true,
     ctx,
     iters: MAX_ITERS,
@@ -1599,9 +1623,9 @@ Original system prompt follows:
           chatLog(reqId, `start turns=${messages.length} voice=${!!voiceMode}`);
 
           runAgentLoop({ systemPrompt, userMessages: messages, reqId })
-            .then(({ finalText, ctx, cappedOut, iters }) => {
+            .then(({ finalText, ctx, cappedOut, iterTimedOut, iters }) => {
               const followup = buildFollowup(ctx);
-              chatLog(reqId, `done total=${Date.now() - turnStart}ms iters=${iters} capped=${!!cappedOut}`);
+              chatLog(reqId, `done total=${Date.now() - turnStart}ms iters=${iters} capped=${!!cappedOut}${iterTimedOut ? ' iter_timeout' : ''}`);
               if (voiceMode) {
                 const parsedReply = extractJsonReply(finalText);
                 if (parsedReply && (parsedReply.speak || parsedReply.display)) {

--- a/tests/api/issue-399.test.js
+++ b/tests/api/issue-399.test.js
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/api/issue-399.test.js
+// Regression seed for #399: chat agent must fail fast with a refusal reply
+// when no available tool fits the user's request, instead of letting the
+// gateway sit on the call until the 180s hard ceiling fires. We can't
+// trigger the model's "fudge it through write_manifest_data" path from a
+// stub, but we CAN drive the same outcome: a hanging gateway response
+// past the soft per-iter budget. The agent loop must convert that into
+// a 200 response carrying the standard refusal copy, not a 504.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('http');
+const {
+  createSandbox, cleanupSandbox, spawnServer, req,
+} = require('../helpers/sandbox');
+
+// Stub gateway that NEVER replies to the first request and replies
+// normally on every subsequent one. Lets us simulate a single iteration
+// that runs past the soft cap.
+function startHangingGateway() {
+  let hangNext = false;
+  let firstHeld = null;
+  const responseQueue = [];
+  const server = http.createServer((request, response) => {
+    let body = '';
+    request.on('data', c => { body += c; });
+    request.on('end', () => {
+      if (hangNext) {
+        hangNext = false;
+        firstHeld = response;
+        return;
+      }
+      const next = responseQueue.shift();
+      if (!next) {
+        response.writeHead(500, { 'Content-Type': 'application/json' });
+        response.end(JSON.stringify({ error: 'stub queue exhausted' }));
+        return;
+      }
+      response.writeHead(200, { 'Content-Type': 'application/json' });
+      response.end(JSON.stringify(next));
+    });
+  });
+  return new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => {
+      const port = server.address().port;
+      resolve({
+        port,
+        close: () => new Promise(r => {
+          if (firstHeld && !firstHeld.writableEnded) {
+            try { firstHeld.destroy(); } catch {}
+          }
+          server.close(r);
+        }),
+        hangNext: () => { hangNext = true; },
+        pushResponse: (r) => responseQueue.push(r),
+      });
+    });
+  });
+}
+
+describe('#399 chat: iter-timeout returns refusal in <10s, not 504', () => {
+  let sandbox, server, gateway;
+
+  before(async () => {
+    gateway = await startHangingGateway();
+    sandbox = createSandbox();
+    server = await spawnServer(sandbox, {
+      CHAT_ENDPOINT_URL: `http://127.0.0.1:${gateway.port}/v1/chat/completions`,
+      CHAT_API_KEY: 'stub-token',
+      CHAT_MODEL: 'stub-model',
+      CHAT_ITER_TIMEOUT_MS: '500',
+    });
+  });
+  after(async () => {
+    if (server) await server.kill();
+    if (gateway) await gateway.close();
+    cleanupSandbox(sandbox);
+  });
+
+  test('hung first iter -> refusal reply, 200 status, in well under 10s', async () => {
+    gateway.hangNext();
+    const t0 = Date.now();
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'reorder the rows in peptides' }] },
+    });
+    const elapsed = Date.now() - t0;
+    assert.equal(res.status, 200, 'iter timeout must surface as 200 with a refusal, not 504');
+    assert.ok(res.json.reply, 'response must carry a reply field');
+    assert.match(
+      res.json.reply,
+      /can't do that in one step/i,
+      'reply should be the standard refusal copy'
+    );
+    assert.ok(elapsed < 10000, `must return in <10s; got ${elapsed}ms`);
+  });
+});
+
+describe('#399 chat: system prompt instructs fail-fast refusal', () => {
+  let sandbox, server, gateway, lastPrompt;
+
+  before(async () => {
+    lastPrompt = null;
+    gateway = await new Promise(resolve => {
+      const srv = http.createServer((request, response) => {
+        let body = '';
+        request.on('data', c => { body += c; });
+        request.on('end', () => {
+          try {
+            const parsed = JSON.parse(body);
+            const sys = parsed.messages?.find(m => m.role === 'system');
+            lastPrompt = sys?.content || null;
+          } catch {}
+          response.writeHead(200, { 'Content-Type': 'application/json' });
+          response.end(JSON.stringify({
+            choices: [{ message: { role: 'assistant', content: 'ack' } }],
+          }));
+        });
+      });
+      srv.listen(0, '127.0.0.1', () => resolve({
+        port: srv.address().port,
+        close: () => new Promise(r => srv.close(r)),
+      }));
+    });
+    sandbox = createSandbox();
+    server = await spawnServer(sandbox, {
+      CHAT_ENDPOINT_URL: `http://127.0.0.1:${gateway.port}/v1/chat/completions`,
+      CHAT_API_KEY: 'stub-token',
+      CHAT_MODEL: 'stub-model',
+    });
+  });
+  after(async () => {
+    if (server) await server.kill();
+    if (gateway) await gateway.close();
+    cleanupSandbox(sandbox);
+  });
+
+  test('system prompt names the no-tool-fits refusal pattern', async () => {
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'hi' }] },
+    });
+    assert.equal(res.status, 200);
+    assert.ok(lastPrompt, 'stub captured a system prompt');
+    assert.ok(
+      /When no tool fits/i.test(lastPrompt),
+      'prompt must contain the no-tool-fits section header'
+    );
+    assert.ok(
+      /refuse fast/i.test(lastPrompt),
+      'prompt must steer toward fast refusal'
+    );
+    assert.ok(
+      /can't do that in one step/i.test(lastPrompt),
+      'prompt must include the standard refusal template'
+    );
+  });
+});


### PR DESCRIPTION
# What changed

When the chat agent receives a request that no available tool can
carry out in a reasonable single generation (canonical case: reorder
rows on a card with a large data block), it now refuses fast in
plain language instead of grinding `write_manifest_data` for 180s
until the gateway times out.

Two complementary mechanisms:

1. **System-prompt steering.** A new "When no tool fits" section in
   the chat agent contract spells out when to refuse, gives a
   one-or-two-sentence refusal template, and warns specifically
   against fudging row-level intents through `write_manifest_data`
   when the data block is large.
2. **Soft per-iter budget.** `runAgentLoop` now passes a tighter
   `timeoutMs` (default 60000, configurable via
   `CHAT_ITER_TIMEOUT_MS`) into `callGateway`. If any iteration runs
   past the soft cap, the in-flight gateway call is aborted and the
   loop returns the standard refusal copy at HTTP 200 (not 504).
   The 180s transport-level ceiling stays as the hard ceiling. Set
   `CHAT_ITER_TIMEOUT_MS=0` to disable the soft cap.

# Why

Reproduced in `eddzklebb` logs: four `[chat:*]` requests each hung
on iter 3 (the `write_manifest_data` generation) for ~199s before
timing out. The user saw "Request timed out" three times for what
was actually "no tool can do that". Three minutes of dead air per
attempt is the worst possible UX for a "I can't do that" answer.

This stays relevant after future tool additions (e.g. #398's
`reorder_rows`) - the no-tool-fits case will keep happening as
Klebbius's ambitions outgrow its tool list. Fix is in the agent
contract, not in tool count.

# How

- `config/env.js`: new `CHAT_ITER_TIMEOUT_MS` env (default 60000),
  parsed safely; `0` disables. New "When no tool fits" section in
  the default system prompt.
- `server.js`: `callGateway` accepts an optional `timeoutMs`,
  capped at the 180s hard ceiling; on soft-cap fire it rejects with
  `gateway_iter_timeout` so callers can distinguish. `runAgentLoop`
  catches that error and returns the refusal text + `iterTimedOut`
  flag at 200. Done-line debug log gains an `iter_timeout` token
  when set.
- `docs/CHAT-AGENT.md`: documents the refusal template and the
  per-iter budget knob.
- `tests/api/issue-399.test.js`: new regression seed covering both
  paths.

# Testing

- [x] `npm test` passes locally (1378 tests, 0 fail)
- [ ] `npm run test:e2e` (no UI surface touched)
- [x] New regression test added at the right layer:
  Backend / agent loop change -> `tests/api/issue-399.test.js`
- [x] Test fails against `main` before the fix and passes with it
  - On `main`: hung-gateway test errors out at the helper's 10s
    request timeout (the agent loop just sat on the 180s ceiling);
    system-prompt test fails because the "When no tool fits"
    section doesn't exist.
  - On the branch: refusal returns in ~545ms; system prompt
    contains the new section.
- [ ] Manual repro on `eddzklebb` after merge: ask Klebbius to
  reorder rows on the peptides card (which still doesn't have
  `reorder_rows` until #398 lands) and expect a refusal in <10s.

# Checklist

- [x] Commit messages follow the conventions in `CONTRIBUTING.md`
- [x] `CHANGELOG.md` updated under `## Unreleased`
- [x] Docs updated (`docs/CHAT-AGENT.md`)
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Breaking changes

None. The new env var is additive with a sensible default. Existing
deploys see the same behaviour for any iteration that completes
inside 60s; the only behaviour change is on iterations that would
previously have run for 60-180s, which now return a refusal
instead.

Closes #399.