### PR TITLE
feat(renderers): add numericSeries and adherenceSeries helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **`numericSeries` + `adherenceSeries` series extractors.** Two pure
+  helpers that turn a card's rows into the arrays a future sparkline
+  will draw. `numericSeries(rows, field, {endDate, limit})` in
+  `public/js/lib/display-template.js` (and its ESM twin) pulls the last
+  N numeric values for a field in ascending date order, reusing
+  `getValue` and the same numeric predicate as `computeTrend`. The new
+  `public/js/lib/adherence-series.esm.js` adds `adherenceSeries` (a
+  per-day done/due ratio over a date window, `null` for no-due days so
+  rest days read as gaps rather than misses) plus a per-item
+  `itemAdherenceSeries`; both take schedule logic as callbacks so the
+  file stays decoupled from any engine. Refs #420.
+
 - **`reorder_rows` chat tool.** New row-level primitive in
   `chat/tools.js` for reordering an array of rows inside a card's
   data block. Args are tiny (`{id, path, key, order:[<value>, ...]}`),

--- a/public/js/lib/adherence-series.esm.js
+++ b/public/js/lib/adherence-series.esm.js
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// public/js/lib/adherence-series.esm.js
+// Pure adherence-series extractors for schedule sparklines. Schedule logic
+// is injected as callbacks so this file stays decoupled from any engine.
+
+// Enumerate the last `limit` ISO dates (YYYY-MM-DD) ending at and including
+// `endDate`, oldest to newest. UTC-anchored so DST can't shift a day.
+function dateWindow(endDate, limit) {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(endDate);
+  if (!m || !(limit > 0)) return [];
+  const end = Date.UTC(+m[1], +m[2] - 1, +m[3]);
+  const out = [];
+  for (let i = limit - 1; i >= 0; i--) {
+    const d = new Date(end - i * 86_400_000);
+    const y = d.getUTCFullYear();
+    const mo = String(d.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(d.getUTCDate()).padStart(2, '0');
+    out.push(`${y}-${mo}-${day}`);
+  }
+  return out;
+}
+
+// Card-level adherence over a window of days, oldest to newest.
+//
+// For each day D in the window:
+//   - due  = items where isDueOn(item, D)
+//   - if no items are due, push null (a no-due day is a gap, not a miss)
+//   - else push doneCount / due.length, where doneCount counts due items
+//     for which isTakenOn(item, D)
+//
+// Returns (number|null)[] of length `limit` (empty if endDate malformed).
+export function adherenceSeries(items, { endDate, limit = 30, isDueOn, isTakenOn } = {}) {
+  if (!Array.isArray(items)) return [];
+  if (typeof isDueOn !== 'function' || typeof isTakenOn !== 'function') return [];
+  return dateWindow(endDate, limit).map(day => {
+    const due = items.filter(i => isDueOn(i, day));
+    if (due.length === 0) return null;
+    const done = due.reduce((n, i) => n + (isTakenOn(i, day) ? 1 : 0), 0);
+    return done / due.length;
+  });
+}
+
+// Per-item variant: 1 when taken, 0 when scheduled-but-not-taken, null on
+// days the item isn't scheduled (rest/off days are gaps, not misses).
+export function itemAdherenceSeries(item, { endDate, limit = 30, isScheduled, isTaken } = {}) {
+  if (typeof isScheduled !== 'function' || typeof isTaken !== 'function') return [];
+  return dateWindow(endDate, limit).map(day => {
+    if (!isScheduled(item, day)) return null;
+    return isTaken(item, day) ? 1 : 0;
+  });
+}

--- a/public/js/lib/display-template.esm.js
+++ b/public/js/lib/display-template.esm.js
@@ -169,3 +169,20 @@ export function computeTrend(row, key, allRows) {
   else if (delta < 0) dir = 'down';
   return { dir, delta, prev };
 }
+
+// --- Numeric series extractor ---
+// See display-template.js for detailed docs. Same numeric predicate as
+// computeTrend; ascending date order; tail-sliced to `limit`.
+export function numericSeries(rows, field, options) {
+  if (!Array.isArray(rows) || !field) return [];
+  const { endDate = null, limit = 30 } = options || {};
+  return rows
+    .filter(r => r && r.date && (!endDate || r.date <= endDate))
+    .filter(r => {
+      const v = getValue(r, field);
+      return v !== null && v !== undefined && !Number.isNaN(Number(v));
+    })
+    .sort((a, b) => (a.date || '').localeCompare(b.date || ''))
+    .map(r => Number(getValue(r, field)))
+    .slice(-limit);
+}

--- a/public/js/lib/display-template.js
+++ b/public/js/lib/display-template.js
@@ -234,6 +234,34 @@
     return { dir, delta, prev };
   }
 
+  // --- Numeric series extractor ---
+  //
+  // Pulls the numeric values for `field` over the last N dated rows, oldest
+  // to newest, ready to feed a sparkline. A row qualifies only when it has a
+  // truthy `date` and `Number(getValue(row, field))` is not NaN (the same
+  // predicate computeTrend uses, so the two stay consistent).
+  //
+  // Input:
+  //   rows     : the full data array from the manifest
+  //   field    : the field to extract (dotted paths allowed, via getValue)
+  //   endDate  : optional ISO date; rows with date > endDate are excluded
+  //   limit    : keep at most this many of the most recent qualifying rows
+  //
+  // Returns: number[] in ascending date order, or [] if nothing qualifies.
+  function numericSeries(rows, field, options) {
+    if (!Array.isArray(rows) || !field) return [];
+    const { endDate = null, limit = 30 } = options || {};
+    return rows
+      .filter(r => r && r.date && (!endDate || r.date <= endDate))
+      .filter(r => {
+        const v = getValue(r, field);
+        return v !== null && v !== undefined && !Number.isNaN(Number(v));
+      })
+      .sort((a, b) => (a.date || '').localeCompare(b.date || ''))
+      .map(r => Number(getValue(r, field)))
+      .slice(-limit);
+  }
+
   return {
     renderTemplate,
     getValue,
@@ -241,5 +269,6 @@
     applyRound,
     evaluateThresholds,
     computeTrend,
+    numericSeries,
   };
 }));

--- a/tests/series-helpers.test.js
+++ b/tests/series-helpers.test.js
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/series-helpers.test.js
+// Coverage for the pure series extractors that feed sparklines:
+// numericSeries (display-template.js) and adherenceSeries +
+// itemAdherenceSeries (adherence-series.esm.js). The ESM module is pulled
+// in via dynamic import so the CJS test runner can exercise it directly.
+
+const { test, describe, before } = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+const { pathToFileURL } = require('url');
+const { numericSeries } = require('../public/js/lib/display-template.js');
+
+let adherenceSeries;
+let itemAdherenceSeries;
+
+before(async () => {
+  const p = path.join(__dirname, '..', 'public', 'js', 'lib', 'adherence-series.esm.js');
+  const mod = await import(pathToFileURL(p).href);
+  adherenceSeries = mod.adherenceSeries;
+  itemAdherenceSeries = mod.itemAdherenceSeries;
+});
+
+describe('numericSeries', () => {
+  test('returns values in ascending date order regardless of input order', () => {
+    const rows = [
+      { date: '2026-01-03', kg: 82 },
+      { date: '2026-01-01', kg: 80 },
+      { date: '2026-01-02', kg: 81 },
+    ];
+    assert.deepStrictEqual(numericSeries(rows, 'kg'), [80, 81, 82]);
+  });
+
+  test('clips rows after endDate (inclusive of endDate itself)', () => {
+    const rows = [
+      { date: '2026-01-01', kg: 80 },
+      { date: '2026-01-02', kg: 81 },
+      { date: '2026-01-03', kg: 82 },
+    ];
+    assert.deepStrictEqual(numericSeries(rows, 'kg', { endDate: '2026-01-02' }), [80, 81]);
+  });
+
+  test('keeps only the most recent `limit` values (tail slice)', () => {
+    const rows = [
+      { date: '2026-01-01', kg: 1 },
+      { date: '2026-01-02', kg: 2 },
+      { date: '2026-01-03', kg: 3 },
+      { date: '2026-01-04', kg: 4 },
+    ];
+    assert.deepStrictEqual(numericSeries(rows, 'kg', { limit: 2 }), [3, 4]);
+  });
+
+  test('drops rows missing a date', () => {
+    const rows = [
+      { date: '2026-01-01', kg: 80 },
+      { kg: 99 },
+      { date: '2026-01-02', kg: 81 },
+    ];
+    assert.deepStrictEqual(numericSeries(rows, 'kg'), [80, 81]);
+  });
+
+  test('drops rows whose value is not Number-able', () => {
+    const rows = [
+      { date: '2026-01-01', kg: 80 },
+      { date: '2026-01-02', kg: 'heavy' },
+      { date: '2026-01-03', kg: null },
+      { date: '2026-01-04', kg: 82 },
+    ];
+    assert.deepStrictEqual(numericSeries(rows, 'kg'), [80, 82]);
+  });
+
+  test('resolves dotted-path fields via getValue', () => {
+    const rows = [
+      { date: '2026-01-01', bp: { systolic: 120 } },
+      { date: '2026-01-02', bp: { systolic: 118 } },
+    ];
+    assert.deepStrictEqual(numericSeries(rows, 'bp.systolic'), [120, 118]);
+  });
+
+  test('returns [] when no rows qualify', () => {
+    assert.deepStrictEqual(numericSeries([{ kg: 80 }], 'kg'), []);
+    assert.deepStrictEqual(numericSeries([], 'kg'), []);
+    assert.deepStrictEqual(numericSeries(null, 'kg'), []);
+  });
+
+  test('numeric strings count and coerce to numbers', () => {
+    const rows = [
+      { date: '2026-01-01', kg: '80' },
+      { date: '2026-01-02', kg: '81.5' },
+    ];
+    assert.deepStrictEqual(numericSeries(rows, 'kg'), [80, 81.5]);
+  });
+});
+
+describe('adherenceSeries', () => {
+  // Items carry a set of due dates and a set of taken dates for the test
+  // callbacks to read; the helper itself stays schedule-agnostic.
+  const isDueOn = (item, day) => item.due.includes(day);
+  const isTakenOn = (item, day) => item.taken.includes(day);
+
+  test('emits the per-day done/due ratio, oldest to newest', () => {
+    const items = [
+      { due: ['2026-01-01', '2026-01-02', '2026-01-03'], taken: ['2026-01-01', '2026-01-03'] },
+      { due: ['2026-01-01', '2026-01-02', '2026-01-03'], taken: ['2026-01-02', '2026-01-03'] },
+    ];
+    const series = adherenceSeries(items, {
+      endDate: '2026-01-03', limit: 3, isDueOn, isTakenOn,
+    });
+    // 01: item-a taken only -> 1/2; 02: item-b taken only -> 1/2; 03: both -> 2/2
+    assert.deepStrictEqual(series, [0.5, 0.5, 1]);
+  });
+
+  test('pushes null for a day with no due items (gap, not a miss)', () => {
+    const items = [
+      { due: ['2026-01-01', '2026-01-03'], taken: ['2026-01-01'] },
+    ];
+    const series = adherenceSeries(items, {
+      endDate: '2026-01-03', limit: 3, isDueOn, isTakenOn,
+    });
+    // 01 due+taken -> 1; 02 not due -> null; 03 due+not-taken -> 0
+    assert.deepStrictEqual(series, [1, null, 0]);
+  });
+
+  test('a rest/off day is null, never counted as a zero miss', () => {
+    const items = [{ due: ['2026-01-02'], taken: [] }];
+    const series = adherenceSeries(items, {
+      endDate: '2026-01-02', limit: 2, isDueOn, isTakenOn,
+    });
+    // 01 nothing due -> null; 02 due but not taken -> 0
+    assert.deepStrictEqual(series, [null, 0]);
+  });
+
+  test('window length matches limit and ends at endDate', () => {
+    const items = [{ due: ['2026-03-10'], taken: ['2026-03-10'] }];
+    const series = adherenceSeries(items, {
+      endDate: '2026-03-10', limit: 5, isDueOn, isTakenOn,
+    });
+    assert.strictEqual(series.length, 5);
+    assert.deepStrictEqual(series, [null, null, null, null, 1]);
+  });
+
+  test('window is UTC-safe across a month boundary', () => {
+    const items = [
+      { due: ['2026-01-31', '2026-02-01'], taken: ['2026-02-01'] },
+    ];
+    const series = adherenceSeries(items, {
+      endDate: '2026-02-01', limit: 2, isDueOn, isTakenOn,
+    });
+    assert.deepStrictEqual(series, [0, 1]);
+  });
+
+  test('returns [] when callbacks or items are invalid', () => {
+    assert.deepStrictEqual(adherenceSeries(null, { endDate: '2026-01-01', isDueOn, isTakenOn }), []);
+    assert.deepStrictEqual(adherenceSeries([], { endDate: '2026-01-01' }), []);
+    assert.deepStrictEqual(adherenceSeries([], { endDate: 'not-a-date', limit: 3, isDueOn, isTakenOn }), []);
+  });
+});
+
+describe('itemAdherenceSeries', () => {
+  const isScheduled = (item, day) => item.due.includes(day);
+  const isTaken = (item, day) => item.taken.includes(day);
+
+  test('emits 1 taken / 0 missed over scheduled days, null otherwise', () => {
+    const item = { due: ['2026-01-01', '2026-01-03'], taken: ['2026-01-01'] };
+    const series = itemAdherenceSeries(item, {
+      endDate: '2026-01-03', limit: 3, isScheduled, isTaken,
+    });
+    assert.deepStrictEqual(series, [1, null, 0]);
+  });
+
+  test('returns [] when callbacks are missing', () => {
+    assert.deepStrictEqual(itemAdherenceSeries({}, { endDate: '2026-01-01' }), []);
+  });
+});


### PR DESCRIPTION
# What changed
Two pure series-extractor helpers feeding the upcoming sparkline work: `numericSeries(rows, field, {endDate, limit})` in `display-template.js` (+ its `.esm.js` twin), and `adherenceSeries(items, {endDate, limit, isDueOn, isTakenOn})` in a new `adherence-series.esm.js`.

# Why
Sparklines (and other trend surfaces) need a numeric series over the last N dated rows, and an adherence (done/not-done) series for checklist/schedule cards. Pulled out as pure functions so they are unit-testable and shared.

# How
`numericSeries` reuses `getValue` and the exact numeric predicate `computeTrend` already uses (so the two stay consistent). `adherenceSeries` takes the due/taken predicates as callbacks so it stays decoupled from card internals; a no-due day is `null` (a gap), not a zero miss.

# Testing
- [x] `npm test` passes (grew by 16, no regressions).
- [x] New unit tests at `tests/series-helpers.test.js`; the ESM adherence helper is exercised via dynamic import in a `before()` hook.

# Checklist
- [x] CHANGELOG updated under Unreleased
- [x] No personal identifiers/secrets

Refs #420