### PR TITLE
refactor(server): remove dead fullMessages assembly in chat handler

### DIFF
--- a/server.js
+++ b/server.js
@@ -1608,12 +1608,6 @@ Original system prompt follows:
 ` + HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock + haeCatalogueBlock + ccSchemaBlock + docsCatalogueBlock + reportsCatalogueBlock + categoryBlock;
           }
 
-          // Prepend system prompt
-          const fullMessages = [
-            { role: 'system', content: systemPrompt },
-            ...messages,
-          ];
-
           if (!CHAT_ENDPOINT) {
             return sendJSON(res, { error: 'Chat endpoint not configured' }, 503);
           }


### PR DESCRIPTION
# What changed
Removes the unused `fullMessages` array in the /api/chat handler.

# Why
`runAgentLoop` reassembles its own messages from `systemPrompt` + `userMessages`; `fullMessages` was built and never consumed. Removing it ahead of the prompt-block work that touches the same region, so it can't be mistaken for what is actually sent.

# How
Pure deletion of the dead declaration.

# Testing
- [x] `npm test` passes; existing chat tests unchanged.
- [ ] No new test: pure dead-code removal, no behaviour change (noted here per the template).

Refs #419