### PR TITLE
feat(server): add anonymised feedback log + note_feature_request tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Anonymised feature-request log (`POST /api/feedback` +
+  `note_feature_request` tool).** When a user asks for something Klebb
+  genuinely cannot do, Klebbius states the boundary, offers the nearest
+  supported alternative, and records the unmet need via the
+  `note_feature_request` tool, which appends one anonymised line to
+  `data/_meta/feedback.jsonl`. `lib/feedback.anonymise()` is the privacy
+  boundary: it keeps only a paraphrased capability intent, structural
+  context, considered tool names, and a timestamp; it never writes raw
+  values, labels, or the verbatim message. The operator reviews the file
+  to decide what to build next. Refs #417.
+
 - **`validate_manifest` chat tool.** A no-write dry-run that runs the
   exact structural validator the create/patch path enforces, plus
   renderer-shape checks (combination-card needs `meta.view.combines[]`

--- a/chat/tools.js
+++ b/chat/tools.js
@@ -13,6 +13,7 @@ const { readDoc } = require('./docs');
 const { readReport } = require('./reports');
 const { buildRecentActivity } = require('./recent-activity');
 const { validateManifest } = require('./validate-manifest');
+const { appendFeedback } = require('../lib/feedback');
 
 // Server-local "today" (YYYY-MM-DD) in the configured TZ, matching the
 // server's todayIso(). Used for the ageDays maths in get_recent_activity.
@@ -175,6 +176,34 @@ const TOOL_DEFS = [
           },
         },
         required: ['name'],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'note_feature_request',
+      description:
+        "Log an anonymised feature request when the user asks for something Klebb genuinely cannot do (no tool and no renderer can serve it, even with more detail). Call this ONLY after you have told the user plainly that it is unsupported and offered the nearest supported alternative; it is not for requests that just need a clarifying question or were phrased badly. Pass a PARAPHRASED capability intent, never the user's data: 'wants to chart sleep as a heatmap' is fine; the actual sleep values, card labels naming a condition, or the verbatim message are NOT. The operator reviews these to decide what to build next. Returns {logged:true}.",
+      parameters: {
+        type: 'object',
+        properties: {
+          intent: {
+            type: 'string',
+            description: 'A short paraphrased description of the capability the user wanted (no personal data, no logged values, no verbatim message).',
+          },
+          context: {
+            type: 'string',
+            description: 'Optional structural context: which renderers/tools exist and were considered, why none fit. No personal data.',
+          },
+          toolsConsidered: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Optional list of tool names you considered before concluding it is unsupported.',
+          },
+        },
+        required: ['intent'],
         additionalProperties: false,
       },
     },
@@ -575,6 +604,13 @@ function dispatchToolCall(tc, ctx) {
       }
       case 'validate_manifest': {
         return JSON.stringify(validateManifest(args.manifest));
+      }
+      case 'note_feature_request': {
+        return JSON.stringify(appendFeedback({
+          intent: args.intent,
+          context: args.context,
+          toolsConsidered: args.toolsConsidered,
+        }));
       }
       case 'set_notification': {
         const entry = registry.get(args.card_id);

--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// lib/feedback.js
+// Append-only, anonymised feature-request log. When Klebbius decides a user
+// request is genuinely unsupported, it records the unmet intent here so the
+// operator can later review what users actually want. No external calls, no
+// PII: only a paraphrased capability intent + structural context + a
+// timestamp. One JSON object per line (JSONL), reusing the recordAuthEvent
+// append style.
+
+const fs = require('fs');
+const path = require('path');
+const PATHS = require('../config/paths');
+
+// Lives in the gitignored, discovery-skipped data/_meta/ sidecar namespace,
+// next to cc-suggestions-dismissed.json. Created lazily on first append.
+const FEEDBACK_FILE = path.join(PATHS.DATA_DIR, '_meta', 'feedback.jsonl');
+
+const MAX_INTENT = 280;
+const MAX_CONTEXT = 500;
+const MAX_TOOLS = 12;
+
+// Build the anonymised log line from a raw {intent, context, toolsConsidered}.
+// This is the load-bearing privacy boundary: nothing strips PII upstream, so
+// we keep ONLY a paraphrased capability intent, the structural context, and
+// the considered tool names, each length-capped. The model is instructed to
+// paraphrase, but anonymise() is the backstop, never the raw user message.
+// Returns null when there is no usable intent to log.
+function anonymise(input, now) {
+  const intent = clampString(input && input.intent, MAX_INTENT);
+  if (!intent) return null;
+  const line = { ts: now, intent };
+  const context = clampString(input && input.context, MAX_CONTEXT);
+  if (context) line.context = context;
+  const tools = Array.isArray(input && input.toolsConsidered)
+    ? input.toolsConsidered
+        .filter(t => typeof t === 'string' && t)
+        .map(t => t.slice(0, 64))
+        .slice(0, MAX_TOOLS)
+    : [];
+  if (tools.length) line.toolsConsidered = tools;
+  return line;
+}
+
+function clampString(v, max) {
+  if (typeof v !== 'string') return '';
+  const trimmed = v.trim();
+  if (!trimmed) return '';
+  return trimmed.length > max ? trimmed.slice(0, max) : trimmed;
+}
+
+// Anonymise + append one feedback line. Returns {logged:true} on success or
+// {logged:false, reason} when there was nothing usable to log. Append errors
+// are swallowed (best-effort logging must never break a chat turn), matching
+// recordAuthEvent.
+function appendFeedback(input, nowIso) {
+  const ts = nowIso || new Date().toISOString();
+  const line = anonymise(input, ts);
+  if (!line) return { logged: false, reason: 'no intent' };
+  try {
+    fs.mkdirSync(path.dirname(FEEDBACK_FILE), { recursive: true });
+    fs.appendFileSync(FEEDBACK_FILE, JSON.stringify(line) + '\n');
+  } catch {
+    return { logged: false, reason: 'write failed' };
+  }
+  return { logged: true };
+}
+
+module.exports = { anonymise, appendFeedback, FEEDBACK_FILE };

--- a/server.js
+++ b/server.js
@@ -26,6 +26,7 @@ const haeDiscoveries = require('./health-auto-export/discoveries');
 const haeTokenStore = require('./health-auto-export/token-store');
 const { describeCatalogue: describeHaeCatalogue } = require('./health-auto-export/describe');
 const userTz = require('./lib/user-tz');
+const feedback = require('./lib/feedback');
 const notificationsState = require('./lib/notifications-state');
 const notificationsScheduler = require('./lib/notifications-scheduler');
 const webPushSend = require('./lib/web-push-send');
@@ -1199,6 +1200,27 @@ const server = http.createServer(async (req, res) => {
         const ok = ccSuggestions.dismiss(category, cardIds);
         if (!ok) return sendJSON(res, { error: 'dismiss failed' }, 400);
         return sendJSON(res, { ok: true });
+      });
+      return;
+    }
+
+    // POST /api/feedback — append an anonymised feature-request line.
+    // Body: { intent, context?, toolsConsidered? }. Fired by Klebbius (via
+    // the note_feature_request tool) when a request is genuinely unsupported,
+    // so the operator can review unmet needs. Anonymisation happens in
+    // lib/feedback; behind the same global auth gate as every other /api route.
+    if (parts[0] === 'feedback' && parts.length === 1 && req.method === 'POST') {
+      let body = '';
+      req.on('data', c => body += c);
+      req.on('end', () => {
+        let parsed;
+        try { parsed = JSON.parse(body || '{}'); }
+        catch { return sendJSON(res, { error: 'invalid json' }, 400); }
+        if (!parsed.intent || typeof parsed.intent !== 'string') {
+          return sendJSON(res, { error: 'intent required' }, 400);
+        }
+        const result = feedback.appendFeedback(parsed);
+        return sendJSON(res, result, result.logged ? 200 : 400);
       });
       return;
     }

--- a/tests/api/feedback-api.test.js
+++ b/tests/api/feedback-api.test.js
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/api/feedback-api.test.js
+// POST /api/feedback appends one anonymised JSONL line to data/_meta/feedback.jsonl.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const { createSandbox, cleanupSandbox, spawnServer, req } = require('../helpers/sandbox');
+
+describe('POST /api/feedback', () => {
+  let sandbox, server;
+  before(async () => {
+    sandbox = createSandbox({ seed: {} });
+    server = await spawnServer(sandbox);
+  });
+  after(async () => { if (server) await server.kill(); cleanupSandbox(sandbox); });
+
+  test('appends one valid JSONL line and returns {logged:true}', async () => {
+    const res = await req(server.baseUrl, '/api/feedback', {
+      method: 'POST',
+      body: { intent: 'wants a heatmap renderer', context: 'no heatmap renderer exists', toolsConsidered: ['create_manifest'] },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.json.logged, true);
+
+    const file = path.join(sandbox, 'data', '_meta', 'feedback.jsonl');
+    assert.ok(fs.existsSync(file), 'feedback.jsonl should be created lazily');
+    const raw = fs.readFileSync(file, 'utf8');
+    assert.ok(raw.endsWith('\n'), 'line must be newline-terminated');
+    const lines = raw.trim().split('\n');
+    assert.equal(lines.length, 1);
+    const parsed = JSON.parse(lines[0]);
+    assert.equal(parsed.intent, 'wants a heatmap renderer');
+    assert.ok(parsed.ts, 'line carries a timestamp');
+  });
+
+  test('a second post appends, not overwrites', async () => {
+    await req(server.baseUrl, '/api/feedback', { method: 'POST', body: { intent: 'wants CSV export' } });
+    const file = path.join(sandbox, 'data', '_meta', 'feedback.jsonl');
+    const lines = fs.readFileSync(file, 'utf8').trim().split('\n');
+    assert.equal(lines.length, 2);
+    assert.equal(JSON.parse(lines[1]).intent, 'wants CSV export');
+  });
+
+  test('rejects a missing intent with 400', async () => {
+    const res = await req(server.baseUrl, '/api/feedback', { method: 'POST', body: { context: 'x' } });
+    assert.equal(res.status, 400);
+    assert.ok(res.json.error);
+  });
+
+  test('rejects invalid JSON with 400', async () => {
+    const res = await req(server.baseUrl, '/api/feedback', {
+      method: 'POST', body: '{not json', headers: { 'Content-Type': 'application/json' },
+    });
+    assert.equal(res.status, 400);
+  });
+});

--- a/tests/feedback.test.js
+++ b/tests/feedback.test.js
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/feedback.test.js
+// Unit tests for the anonymised feedback log. The anonymise() boundary is
+// load-bearing: nothing else strips PII, so it must keep only a paraphrased
+// intent + structural context + timestamp, and never leak raw values.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { anonymise } = require('../lib/feedback');
+const { TOOL_DEFS } = require('../chat/tools');
+
+const NOW = '2026-06-24T04:12:00.000Z';
+
+describe('feedback: anonymise', () => {
+  test('keeps intent, context, toolsConsidered, and the timestamp', () => {
+    const line = anonymise({
+      intent: 'wants to chart sleep as a heatmap',
+      context: 'renderer=line-chart present; no heatmap renderer',
+      toolsConsidered: ['create_manifest', 'write_manifest_data'],
+    }, NOW);
+    assert.deepStrictEqual(line, {
+      ts: NOW,
+      intent: 'wants to chart sleep as a heatmap',
+      context: 'renderer=line-chart present; no heatmap renderer',
+      toolsConsidered: ['create_manifest', 'write_manifest_data'],
+    });
+  });
+
+  test('returns null when there is no usable intent', () => {
+    assert.strictEqual(anonymise({}, NOW), null);
+    assert.strictEqual(anonymise({ intent: '   ' }, NOW), null);
+    assert.strictEqual(anonymise({ context: 'x' }, NOW), null);
+    assert.strictEqual(anonymise(null, NOW), null);
+  });
+
+  test('drops context/tools when absent rather than emitting empties', () => {
+    const line = anonymise({ intent: 'wants CSV export' }, NOW);
+    assert.deepStrictEqual(line, { ts: NOW, intent: 'wants CSV export' });
+    assert.strictEqual('context' in line, false);
+    assert.strictEqual('toolsConsidered' in line, false);
+  });
+
+  test('caps intent and context length (no unbounded blobs)', () => {
+    const longIntent = 'x'.repeat(1000);
+    const longContext = 'y'.repeat(1000);
+    const line = anonymise({ intent: longIntent, context: longContext }, NOW);
+    assert.ok(line.intent.length <= 280);
+    assert.ok(line.context.length <= 500);
+  });
+
+  test('caps and string-filters toolsConsidered', () => {
+    const tools = Array.from({ length: 30 }, (_, i) => `tool_${i}`).concat([123, null, {}]);
+    const line = anonymise({ intent: 'x', toolsConsidered: tools }, NOW);
+    assert.ok(line.toolsConsidered.length <= 12);
+    assert.ok(line.toolsConsidered.every(t => typeof t === 'string'));
+  });
+
+  test('does NOT pull any other field through (no leakage of raw transcript/values)', () => {
+    const line = anonymise({
+      intent: 'wants a heatmap',
+      rawMessage: 'my weight is 84.2kg and I am worried about my diagnosis',
+      values: [84.2, 83.1],
+      userName: 'someone',
+    }, NOW);
+    // Only the three allowed keys + ts survive; nothing else.
+    assert.deepStrictEqual(Object.keys(line).sort(), ['intent', 'ts']);
+    const serialised = JSON.stringify(line);
+    assert.ok(!serialised.includes('84.2'));
+    assert.ok(!serialised.includes('diagnosis'));
+    assert.ok(!serialised.includes('someone'));
+  });
+});
+
+describe('feedback: tool registration', () => {
+  test('note_feature_request is in TOOL_DEFS requiring intent', () => {
+    const def = TOOL_DEFS.find(t => t.function?.name === 'note_feature_request');
+    assert.ok(def, 'note_feature_request missing from TOOL_DEFS');
+    assert.deepStrictEqual(def.function.parameters.required, ['intent']);
+  });
+});


### PR DESCRIPTION
# What changed
`POST /api/feedback` + a `note_feature_request` chat tool that append an anonymised line to `data/_meta/feedback.jsonl` when a request is genuinely unsupported.

# Why
So the operator can discover what users actually want, without any external call or PII.

# How
`lib/feedback.anonymise()` is the privacy boundary (nothing else strips PII): it keeps only a paraphrased intent, structural context, considered tool names, and a timestamp, each length-capped, and pulls no other field through. The endpoint sits behind the same global auth gate as every other /api route and reuses the `recordAuthEvent`-style `appendFileSync` primitive into the gitignored `data/_meta/` namespace.

**Stacked on #416** because both edit `chat/tools.js`.

# Testing
- [x] `npm test` passes (+11).
- [x] Unit tests (`tests/feedback.test.js`) prove anonymise() leaks no raw values/labels/message; API test (`tests/api/feedback-api.test.js`) proves a single newline-terminated JSONL line and append-not-overwrite.

Refs #417