### PR TITLE
feat(renderers): add hero/pinned tier to Today via priority sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Hero / pinned tier on the Today view.** A card can declare
+  `meta.view.priority` (a number; lower = higher up). Any card with a
+  numeric priority is "pinned": it lifts into a full-width band at the
+  top of the Today view, above the normal `order`-sorted masonry, so
+  the 2-4 cards that matter most read as a distinct hero band under the
+  greeting banner. Pure presentation: the partition is a stable sort in
+  `public/js/lib/hero-tier.js` and a `.card-wrap.pinned` CSS class in
+  the view renderer; no server or data-shape change. Gated to the live
+  Today view only (`view` + `dateMode: "today"`, and never in reorder
+  mode), so Trends/Calendar/Reports and past-day views are untouched.
+  Manifests with no priority render in exactly their existing order.
+  Refs #422.
+
 - **`reorder_rows` chat tool.** New row-level primitive in
   `chat/tools.js` for reordering an array of rows inside a card's
   data block. Args are tiny (`{id, path, key, order:[<value>, ...]}`),

--- a/MANIFEST-SCHEMA.md
+++ b/MANIFEST-SCHEMA.md
@@ -348,6 +348,13 @@ All view configs share the same shape:
   "enabled":          true,           // required — opts card into this view
   "component":        "generic-card", // required — renderer name
   "order":            5,              // view-specific sort override
+  "priority":         1,              // Today view only; lower = higher up.
+                                      //   Any card with a numeric priority is
+                                      //   "pinned": it lifts into a full-width
+                                      //   hero band at the top of Today, above
+                                      //   the normal order-sorted cards. Keep
+                                      //   it to 2-4 cards. Ignored on every
+                                      //   other view. See #422.
   "slot":             "top",          // "top" spans the full row
   "fallbackToLatest": false,          // generic-card only; default false.
                                       //   true → on Today with no row for

--- a/public/js/components/eh-view-renderer.js
+++ b/public/js/components/eh-view-renderer.js
@@ -7,6 +7,7 @@
 import { LitElement, html, css } from 'https://esm.sh/lit@3';
 import Sortable from 'https://esm.sh/sortablejs@1.15.2';
 import { resolveRenderer } from '../renderer-registry.js';
+import { orderCardsForView } from '../lib/hero-tier.js';
 
 // Ensure all core renderers are loaded
 import './eh-unknown-card.js';
@@ -121,6 +122,14 @@ export class EhViewRenderer extends LitElement {
       display: block;
     }
     .masonry > .slot-top {
+      column-span: all;
+    }
+    /* Hero / pinned tier: cards with meta.view.priority surface as a
+       full-width band at the top of the Today view (gated in render()).
+       column-span:all lifts them out of the column flow so they read as a
+       distinct band under the greeting banner rather than packing into the
+       masonry. */
+    .masonry > .card-wrap.pinned {
       column-span: all;
     }
     @media (min-width: 768px) {
@@ -333,7 +342,7 @@ export class EhViewRenderer extends LitElement {
     if (pending) this._enterReorderMode();
   }
 
-  _renderCard(card) {
+  _renderCard(card, pinned = false) {
     const tag = resolveRenderer(card.viewConfig?.component);
     const isTopSlot = card.viewConfig?.slot === 'top';
     const inner = document.createElement(tag);
@@ -344,7 +353,9 @@ export class EhViewRenderer extends LitElement {
     // Always wrap in a container so Sortable has a stable handle. The
     // wrapper carries the data-card-id attribute the reorder logic reads.
     const wrap = document.createElement('div');
-    wrap.className = 'card-wrap' + (isTopSlot ? ' slot-top' : '');
+    wrap.className = 'card-wrap'
+      + (isTopSlot ? ' slot-top' : '')
+      + (pinned ? ' pinned' : '');
     wrap.dataset.cardId = card.id;
     if (this._reorderMode) {
       const handle = document.createElement('button');
@@ -557,13 +568,20 @@ export class EhViewRenderer extends LitElement {
         </div>
       `;
     }
-    // Normal render
+    // Normal render. The hero/pinned tier is a presentation concern of the
+    // live Today view only; in reorder mode (or on a past-day view) we render
+    // the raw card order so the DOM child order Sortable reads back matches
+    // this.cards exactly and a past day isn't re-banded.
+    const heroEligible = !this._reorderMode && this.dateMode === 'today';
+    const ordered = heroEligible
+      ? orderCardsForView(this.cards, this.view)
+      : this.cards.map(card => ({ card, pinned: false }));
     return html`
       <div class="sr-live" aria-live="polite" aria-atomic="true">${this._ariaAnnouncement}</div>
       ${this._renderReorderBar()}
       ${this._renderErrorPill()}
       <div class=${this._reorderMode ? 'grid' : 'masonry'}>
-        ${this.cards.map(c => this._renderCard(c))}
+        ${ordered.map(({ card, pinned }) => this._renderCard(card, pinned))}
       </div>
     `;
   }

--- a/public/js/lib/hero-tier.js
+++ b/public/js/lib/hero-tier.js
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// public/js/lib/hero-tier.js
+// Partition the Today view's cards into a pinned hero band plus the rest.
+//
+// A card opts into the hero tier by setting a numeric meta.view.priority
+// (lower = higher up). Presence of priority means pinned. The band only
+// applies to the default Today view ('view'); every other view (trends,
+// calendar, reports, dayDetail) is returned untouched with pinned:false so
+// there is no behavioural change away from Today.
+//
+// Input cards are assumed already sorted by the server's order convention
+// (viewConfig.order ?? meta.order). Both the partition (within pinned) and
+// the rest preserve that incoming order for ties, so absent any priority
+// the output order is identical to the input.
+
+const HERO_VIEW = 'view';
+
+function priorityOf(card) {
+  const p = card?.meta?.view?.priority;
+  return typeof p === 'number' && Number.isFinite(p) ? p : null;
+}
+
+// Returns a new array of { card, pinned } in render order. Stable: equal
+// priorities keep their incoming relative order.
+export function orderCardsForView(cards, view) {
+  const list = Array.isArray(cards) ? cards : [];
+  if (view !== HERO_VIEW) {
+    return list.map(card => ({ card, pinned: false }));
+  }
+  const pinned = [];
+  const rest = [];
+  list.forEach((card, i) => {
+    const p = priorityOf(card);
+    if (p !== null) pinned.push({ card, priority: p, i });
+    else rest.push({ card });
+  });
+  pinned.sort((a, b) => (a.priority - b.priority) || (a.i - b.i));
+  return [
+    ...pinned.map(({ card }) => ({ card, pinned: true })),
+    ...rest.map(({ card }) => ({ card, pinned: false })),
+  ];
+}

--- a/tests/hero-tier.test.js
+++ b/tests/hero-tier.test.js
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/hero-tier.test.js
+// Unit tests for public/js/lib/hero-tier.js: the pinned/hero tier sort
+// that lifts meta.view.priority cards to the top of the Today view.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { orderCardsForView } from '../public/js/lib/hero-tier.js';
+
+// Cards arrive already sorted by the server's order convention, so these
+// fixtures are written in that incoming order.
+function card(id, { priority, order } = {}) {
+  const view = { enabled: true, component: 'generic-card' };
+  if (priority !== undefined) view.priority = priority;
+  return { id, meta: { id, label: id, order, view }, viewConfig: view };
+}
+
+const ids = (rows) => rows.map(r => r.card.id);
+
+describe('orderCardsForView', () => {
+  test('lower priority sorts ahead among pinned cards', () => {
+    const cards = [card('a', { priority: 30 }), card('b', { priority: 10 }), card('c', { priority: 20 })];
+    const out = orderCardsForView(cards, 'view');
+    assert.deepEqual(ids(out), ['b', 'c', 'a']);
+    assert.ok(out.every(r => r.pinned === true));
+  });
+
+  test('pinned cards precede unpinned cards', () => {
+    const cards = [
+      card('plain1'),
+      card('pinned', { priority: 5 }),
+      card('plain2'),
+    ];
+    const out = orderCardsForView(cards, 'view');
+    assert.deepEqual(ids(out), ['pinned', 'plain1', 'plain2']);
+    assert.deepEqual(out.map(r => r.pinned), [true, false, false]);
+  });
+
+  test('among unpinned cards the incoming order is preserved', () => {
+    // Incoming is already order-sorted; ties must stay stable.
+    const cards = [card('first'), card('second'), card('third')];
+    const out = orderCardsForView(cards, 'view');
+    assert.deepEqual(ids(out), ['first', 'second', 'third']);
+  });
+
+  test('no priority anywhere yields the same order as input', () => {
+    const cards = [card('a'), card('b'), card('c'), card('d')];
+    const out = orderCardsForView(cards, 'view');
+    assert.deepEqual(ids(out), ['a', 'b', 'c', 'd']);
+    assert.ok(out.every(r => r.pinned === false));
+  });
+
+  test('equal priorities keep their incoming relative order (stable)', () => {
+    const cards = [
+      card('p1', { priority: 10 }),
+      card('p2', { priority: 10 }),
+      card('p3', { priority: 5 }),
+    ];
+    const out = orderCardsForView(cards, 'view');
+    assert.deepEqual(ids(out), ['p3', 'p1', 'p2']);
+  });
+
+  test('hero treatment applies only to the today/default view', () => {
+    const cards = [card('plain'), card('pinned', { priority: 1 })];
+    for (const view of ['trends', 'calendar', 'reports', 'dayDetail']) {
+      const out = orderCardsForView(cards, view);
+      assert.deepEqual(ids(out), ['plain', 'pinned'], `order untouched for ${view}`);
+      assert.ok(out.every(r => r.pinned === false), `nothing pinned for ${view}`);
+    }
+  });
+
+  test('non-numeric / non-finite priority is treated as unpinned', () => {
+    const weird = [
+      card('a', { priority: 'high' }),
+      card('b', { priority: NaN }),
+      card('c', { priority: 0 }),
+    ];
+    const out = orderCardsForView(weird, 'view');
+    // Only c (priority 0, finite) is pinned; the rest keep input order.
+    assert.deepEqual(ids(out), ['c', 'a', 'b']);
+    assert.deepEqual(out.map(r => r.pinned), [true, false, false]);
+  });
+
+  test('empty / non-array input is safe', () => {
+    assert.deepEqual(orderCardsForView([], 'view'), []);
+    assert.deepEqual(orderCardsForView(undefined, 'view'), []);
+    assert.deepEqual(orderCardsForView(null, 'trends'), []);
+  });
+});


### PR DESCRIPTION
# What changed
`meta.view.priority` (numeric, lower = higher) lifts the most important 1-4 cards into a full-width band at the top of the Today view.

# Why
The Today view was an undifferentiated masonry with no hero tier; every comparable dashboard leads with a few hero metrics (preattentive triage / progressive disclosure).

# How
A pure `orderCardsForView(cards, view)` helper (`public/js/lib/hero-tier.js`) partitions pinned-before-unpinned (stable within each group), and the renderer applies a `column-span: all` class (reusing the existing `.slot-top` mechanism). No server change: `meta` is already client-side. Gated to the Today view only (by both `view === 'view'` and `dateMode === 'today'`, and suppressed during reorder mode so reorder saves are not corrupted).

# Testing
- [x] `npm test` passes (grew by 8, no regressions).
- [x] Unit tests at `tests/hero-tier.test.js`; e2e storyboard is a later issue.

# Checklist
- [x] CHANGELOG + MANIFEST-SCHEMA updated
- [x] No personal identifiers/secrets

Refs #422