### PR TITLE
feat(chat): add validate_manifest dry-run tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **`validate_manifest` chat tool.** A no-write dry-run that runs the
+  exact structural validator the create/patch path enforces, plus
+  renderer-shape checks (combination-card needs `meta.view.combines[]`
+  with `sourceId`; `meta.view.display` must be an object), returning
+  `{ok}` or `{ok:false, errors:[{path, message}]}`. Klebbius is steered
+  to call it before any manifest write so it can self-correct shape
+  mistakes first. The renderer checks deliberately match real renderer
+  behaviour (line-chart `series` is optional, since the renderer
+  auto-detects a y-field) rather than inventing requirements. Refs #416.
+
 - **`get_recent_activity` chat tool.** A one-pass recency summary of
   every card (`{id, label, renderer, rowCount, lastEntryDate, ageDays,
   lastNDelta, staleSource}`) so Klebbius can answer "what's stale?" or

--- a/chat/tools.js
+++ b/chat/tools.js
@@ -12,6 +12,7 @@ const notificationsState = require('../lib/notifications-state');
 const { readDoc } = require('./docs');
 const { readReport } = require('./reports');
 const { buildRecentActivity } = require('./recent-activity');
+const { validateManifest } = require('./validate-manifest');
 
 // Server-local "today" (YYYY-MM-DD) in the configured TZ, matching the
 // server's todayIso(). Used for the ageDays maths in get_recent_activity.
@@ -174,6 +175,24 @@ const TOOL_DEFS = [
           },
         },
         required: ['name'],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'validate_manifest',
+      description:
+        "Dry-run a candidate klebb.datafile.v1 manifest WITHOUT writing it. Returns {ok:true} or {ok:false, errors:[{path, message}]}. This runs the exact same structural validation the create/patch write path enforces (so 'ok' here means the write will not be rejected on shape grounds), plus a few renderer-specific checks (e.g. combination-card needs meta.view.combines[] with sourceId; meta.view.display must be an object). ALWAYS call this before create_manifest or patch_manifest and fix any reported errors first; each error names the JSON path and what to change. It does not catch every possible problem (it cannot know your data semantics), but it catches the shape mistakes that cause a write to fail.",
+      parameters: {
+        type: 'object',
+        properties: {
+          manifest: {
+            description: 'The full candidate klebb.datafile.v1 manifest object to check (same shape you would pass to create_manifest).',
+          },
+        },
+        required: ['manifest'],
         additionalProperties: false,
       },
     },
@@ -553,6 +572,9 @@ function dispatchToolCall(tc, ctx) {
       }
       case 'get_recent_activity': {
         return JSON.stringify({ cards: buildRecentActivity(registry, serverTodayIso()) });
+      }
+      case 'validate_manifest': {
+        return JSON.stringify(validateManifest(args.manifest));
       }
       case 'set_notification': {
         const entry = registry.get(args.card_id);

--- a/chat/validate-manifest.js
+++ b/chat/validate-manifest.js
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// chat/validate-manifest.js
+// Dry-run manifest validation for the Klebbius agent: the same structural
+// gate the write path enforces (registry.validateManifestShape) PLUS a few
+// renderer-shape checks keyed off meta.view.component, surfaced as a list of
+// {path, message} so the agent can self-correct before committing a write.
+//
+// Important: the renderer checks only assert what genuinely breaks rendering.
+// They do NOT invent requirements the renderers tolerate (e.g. line-chart
+// auto-detects its y-field, so `series` is optional and is only shape-checked
+// when present).
+
+const registry = require('../manifests/registry');
+
+// Renderer-specific shape checks. Each returns an array of {path, message}.
+// Run against a structurally-valid manifest (validateManifestShape already
+// passed), so meta/meta.view are safe to read defensively.
+function rendererShapeErrors(manifest) {
+  const errors = [];
+  const meta = manifest.meta || {};
+  const view = meta.view || {};
+  const component = view.component;
+
+  if (view.display !== undefined && (typeof view.display !== 'object' || Array.isArray(view.display) || view.display === null)) {
+    errors.push({ path: 'meta.view.display', message: 'display must be an object (e.g. {template, unit}), not a string or array' });
+  }
+
+  if (component === 'combination-card') {
+    const combines = view.combines;
+    if (!Array.isArray(combines) || combines.length === 0) {
+      errors.push({ path: 'meta.view.combines', message: 'combination-card requires meta.view.combines[] with at least one donor' });
+    } else {
+      combines.forEach((c, i) => {
+        if (!c || typeof c !== 'object' || typeof c.sourceId !== 'string' || !c.sourceId) {
+          errors.push({ path: `meta.view.combines[${i}].sourceId`, message: 'each combines entry needs a sourceId (the referenced manifest meta.id)' });
+        }
+      });
+    }
+  }
+
+  if (component === 'line-chart' || component === 'area-chart' || component === 'bar-chart') {
+    // series is OPTIONAL: the renderer auto-detects a y-field when absent.
+    // Only shape-check it when the author has supplied it.
+    if (view.series !== undefined) {
+      if (!Array.isArray(view.series)) {
+        errors.push({ path: 'meta.view.series', message: 'series, when set, must be an array of {field, label?, colour?}' });
+      } else {
+        view.series.forEach((s, i) => {
+          if (!s || typeof s !== 'object' || typeof s.field !== 'string' || !s.field) {
+            errors.push({ path: `meta.view.series[${i}].field`, message: 'each series entry needs a string field naming the numeric key to plot' });
+          }
+        });
+      }
+    }
+  }
+
+  return errors;
+}
+
+// Validate a candidate manifest object without writing anything. Returns
+// { ok: true } or { ok: false, errors: [{path, message}] }. Mirrors the write
+// path exactly for the structural subset (strictId:true, like create), then
+// layers the renderer-shape checks on top.
+function validateManifest(manifest) {
+  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+    return { ok: false, errors: [{ path: '', message: 'manifest must be an object' }] };
+  }
+  // validateManifestShape mutates its input (drops bad category, normalises
+  // notifications). Validate a deep clone so a dry-run never alters what the
+  // agent will later submit.
+  let clone;
+  try {
+    clone = JSON.parse(JSON.stringify(manifest));
+  } catch {
+    return { ok: false, errors: [{ path: '', message: 'manifest is not JSON-serialisable' }] };
+  }
+
+  const errors = [];
+  try {
+    registry.validateManifestShape(clone, { strictId: true, strictNotifications: true });
+  } catch (e) {
+    errors.push(structuralError(e.message || String(e)));
+  }
+
+  // Renderer-shape checks only run once the structure is sound; a missing
+  // meta block makes per-renderer checks meaningless.
+  if (errors.length === 0) {
+    errors.push(...rendererShapeErrors(clone));
+  }
+
+  return errors.length === 0 ? { ok: true } : { ok: false, errors };
+}
+
+// Map a validateManifestShape throw message to a {path, message}. The
+// validator's messages are already prefixed (missing meta.id, invalid id:
+// ..., invalid notifications: ..., etc.); we lift the obvious JSON path out
+// of the prefix so the agent gets a pointer, not just prose.
+function structuralError(msg) {
+  const m = String(msg);
+  if (/^missing \$schema|unsupported \$schema/.test(m)) return { path: '$schema', message: m };
+  if (/^missing meta\.id|^invalid id/.test(m)) return { path: 'meta.id', message: m };
+  if (/^missing meta\.label/.test(m)) return { path: 'meta.label', message: m };
+  if (/^missing meta/.test(m)) return { path: 'meta', message: m };
+  if (/^invalid notifications/.test(m)) return { path: 'meta.notifications', message: m };
+  if (/^invalid schedule\.time_of_day/.test(m)) return { path: 'data.items[].schedule.time_of_day', message: m };
+  return { path: '', message: m };
+}
+
+module.exports = { validateManifest, rendererShapeErrors };

--- a/tests/validate-manifest.test.js
+++ b/tests/validate-manifest.test.js
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/validate-manifest.test.js
+// The validate_manifest dry-run tool: structural parity with the write-path
+// validator, renderer-shape checks, and that the dry-run never mutates input.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { validateManifest, rendererShapeErrors } = require('../chat/validate-manifest');
+const registry = require('../manifests/registry');
+const { TOOL_DEFS, dispatchToolCall } = require('../chat/tools');
+
+function makeToolCall(name, args) {
+  return { function: { name, arguments: JSON.stringify(args) } };
+}
+
+const goodGeneric = {
+  $schema: 'klebb.datafile.v1',
+  meta: { id: 'weight', label: 'Weight', view: { component: 'generic-card', display: { template: '{kg}', unit: 'kg' } } },
+  data: [],
+};
+
+describe('validate_manifest: structural validation', () => {
+  test('accepts a well-formed generic-card manifest', () => {
+    assert.deepStrictEqual(validateManifest(goodGeneric), { ok: true });
+  });
+
+  test('rejects a missing meta.label, pointing at the path', () => {
+    const r = validateManifest({ $schema: 'klebb.datafile.v1', meta: { id: 'x' } });
+    assert.strictEqual(r.ok, false);
+    assert.ok(r.errors.some(e => e.path === 'meta.label'));
+  });
+
+  test('rejects a bad id format', () => {
+    const r = validateManifest({ $schema: 'klebb.datafile.v1', meta: { id: 'Bad Id!', label: 'x' } });
+    assert.strictEqual(r.ok, false);
+    assert.ok(r.errors.some(e => e.path === 'meta.id' && /invalid id/.test(e.message)));
+  });
+
+  test('rejects unsupported $schema', () => {
+    const r = validateManifest({ $schema: 'nope.v9', meta: { id: 'x', label: 'X' } });
+    assert.strictEqual(r.ok, false);
+    assert.ok(r.errors.some(e => e.path === '$schema'));
+  });
+
+  test('rejects a non-object manifest', () => {
+    assert.strictEqual(validateManifest(null).ok, false);
+    assert.strictEqual(validateManifest([]).ok, false);
+    assert.strictEqual(validateManifest('x').ok, false);
+  });
+});
+
+describe('validate_manifest: parity with the write path', () => {
+  // The dry-run must agree with what createManifest would reject for the same
+  // input. We can't call createManifest without a sandbox here, but we can
+  // assert the dry-run uses the SAME validator throw by checking a case the
+  // validator rejects (reserved id) surfaces as an error.
+  test('reserved id is rejected (same gate as create)', () => {
+    const r = validateManifest({ $schema: 'klebb.datafile.v1', meta: { id: '_meta', label: 'X' } });
+    assert.strictEqual(r.ok, false);
+    assert.ok(r.errors.some(e => e.path === 'meta.id'));
+  });
+
+  test('a manifest validate_manifest accepts also passes validateManifestShape directly', () => {
+    // belt-and-braces: the dry-run accepting implies the raw validator accepts
+    assert.doesNotThrow(() => registry.validateManifestShape(JSON.parse(JSON.stringify(goodGeneric)), { strictId: true }));
+  });
+});
+
+describe('validate_manifest: renderer-shape checks', () => {
+  test('combination-card without combines[] is rejected', () => {
+    const r = validateManifest({
+      $schema: 'klebb.datafile.v1',
+      meta: { id: 'combo', label: 'Combo', view: { component: 'combination-card' } },
+      data: [],
+    });
+    assert.strictEqual(r.ok, false);
+    assert.ok(r.errors.some(e => e.path === 'meta.view.combines'));
+  });
+
+  test('combination-card combines entry without sourceId is rejected', () => {
+    const errs = rendererShapeErrors({ meta: { view: { component: 'combination-card', combines: [{ role: 'ring' }] } } });
+    assert.ok(errs.some(e => /sourceId/.test(e.path)));
+  });
+
+  test('line-chart WITHOUT series is accepted (renderer auto-detects)', () => {
+    const errs = rendererShapeErrors({ meta: { view: { component: 'line-chart' } } });
+    assert.deepStrictEqual(errs, []);
+  });
+
+  test('line-chart WITH a malformed series entry is rejected', () => {
+    const errs = rendererShapeErrors({ meta: { view: { component: 'line-chart', series: [{ label: 'x' }] } } });
+    assert.ok(errs.some(e => /series\[0\]\.field/.test(e.path)));
+  });
+
+  test('display as a string is rejected', () => {
+    const errs = rendererShapeErrors({ meta: { view: { component: 'generic-card', display: 'oops' } } });
+    assert.ok(errs.some(e => e.path === 'meta.view.display'));
+  });
+});
+
+describe('validate_manifest: purity + tool wiring', () => {
+  test('dry-run does not mutate the input manifest', () => {
+    const input = { $schema: 'klebb.datafile.v1', meta: { id: 'x', label: 'X', category: 'not-a-real-category' } };
+    const snapshot = JSON.stringify(input);
+    validateManifest(input);
+    assert.strictEqual(JSON.stringify(input), snapshot, 'validate_manifest must not mutate its input (category should not be stripped)');
+  });
+
+  test('is registered in TOOL_DEFS and dispatches', () => {
+    const def = TOOL_DEFS.find(t => t.function?.name === 'validate_manifest');
+    assert.ok(def, 'validate_manifest missing from TOOL_DEFS');
+    const out = JSON.parse(dispatchToolCall(makeToolCall('validate_manifest', { manifest: goodGeneric })));
+    assert.strictEqual(out.ok, true);
+  });
+});


### PR DESCRIPTION
# What changed
A `validate_manifest` chat tool that dry-runs a candidate manifest through the exact write-path validator plus renderer-shape checks, returning `{ok}` or `{ok:false, errors:[{path, message}]}`.

# Why
Klebbius sometimes emitted manifests the write path rejects. A cheap dry-run lets it self-correct before committing.

# How
Calls the same `registry.validateManifestShape` the create/patch path uses (on a deep clone, so a dry-run never mutates the candidate), then layers renderer-shape checks keyed off `meta.view.component`. The checks assert only what genuinely breaks rendering: combination-card needs `combines[]` with `sourceId`, `display` must be an object. **Line-chart `series` is left optional** because the renderer auto-detects a y-field; requiring it would reject valid manifests.

**Stacked on #415** (`feat/415-get-recent-activity`) because both edit `chat/tools.js`. Merge #415 first, then this retargets to main.

# Testing
- [x] `npm test` passes (+14).
- [x] Unit tests at `tests/validate-manifest.test.js` incl. a purity test (input not mutated) and write-path parity.

Refs #416