### PR TITLE
feat(renderers): add standalone eh-sparkline inline-SVG component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **`<eh-sparkline>` trend-glyph component.** A standalone, dependency-free
+  Lit element (`public/js/components/eh-sparkline.js`) that maps a
+  `number[]` to an inline `<svg>` polyline. It is deliberately not an
+  `EhChartBase`/`EhBaseCard` subclass and never imports ECharts: a
+  64x22 glyph cannot justify a ~1MB chart library built for one ~240px
+  chart per card. Props: `values`, `mode` (`line`/`bar`/`adherence`),
+  `width`, `height`, `baseline`, `threshold`, `colour`. Renders nothing
+  below two non-null points (a single point is not a trend), guards the
+  flat-series divide-by-zero, and inverts SVG y so higher values sit
+  higher. Colours come from inherited CSS custom properties
+  (`--accent`, `--chart-grid`) so it tracks dark/light with no JS theme
+  code; the inner `<svg>` is `aria-hidden` while the host carries a
+  summarising `aria-label` (direction + latest value). The pure scaling
+  and path maths live in `public/js/lib/sparkline.js` (UMD) and its
+  `sparkline.esm.js` mirror so they are unit-testable under Node without
+  a DOM. Refs #421.
+
 - **`reorder_rows` chat tool.** New row-level primitive in
   `chat/tools.js` for reordering an array of rows inside a card's
   data block. Args are tiny (`{id, path, key, order:[<value>, ...]}`),

--- a/public/js/components/eh-sparkline.js
+++ b/public/js/components/eh-sparkline.js
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// public/js/components/eh-sparkline.js
+// Standalone trend-glyph: maps a number[] to an inline SVG polyline.
+//
+// Deliberately NOT an EhChartBase/EhBaseCard subclass and it never
+// imports ECharts: that library is ~1MB and assumes one ~240px chart
+// per card. A 64x22 inline sparkline cannot justify that weight, so
+// this is a dumb, dependency-free Lit element doing only the maths in
+// sparkline.esm.js. Colours come from inherited CSS custom properties
+// (--accent, --chart-grid, --warning/--danger/--success) so the glyph
+// tracks dark/light with no JS theme code and no getComputedStyle.
+
+import { LitElement, html, svg, css } from 'https://esm.sh/lit@3';
+import { buildSparklinePath, referenceY, summarise, MIN_POINTS }
+  from '../lib/sparkline.esm.js';
+
+export class EhSparkline extends LitElement {
+  static properties = {
+    values: { type: Array },
+    mode: { type: String },
+    width: { type: Number },
+    height: { type: Number },
+    baseline: { type: Number },
+    threshold: { type: Number },
+    colour: { type: String },
+  };
+
+  constructor() {
+    super();
+    this.values = [];
+    this.mode = 'line';
+    this.width = 64;
+    this.height = 22;
+    this.baseline = null;
+    this.threshold = null;
+    this.colour = null;
+  }
+
+  static styles = css`
+    :host {
+      display: inline-block;
+      line-height: 0;
+      color: var(--accent);
+    }
+    svg { display: block; overflow: visible; }
+    .line {
+      fill: none;
+      stroke: var(--spark-colour, var(--accent));
+      stroke-width: 1.5;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+    .dot { fill: var(--spark-colour, var(--accent)); }
+    .bar {
+      fill: var(--spark-colour, var(--accent));
+      stroke: none;
+    }
+    .gap { fill: var(--chart-grid, currentColor); opacity: 0.35; }
+    .ref {
+      stroke: var(--chart-grid, currentColor);
+      stroke-dasharray: 2 3;
+      opacity: 0.6;
+    }
+  `;
+
+  render() {
+    const W = this.width;
+    const H = this.height;
+    const pad = 2;
+    const opts = { width: W, height: H, pad };
+
+    if (this.mode === 'adherence') return this._renderAdherence(W, H, pad);
+
+    const built = buildSparklinePath(this.values, opts);
+    if (built.count < MIN_POINTS) { this._applyHostA11y(null); return html``; }
+
+    const sum = summarise(this.values);
+    const baselineY = referenceY(this.values, this.baseline, opts);
+    const thresholdY = referenceY(this.values, this.threshold, opts);
+    const style = this.colour ? `--spark-colour:${this.colour}` : '';
+    this._applyHostA11y(sum.label);
+
+    return html`
+      <svg
+        viewBox="0 0 ${W} ${H}"
+        width="${W}"
+        height="${H}"
+        preserveAspectRatio="none"
+        aria-hidden="true"
+        style="${style}"
+      >
+        ${baselineY == null ? '' : svg`<line class="ref" x1="0" y1="${baselineY}" x2="${W}" y2="${baselineY}"></line>`}
+        ${thresholdY == null ? '' : svg`<line class="ref" x1="0" y1="${thresholdY}" x2="${W}" y2="${thresholdY}"></line>`}
+        ${this.mode === 'bar'
+          ? this._bars(built, W, H, pad)
+          : svg`<polyline class="line" points="${built.points}"></polyline>`}
+        ${built.lastPoint
+          ? svg`<circle class="dot" cx="${built.lastPoint.x}" cy="${built.lastPoint.y}" r="1.6"></circle>`
+          : ''}
+      </svg>
+    `;
+  }
+
+  _bars(built, W, H, pad) {
+    const pts = built.points.split(' ').map(p => {
+      const [x, y] = p.split(',').map(Number);
+      return { x, y };
+    });
+    const bw = Math.max(1, ((W - 2 * pad) / pts.length) * 0.6);
+    return pts.map(p => svg`<rect class="bar" x="${p.x - bw / 2}" y="${p.y}"
+      width="${bw}" height="${Math.max(0.5, H - pad - p.y)}"></rect>`);
+  }
+
+  // Adherence: render the window as small bars/dots, one per slot, with
+  // nulls as faint gap ticks so a missed day reads as a gap not a zero.
+  // Values are treated as a 0..1 ratio (1 = taken, 0 = missed).
+  _renderAdherence(W, H, pad) {
+    const slots = Array.isArray(this.values) ? this.values : [];
+    if (slots.length < MIN_POINTS) { this._applyHostA11y(null); return html``; }
+
+    const sum = summarise(this.values);
+    const style = this.colour ? `--spark-colour:${this.colour}` : '';
+    this._applyHostA11y(`adherence, ${sum.label}`);
+    const n = slots.length;
+    const gap = 1;
+    const bw = Math.max(1, (W - 2 * pad - gap * (n - 1)) / n);
+    const top = pad;
+    const full = H - 2 * pad;
+
+    const bars = slots.map((v, i) => {
+      const x = pad + i * (bw + gap);
+      if (v === null || v === undefined || v === '' || !Number.isFinite(Number(v))) {
+        return svg`<rect class="gap" x="${x}" y="${H / 2 - 0.5}" width="${bw}" height="1"></rect>`;
+      }
+      const ratio = Math.max(0, Math.min(1, Number(v)));
+      const h = Math.max(0.5, full * ratio);
+      return svg`<rect class="bar" x="${x}" y="${top + (full - h)}" width="${bw}" height="${h}"></rect>`;
+    });
+
+    return html`
+      <svg
+        viewBox="0 0 ${W} ${H}"
+        width="${W}"
+        height="${H}"
+        preserveAspectRatio="none"
+        aria-hidden="true"
+        style="${style}"
+      >${bars}</svg>
+    `;
+  }
+
+  // The inner <svg> is decorative (aria-hidden); the host carries the
+  // summary so assistive tech announces direction + latest once. Clear
+  // both when there is nothing to render so no stale glyph is read out.
+  _applyHostA11y(label) {
+    if (label) {
+      this.setAttribute('role', 'img');
+      this.setAttribute('aria-label', label);
+    } else {
+      this.removeAttribute('role');
+      this.removeAttribute('aria-label');
+    }
+  }
+}
+
+customElements.define('eh-sparkline', EhSparkline);

--- a/public/js/lib/sparkline.esm.js
+++ b/public/js/lib/sparkline.esm.js
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// public/js/lib/sparkline.esm.js
+// ES-module mirror of the sparkline scaling + path maths. Keep in sync
+// with sparkline.js (UMD): Node tests use the UMD version, the
+// eh-sparkline component imports this one.
+
+// A single point is not a trend; below this we render nothing.
+export const MIN_POINTS = 2;
+
+function toNumbers(values) {
+  return (Array.isArray(values) ? values : [])
+    .map(v => (v === null || v === undefined || v === '' ? null : Number(v)));
+}
+
+export function buildSparklinePath(values, opts = {}) {
+  const width = Number(opts.width) || 64;
+  const height = Number(opts.height) || 22;
+  const pad = opts.pad == null ? 2 : Number(opts.pad);
+
+  const nums = toNumbers(values);
+  const finite = nums.filter(v => v !== null && Number.isFinite(v));
+  const empty = { points: '', count: 0, lastPoint: null, min: 0, max: 0 };
+  if (finite.length < MIN_POINTS) return empty;
+
+  const min = Math.min(...finite);
+  const max = Math.max(...finite);
+  const range = (max - min) || 1;
+  const innerH = height - 2 * pad;
+  const stepX = nums.length > 1 ? (width - 2 * pad) / (nums.length - 1) : 0;
+
+  const scaleY = (v) => height - pad - ((v - min) / range) * innerH;
+  const scaleX = (i) => pad + i * stepX;
+
+  const coords = [];
+  nums.forEach((v, i) => {
+    if (v === null || !Number.isFinite(v)) return;
+    coords.push({ x: round(scaleX(i)), y: round(scaleY(v)) });
+  });
+
+  const points = coords.map(c => `${c.x},${c.y}`).join(' ');
+  const lastPoint = coords.length ? coords[coords.length - 1] : null;
+  return { points, count: coords.length, lastPoint, min, max };
+}
+
+export function referenceY(values, value, opts = {}) {
+  if (value == null || !Number.isFinite(Number(value))) return null;
+  const height = Number(opts.height) || 22;
+  const pad = opts.pad == null ? 2 : Number(opts.pad);
+
+  const finite = toNumbers(values).filter(v => v !== null && Number.isFinite(v));
+  if (finite.length < MIN_POINTS) return null;
+
+  const min = Math.min(...finite);
+  const max = Math.max(...finite);
+  const range = (max - min) || 1;
+  const innerH = height - 2 * pad;
+  return round(height - pad - ((Number(value) - min) / range) * innerH);
+}
+
+export function summarise(values) {
+  const finite = toNumbers(values).filter(v => v !== null && Number.isFinite(v));
+  if (finite.length === 0) return { direction: 'flat', latest: null, label: 'no data' };
+
+  const latest = finite[finite.length - 1];
+  let direction = 'flat';
+  if (finite.length >= MIN_POINTS) {
+    const prev = finite[finite.length - 2];
+    if (latest > prev) direction = 'up';
+    else if (latest < prev) direction = 'down';
+  }
+  return { direction, latest, label: `trend ${direction}, latest ${trim(latest)}` };
+}
+
+function round(n) {
+  return Math.round(n * 100) / 100;
+}
+
+function trim(n) {
+  return Number.isInteger(n) ? String(n) : String(round(n));
+}

--- a/public/js/lib/sparkline.js
+++ b/public/js/lib/sparkline.js
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// public/js/lib/sparkline.js
+// Pure scaling + path maths for the eh-sparkline glyph. Dual-runtime:
+// browser (ESM mirror) + Node (CommonJS) via UMD. Keep in sync with
+// sparkline.esm.js. No DOM, no Lit, so the maths stays unit-testable.
+
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.ehSparkline = factory();
+  }
+}(typeof self !== 'undefined' ? self : this, function () {
+
+  // A single point is not a trend; below this we render nothing.
+  const MIN_POINTS = 2;
+
+  function toNumbers(values) {
+    return (Array.isArray(values) ? values : [])
+      .map(v => (v === null || v === undefined || v === '' ? null : Number(v)));
+  }
+
+  // Map a value array to evenly-spaced SVG coordinates. Non-null points
+  // are spaced across the full width by their index in the original
+  // array so gaps stay positioned; nulls are skipped (returned as gaps).
+  // SVG y is inverted: larger values sit higher. Flat series guard the
+  // divide-by-zero with range || 1.
+  function buildSparklinePath(values, opts = {}) {
+    const width = Number(opts.width) || 64;
+    const height = Number(opts.height) || 22;
+    const pad = opts.pad == null ? 2 : Number(opts.pad);
+
+    const nums = toNumbers(values);
+    const finite = nums.filter(v => v !== null && Number.isFinite(v));
+    const empty = { points: '', count: 0, lastPoint: null, min: 0, max: 0 };
+    if (finite.length < MIN_POINTS) return empty;
+
+    const min = Math.min(...finite);
+    const max = Math.max(...finite);
+    const range = (max - min) || 1;
+    const innerH = height - 2 * pad;
+    const stepX = nums.length > 1 ? (width - 2 * pad) / (nums.length - 1) : 0;
+
+    const scaleY = (v) => height - pad - ((v - min) / range) * innerH;
+    const scaleX = (i) => pad + i * stepX;
+
+    const coords = [];
+    nums.forEach((v, i) => {
+      if (v === null || !Number.isFinite(v)) return;
+      coords.push({ x: round(scaleX(i)), y: round(scaleY(v)) });
+    });
+
+    const points = coords.map(c => `${c.x},${c.y}`).join(' ');
+    const lastPoint = coords.length ? coords[coords.length - 1] : null;
+    return { points, count: coords.length, lastPoint, min, max };
+  }
+
+  // y for a horizontal reference line (baseline / threshold) scaled into
+  // the same min/max viewBox as the data. Returns null when there is no
+  // trend to scale against, or the value clamps outside the data range.
+  function referenceY(values, value, opts = {}) {
+    if (value == null || !Number.isFinite(Number(value))) return null;
+    const height = Number(opts.height) || 22;
+    const pad = opts.pad == null ? 2 : Number(opts.pad);
+
+    const finite = toNumbers(values).filter(v => v !== null && Number.isFinite(v));
+    if (finite.length < MIN_POINTS) return null;
+
+    const min = Math.min(...finite);
+    const max = Math.max(...finite);
+    const range = (max - min) || 1;
+    const innerH = height - 2 * pad;
+    return round(height - pad - ((Number(value) - min) / range) * innerH);
+  }
+
+  // Compact direction + latest-value summary for the aria-label.
+  // direction compares the last two finite points: 'up' | 'down' | 'flat'.
+  function summarise(values) {
+    const finite = toNumbers(values).filter(v => v !== null && Number.isFinite(v));
+    if (finite.length === 0) return { direction: 'flat', latest: null, label: 'no data' };
+
+    const latest = finite[finite.length - 1];
+    let direction = 'flat';
+    if (finite.length >= MIN_POINTS) {
+      const prev = finite[finite.length - 2];
+      if (latest > prev) direction = 'up';
+      else if (latest < prev) direction = 'down';
+    }
+    return { direction, latest, label: `trend ${direction}, latest ${trim(latest)}` };
+  }
+
+  function round(n) {
+    return Math.round(n * 100) / 100;
+  }
+
+  // Drop trailing zeros from the aria latest value without locale noise.
+  function trim(n) {
+    return Number.isInteger(n) ? String(n) : String(round(n));
+  }
+
+  return { MIN_POINTS, buildSparklinePath, referenceY, summarise };
+}));

--- a/tests/sparkline.test.js
+++ b/tests/sparkline.test.js
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/sparkline.test.js
+// Unit tests for the pure sparkline maths. The eh-sparkline component
+// itself imports Lit from a CDN and needs a DOM, so it is not loadable
+// under Node; these cover the scaling/path/summary logic it delegates.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { MIN_POINTS, buildSparklinePath, referenceY, summarise } =
+  require('../public/js/lib/sparkline.js');
+
+const opts = { width: 64, height: 22, pad: 2 };
+
+function pairs(points) {
+  return points === '' ? [] : points.trim().split(/\s+/);
+}
+
+describe('buildSparklinePath', () => {
+  test('N >= 2 values produce a points string with N coordinate pairs', () => {
+    const built = buildSparklinePath([1, 2, 3, 4], opts);
+    assert.equal(built.count, 4);
+    const p = pairs(built.points);
+    assert.equal(p.length, 4);
+    for (const pair of p) {
+      const [x, y] = pair.split(',').map(Number);
+      assert.ok(Number.isFinite(x) && Number.isFinite(y));
+    }
+  });
+
+  test('fewer than two finite points renders nothing', () => {
+    assert.equal(buildSparklinePath([5], opts).points, '');
+    assert.equal(buildSparklinePath([], opts).points, '');
+    assert.equal(buildSparklinePath([null, 5, null], opts).points, '');
+    assert.equal(buildSparklinePath(undefined, opts).count, 0);
+  });
+
+  test('MIN_POINTS is 2', () => {
+    assert.equal(MIN_POINTS, 2);
+  });
+
+  test('flat series does not divide-by-zero', () => {
+    const built = buildSparklinePath([7, 7, 7], opts);
+    assert.equal(built.count, 3);
+    for (const pair of pairs(built.points)) {
+      const [x, y] = pair.split(',').map(Number);
+      assert.ok(Number.isFinite(x) && Number.isFinite(y));
+      assert.ok(!Number.isNaN(y));
+    }
+  });
+
+  test('nulls are skipped but later points stay positioned', () => {
+    const built = buildSparklinePath([1, null, 3, 4], opts);
+    assert.equal(built.count, 3);
+    const xs = pairs(built.points).map(p => Number(p.split(',')[0]));
+    // First point pinned left, last point pinned right; the gap leaves
+    // a wider x-step where the null was dropped.
+    assert.equal(xs[0], 2);
+    assert.equal(xs[xs.length - 1], 62);
+    assert.ok(xs[1] > xs[0] + (xs[xs.length - 1] - xs[0]) / 3);
+  });
+
+  test('y is inverted: larger values sit higher (smaller y)', () => {
+    const built = buildSparklinePath([0, 10], opts);
+    const [, y0] = pairs(built.points)[0].split(',').map(Number);
+    const [, y1] = pairs(built.points)[1].split(',').map(Number);
+    assert.ok(y1 < y0, 'the higher value should have the smaller y');
+  });
+
+  test('lastPoint is the final coordinate', () => {
+    const built = buildSparklinePath([1, 2, 3], opts);
+    const last = pairs(built.points).at(-1).split(',').map(Number);
+    assert.equal(built.lastPoint.x, last[0]);
+    assert.equal(built.lastPoint.y, last[1]);
+  });
+});
+
+describe('referenceY', () => {
+  test('null/unset reference returns null', () => {
+    assert.equal(referenceY([1, 2, 3], null, opts), null);
+    assert.equal(referenceY([1, 2, 3], undefined, opts), null);
+  });
+
+  test('a set baseline scales into the same viewBox', () => {
+    const y = referenceY([0, 10], 5, opts);
+    assert.ok(Number.isFinite(y));
+    assert.ok(y > 2 && y < 20);
+  });
+
+  test('no trend (fewer than two points) has no reference', () => {
+    assert.equal(referenceY([5], 5, opts), null);
+  });
+});
+
+describe('summarise', () => {
+  test('reports downward direction and the latest value', () => {
+    const s = summarise([90, 85, 81.2]);
+    assert.equal(s.direction, 'down');
+    assert.equal(s.latest, 81.2);
+    assert.equal(s.label, 'trend down, latest 81.2');
+  });
+
+  test('reports upward direction', () => {
+    assert.equal(summarise([1, 2, 3]).direction, 'up');
+  });
+
+  test('equal last two points read as flat', () => {
+    assert.equal(summarise([3, 5, 5]).direction, 'flat');
+  });
+
+  test('nulls are skipped when finding the latest value', () => {
+    const s = summarise([1, 2, null]);
+    assert.equal(s.latest, 2);
+    assert.equal(s.direction, 'up');
+  });
+
+  test('empty input is safe', () => {
+    const s = summarise([]);
+    assert.equal(s.latest, null);
+    assert.equal(s.label, 'no data');
+  });
+});


### PR DESCRIPTION
# What changed
A new `<eh-sparkline>` Lit component that maps a `number[]` to an inline-SVG polyline, plus its pure path-building maths in `public/js/lib/sparkline.js` (+ `.esm.js` twin).

# Why
Cards need a word-sized trend glyph. The existing ECharts layer (~1MB, one 240px chart per card) is far too heavy for a corner sparkline, so this is deliberately dependency-free inline SVG.

# How
Plain `LitElement` (NOT EhChartBase/EhBaseCard), no fetch/observer/CDN beyond Lit itself. Colours come from inherited CSS custom properties (`--accent`, `--chart-grid`) so it tracks dark/light with no JS theme code. The `<svg>` is decorative (`aria-hidden`) with a summarising `aria-label` on the host (`role=img`); no animation, so `prefers-reduced-motion` needs no gating. All arithmetic lives in the testable lib helpers.

# Testing
- [x] `npm test` passes (grew by 15, no regressions).
- [x] Unit tests at `tests/sparkline.test.js` cover path building, the <2-point empty case, flat-series divide-by-zero, null skipping, and the aria summary.

# Checklist
- [x] CHANGELOG updated under Unreleased
- [x] No personal identifiers/secrets

Refs #421