### PR TITLE
feat(chat): add hygiene_scan tool for on-demand card hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **`hygiene_scan` chat tool.** On-demand dashboard health check
+  returning `{findings:[{cardId, kind, severity, detail}]}` so Klebbius
+  can answer "is anything stale?" or "tidy up my cards". Kinds: `stale`
+  (no entry well past the expected cadence, with a tighter window for
+  schedule-bearing cards), `growth` (a very large data block that wants
+  archiving or a rolling window), and `orphaned-input` (a capture field
+  no row ever uses). Findings are conservative (near-empty cards are
+  skipped) and are suggestions only: the tool never mutates anything.
+  Built on the shared staleness derivation from `get_recent_activity`.
+  Refs #439.
+
 - **Chat resolves references against the card in focus.** When the user
   expands a card and then asks Klebbius something vague ("change the
   target to 80kg"), the client passes the opened card's id with the

--- a/chat/hygiene.js
+++ b/chat/hygiene.js
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// chat/hygiene.js
+// Card-hygiene findings for the Klebbius agent. Pure, deterministic checks
+// over the manifest registry; never auto-corrects, only reports. Builds on
+// the shared recency/staleness derivation in recent-activity.js so freshness
+// is computed in exactly one place.
+//
+// Severity is advisory: 'info' < 'warn'. The ambient surface (GET /api/hygiene)
+// only carries high-confidence staleness; the full set is for the on-demand
+// hygiene_scan tool, where the agent mediates whether to surface a finding.
+
+const { buildRecentActivity, dateFieldFor } = require('./recent-activity');
+
+// How long a card may sit untouched before it reads as "stale". Cards with a
+// daily-ish cadence go stale fast; everything else gets a generous window.
+const STALE_DAYS_DEFAULT = 21;
+const STALE_DAYS_SCHEDULED = 7;
+// Don't flag growth until a card is genuinely large enough to matter.
+const ROW_GROWTH_SOFT_CAP = 730;
+// Don't flag staleness/orphans on near-empty cards: too little signal.
+const MIN_ROWS_FOR_STALE = 3;
+
+// Does any data.items[] entry carry a recurring schedule? Such cards expect
+// frequent check-offs, so they go stale faster. Defensive: data shape varies.
+function hasScheduleCadence(data) {
+  const items = Array.isArray(data) ? data : (data && Array.isArray(data.items) ? data.items : null);
+  if (!items) return false;
+  return items.some(it => it && typeof it === 'object' && it.schedule && typeof it.schedule === 'object');
+}
+
+// Inputs whose key never appears in any data row. A genuine "you built a
+// field nobody fills" signal. Only meaningful for array-of-rows cards that
+// actually declare inputs.
+function orphanedInputKeys(meta, data) {
+  const inputs = meta && meta.writeable && Array.isArray(meta.writeable.inputs) ? meta.writeable.inputs : [];
+  if (inputs.length === 0 || !Array.isArray(data) || data.length === 0) return [];
+  const seen = new Set();
+  for (const row of data) {
+    if (row && typeof row === 'object') for (const k of Object.keys(row)) seen.add(k);
+  }
+  return inputs
+    .map(i => i && typeof i.key === 'string' ? i.key : null)
+    .filter(k => k && !seen.has(k));
+}
+
+// Build the full hygiene finding list.
+//   registry : manifest registry (list/get/sourceMtime)
+//   today    : server-local ISO date (YYYY-MM-DD)
+// Returns { findings: [{cardId, kind, severity, detail}] }.
+function scanHygiene(registry, today) {
+  const activity = buildRecentActivity(registry, today);
+  const findings = [];
+
+  for (const card of activity) {
+    const entry = typeof registry.get === 'function' ? registry.get(card.id) : null;
+    const meta = entry ? entry.meta || {} : {};
+    const data = entry ? entry.data : null;
+    const scheduled = hasScheduleCadence(data);
+
+    // Stale-vs-cadence: a card with enough history that has gone quiet past
+    // its expected window. Tighter window for schedule-bearing cards.
+    if (card.ageDays != null && card.rowCount >= MIN_ROWS_FOR_STALE) {
+      const limit = scheduled ? STALE_DAYS_SCHEDULED : STALE_DAYS_DEFAULT;
+      if (card.ageDays > limit) {
+        findings.push({
+          cardId: card.id,
+          kind: 'stale',
+          severity: card.ageDays > limit * 2 ? 'warn' : 'info',
+          detail: `No entry in ${card.ageDays} days (expected within ~${limit}). Last: ${card.lastEntryDate || 'unknown'}.`,
+        });
+      }
+    }
+
+    // Unbounded growth: a very large data block that would benefit from a
+    // rolling window or archive.
+    if (card.rowCount > ROW_GROWTH_SOFT_CAP) {
+      findings.push({
+        cardId: card.id,
+        kind: 'growth',
+        severity: 'info',
+        detail: `${card.rowCount} rows; consider archiving old data or a rolling window.`,
+      });
+    }
+
+    // Orphaned inputs: declared capture fields that no row ever uses.
+    const orphans = orphanedInputKeys(meta, data);
+    if (orphans.length) {
+      findings.push({
+        cardId: card.id,
+        kind: 'orphaned-input',
+        severity: 'info',
+        detail: `Input field(s) never logged: ${orphans.join(', ')}. Remove from meta.writeable.inputs or start logging them.`,
+      });
+    }
+  }
+
+  return { findings };
+}
+
+// The ambient surface (GET /api/hygiene) only ever shows high-confidence
+// staleness: unambiguous, self-explanatory, and the one signal worth a passive
+// nudge. Everything else is pull-only via hygiene_scan to avoid nagging.
+function ambientStaleness(registry, today) {
+  return scanHygiene(registry, today).findings.filter(f => f.kind === 'stale');
+}
+
+module.exports = { scanHygiene, ambientStaleness, orphanedInputKeys, hasScheduleCadence };

--- a/chat/tools.js
+++ b/chat/tools.js
@@ -14,6 +14,7 @@ const { readReport } = require('./reports');
 const { buildRecentActivity } = require('./recent-activity');
 const { validateManifest } = require('./validate-manifest');
 const { appendFeedback } = require('../lib/feedback');
+const { scanHygiene } = require('./hygiene');
 
 // Server-local "today" (YYYY-MM-DD) in the configured TZ, matching the
 // server's todayIso(). Used for the ageDays maths in get_recent_activity.
@@ -222,6 +223,19 @@ const TOOL_DEFS = [
           },
         },
         required: ['manifest'],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'hygiene_scan',
+      description:
+        "Scan every card for hygiene problems and return {findings:[{cardId, kind, severity, detail}]}. Use this when the user asks to 'tidy up', 'what's stale/messy', 'is anything out of date', or wants a dashboard health check. Kinds: 'stale' (no entry well past the expected cadence), 'growth' (very large data block that wants archiving/a rolling window), 'orphaned-input' (a capture field no row ever uses). Findings are conservative (near-empty cards are skipped) and are SUGGESTIONS only: never act on them without the user's say-so, and surface them conversationally rather than dumping the raw list.",
+      parameters: {
+        type: 'object',
+        properties: {},
         additionalProperties: false,
       },
     },
@@ -601,6 +615,9 @@ function dispatchToolCall(tc, ctx) {
       }
       case 'get_recent_activity': {
         return JSON.stringify({ cards: buildRecentActivity(registry, serverTodayIso()) });
+      }
+      case 'hygiene_scan': {
+        return JSON.stringify(scanHygiene(registry, serverTodayIso()));
       }
       case 'validate_manifest': {
         return JSON.stringify(validateManifest(args.manifest));

--- a/tests/hygiene.test.js
+++ b/tests/hygiene.test.js
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/hygiene.test.js
+// Unit tests for the hygiene scan: stale/growth/orphaned-input detection,
+// the conservative suppression rules, the ambient staleness-only filter,
+// and TOOL_DEFS membership.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { scanHygiene, ambientStaleness, orphanedInputKeys, hasScheduleCadence } = require('../chat/hygiene');
+const { TOOL_DEFS } = require('../chat/tools');
+
+const TODAY = '2026-06-24';
+
+function makeRegistry(cards, mtimes = {}) {
+  const byId = new Map(cards.map(c => [c.id, c]));
+  return {
+    list: () => cards.map(c => ({ id: c.id, meta: c.meta || {} })),
+    get: id => (byId.has(id) ? { meta: byId.get(id).meta || {}, data: byId.get(id).data } : null),
+    sourceMtime: id => (id in mtimes ? mtimes[id] : null),
+  };
+}
+
+// rows ending N days before TODAY, daily
+function rowsEnding(daysAgo, count, field = 'v') {
+  const out = [];
+  const end = Date.parse(`${TODAY}T00:00:00Z`) - daysAgo * 86400000;
+  for (let i = count - 1; i >= 0; i--) {
+    out.push({ date: new Date(end - i * 86400000).toISOString().slice(0, 10), [field]: i });
+  }
+  return out;
+}
+
+describe('hygiene: stale detection', () => {
+  test('flags an atomic card untouched well past the default window', () => {
+    const reg = makeRegistry([{ id: 'weight', meta: { label: 'Weight' }, data: rowsEnding(30, 5) }]);
+    const { findings } = scanHygiene(reg, TODAY);
+    const stale = findings.find(f => f.cardId === 'weight' && f.kind === 'stale');
+    assert.ok(stale, 'expected a stale finding');
+    assert.match(stale.detail, /No entry in 30 days/);
+  });
+
+  test('does NOT flag a fresh card', () => {
+    const reg = makeRegistry([{ id: 'weight', meta: {}, data: rowsEnding(1, 5) }]);
+    assert.deepStrictEqual(scanHygiene(reg, TODAY).findings.filter(f => f.kind === 'stale'), []);
+  });
+
+  test('does NOT flag a near-empty card (too little signal)', () => {
+    const reg = makeRegistry([{ id: 'weight', meta: {}, data: rowsEnding(60, 2) }]);
+    assert.deepStrictEqual(scanHygiene(reg, TODAY).findings.filter(f => f.kind === 'stale'), []);
+  });
+
+  test('uses the tighter window for schedule-bearing cards', () => {
+    // A card 10 days quiet: under the 21-day default it would NOT be stale,
+    // but a recurring schedule tightens the window to 7 days so it trips.
+    const reg = makeRegistry([{ id: 'p', meta: {}, data: rowsEnding(10, 5).map(r => ({ ...r, schedule: { type: 'daily' } })) }]);
+    const stale = scanHygiene(reg, TODAY).findings.find(f => f.kind === 'stale');
+    assert.ok(stale, 'a 10-day-old scheduled card should be stale under the 7-day window');
+  });
+});
+
+describe('hygiene: growth + orphaned inputs', () => {
+  test('flags a very large data block', () => {
+    const reg = makeRegistry([{ id: 'big', meta: {}, data: rowsEnding(0, 800) }]);
+    const growth = scanHygiene(reg, TODAY).findings.find(f => f.kind === 'growth');
+    assert.ok(growth);
+    assert.match(growth.detail, /800 rows/);
+  });
+
+  test('orphanedInputKeys finds a declared input no row uses', () => {
+    const meta = { writeable: { inputs: [{ key: 'kg' }, { key: 'bodyFat' }] } };
+    const data = [{ date: '2026-06-20', kg: 84 }];
+    assert.deepStrictEqual(orphanedInputKeys(meta, data), ['bodyFat']);
+  });
+
+  test('orphanedInputKeys is empty when every input is used', () => {
+    const meta = { writeable: { inputs: [{ key: 'kg' }] } };
+    assert.deepStrictEqual(orphanedInputKeys(meta, [{ date: 'x', kg: 1 }]), []);
+  });
+
+  test('hasScheduleCadence detects items[] with a schedule', () => {
+    assert.strictEqual(hasScheduleCadence({ items: [{ schedule: {} }] }), true);
+    assert.strictEqual(hasScheduleCadence([{ date: 'x', v: 1 }]), false);
+  });
+});
+
+describe('hygiene: ambient filter', () => {
+  test('ambientStaleness returns only stale findings', () => {
+    const reg = makeRegistry([
+      { id: 'stalecard', meta: {}, data: rowsEnding(40, 5) },
+      { id: 'bigcard', meta: {}, data: rowsEnding(0, 800) },
+    ]);
+    const ambient = ambientStaleness(reg, TODAY);
+    assert.ok(ambient.length >= 1);
+    assert.ok(ambient.every(f => f.kind === 'stale'));
+  });
+});
+
+describe('hygiene: tool registration', () => {
+  test('hygiene_scan is in TOOL_DEFS with no required params', () => {
+    const def = TOOL_DEFS.find(t => t.function?.name === 'hygiene_scan');
+    assert.ok(def, 'hygiene_scan missing from TOOL_DEFS');
+    assert.deepStrictEqual(def.function.parameters.properties, {});
+  });
+});


### PR DESCRIPTION
# What changed
A `hygiene_scan` chat tool returning `{findings:[{cardId, kind, severity, detail}]}` for stale / oversized / orphaned-input cards.

# Why
Klebbius had no way to answer 'is anything stale?' or 'tidy up my cards'.

# How
Pure deterministic scan in `chat/hygiene.js` built on the shared staleness derivation from #415. Conservative: skips near-empty cards, tighter stale-window for schedule-bearing cards, report-only (never mutates). **Stacked on #418** (chat-tool stack).

# Testing
- [x] `npm test` passes (+10). Unit tests in `tests/hygiene.test.js`.

Refs #439