### PR TITLE
feat(chat): resolve vague references against the card in focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Chat resolves references against the card in focus.** When the user
+  expands a card and then asks Klebbius something vague ("change the
+  target to 80kg"), the client passes the opened card's id with the
+  chat request and the server injects a "Card in focus" block into the
+  system prompt so the agent resolves "this card"/"the target" against
+  it before asking a clarifying question. Only injected when the id
+  resolves to a real card. Refs #418.
+
 - **Anonymised feature-request log (`POST /api/feedback` +
   `note_feature_request` tool).** When a user asks for something Klebb
   genuinely cannot do, Klebbius states the boundary, offers the nearest

--- a/public/js/components/eh-base-card.js
+++ b/public/js/components/eh-base-card.js
@@ -126,6 +126,12 @@ export class EhBaseCard extends LitElement {
   _toggleExpand() {
     if (!this._canExpand) return;
     this.expanded = !this.expanded;
+    // Broadcast the card the user just opened so the chat can resolve
+    // vague references ("change the target to 80kg") against it. Only on
+    // expand, not collapse: collapsing doesn't change what they're looking at.
+    if (this.expanded && this.card?.id) {
+      window.dispatchEvent(new CustomEvent('klebb-card-focused', { detail: { id: this.card.id } }));
+    }
   }
 
   static styles = css`

--- a/public/js/components/health-chat.js
+++ b/public/js/components/health-chat.js
@@ -847,6 +847,15 @@ class HealthChat extends LitElement {
       });
     };
     window.addEventListener('klebb-paste-into-chat', this._onPasteIntoChat);
+
+    // Remember the last card the user opened, so a question can be resolved
+    // against it server-side. Not reactive state: it only rides the next
+    // /api/chat request as immediate context.
+    this._onCardFocused = (e) => {
+      const id = e?.detail?.id;
+      if (typeof id === 'string' && id) this._viewedCardId = id;
+    };
+    window.addEventListener('klebb-card-focused', this._onCardFocused);
   }
 
   disconnectedCallback() {
@@ -859,6 +868,9 @@ class HealthChat extends LitElement {
     }
     if (this._onPasteIntoChat) {
       window.removeEventListener('klebb-paste-into-chat', this._onPasteIntoChat);
+    }
+    if (this._onCardFocused) {
+      window.removeEventListener('klebb-card-focused', this._onCardFocused);
     }
   }
 
@@ -876,10 +888,12 @@ class HealthChat extends LitElement {
     this._abortController = new AbortController();
     const timeoutId = setTimeout(() => this._abortController?.abort(), timeoutMs);
     try {
+      const body = { messages, voiceMode };
+      if (this._viewedCardId) body.viewedCardId = this._viewedCardId;
       const res = await fetch('/api/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'Connection': 'close' },
-        body: JSON.stringify({ messages, voiceMode }),
+        body: JSON.stringify(body),
         signal: this._abortController.signal,
         cache: 'no-store',
       });

--- a/server.js
+++ b/server.js
@@ -1515,7 +1515,7 @@ const server = http.createServer(async (req, res) => {
       req.on('end', () => {
         try {
           const parsed = JSON.parse(body);
-          const { messages, voiceMode } = parsed;
+          const { messages, voiceMode, viewedCardId } = parsed;
           if (!Array.isArray(messages) || messages.length === 0) {
             return sendJSON(res, { error: 'messages required' }, 400);
           }
@@ -1536,6 +1536,19 @@ const server = http.createServer(async (req, res) => {
           const cardListBlock = cardList
             ? `\n\n## Currently available cards\n\n${cardList}\n`
             : '\n\n## Currently available cards\n\n(none yet)\n';
+
+          // If the client told us which card the user just opened, name it as
+          // privileged immediate context so vague references ("change the
+          // target to 80kg") resolve against it before the agent considers a
+          // clarifying question. Only when the id resolves to a real card.
+          let viewedCardBlock = '';
+          if (typeof viewedCardId === 'string' && viewedCardId) {
+            const vc = registry.get(viewedCardId);
+            if (vc) {
+              const vlabel = vc.meta?.label || viewedCardId;
+              viewedCardBlock = `\n\n## Card in focus\n\nThe user is currently looking at the "${vlabel}" card (id: ${viewedCardId}). Resolve vague references ("this card", "the target", "change it") against this card first.\n`;
+            }
+          }
 
           // Inject today's absolute date + a pre-computed weekday lookup
           // table in the server's TZ. Language models are unreliable at
@@ -1594,7 +1607,7 @@ const server = http.createServer(async (req, res) => {
             '',
           ].join('\n');
 
-          let systemPrompt = HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock + haeCatalogueBlock + ccSchemaBlock + docsCatalogueBlock + reportsCatalogueBlock + categoryBlock;
+          let systemPrompt = HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock + viewedCardBlock + haeCatalogueBlock + ccSchemaBlock + docsCatalogueBlock + reportsCatalogueBlock + categoryBlock;
           if (voiceMode) {
             systemPrompt = `You are ${process.env.CHAT_AGENT_NAME || 'Chat'}, a health assistant.
 Voice mode is active: the user is speaking to you and will hear your reply aloud.
@@ -1627,7 +1640,7 @@ Return STRICTLY the JSON object. No leading/trailing text. No markdown fences.
 
 Original system prompt follows:
 
-` + HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock + haeCatalogueBlock + ccSchemaBlock + docsCatalogueBlock + reportsCatalogueBlock + categoryBlock;
+` + HEALTH_SYSTEM_PROMPT + todayBlock + cardListBlock + viewedCardBlock + haeCatalogueBlock + ccSchemaBlock + docsCatalogueBlock + reportsCatalogueBlock + categoryBlock;
           }
 
           // Prepend system prompt

--- a/tests/chat-viewed-card.test.js
+++ b/tests/chat-viewed-card.test.js
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/chat-viewed-card.test.js
+// Verifies the chat proxy injects a "Card in focus" block into the system
+// prompt when the client passes viewedCardId, and leaves the prompt unchanged
+// when it is absent or unknown.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('http');
+const { createSandbox, cleanupSandbox, spawnServer, req } = require('./helpers/sandbox');
+
+function makeCard(id, label) {
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: { id, label, emoji: '⚖️', view: { enabled: true, component: 'generic-card' } },
+    description: 'test card',
+    data: [{ date: '2026-04-20', kg: 85 }],
+  };
+}
+
+function startStubGateway() {
+  let lastSystemPrompt = null;
+  const server = http.createServer((request, response) => {
+    let body = '';
+    request.on('data', c => { body += c; });
+    request.on('end', () => {
+      try {
+        const parsed = JSON.parse(body);
+        lastSystemPrompt = parsed.messages?.find(m => m.role === 'system')?.content || null;
+      } catch {}
+      response.writeHead(200, { 'Content-Type': 'application/json' });
+      response.end(JSON.stringify({ choices: [{ message: { role: 'assistant', content: 'ack' } }] }));
+    });
+  });
+  return new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => resolve({
+      port: server.address().port,
+      close: () => new Promise(r => server.close(r)),
+      getLastPrompt: () => lastSystemPrompt,
+    }));
+  });
+}
+
+describe('chat proxy: viewed-card immediate context', () => {
+  let sandbox, server, gateway;
+
+  before(async () => {
+    gateway = await startStubGateway();
+    sandbox = createSandbox({ seed: { 'weight.json': makeCard('weight', 'Body Weight') } });
+    server = await spawnServer(sandbox, {
+      CHAT_ENDPOINT_URL: `http://127.0.0.1:${gateway.port}/v1/chat/completions`,
+      CHAT_API_KEY: 'stub-token',
+      CHAT_MODEL: 'stub-model',
+    });
+  });
+  after(async () => {
+    if (server) await server.kill();
+    if (gateway) await gateway.close();
+    cleanupSandbox(sandbox);
+  });
+
+  test('injects a Card in focus block when viewedCardId resolves', async () => {
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'change it to 80' }], viewedCardId: 'weight' },
+    });
+    assert.equal(res.status, 200);
+    const sp = gateway.getLastPrompt();
+    assert.ok(sp.includes('Card in focus'), 'prompt has the focus header');
+    assert.ok(sp.includes('Body Weight'), 'prompt names the focused card label');
+    assert.ok(sp.includes('weight'), 'prompt names the focused card id');
+  });
+
+  test('omits the block when no viewedCardId is sent', async () => {
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'hi' }] },
+    });
+    assert.equal(res.status, 200);
+    assert.ok(!gateway.getLastPrompt().includes('Card in focus'));
+  });
+
+  test('omits the block when viewedCardId is an unknown id (no injection of arbitrary text)', async () => {
+    const res = await req(server.baseUrl, '/api/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'hi' }], viewedCardId: 'does-not-exist' },
+    });
+    assert.equal(res.status, 200);
+    assert.ok(!gateway.getLastPrompt().includes('Card in focus'));
+  });
+});


### PR DESCRIPTION
# What changed
When the user expands a card then asks Klebbius something vague, the client passes the opened card's id and the server injects a 'Card in focus' block into the system prompt.

# Why
'Change the target to 80kg' should resolve against the card the user is looking at, not trigger a clarifying question.

# How
`eh-base-card` broadcasts `klebb-card-focused` on expand; `health-chat` remembers the last id and rides it on the next /api/chat request as `viewedCardId`; the server injects the block only when the id resolves to a real card (so a stale/forged id can't inject arbitrary prompt text).

**Stacked on #417** because both edit the server.js chat handler.

# Testing
- [x] `npm test` passes (+3).
- [x] Stub-gateway test (`tests/chat-viewed-card.test.js`) asserts the block is injected for a real id, omitted when absent, and omitted for an unknown id.

Refs #418