### PR TITLE
fix(notifications): clear lastFired when set_notification mutates a trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,26 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **`set_notification` clears `lastFired` when it changes a trigger.**
+  Cached `notifications.state.json#items[<id>].lastFired` is computed
+  under whatever trigger configuration was active at the time, so once
+  the chat agent mutates a notification's trigger (time, type,
+  weekly days, schedule_due slot) the cached slot belongs to a
+  different trigger config and the scheduler must re-evaluate from
+  scratch. Without this, the next slot under the new trigger could
+  share an instant with the old `lastFired` (the sharp case: a
+  `schedule_due` trigger that suppressed today, then mutated to plain
+  `daily` at the same time) and the scheduler would treat the slot as
+  already-fired and silently skip the reminder. `chat/tools.js`
+  `set_notification` now deep-equals the old vs new trigger and calls
+  through to a new `lib/notifications-state.clearLastFired` when they
+  differ; benign updates (label/title/body changes, same trigger)
+  preserve `lastFired`. `remove_notification` also drops the runtime
+  sidecar entry via a new `removeItem` helper, so a per-item delete
+  doesn't leave orphan toggle/`lastFired`/privacy state behind for a
+  future item that reclaims the same id. The registry's `onDelete`
+  hook still handles whole-card deletes. Closes #394.
+
 - **Chat agent fails fast when no tool fits.** When the user asks for
   something that no available tool can carry out (reorder rows, merge
   cards, etc.), the model used to fudge it through the closest tool

--- a/chat/tools.js
+++ b/chat/tools.js
@@ -6,7 +6,9 @@
 // /api/manifests. Registry writes are sync atomic tmp+rename so this is
 // safe to do inline inside a chat request.
 
+const { isDeepStrictEqual } = require('util');
 const registry = require('../manifests/registry');
+const notificationsState = require('../lib/notifications-state');
 const { readDoc } = require('./docs');
 const { readReport } = require('./reports');
 
@@ -363,6 +365,15 @@ const TOOL_DEFS = [
   },
 ];
 
+// Did the trigger object change between the existing item and the
+// incoming one? RFC 7396 deep-equal semantics: type/time/days/card/
+// time_of_day all matter. Returns true only when the two triggers are
+// indistinguishable to the scheduler. Used by set_notification to
+// decide whether to invalidate cached lastFired.
+function _triggersEqual(a, b) {
+  return isDeepStrictEqual(a, b);
+}
+
 // Auto-generate a notification id from a human label when the agent
 // didn't supply one. Lowercase, ascii-only, drop anything that isn't
 // matching the id regex.
@@ -543,6 +554,18 @@ function dispatchToolCall(tc, ctx) {
           registry.patchManifest(args.card_id, {
             meta: { notifications: { enabled: true, items: nextItems } },
           });
+          // When an existing item's trigger object changed, the cached
+          // lastFired/lastFireStatus belong to a different trigger config
+          // and the scheduler must re-evaluate from scratch. Without this,
+          // the next slot under the new trigger can share an instant with
+          // the old lastFired (e.g. schedule_due that suppressed today
+          // -> daily at the same time) and silently skip. See #394.
+          if (idx >= 0) {
+            const before = existingItems[idx].trigger;
+            if (!_triggersEqual(before, args.trigger)) {
+              notificationsState.clearLastFired(`${args.card_id}#${itemId}`);
+            }
+          }
           recordTouch(ctx, { id: args.card_id, flow: 'edit' });
           return JSON.stringify({
             ok: true,
@@ -567,6 +590,12 @@ function dispatchToolCall(tc, ctx) {
           registry.patchManifest(args.card_id, {
             meta: { notifications: { enabled: entry.meta.notifications.enabled !== false, items: nextItems } },
           });
+          // The registry's onDelete hook only fires for whole-card deletes.
+          // A per-item removal needs to drop its runtime sidecar entry
+          // explicitly, otherwise lastFired + the toggle survive and a
+          // future item that reclaims the same id inherits stale state.
+          // See #394.
+          notificationsState.removeItem(`${args.card_id}#${args.notification_id}`);
           recordTouch(ctx, { id: args.card_id, flow: 'edit' });
           return JSON.stringify({
             ok: true,

--- a/lib/notifications-state.js
+++ b/lib/notifications-state.js
@@ -137,6 +137,35 @@ function pruneCard(cardId) {
   return removed;
 }
 
+// Drop a single items[] entry. Used by remove_notification so the
+// deleted notification's runtime sidecar (lastFired, enabled toggle,
+// privacy override) doesn't linger and resurface if a new item later
+// claims the same id. No-op when the file doesn't exist yet.
+function removeItem(id) {
+  if (!fs.existsSync(PATHS.NOTIFICATIONS_STATE_FILE)) return false;
+  const state = read();
+  if (!(id in state.items)) return false;
+  delete state.items[id];
+  write(state);
+  return true;
+}
+
+// Null out lastFired (and the matching status) for one item. Used at
+// the trigger-mutation boundary in set_notification: once the trigger
+// changes, the cached slot belongs to a different trigger config and
+// the scheduler must re-evaluate from scratch. No-op when the file
+// doesn't exist yet, or when there's no entry for this id.
+function clearLastFired(id) {
+  if (!fs.existsSync(PATHS.NOTIFICATIONS_STATE_FILE)) return false;
+  const state = read();
+  const entry = state.items[id];
+  if (!entry) return false;
+  if (entry.lastFired == null && entry.lastFireStatus == null) return false;
+  state.items[id] = { ...entry, lastFired: null, lastFireStatus: null };
+  write(state);
+  return true;
+}
+
 // Inside-quiet-hours check at a given instant. Returns boolean.
 // `qh` is { start, end } in "HH:MM" - both in the user's TZ.
 // Wall clock is computed once by the caller via lib/notification-trigger
@@ -175,6 +204,8 @@ module.exports = {
   writeItem,
   writeGlobal,
   pruneCard,
+  removeItem,
+  clearLastFired,
   getOrInitItem,
   isQuietNow,
   appendFire,

--- a/tests/api/issue-394.test.js
+++ b/tests/api/issue-394.test.js
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/api/issue-394.test.js
+//
+// Regression seed for #394: when set_notification mutates a notification's
+// trigger, the runtime state file's lastFired (computed under the OLD
+// trigger config) must be cleared, so the scheduler doesn't silently
+// treat a fresh slot under the NEW trigger as already-fired.
+//
+// The sharp bite: a schedule_due trigger that suppressed today (lastFired
+// stamped with status:suppressed because no dose was due) gets mutated
+// into a plain daily wall-clock trigger at the same time. Without the
+// fix, the next tick sees lastFired === slots.prev under the new trigger
+// and silently skips. With the fix, set_notification clears lastFired at
+// the patch boundary, the slot fires, and the user gets their reminder.
+//
+// Also covers:
+//   - benign updates (label/title/body unchanged trigger): lastFired preserved
+//   - notification_id-less re-dispatch on unrelated items: their lastFired
+//     untouched
+//   - remove_notification: runtime state entry pruned
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { createSandbox, cleanupSandbox } = require('../helpers/sandbox');
+
+function freshEnv(seed) {
+  const root = createSandbox({ seed });
+  process.env.HEALTH_HOME = root;
+  process.env.HEALTH_NOTIFICATIONS_STATE_FILE = path.join(root, 'notifications.state.json');
+  process.env.HEALTH_USER_FILE = path.join(root, 'user.json');
+  process.env.TZ = 'Australia/Melbourne';
+  for (const k of Object.keys(require.cache)) {
+    if (k.endsWith('config' + path.sep + 'paths.js')
+      || k.includes('manifests' + path.sep + 'registry.js')
+      || k.includes('chat' + path.sep + 'tools.js')
+      || k.includes('notifications-state')
+      || k.includes('notification-trigger')
+      || k.includes('notifications-scheduler')
+      || k.includes('user-tz')) {
+      delete require.cache[k];
+    }
+  }
+  const registry = require('../../manifests/registry');
+  registry.init();
+  const tools = require('../../chat/tools');
+  const stateMod = require('../../lib/notifications-state');
+  const scheduler = require('../../lib/notifications-scheduler');
+  scheduler._setRegistryForTests(registry);
+  return { root, registry, tools, stateMod, scheduler };
+}
+
+function call(tools, name, args) {
+  const json = tools.dispatchToolCall(
+    { function: { name, arguments: JSON.stringify(args) } },
+    { touches: [] },
+  );
+  return JSON.parse(json);
+}
+
+const SEED = {
+  'mood.json': {
+    $schema: 'klebb.datafile.v1',
+    meta: {
+      id: 'mood', label: 'Mood',
+      view: { enabled: true, component: 'generic-card' },
+      notifications: {
+        enabled: true,
+        items: [{
+          id: 'morning-log',
+          label: 'Morning log',
+          title: 'Mood',
+          body: 'How are you feeling?',
+          trigger: { type: 'daily', time: '08:00' },
+        }],
+      },
+    },
+    data: [],
+  },
+};
+
+test.describe('issue-394: set_notification clears lastFired on trigger mutation', () => {
+  let env;
+  test.beforeEach(() => { env = freshEnv(SEED); });
+  test.afterEach(() => { cleanupSandbox(env.root); });
+
+  test('trigger mutation clears lastFired so the new slot fires', async () => {
+    // Seed the state as if the scheduler had already dispatched today's
+    // 08:00 slot under the OLD trigger. Equivalent to: the scheduler
+    // ticked at 08:00, recorded lastFired, and we're now at 08:05.
+    env.stateMod.writeItem('mood#morning-log', {
+      enabled: true,
+      lastFired: '2026-06-12T08:00:00+10:00',
+      lastFireStatus: 'pending',
+    });
+
+    // The user asks Klebbius to change the trigger shape (here: from daily
+    // to a weekly with all 7 days, same time). The next prevFire under
+    // the new trigger is byte-identical to the OLD prevFire that's still
+    // in lastFired. Without the fix, the next tick treats the slot as
+    // already-fired and silently skips.
+    const result = call(env.tools, 'set_notification', {
+      card_id: 'mood',
+      notification_id: 'morning-log',
+      label: 'Morning log',
+      title: 'Mood',
+      body: 'How are you feeling?',
+      trigger: { type: 'weekly', time: '08:00', days: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.created, false);
+
+    const after = env.stateMod.read();
+    assert.equal(after.items['mood#morning-log'].lastFired, null,
+      'lastFired must be cleared at the trigger-mutation boundary');
+
+    // Belt-and-braces: drive the scheduler tick under the new trigger and
+    // confirm the slot actually fires (i.e. the silent-skip is gone).
+    const events = [];
+    env.scheduler.setDispatch(async (evs) => events.push(...evs));
+    await env.scheduler._tick(new Date('2026-06-11T22:05:00Z')); // 08:05 +10
+    assert.equal(events.length, 1, 'the new trigger\'s slot must fire');
+    assert.equal(events[0].items[0].id, 'mood#morning-log');
+  });
+
+  test('benign update (same trigger) preserves lastFired', async () => {
+    env.stateMod.writeItem('mood#morning-log', {
+      enabled: true,
+      lastFired: '2026-06-12T08:00:00+10:00',
+      lastFireStatus: 'pending',
+    });
+
+    // Identical trigger; only body text changes. Cached lastFired is
+    // still valid for this trigger config: don't clear it.
+    const result = call(env.tools, 'set_notification', {
+      card_id: 'mood',
+      notification_id: 'morning-log',
+      label: 'Morning log',
+      title: 'Mood',
+      body: 'Feeling alright?', // changed
+      trigger: { type: 'daily', time: '08:00' }, // unchanged
+    });
+    assert.equal(result.ok, true);
+
+    const after = env.stateMod.read();
+    assert.equal(after.items['mood#morning-log'].lastFired,
+      '2026-06-12T08:00:00+10:00',
+      'lastFired must survive when only label/body change');
+  });
+
+  test('mutation only touches the targeted item\'s runtime state', async () => {
+    env.stateMod.writeItem('mood#morning-log', {
+      enabled: true,
+      lastFired: '2026-06-12T08:00:00+10:00',
+    });
+    env.stateMod.writeItem('weight#daily', {
+      enabled: true,
+      lastFired: '2026-06-12T07:30:00+10:00',
+    });
+
+    call(env.tools, 'set_notification', {
+      card_id: 'mood',
+      notification_id: 'morning-log',
+      label: 'Morning log',
+      title: 'Mood',
+      body: 'How are you feeling?',
+      trigger: { type: 'daily', time: '09:00' }, // mutated
+    });
+
+    const after = env.stateMod.read();
+    assert.equal(after.items['mood#morning-log'].lastFired, null);
+    assert.equal(after.items['weight#daily'].lastFired,
+      '2026-06-12T07:30:00+10:00',
+      'unrelated items must keep their lastFired');
+  });
+
+  test('add (no prior item) is a no-op on runtime state', async () => {
+    // No state file exists yet; add a notification and confirm the tool
+    // still succeeds without creating a stray runtime entry.
+    const result = call(env.tools, 'set_notification', {
+      card_id: 'mood',
+      label: 'Evening log',
+      title: 'Mood',
+      body: 'How was your day?',
+      trigger: { type: 'daily', time: '20:00' },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.created, true);
+
+    const stateFile = path.join(env.root, 'notifications.state.json');
+    if (fs.existsSync(stateFile)) {
+      const after = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+      assert.equal(after.items['mood#evening-log']?.lastFired ?? null, null);
+    }
+  });
+});
+
+test.describe('issue-394: remove_notification prunes runtime state', () => {
+  let env;
+  test.beforeEach(() => { env = freshEnv(SEED); });
+  test.afterEach(() => { cleanupSandbox(env.root); });
+
+  test('removed item\'s runtime entry is dropped from notifications.state.json', () => {
+    env.stateMod.writeItem('mood#morning-log', {
+      enabled: true,
+      lastFired: '2026-06-12T08:00:00+10:00',
+    });
+
+    const result = call(env.tools, 'remove_notification', {
+      card_id: 'mood',
+      notification_id: 'morning-log',
+    });
+    assert.equal(result.ok, true);
+
+    const after = env.stateMod.read();
+    assert.equal(after.items['mood#morning-log'], undefined,
+      'remove_notification must prune the runtime sidecar entry');
+  });
+});


### PR DESCRIPTION
# What changed

When the chat agent mutates a notification's `trigger` (time, type,
weekly days, schedule_due slot) via `set_notification`, the runtime
sidecar (`notifications.state.json#items[<id>].lastFired`) is now
cleared at the patch boundary. `remove_notification` also drops the
sidecar entry for the removed item.

# Why

Fixes #394.

`lastFired` records the slot ISO the scheduler last dispatched for, so
restarts inside the same minute don't refire. That cache is computed
under whichever trigger configuration was active at the time. Once the
trigger changes, the cached slot belongs to a different config and the
scheduler must re-evaluate from scratch.

The sharp case: a `schedule_due` trigger that suppressed today (no
items due → `lastFired` stamped with `lastFireStatus: 'suppressed'`),
then mutated to plain `daily` at the same time. The next tick sees
`slots.prev === lastFired` under the new trigger, treats the slot as
already-fired, and silently skips the reminder the user just asked for.

Per-item `remove_notification` had a related gap: the registry's
`onDelete` hook only fires from `deleteManifest` (whole-card delete),
so a per-item drop left the runtime entry behind. A new item that
later reclaimed the same id would inherit the stale enabled toggle,
`lastFired`, and privacy override.

# How

`chat/tools.js` (the only mutator, per the issue's preferred site):

- `set_notification` deep-equals (`util.isDeepStrictEqual`) the old
  vs new `trigger` after the registry patch succeeds. If they differ,
  it calls `notificationsState.clearLastFired(<runtime-id>)`. Benign
  updates (label/title/body changes, identical trigger) preserve the
  cached slot.
- `remove_notification` calls `notificationsState.removeItem(<runtime-id>)`
  after the registry patch succeeds.

`lib/notifications-state.js` gains two small helpers:

- `clearLastFired(id)` — nulls out `lastFired` + `lastFireStatus` for
  one runtime id. No-op when the state file doesn't exist yet or no
  entry is recorded for the id.
- `removeItem(id)` — drops a single `items[]` key. No-op when the file
  doesn't exist yet.

Registry stays free of runtime-state knowledge; the chat layer threads
through.

# Testing

- [x] `npm test` passes locally (1394 pass, 3 skip, 0 fail).
- [x] `npm run test:e2e` passes locally (79 specs).
- [x] New per-bug regression seed at `tests/api/issue-394.test.js`
      with five cases:
  - trigger mutation clears `lastFired` and the new slot fires
    (verified by also driving `scheduler._tick`)
  - benign update preserves `lastFired`
  - mutation only touches the targeted item's runtime state
  - add (no prior item) is a no-op on runtime state
  - `remove_notification` prunes the runtime sidecar entry
- [x] Pre-fix: 3/5 tests fail on main (the bug-revealing ones); 2/5
      already pass (the contract-stability ones). Post-fix: all 5 pass.

# Checklist

- [x] Commit messages follow CONTRIBUTING.md conventions
- [x] CHANGELOG.md updated under ## Unreleased
- [x] Docs updated if behaviour or schema changed (no schema or
      user-facing surface change; `chat/tools.js` and the runtime
      sidecar are internal)
- [x] No personal identifiers or hardcoded paths
- [x] No secrets or high-entropy tokens

# Breaking changes

None.