### PR TITLE
fix(renderers): point chartTheme at real --warning/--danger/--success tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,16 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Chart colours now follow the active theme.** `chartTheme()` in
+  `public/js/components/eh-chart-base.js` read three CSS custom
+  properties (`--accent-amber`, `--accent-red`, `--accent-green`) that
+  were never defined in `public/css/app.css`, so the amber/red/green
+  entries in the chart palette always fell through to their hardcoded
+  hex fallbacks and ignored both the light theme and any custom
+  accent. The palette now reads the real `--warning`, `--danger`, and
+  `--success` tokens, which resolve per theme. The hex fallbacks are
+  retained as a safety net. Fixes #425.
+
 - **`set_notification` clears `lastFired` when it changes a trigger.**
   Cached `notifications.state.json#items[<id>].lastFired` is computed
   under whatever trigger configuration was active at the time, so once

--- a/public/js/components/eh-chart-base.js
+++ b/public/js/components/eh-chart-base.js
@@ -38,9 +38,9 @@ export function chartTheme() {
     },
     color: [
       get('--accent') || '#00d4aa',
-      get('--accent-amber') || '#ffaa00',
-      get('--accent-red') || '#ff4444',
-      get('--accent-green') || '#44ff88',
+      get('--warning') || '#ffaa00',
+      get('--danger') || '#ff4444',
+      get('--success') || '#44ff88',
       '#8a7cff',
       '#4682b4',
     ],

--- a/tests/charttheme-tokens.test.js
+++ b/tests/charttheme-tokens.test.js
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/charttheme-tokens.test.js
+//
+// Regression seed for #425: chartTheme() read CSS custom properties
+// (--accent-amber/-red/-green) that were never defined in app.css, so the
+// amber/red/green chart colours always fell through to their hex fallbacks
+// and ignored the active theme. It must read the real --warning/--danger/
+// --success tokens instead. chartTheme() needs a DOM (getComputedStyle on
+// document.documentElement), so this asserts at the source level.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const chartBase = fs.readFileSync(
+  path.join(REPO_ROOT, 'public/js/components/eh-chart-base.js'),
+  'utf8',
+);
+const appCss = fs.readFileSync(
+  path.join(REPO_ROOT, 'public/css/app.css'),
+  'utf8',
+);
+
+describe('chartTheme reads real theme tokens', () => {
+  test('references --warning/--danger/--success', () => {
+    for (const token of ['--warning', '--danger', '--success']) {
+      assert.ok(
+        chartBase.includes(`get('${token}')`),
+        `eh-chart-base.js should read ${token}`,
+      );
+    }
+  });
+
+  test('no longer references the non-existent --accent-* tokens', () => {
+    for (const token of ['--accent-amber', '--accent-red', '--accent-green']) {
+      assert.ok(
+        !chartBase.includes(token),
+        `eh-chart-base.js should not reference ${token} (never defined in app.css)`,
+      );
+    }
+  });
+
+  test('every token chartTheme reads is defined in app.css', () => {
+    const tokens = [...chartBase.matchAll(/get\('(--[\w-]+)'\)/g)].map(m => m[1]);
+    assert.ok(tokens.length > 0, 'expected chartTheme to read at least one token');
+    for (const token of [...new Set(tokens)]) {
+      assert.ok(
+        appCss.includes(`${token}:`),
+        `${token} is read by chartTheme but not defined in app.css`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
# What changed
`chartTheme()` in `eh-chart-base.js` read three CSS custom properties that do not exist (`--accent-amber`, `--accent-red`, `--accent-green`), so those chart colours always fell through to hardcoded hex and ignored the theme. Now reads the real tokens (`--warning`/`--danger`/`--success`).

# Why
Theme-tracking bug: chart status colours did not follow the active theme.

# How
Mapped the three palette entries to the real tokens (defined in `app.css`). The dark-theme values happen to equal the old hex fallbacks, so dark mode is visually unchanged while light mode now tracks correctly.

# Testing
- [x] `npm test` passes (grew by 1 file, no regressions).
- [x] Source-level test at `tests/charttheme-tokens.test.js`; verified it fails on the pre-fix source and passes after. (No DOM/component harness exists in `tests/`, so a source assertion is the house-compatible approach for a pure CSS-var rename.)

# Checklist
- [x] CHANGELOG updated under Unreleased
- [x] No personal identifiers/secrets

Fixes #425