### PR TITLE
feat(chat): add get_recent_activity tool + staleness primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **`get_recent_activity` chat tool.** A one-pass recency summary of
+  every card (`{id, label, renderer, rowCount, lastEntryDate, ageDays,
+  lastNDelta, staleSource}`) so Klebbius can answer "what's stale?" or
+  reuse a sibling card's conventions without reading each card. Staleness
+  is derived from per-row `date` fields (override with `meta.view.dateField`),
+  falling back to the manifest file's modification time when a card has no
+  dated rows. The derivation lives in `chat/recent-activity.js` and is the
+  shared freshness primitive the hygiene checks build on. Refs #415.
+
 - **`reorder_rows` chat tool.** New row-level primitive in
   `chat/tools.js` for reordering an array of rows inside a card's
   data block. Args are tiny (`{id, path, key, order:[<value>, ...]}`),

--- a/chat/recent-activity.js
+++ b/chat/recent-activity.js
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// chat/recent-activity.js
+// Server-computed per-card activity summary for the Klebbius agent. One pass
+// over the registry so the agent gets recency/staleness signals without N+1
+// reading every card. Shared by the get_recent_activity tool and (later) the
+// hygiene checks, so the freshness derivation lives in exactly one place.
+
+// Resolve the per-row date key for a card. Authors can override via
+// meta.view.dateField; otherwise we use the de-facto `date` convention.
+function dateFieldFor(meta) {
+  const override = meta && meta.view && typeof meta.view.dateField === 'string'
+    ? meta.view.dateField.trim()
+    : '';
+  return override || 'date';
+}
+
+// Pull the sorted (ascending) list of row date strings present on an array
+// data block, using the resolved date field. Non-array data (single-doc
+// cards, schedule blocks) yields []. Only string dates are kept.
+function rowDates(data, dateField) {
+  if (!Array.isArray(data)) return [];
+  return data
+    .map(r => (r && typeof r === 'object' ? r[dateField] : null))
+    .filter(d => typeof d === 'string' && d)
+    .sort((a, b) => a.localeCompare(b));
+}
+
+// Whole-day difference between two ISO (YYYY-MM-DD) dates, today - then.
+// Both are treated as calendar dates in the same zone (the caller passes a
+// server-local `today`), so this is a plain UTC-midnight subtraction and is
+// not affected by wall-clock time or DST.
+function ageInDays(today, then) {
+  const a = Date.parse(`${today}T00:00:00Z`);
+  const b = Date.parse(`${then}T00:00:00Z`);
+  if (Number.isNaN(a) || Number.isNaN(b)) return null;
+  return Math.round((a - b) / 86400000);
+}
+
+// Build the activity summary for every card the registry knows about.
+//
+// deps:
+//   registry : the manifest registry (needs list() + get(id) + sourceMtime(id))
+//   today    : server-local ISO date string (YYYY-MM-DD) for ageDays maths
+//
+// Returns an array (registry order) of:
+//   { id, label, renderer, rowCount, lastEntryDate, ageDays, lastNDelta,
+//     staleSource }
+// where:
+//   - lastEntryDate is the newest per-row date, or null if the card has no
+//     dated rows (single-doc / schedule cards, or empty data)
+//   - ageDays is days since lastEntryDate; when no row date exists it falls
+//     back to the file mtime (staleSource:'mtime') so the agent still gets a
+//     freshness signal; null only when neither is available
+//   - lastNDelta is last - previous row value when the newest two dated rows
+//     expose a single obvious numeric field; null otherwise (best-effort, the
+//     agent treats it as a hint, not a computed trend)
+function buildRecentActivity(registry, today) {
+  const cards = typeof registry.list === 'function' ? registry.list() : [];
+  return cards.map(c => {
+    const meta = c.meta || {};
+    const entry = typeof registry.get === 'function' ? registry.get(c.id) : null;
+    const data = entry ? entry.data : null;
+    const dateField = dateFieldFor(meta);
+
+    const dates = rowDates(data, dateField);
+    const rowCount = Array.isArray(data) ? data.length : (data === null ? 0 : 1);
+    const lastEntryDate = dates.length ? dates[dates.length - 1] : null;
+
+    let ageDays = null;
+    let staleSource = null;
+    if (lastEntryDate) {
+      ageDays = ageInDays(today, lastEntryDate);
+      staleSource = 'rows';
+    } else if (typeof registry.sourceMtime === 'function') {
+      const mtime = registry.sourceMtime(c.id);
+      if (mtime != null) {
+        ageDays = ageInDays(today, isoFromMs(mtime));
+        staleSource = 'mtime';
+      }
+    }
+
+    return {
+      id: c.id,
+      label: meta.label || c.id,
+      renderer: meta.view?.component || null,
+      rowCount,
+      lastEntryDate,
+      ageDays,
+      lastNDelta: lastNDelta(data, dateField),
+      staleSource,
+    };
+  });
+}
+
+function isoFromMs(ms) {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+// Best-effort last-vs-previous delta for the newest two dated rows. Only
+// fires when the rows share exactly one numeric field besides the date key,
+// so it never guesses on multi-metric rows. Returns a Number or null.
+function lastNDelta(data, dateField) {
+  if (!Array.isArray(data) || data.length < 2) return null;
+  const dated = data
+    .filter(r => r && typeof r === 'object' && typeof r[dateField] === 'string')
+    .sort((a, b) => a[dateField].localeCompare(b[dateField]));
+  if (dated.length < 2) return null;
+  const last = dated[dated.length - 1];
+  const prev = dated[dated.length - 2];
+  const numericKeys = Object.keys(last).filter(k => k !== dateField && isFiniteNumber(last[k]));
+  if (numericKeys.length !== 1) return null;
+  const key = numericKeys[0];
+  if (!isFiniteNumber(prev[key])) return null;
+  return Number(last[key]) - Number(prev[key]);
+}
+
+function isFiniteNumber(v) {
+  return v !== null && v !== '' && v !== undefined && Number.isFinite(Number(v));
+}
+
+module.exports = { buildRecentActivity, dateFieldFor, rowDates, ageInDays };

--- a/chat/tools.js
+++ b/chat/tools.js
@@ -11,6 +11,13 @@ const registry = require('../manifests/registry');
 const notificationsState = require('../lib/notifications-state');
 const { readDoc } = require('./docs');
 const { readReport } = require('./reports');
+const { buildRecentActivity } = require('./recent-activity');
+
+// Server-local "today" (YYYY-MM-DD) in the configured TZ, matching the
+// server's todayIso(). Used for the ageDays maths in get_recent_activity.
+function serverTodayIso() {
+  return new Date().toLocaleDateString('en-CA', { timeZone: process.env.TZ || 'UTC' });
+}
 
 const TOOL_DEFS = [
   {
@@ -167,6 +174,19 @@ const TOOL_DEFS = [
           },
         },
         required: ['name'],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'get_recent_activity',
+      description:
+        "Get a one-pass recency summary of EVERY card without reading each one. Returns {cards:[{id, label, renderer, rowCount, lastEntryDate, ageDays, lastNDelta, staleSource}]}. Use this FIRST when the user asks anything about how their tracking is going, what is stale or untouched, what changed recently, or before suggesting a new card (so you reuse the conventions of sibling cards). `ageDays` is days since the newest entry; when a card has no dated rows it falls back to the file modification time (staleSource:'mtime') so you still get a freshness hint. `lastNDelta` is a best-effort last-minus-previous value when a card has one obvious numeric field; treat it as a hint, not a computed trend. Cheaper and faster than calling read_manifest on each card.",
+      parameters: {
+        type: 'object',
+        properties: {},
         additionalProperties: false,
       },
     },
@@ -530,6 +550,9 @@ function dispatchToolCall(tc, ctx) {
       }
       case 'read_report': {
         return JSON.stringify(readReport(args.name));
+      }
+      case 'get_recent_activity': {
+        return JSON.stringify({ cards: buildRecentActivity(registry, serverTodayIso()) });
       }
       case 'set_notification': {
         const entry = registry.get(args.card_id);

--- a/manifests/registry.js
+++ b/manifests/registry.js
@@ -302,6 +302,19 @@ function data(id) {
   return e ? e.data : null;
 }
 
+// Last-modified time (epoch ms) of the manifest's backing file, or null
+// if the id is unknown or the file can't be stat'd. Used as a staleness
+// fallback when a card's rows carry no usable per-row date.
+function sourceMtime(id) {
+  const e = _entries.get(id);
+  if (!e || !e.source) return null;
+  try {
+    return fs.statSync(e.source).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
 function errors() {
   return [..._errors];
 }
@@ -895,6 +908,7 @@ module.exports = {
   listForView,
   get,
   data,
+  sourceMtime,
   writeData,
   readRows,
   appendRow,

--- a/tests/recent-activity.test.js
+++ b/tests/recent-activity.test.js
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/recent-activity.test.js
+// Unit tests for the get_recent_activity summary: per-card recency/staleness
+// derivation (per-row date with dateField override and mtime fallback) and
+// TOOL_DEFS membership.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { buildRecentActivity, dateFieldFor, ageInDays } = require('../chat/recent-activity');
+const { TOOL_DEFS } = require('../chat/tools');
+
+// Minimal registry stub: list() yields {id, meta}, get(id) yields {data},
+// sourceMtime(id) yields an epoch-ms or null. Mirrors the real registry's
+// shape for these three accessors only.
+function makeRegistry(cards, mtimes = {}) {
+  const byId = new Map(cards.map(c => [c.id, c]));
+  return {
+    list: () => cards.map(c => ({ id: c.id, meta: c.meta || {} })),
+    get: id => (byId.has(id) ? { data: byId.get(id).data } : null),
+    sourceMtime: id => (id in mtimes ? mtimes[id] : null),
+  };
+}
+
+const TODAY = '2026-06-24';
+
+describe('recent-activity: date field resolution', () => {
+  test('defaults to "date"', () => {
+    assert.strictEqual(dateFieldFor({}), 'date');
+    assert.strictEqual(dateFieldFor({ view: {} }), 'date');
+  });
+  test('honours meta.view.dateField override', () => {
+    assert.strictEqual(dateFieldFor({ view: { dateField: 'loggedOn' } }), 'loggedOn');
+  });
+});
+
+describe('recent-activity: ageInDays', () => {
+  test('whole-day difference, today - then', () => {
+    assert.strictEqual(ageInDays('2026-06-24', '2026-06-12'), 12);
+    assert.strictEqual(ageInDays('2026-06-24', '2026-06-24'), 0);
+  });
+  test('returns null on unparseable input', () => {
+    assert.strictEqual(ageInDays('2026-06-24', 'nope'), null);
+  });
+});
+
+describe('recent-activity: buildRecentActivity', () => {
+  test('derives lastEntryDate/ageDays/rowCount from per-row date (staleSource rows)', () => {
+    const reg = makeRegistry([
+      {
+        id: 'weight', meta: { label: 'Weight', view: { component: 'generic-card' } },
+        data: [{ date: '2026-06-10', kg: 84 }, { date: '2026-06-22', kg: 83 }],
+      },
+    ]);
+    const [w] = buildRecentActivity(reg, TODAY);
+    assert.strictEqual(w.id, 'weight');
+    assert.strictEqual(w.label, 'Weight');
+    assert.strictEqual(w.renderer, 'generic-card');
+    assert.strictEqual(w.rowCount, 2);
+    assert.strictEqual(w.lastEntryDate, '2026-06-22');
+    assert.strictEqual(w.ageDays, 2);
+    assert.strictEqual(w.staleSource, 'rows');
+  });
+
+  test('lastNDelta is last-minus-previous for a single numeric field', () => {
+    const reg = makeRegistry([
+      { id: 'weight', meta: {}, data: [{ date: '2026-06-10', kg: 84 }, { date: '2026-06-22', kg: 83 }] },
+    ]);
+    const [w] = buildRecentActivity(reg, TODAY);
+    assert.strictEqual(w.lastNDelta, -1);
+  });
+
+  test('lastNDelta is null when rows carry more than one numeric field', () => {
+    const reg = makeRegistry([
+      { id: 'bp', meta: {}, data: [{ date: '2026-06-10', sys: 120, dia: 80 }, { date: '2026-06-22', sys: 118, dia: 78 }] },
+    ]);
+    const [bp] = buildRecentActivity(reg, TODAY);
+    assert.strictEqual(bp.lastNDelta, null);
+  });
+
+  test('honours meta.view.dateField override for staleness', () => {
+    const reg = makeRegistry([
+      { id: 'odd', meta: { view: { dateField: 'loggedOn' } }, data: [{ loggedOn: '2026-06-20', v: 1 }] },
+    ]);
+    const [o] = buildRecentActivity(reg, TODAY);
+    assert.strictEqual(o.lastEntryDate, '2026-06-20');
+    assert.strictEqual(o.ageDays, 4);
+  });
+
+  test('falls back to file mtime when no row date exists (staleSource mtime)', () => {
+    const mtimeMs = Date.parse('2026-06-19T08:00:00Z');
+    const reg = makeRegistry(
+      [{ id: 'notes', meta: { view: { component: 'markdown-doc' } }, data: { markdown: 'hi' } }],
+      { notes: mtimeMs },
+    );
+    const [n] = buildRecentActivity(reg, TODAY);
+    assert.strictEqual(n.lastEntryDate, null);
+    assert.strictEqual(n.staleSource, 'mtime');
+    assert.strictEqual(n.ageDays, 5);
+    assert.strictEqual(n.rowCount, 1);
+  });
+
+  test('null data yields rowCount 0 and no age when no mtime', () => {
+    const reg = makeRegistry([{ id: 'empty', meta: {}, data: null }]);
+    const [e] = buildRecentActivity(reg, TODAY);
+    assert.strictEqual(e.rowCount, 0);
+    assert.strictEqual(e.lastEntryDate, null);
+    assert.strictEqual(e.ageDays, null);
+    assert.strictEqual(e.staleSource, null);
+  });
+});
+
+describe('recent-activity: tool registration', () => {
+  test('get_recent_activity is in TOOL_DEFS with no required params', () => {
+    const def = TOOL_DEFS.find(t => t.function?.name === 'get_recent_activity');
+    assert.ok(def, 'get_recent_activity missing from TOOL_DEFS');
+    assert.deepStrictEqual(def.function.parameters.properties, {});
+  });
+});


### PR DESCRIPTION
# What changed
A `get_recent_activity` chat tool returning a one-pass per-card recency summary (`{id, label, renderer, rowCount, lastEntryDate, ageDays, lastNDelta, staleSource}`), plus the shared staleness derivation in `chat/recent-activity.js` and a `registry.sourceMtime(id)` accessor.

# Why
Klebbius needs cheap recency/staleness signals (to answer 'what's stale?' and to reuse sibling-card conventions) without N+1 reading every card. This is also the shared freshness primitive the hygiene work builds on.

# How
Staleness derives from per-row `date` fields (override via `meta.view.dateField`), falling back to the manifest file mtime when a card has no dated rows (`staleSource` reports which). `lastNDelta` is a best-effort last-minus-previous when a card has exactly one obvious numeric field.

# Testing
- [x] `npm test` passes (+11).
- [x] Unit tests at `tests/recent-activity.test.js` (date-vs-mtime derivation, dateField override, lastNDelta, rowCount, TOOL_DEFS membership).

Refs #415