### PR TITLE
feat(server): add ambient GET /api/hygiene staleness surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Added
 
+- **Ambient hygiene surface (`GET /api/hygiene`).** A quiet,
+  high-confidence staleness feed (only the `stale` finding kind; the
+  full multi-kind scan stays pull-only via `hygiene_scan`), mirroring
+  the cc-suggestions transport. `POST /api/hygiene/:cardId/dismiss`
+  silences one finding kind for one card, persisted whole-file-atomic at
+  `data/_meta/hygiene-dismissed.json` and keyed by `cardId::kind` so
+  dismissing one nudge never suppresses another. Refs #440.
+
 - **`hygiene_scan` chat tool.** On-demand dashboard health check
   returning `{findings:[{cardId, kind, severity, detail}]}` so Klebbius
   can answer "is anything stale?" or "tidy up my cards". Kinds: `stale`

--- a/lib/hygiene-state.js
+++ b/lib/hygiene-state.js
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// lib/hygiene-state.js
+// Dismissal sidecar for the ambient hygiene surface (GET /api/hygiene),
+// mirroring meta/cc-suggestions dismissals: whole-file atomic JSON under the
+// gitignored data/_meta/ namespace, created lazily on first dismiss.
+//
+// A dismissal is keyed by cardId + kind, so silencing a stale nudge for one
+// card never suppresses a different card or a different finding kind.
+
+const fs = require('fs');
+const path = require('path');
+const PATHS = require('../config/paths');
+
+const FILE = path.join(PATHS.DATA_DIR, '_meta', 'hygiene-dismissed.json');
+
+function key(cardId, kind) {
+  return `${cardId}::${kind}`;
+}
+
+function loadDismissed() {
+  try {
+    return JSON.parse(fs.readFileSync(FILE, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function saveDismissed(state) {
+  try {
+    fs.mkdirSync(path.dirname(FILE), { recursive: true });
+    const tmp = `${FILE}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(state, null, 2));
+    fs.renameSync(tmp, FILE);
+  } catch (e) {
+    console.error('[hygiene] failed to write dismissed state:', e.message);
+  }
+}
+
+function isDismissed(cardId, kind) {
+  return Object.prototype.hasOwnProperty.call(loadDismissed(), key(cardId, kind));
+}
+
+function dismiss(cardId, kind, now = new Date().toISOString()) {
+  if (!cardId || !kind) return false;
+  const state = loadDismissed();
+  state[key(cardId, kind)] = { cardId, kind, dismissedAt: now };
+  saveDismissed(state);
+  return true;
+}
+
+// Drop findings the user has already dismissed.
+function filterDismissed(findings) {
+  const state = loadDismissed();
+  return findings.filter(f => !Object.prototype.hasOwnProperty.call(state, key(f.cardId, f.kind)));
+}
+
+module.exports = { isDismissed, dismiss, filterDismissed, loadDismissed, FILE };

--- a/server.js
+++ b/server.js
@@ -27,6 +27,8 @@ const haeTokenStore = require('./health-auto-export/token-store');
 const { describeCatalogue: describeHaeCatalogue } = require('./health-auto-export/describe');
 const userTz = require('./lib/user-tz');
 const feedback = require('./lib/feedback');
+const { ambientStaleness } = require('./chat/hygiene');
+const hygieneState = require('./lib/hygiene-state');
 const notificationsState = require('./lib/notifications-state');
 const notificationsScheduler = require('./lib/notifications-scheduler');
 const webPushSend = require('./lib/web-push-send');
@@ -1198,6 +1200,34 @@ const server = http.createServer(async (req, res) => {
           return sendJSON(res, { error: 'cardIds required' }, 400);
         }
         const ok = ccSuggestions.dismiss(category, cardIds);
+        if (!ok) return sendJSON(res, { error: 'dismiss failed' }, 400);
+        return sendJSON(res, { ok: true });
+      });
+      return;
+    }
+
+    // GET /api/hygiene — ambient, high-confidence staleness only, minus
+    // anything the user has dismissed. The full multi-kind scan is pull-only
+    // via the hygiene_scan chat tool; this surface is the quiet nudge.
+    if (parts[0] === 'hygiene' && parts.length === 1 && req.method === 'GET') {
+      const findings = hygieneState.filterDismissed(ambientStaleness(registry, todayIso()));
+      return sendJSON(res, { findings });
+    }
+
+    // POST /api/hygiene/:cardId/dismiss
+    // Body: { kind } — silence one finding kind for one card until its
+    // condition is re-raised. Mirrors the cc-suggestions dismissal model.
+    if (parts[0] === 'hygiene' && parts[2] === 'dismiss'
+        && parts.length === 3 && req.method === 'POST') {
+      const cardId = decodeURIComponent(parts[1]);
+      let body = '';
+      req.on('data', c => body += c);
+      req.on('end', () => {
+        let parsed;
+        try { parsed = JSON.parse(body || '{}'); }
+        catch { return sendJSON(res, { error: 'invalid json' }, 400); }
+        const kind = typeof parsed.kind === 'string' ? parsed.kind : 'stale';
+        const ok = hygieneState.dismiss(cardId, kind);
         if (!ok) return sendJSON(res, { error: 'dismiss failed' }, 400);
         return sendJSON(res, { ok: true });
       });

--- a/tests/api/hygiene-api.test.js
+++ b/tests/api/hygiene-api.test.js
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/api/hygiene-api.test.js
+// GET /api/hygiene surfaces high-confidence staleness; POST .../dismiss
+// suppresses it. Mirrors the cc-suggestions dismissal model.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const { createSandbox, cleanupSandbox, spawnServer, req } = require('../helpers/sandbox');
+
+// A generic-card with dated rows ending ~40 days ago: comfortably stale, and
+// enough rows to clear the near-empty suppression.
+function staleCard(id) {
+  const rows = [];
+  const base = Date.parse('2000-01-01T00:00:00Z'); // any fixed past; ages are huge
+  for (let i = 0; i < 5; i++) {
+    rows.push({ date: new Date(base + i * 86400000).toISOString().slice(0, 10), kg: 80 + i });
+  }
+  return {
+    $schema: 'klebb.datafile.v1',
+    meta: { id, label: `Card ${id}`, view: { enabled: true, component: 'generic-card' } },
+    data: rows,
+  };
+}
+
+describe('GET /api/hygiene', () => {
+  let sandbox, server;
+  before(async () => {
+    sandbox = createSandbox({ seed: { 'old.json': staleCard('old') } });
+    server = await spawnServer(sandbox);
+  });
+  after(async () => { if (server) await server.kill(); cleanupSandbox(sandbox); });
+
+  test('surfaces a stale finding for an old card', async () => {
+    const res = await req(server.baseUrl, '/api/hygiene');
+    assert.equal(res.status, 200);
+    assert.ok(Array.isArray(res.json.findings));
+    const f = res.json.findings.find(x => x.cardId === 'old');
+    assert.ok(f, 'expected a stale finding for the old card');
+    assert.equal(f.kind, 'stale');
+  });
+
+  test('dismiss suppresses the finding and persists', async () => {
+    const d = await req(server.baseUrl, '/api/hygiene/old/dismiss', {
+      method: 'POST', body: { kind: 'stale' },
+    });
+    assert.equal(d.status, 200);
+    assert.equal(d.json.ok, true);
+
+    const file = path.join(sandbox, 'data', '_meta', 'hygiene-dismissed.json');
+    assert.ok(fs.existsSync(file), 'dismissal sidecar created');
+    const state = JSON.parse(fs.readFileSync(file, 'utf8'));
+    assert.ok(state['old::stale'], 'dismissal keyed by cardId::kind');
+
+    const res = await req(server.baseUrl, '/api/hygiene');
+    assert.equal(res.json.findings.find(x => x.cardId === 'old'), undefined,
+      'dismissed finding no longer surfaces');
+  });
+
+  test('invalid json on dismiss returns 400', async () => {
+    const res = await req(server.baseUrl, '/api/hygiene/old/dismiss', {
+      method: 'POST', body: '{nope', headers: { 'Content-Type': 'application/json' },
+    });
+    assert.equal(res.status, 400);
+  });
+});


### PR DESCRIPTION
# What changed
`GET /api/hygiene` (high-confidence staleness only) + `POST /api/hygiene/:cardId/dismiss`, mirroring the cc-suggestions transport.

# Why
A quiet ambient nudge for stale cards, separate from the on-demand full scan.

# How
`GET` filters `ambientStaleness` (stale-only) through dismissals; dismissals persist at `data/_meta/hygiene-dismissed.json` keyed `cardId::kind`. **Stacked on #439.**

# Testing
- [x] `npm test` passes (+3). API test in `tests/api/hygiene-api.test.js` covers surface + dismiss round-trip.

Refs #440