### PR TITLE
feat(renderers): make welcome-card a first-run empty state with CTA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,19 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Changed
 
+- **Welcome card is now a proper first-run empty state.** When a fresh
+  install has zero user cards, `eh-welcome-card` leads with a short
+  explanation of how cards come to exist (drop a `.json` manifest into
+  the data folder, or ask Klebbius to make one) and a primary "Add your
+  first card" CTA. The CTA seeds the chat via the existing
+  `klebb-paste-into-chat` event with a "Help me create my first card"
+  prompt, so it works today with no extra plumbing; it also dispatches a
+  `klebb-open-card-gallery` event as a forward-compat seam for a future
+  card gallery to listen on. The three existing add-a-card paths (starter
+  prompt, describe-it-yourself, hand-author JSON) are kept below as
+  secondary options. Server-side seed + auto-hide behaviour is unchanged.
+  Refs #424.
+
 - **Notifications row mobile touch + a11y polish.** The Notifications
   tab toggles in `eh-settings-notifications` now meet a 44×44 touch
   target (WCAG 2.5.5 / Apple HIG): the visible 36×20 track is wrapped

--- a/public/js/components/eh-welcome-card.js
+++ b/public/js/components/eh-welcome-card.js
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
-// eh-welcome-card.js — onboarding card shown on a fresh install. Explains
-// the three ways to add cards. Hides itself when the user creates their
-// first card (server-side, in registry.createManifest). Visibility can be
-// restored from Settings.
+// eh-welcome-card.js: first-run empty state shown when no user cards exist.
+// Teaches how cards come to exist (drop a JSON manifest, or ask Klebbius) and
+// offers a primary CTA that seeds the chat to build the first card. Hides
+// itself when the user creates their first card (server-side, in
+// registry.createManifest). Visibility can be restored from Settings.
 
 import { html, css } from 'https://esm.sh/lit@3';
 import { EhBaseCard } from './eh-base-card.js';
@@ -14,6 +15,57 @@ export class EhWelcomeCard extends EhBaseCard {
   static styles = [
     EhBaseCard.styles,
     css`
+      .intro {
+        margin: 0 0 16px;
+      }
+      .intro-lead {
+        font-size: 13.5px;
+        line-height: 1.5;
+        color: var(--text-primary);
+        margin: 0 0 14px;
+      }
+      .intro-lead code {
+        font-size: 12.5px;
+        padding: 1px 5px;
+        border-radius: 5px;
+        background: var(--bg-input, rgba(0, 0, 0, 0.05));
+        border: 1px solid var(--border);
+      }
+      .cta {
+        font: inherit;
+        font-size: 14px;
+        font-weight: 700;
+        padding: 11px 18px;
+        border-radius: 10px;
+        border: 1px solid var(--accent, #00d4aa);
+        background: var(--accent, #00d4aa);
+        color: #000;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        transition: transform 0.12s ease, box-shadow 0.12s ease,
+                    filter 0.12s ease;
+      }
+      .cta:hover {
+        filter: brightness(1.06);
+        transform: translateY(-1px);
+        box-shadow: 0 4px 14px rgba(0, 212, 170, 0.25);
+      }
+      .cta:active { transform: translateY(0); }
+      .cta:focus-visible {
+        outline: 2px solid var(--accent, #00d4aa);
+        outline-offset: 3px;
+      }
+      .cta-emoji { font-size: 16px; line-height: 1; }
+      .or {
+        margin: 14px 0 4px;
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.6px;
+        text-transform: uppercase;
+        color: var(--text-muted, var(--text-secondary));
+      }
       .paths {
         display: grid;
         grid-template-columns: 1fr;
@@ -145,8 +197,31 @@ export class EhWelcomeCard extends EhBaseCard {
     window.dispatchEvent(new CustomEvent('klebb-open-chat'));
   }
 
+  _addFirstCard() {
+    // Forward-compat seam: a future card gallery can listen for this and
+    // open itself. Until that ships, the chat seed below is the working
+    // path: Klebbius proposes the manifest and creates it on approval.
+    window.dispatchEvent(new CustomEvent('klebb-open-card-gallery'));
+    window.dispatchEvent(new CustomEvent('klebb-paste-into-chat', {
+      detail: { text: 'Help me create my first card.' },
+    }));
+  }
+
   renderCard() {
     return html`
+      <div class="intro">
+        <p class="intro-lead">
+          Klebb has no cards yet. A card appears the moment you drop a
+          <code>.json</code> manifest into your data folder, or ask
+          Klebbius to make one for you. Each card tracks one thing:
+          weight, bloods, a supplement stack, mood, sleep, whatever you
+          like. Add your first one to get started.
+        </p>
+        <button type="button" class="cta" @click=${this._addFirstCard}>
+          <span class="cta-emoji">✨</span> Add your first card
+        </button>
+        <p class="or">Or pick a path</p>
+      </div>
       <div class="paths">
         <button type="button" class="path featured" @click=${this._openPrompts}>
           <span class="start-chip">★ Start here</span>

--- a/tests/welcome-empty-state.test.js
+++ b/tests/welcome-empty-state.test.js
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/welcome-empty-state.test.js
+// Static coverage for the first-run empty state in eh-welcome-card. The Lit
+// component can't be exercised in Node (esm.sh imports), so this layer guards
+// the teaching copy and the primary CTA wiring against drift. The server-side
+// seed + auto-hide behaviour is covered separately in welcome-card.test.js.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'public', 'js', 'components', 'eh-welcome-card.js'),
+  'utf8',
+);
+
+describe('welcome-card first-run empty state', () => {
+  test('teaches that cards come from a dropped JSON file', () => {
+    assert.match(SRC, /drop a/i);
+    assert.match(SRC, /\.json/);
+    assert.match(SRC, /data folder/i);
+  });
+
+  test('teaches that Klebbius can make a card', () => {
+    assert.match(SRC, /ask\s+Klebbius/i);
+  });
+
+  test('renders a primary "Add your first card" CTA', () => {
+    assert.match(SRC, /Add your first card/);
+  });
+
+  test('CTA seeds the chat via klebb-paste-into-chat with a starter prompt', () => {
+    assert.match(SRC, /klebb-paste-into-chat/);
+    assert.match(SRC, /Help me create my first card/);
+  });
+
+  test('CTA also dispatches the forward-compat gallery event', () => {
+    assert.match(SRC, /klebb-open-card-gallery/);
+  });
+});


### PR DESCRIPTION
# What changed
The welcome card now leads with the mental model ("a card appears when you drop a JSON manifest into your data folder, or ask Klebbius to make one") and a primary "Add your first card" CTA, with the existing add paths demoted below.

# Why
A fresh install with zero cards should teach + offer a direct pathway, not read as a thin placeholder.

# How
The CTA dispatches `klebb-paste-into-chat` (the proven idiom consumed by `health-chat.js`) to seed "Help me create my first card", and also fires a forward-compat `klebb-open-card-gallery` event for the future gallery to listen on. Degrades gracefully: if nothing listens to the gallery event, the chat seed still works. Server-side welcome auto-hide is untouched.

# Testing
- [x] `npm test` passes (grew by 5; server-side welcome auto-hide tests still 10/10).
- [x] Source-level test at `tests/welcome-empty-state.test.js` (house pattern for Lit components that can't run in Node).

# Checklist
- [x] CHANGELOG updated under Unreleased
- [x] No personal identifiers/secrets

Refs #424