### PR TITLE
fix(notifications): mobile touch + a11y polish on Notifications tab rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,25 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
   where applicable. Honours `meta.writeable.fromWebapp` like every
   other mutator. Closes #398.
 
+### Changed
+
+- **Notifications row mobile touch + a11y polish.** The Notifications
+  tab toggles in `eh-settings-notifications` now meet a 44×44 touch
+  target (WCAG 2.5.5 / Apple HIG): the visible 36×20 track is wrapped
+  in a 44×44 button so the hit area extends without changing the
+  visual geometry. On viewports ≤560px a one-line privacy hint
+  renders next to the privacy toggle ("Lock screen says 'You have a
+  reminder'." / "Lock screen shows the full reminder text."), driven
+  by `item.privacy`, so the explanation is reachable without a
+  hover-only `title` tooltip. The "Show full text" caption is now
+  tappable and flips the privacy toggle, matching its dotted-underline
+  affordance. Both toggles carry `aria-busy` while a state POST is in
+  flight, with a small animated dots indicator in a reserved slot
+  next to the toggle so a tap is visibly acknowledged before the
+  switch flips. The two toggles also carry stable `data-role="enabled"`
+  / `data-role="privacy"` selectors used by the e2e spec, replacing
+  the brittle `.toggle:first()` lookup. Fixes #393.
+
 ### Fixed
 
 - **Chat agent fails fast when no tool fits.** When the user asks for

--- a/public/js/components/eh-settings-notifications.js
+++ b/public/js/components/eh-settings-notifications.js
@@ -3,10 +3,10 @@
 // public/js/components/eh-settings-notifications.js
 //
 // Settings > Notifications pane. Per-card section list with two
-// toggles per row (enabled, show-full-text=privacy), Test button,
-// global Quiet hours + Pause-for chips, status banner across the
-// supported permission states (incl. iOS install instructions),
-// empty state and the "ask Klebbius" footer note.
+// toggles per row (enabled, show-full-text=privacy), global Quiet
+// hours + Pause-for chips, status banner across the supported
+// permission states (incl. iOS install instructions), empty state
+// and the "ask Klebbius" footer note.
 
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
 import {
@@ -90,6 +90,7 @@ export class EhSettingsNotifications extends LitElement {
   }
 
   async _onToggleEnabled(item) {
+    if (this._busyId === item.id) return;
     this._busyId = item.id;
     try {
       const r = await fetch('/api/notifications/state', {
@@ -112,6 +113,7 @@ export class EhSettingsNotifications extends LitElement {
   }
 
   async _onTogglePrivacy(item) {
+    if (this._busyId === item.id + ':privacy') return;
     this._busyId = item.id + ':privacy';
     try {
       const next = item.privacy === 'public' ? 'private' : 'public';
@@ -330,27 +332,50 @@ export class EhSettingsNotifications extends LitElement {
       align-items: center;
       gap: 12px;
       flex-shrink: 0;
+      flex-wrap: wrap;
+      justify-content: flex-end;
     }
     .toggle-pair {
       display: flex;
       align-items: center;
-      gap: 6px;
+      gap: 4px;
       font-size: 11px;
       color: var(--text-muted, var(--text-secondary));
     }
+    /* Reserve a slot the busy-dots can occupy without shifting the
+       toggle when a saving indicator appears mid-tap. */
+    .toggle-pair .busy-slot {
+      width: 18px;
+      display: inline-flex;
+      justify-content: center;
+      flex-shrink: 0;
+    }
     .toggle {
       appearance: none;
+      background: transparent;
+      border: none;
+      padding: 0;
+      margin: 0;
+      cursor: pointer;
+      /* 44x44 hit target per WCAG 2.5.5 / Apple HIG. The visible
+         track is rendered inside as .toggle-track + .toggle-thumb. */
+      width: 44px;
+      height: 44px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+    .toggle-track {
       width: 36px;
       height: 20px;
       border-radius: 10px;
       background: var(--border);
       position: relative;
-      cursor: pointer;
-      border: none;
       transition: background 0.15s;
+      pointer-events: none;
     }
-    .toggle::after {
-      content: '';
+    .toggle-thumb {
       position: absolute;
       top: 2px;
       left: 2px;
@@ -360,12 +385,49 @@ export class EhSettingsNotifications extends LitElement {
       background: var(--bg-card);
       transition: transform 0.15s;
     }
-    .toggle[aria-pressed="true"] { background: var(--accent); }
-    .toggle[aria-pressed="true"]::after { transform: translateX(16px); }
-    .toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-    .toggle[disabled] { opacity: 0.5; cursor: wait; }
+    .toggle[aria-pressed="true"] .toggle-track { background: var(--accent); }
+    .toggle[aria-pressed="true"] .toggle-thumb { transform: translateX(16px); }
+    .toggle:focus-visible .toggle-track {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
+    .toggle[aria-busy="true"] .toggle-track {
+      box-shadow: 0 0 0 2px var(--accent);
+    }
     @media (prefers-reduced-motion: reduce) {
-      .toggle, .toggle::after { transition: none; }
+      .toggle-track, .toggle-thumb { transition: none; }
+    }
+    .busy-dots {
+      display: inline-flex;
+      gap: 2px;
+      font-size: 11px;
+      color: var(--text-muted, var(--text-secondary));
+      align-items: center;
+      flex-shrink: 0;
+    }
+    .busy-dots span {
+      width: 4px;
+      height: 4px;
+      border-radius: 50%;
+      background: currentColor;
+      animation: busy-dot 1s ease-in-out infinite;
+    }
+    .busy-dots span:nth-child(2) { animation-delay: 0.15s; }
+    .busy-dots span:nth-child(3) { animation-delay: 0.3s; }
+    @keyframes busy-dot {
+      0%, 80%, 100% { opacity: 0.2; }
+      40% { opacity: 1; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .busy-dots span { animation: none; opacity: 0.6; }
+    }
+    .privacy-hint {
+      display: none;
+      font-size: 12px;
+      color: var(--text-muted, var(--text-secondary));
+      margin-top: 6px;
+      text-align: right;
+      flex-basis: 100%;
     }
     @media (max-width: 560px) {
       .item-toggles {
@@ -374,6 +436,7 @@ export class EhSettingsNotifications extends LitElement {
         gap: 18px;
       }
       .item-main { row-gap: 6px; }
+      .privacy-hint { display: block; }
     }
     .item-meta {
       font-size: 11px;
@@ -411,9 +474,11 @@ export class EhSettingsNotifications extends LitElement {
       text-align: center;
     }
     .privacy-help {
-      cursor: help;
+      cursor: pointer;
       border-bottom: 1px dotted var(--text-muted, var(--text-secondary));
+      user-select: none;
     }
+    .privacy-help:hover { color: var(--text-primary); }
   `;
 
   render() {
@@ -542,6 +607,9 @@ export class EhSettingsNotifications extends LitElement {
     const last = this._formatLast(item.last_fired);
     const enabledBusy = this._busyId === item.id;
     const privacyBusy = this._busyId === item.id + ':privacy';
+    const privacyHint = item.privacy === 'public'
+      ? 'Lock screen shows the full reminder text.'
+      : 'Lock screen says "You have a reminder".';
     return html`
       <div class="item-row">
         <div class="item-main">
@@ -549,28 +617,36 @@ export class EhSettingsNotifications extends LitElement {
           <span class="item-label">${item.label}</span>
           <div class="item-toggles">
             <span class="toggle-pair">
+              <span class="busy-slot">${enabledBusy ? this._renderBusyDots() : ''}</span>
               <button
                 class="toggle"
+                data-role="enabled"
                 role="switch"
                 aria-checked=${item.enabled}
                 aria-pressed=${item.enabled}
+                aria-busy=${enabledBusy ? 'true' : 'false'}
                 aria-label="Toggle ${item.label}"
-                ?disabled=${enabledBusy}
                 @click=${() => this._onToggleEnabled(item)}
-              ></button>
+              ><span class="toggle-track"><span class="toggle-thumb"></span></span></button>
             </span>
             <span class="toggle-pair" title="When off, the lock screen says 'You have a reminder' and the real text is shown only when you open Klebb.">
+              <span class="busy-slot">${privacyBusy ? this._renderBusyDots() : ''}</span>
               <button
                 class="toggle"
+                data-role="privacy"
                 role="switch"
                 aria-checked=${item.privacy === 'public'}
                 aria-pressed=${item.privacy === 'public'}
+                aria-busy=${privacyBusy ? 'true' : 'false'}
                 aria-label="Show full text on the lock screen for ${item.label}"
-                ?disabled=${privacyBusy}
                 @click=${() => this._onTogglePrivacy(item)}
-              ></button>
-              <span class="privacy-help">Show full text</span>
+              ><span class="toggle-track"><span class="toggle-thumb"></span></span></button>
+              <span
+                class="privacy-help"
+                @click=${() => this._onTogglePrivacy(item)}
+              >Show full text</span>
             </span>
+            <span class="privacy-hint">${privacyHint}</span>
           </div>
         </div>
         ${(next || last) ? html`
@@ -582,6 +658,10 @@ export class EhSettingsNotifications extends LitElement {
         ` : ''}
       </div>
     `;
+  }
+
+  _renderBusyDots() {
+    return html`<span class="busy-dots" aria-hidden="true"><span></span><span></span><span></span></span>`;
   }
 }
 customElements.define('eh-settings-notifications', EhSettingsNotifications);

--- a/tests-e2e/notifications-tab.spec.js
+++ b/tests-e2e/notifications-tab.spec.js
@@ -90,7 +90,7 @@ test.describe('#387: Notifications tab', () => {
 
     // Toggle the on/off switch and re-fetch /api/notifications to verify
     // persistence.
-    const onOff = tab.locator('.toggle').first();
+    const onOff = tab.locator('[data-role="enabled"]').first();
     await expect(onOff).toHaveAttribute('aria-pressed', 'true');
     await onOff.click();
     // Wait for the post + UI flip to settle.
@@ -139,5 +139,123 @@ test.describe('#387: Notifications tab', () => {
     const json = await r.json();
     expect(json.quiet_hours).toEqual({ start: '22:30', end: '06:30' });
     expect(json.paused_until).toBe(null);
+  });
+});
+
+test.describe('#393: Notifications row mobile touch + a11y polish', () => {
+  // Seed a single-item card before each spec and clean it up after.
+  // The runtime returns privacy='private' by default, so the privacy
+  // toggle starts at aria-pressed='false'.
+  test.beforeEach(async ({ page, sandboxState }) => {
+    const create = await page.request.post(`${sandboxState.baseUrl}/api/manifests`, {
+      data: {
+        $schema: 'klebb.datafile.v1',
+        meta: {
+          id: 'e2e-393',
+          label: '393 Polish',
+          emoji: '🔔',
+          view: { enabled: true, component: 'generic-card' },
+          notifications: {
+            enabled: true,
+            items: [
+              {
+                id: 'morning',
+                label: 'Morning reminder',
+                title: 'Reminder',
+                body: 'Time to log.',
+                trigger: { type: 'daily', time: '09:00' },
+              },
+            ],
+          },
+        },
+        data: [],
+      },
+    });
+    expect(create.status()).toBe(201);
+  });
+
+  test.afterEach(async ({ page, sandboxState }) => {
+    await page.request.delete(`${sandboxState.baseUrl}/api/manifests/e2e-393`);
+  });
+
+  test('toggle hit area meets 44x44 at iPhone 13 mini width', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto('/settings');
+    await page.locator('eh-settings-view [data-tab="notifications"]').click();
+    const tab = page.locator('eh-settings-notifications');
+    await expect(tab).toBeVisible();
+
+    const enabled = tab.locator('[data-role="enabled"]').first();
+    const privacy = tab.locator('[data-role="privacy"]').first();
+    await expect(enabled).toBeVisible();
+    await expect(privacy).toBeVisible();
+
+    const enBox = await enabled.boundingBox();
+    const prBox = await privacy.boundingBox();
+    expect(enBox).not.toBeNull();
+    expect(prBox).not.toBeNull();
+    expect(enBox.width).toBeGreaterThanOrEqual(44);
+    expect(enBox.height).toBeGreaterThanOrEqual(44);
+    expect(prBox.width).toBeGreaterThanOrEqual(44);
+    expect(prBox.height).toBeGreaterThanOrEqual(44);
+  });
+
+  test('privacy hint is visible on small viewports and reflects state', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto('/settings');
+    await page.locator('eh-settings-view [data-tab="notifications"]').click();
+    const tab = page.locator('eh-settings-notifications');
+    await expect(tab).toBeVisible();
+
+    const hint = tab.locator('.privacy-hint').first();
+    await expect(hint).toBeVisible();
+    // Default is privacy='private': lock screen says "You have a reminder".
+    await expect(hint).toContainText('You have a reminder');
+
+    // Flip the privacy toggle and assert the hint copy follows.
+    const privacy = tab.locator('[data-role="privacy"]').first();
+    await privacy.click();
+    await expect(privacy).toHaveAttribute('aria-pressed', 'true', { timeout: 10000 });
+    await expect(hint).toContainText('full reminder text');
+  });
+
+  test('tapping the "Show full text" caption flips the privacy toggle', async ({ page }) => {
+    await page.goto('/settings');
+    await page.locator('eh-settings-view [data-tab="notifications"]').click();
+    const tab = page.locator('eh-settings-notifications');
+    await expect(tab).toBeVisible();
+
+    const privacy = tab.locator('[data-role="privacy"]').first();
+    const caption = tab.locator('.privacy-help').first();
+    await expect(privacy).toHaveAttribute('aria-pressed', 'false');
+
+    await caption.click();
+    await expect(privacy).toHaveAttribute('aria-pressed', 'true', { timeout: 10000 });
+  });
+
+  test('toggle gets aria-busy=true during in-flight state POST', async ({ page }) => {
+    await page.goto('/settings');
+    await page.locator('eh-settings-view [data-tab="notifications"]').click();
+    const tab = page.locator('eh-settings-notifications');
+    await expect(tab).toBeVisible();
+
+    // Stall the POST so the busy state is observable. Resolve it after
+    // we've asserted aria-busy=true.
+    let release;
+    const released = new Promise(r => { release = r; });
+    await page.route('**/api/notifications/state', async (route) => {
+      await released;
+      await route.continue();
+    });
+
+    const enabled = tab.locator('[data-role="enabled"]').first();
+    await enabled.click();
+    await expect(enabled).toHaveAttribute('aria-busy', 'true', { timeout: 5000 });
+    // Spinner is rendered while busy.
+    await expect(tab.locator('.busy-dots').first()).toBeVisible();
+
+    release();
+    await expect(enabled).toHaveAttribute('aria-busy', 'false', { timeout: 10000 });
+    await expect(tab.locator('.busy-dots')).toHaveCount(0);
   });
 });


### PR DESCRIPTION
# What changed

Five mobile-touch + a11y polish items on the per-row Notifications
toggles in `eh-settings-notifications`:

- 44x44 touch target (WCAG 2.5.5 / Apple HIG): the visible 36x20
  track is wrapped in a 44x44 button so `boundingBox()` measures
  44x44 without changing the visible geometry.
- Mobile-visible privacy hint at viewports `=560px`: a one-line
  helper next to the privacy toggle reflecting `item.privacy`
  ("Lock screen says 'You have a reminder'." / "Lock screen shows
  the full reminder text."). The desktop `title=` tooltip stays as
  a redundant hover affordance.
- The dotted-underlined "Show full text" caption is now tappable
  (cursor switches from `help` to `pointer`) and flips the privacy
  toggle.
- `aria-busy="true"` on whichever toggle is in flight, plus a small
  animated three-dot indicator in a fixed-width slot next to it so
  a tap is visibly acknowledged before the switch flips. A busy
  guard early-returns on a re-tap mid-flight, which removes the
  tap-twice-and-flap risk.
- Stable `data-role="enabled"` / `data-role="privacy"` selectors on
  the two toggles; the e2e spec uses them instead of the brittle
  `.toggle:first()` lookup.

# Why

Fixes #393. The earlier overlap fix (commit 93fefac) intentionally
left the touch + a11y items out of scope; this bundles them so they
don't get lost. The 36x20 toggle was genuinely hard to hit on a 375px
viewport with a thumb-sized contact patch, the privacy explainer was
locked behind a `title=` tooltip iOS Safari doesn't surface on tap,
and the dotted-underline caption implied a tap affordance the DOM
didn't carry. The 50% opacity busy state was barely perceptible on a
thumb-obscured 20px control, so users tapping twice could land
back-to-back POSTs.

# How

The button itself becomes the 44x44 hit target with `appearance:none`
and inner `.toggle-track` + `.toggle-thumb` spans for the visible
36x20 pill. `aria-pressed` + `aria-busy` on the button drive the
visual track/thumb/ring states via descendant selectors, so the
existing focus and accent semantics carry over unchanged. The busy
indicator sits in a fixed-width `.busy-slot` so it never shifts the
toggle when it appears mid-tap.

The privacy caption gets a click handler delegating to
`_onTogglePrivacy(item)`. Both `_onToggleEnabled` and
`_onTogglePrivacy` short-circuit when their busy id matches, so a
mid-flight re-tap (caption or toggle) is a no-op.

The privacy hint is a `flex-basis: 100%` span at the end of
`.item-toggles`, hidden by default and shown only inside the
existing `@media (max-width: 560px)` block. `.item-toggles` gets
`flex-wrap: wrap` so it actually breaks onto a new line.

# Testing

- [x] `npm test` passes locally (1389 pass, 3 skipped, 0 fail)
- [x] `npm run test:e2e` passes locally (79/79 chromium specs)
- [x] New regression tests added:
  - `tests-e2e/notifications-tab.spec.js`: four new specs under a
    `#393` describe block: 44x44 hit area at 375x667, mobile
    privacy-hint visibility + state-tracking, caption-tap flips
    privacy, `aria-busy` reflects state across an in-flight stalled
    POST.
  - Existing `#387` spec migrated from `.toggle:first()` to
    `[data-role="enabled"]`.
- [ ] Manual QA on a real iPhone — deferred to operator validation
      against a deployed instance; Playwright covers the bounding-box
      and a11y assertions.

# Checklist

- [x] Commit messages follow the conventions in `CONTRIBUTING.md`
- [x] `CHANGELOG.md` updated under `## Unreleased`
- [x] Docs updated (`README.md` / `docs/*.md` / `MANIFEST-SCHEMA.md`)
      if behaviour or schema changed (no schema or doc-visible
      behaviour changed)
- [x] No personal identifiers or hardcoded paths introduced
- [x] No secrets or high-entropy tokens committed

# Breaking changes

None. Pure client-side polish; the API contract is unchanged. The
`.toggle` class still exists on the buttons (kept for the existing
CSS), so any external selector reaching in via that class still
resolves; the new `data-role` attributes are additive.