### PR TITLE
fix(docs): correct line-chart config drift to match the renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,16 @@ the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
+- **Line-chart config docs now match the renderer.** The docs and the
+  chat system prompt described `line-chart`/`area-chart`/`bar-chart`
+  config as `xKey`/`yKey`/`unit`, but the renderer actually reads
+  `meta.trends.xAxis` (default `"date"`), `series:[{field, label?,
+  colour?}]` (auto-detecting a y-field when omitted), `title`, and
+  `yAxisLabel`. Corrected across `docs/CARDS.md` and the system-prompt
+  renderer line in `config/env.js`, and added `eh-line-chart.js` to the
+  chat docs catalogue so the renderer source is the durable contract.
+  Refs #441.
+
 - **`set_notification` clears `lastFired` when it changes a trigger.**
   Cached `notifications.state.json#items[<id>].lastFired` is computed
   under whatever trigger configuration was active at the time, so once

--- a/chat/docs.js
+++ b/chat/docs.js
@@ -76,6 +76,8 @@ const DOC_INDEX = [
     summary: 'hae-discovery-card — pinned card surfacing HAE metrics not yet subscribed. Reads /api/health-auto-export/discoveries. Per-metric "Build a card" seeds a chat prompt; "Dismiss" persists a Settings-restorable hide.' },
   { kind: 'source', path: 'public/js/components/eh-welcome-card.js',
     summary: 'welcome-card — onboarding card on a fresh install. Auto-hidden by registry.createManifest on first user-card creation; can be restored from Settings.' },
+  { kind: 'source', path: 'public/js/components/eh-line-chart.js',
+    summary: 'line-chart renderer (also registered for area-chart/bar-chart). Read-only in Trends. Reads meta.trends/view xAxis (default "date"), series:[{field,label?,colour?}] (auto-detects a y-field when omitted: value/kg/ml/count/minutes/systolic then first non-date numeric key), title, yAxisLabel. Does NOT read xKey/yKey/unit.' },
 ];
 
 const ALLOWED_PATHS = new Set(DOC_INDEX.map(d => d.path));

--- a/config/env.js
+++ b/config/env.js
@@ -382,7 +382,7 @@ For a workouts card specifically: use \`"template": "{trained:check} {type}"\` (
 - \`schedule-card\` — scheduled doses/events with recurrence; data is \`{items:[{name, dose_mg?, dose_units?, route?, schedule, doses?:[]}]}\`. Each item's \`schedule\` is a schedule-shape object (see below). **Items ALWAYS live in \`data.items[]\`; never in \`meta.schedule\`.** \`meta.schedule\` is only used by the \`schedule-timeline\` renderer for a single card-level cadence, and it's rare.
 - \`schedule-timeline\` — stacked timeline across a window; reads \`meta.schedule\`.
 - \`markdown-doc\` — renders markdown; data \`{markdown:"..."}\`.
-- \`line-chart\` — time-series chart (aliases: \`area-chart\`, \`bar-chart\`); data \`[{date,value}]\` or rows keyed via \`meta.trends.field\`/\`series\`.
+- \`line-chart\` — time-series chart (aliases: \`area-chart\`, \`bar-chart\`); reads \`meta.trends.xAxis\` (default \`"date"\`) and \`meta.trends.series:[{field,label?,colour?}]\` (auto-detects a y-field if omitted); data is \`[{date, <field>}]\` rows.
 - \`table-list\` — arbitrary rowset as a table; columns via \`meta.reports.columns\`.
 - \`adherence-report\` — % adherence report over a window.
 - \`greeting-banner\` — top-of-today banner; uses \`meta.view.slot:"top"\`.

--- a/docs/CARDS.md
+++ b/docs/CARDS.md
@@ -30,7 +30,8 @@ Want to add a weight-tracking card right now? Create this file:
                  "display": { "template": "{kg:round(1)} kg",
                               "emptyHeadline": "No weight today" } },
     "trends":  { "enabled": true, "component": "line-chart",
-                 "xKey": "date", "yKey": "kg", "unit": "kg" },
+                 "xAxis": "date", "series": [{ "field": "kg", "label": "Weight (kg)" }],
+                 "yAxisLabel": "kg" },
     "writeable": {
       "fromWebapp": true,
       "todayAllowed": true,
@@ -201,8 +202,9 @@ Fields:
 
 ### `meta.trends` — the Trends view config
 
-Same shape as `meta.view`. Typical use: `component: "line-chart"` with `xKey`
-and `yKey` pointing into the data rows.
+Same shape as `meta.view`. Typical use: `component: "line-chart"` with `xAxis`
+(the date/category key, default `"date"`) and `series` (an array of
+`{ field, label?, colour? }`) pointing into the data rows.
 
 ### `meta.reports` — the Reports view config
 
@@ -1097,8 +1099,13 @@ Used in `meta.trends.component`, not `meta.view.component`. Read-only
 in the Trends view.
 
 **Reads:**
-- `meta.trends.xKey`, `.yKey`, `.field`, `.series[]`, `.unit`.
-- Data rows by date for the configured field(s).
+- `meta.trends.xAxis` — the x-axis key (default `"date"`).
+- `meta.trends.series` — array of `{ field, label?, colour? }`. When omitted,
+  the renderer auto-detects a y-field (tries `value`/`kg`/`ml`/`count`/
+  `minutes`/`systolic`, then the first non-date numeric key).
+- `meta.trends.title` — optional chart title.
+- `meta.trends.yAxisLabel` — optional y-axis label.
+- Data rows sorted by the `xAxis` key for the configured series field(s).
 
 **Writes:**
 - None.

--- a/tests/line-chart-doc-drift.test.js
+++ b/tests/line-chart-doc-drift.test.js
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Aristocles <https://github.com/Aristocles>
+// tests/line-chart-doc-drift.test.js
+// Guards against the line-chart config drift returning: the docs + chat prompt
+// must describe the config the renderer actually reads (xAxis/series/title/
+// yAxisLabel), not the stale xKey/yKey/unit shape. Also asserts a config-shaped
+// line-chart manifest passes the structural validator.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+const REPO = path.resolve(__dirname, '..');
+const registry = require('../manifests/registry');
+
+function read(rel) {
+  return fs.readFileSync(path.join(REPO, rel), 'utf8');
+}
+
+// The exact keys eh-line-chart.js reads, lifted so the test pins the contract.
+const RENDERER_READS = ['xAxis', 'series', 'title', 'yAxisLabel'];
+const RENDERER_IGNORES = ['xKey', 'yKey'];
+
+describe('line-chart config: renderer is the source of truth', () => {
+  test('eh-line-chart.js reads xAxis/series, not xKey/yKey', () => {
+    const src = read('public/js/components/eh-line-chart.js');
+    for (const k of RENDERER_READS) {
+      assert.ok(src.includes(`cfg.${k}`) || src.includes(`.${k}`), `renderer should reference ${k}`);
+    }
+    for (const k of RENDERER_IGNORES) {
+      assert.ok(!src.includes(k), `renderer must not reference the stale ${k}`);
+    }
+  });
+});
+
+describe('line-chart config: docs match the renderer', () => {
+  test('docs/CARDS.md no longer documents xKey/yKey/unit for line-chart', () => {
+    const cards = read('docs/CARDS.md');
+    assert.ok(!/\bxKey\b/.test(cards), 'CARDS.md must not mention xKey');
+    assert.ok(!/\byKey\b/.test(cards), 'CARDS.md must not mention yKey');
+    // The corrected config keys must appear.
+    assert.ok(cards.includes('xAxis'), 'CARDS.md documents xAxis');
+    assert.ok(/series/.test(cards), 'CARDS.md documents series');
+  });
+
+  test('config/env.js system prompt describes xAxis/series for line-chart', () => {
+    const env = read('config/env.js');
+    const line = env.split('\n').find(l => l.includes('line-chart') && l.includes('time-series chart'));
+    assert.ok(line, 'found the line-chart prompt line');
+    assert.ok(line.includes('xAxis'), 'prompt line mentions xAxis');
+    assert.ok(line.includes('series'), 'prompt line mentions series');
+  });
+
+  test('chat docs catalogue lists eh-line-chart.js with the correct contract', () => {
+    const docs = read('chat/docs.js');
+    assert.ok(docs.includes('eh-line-chart.js'), 'DOC_INDEX includes the line-chart renderer');
+    assert.ok(/Does NOT read xKey\/yKey/.test(docs), 'catalogue summary states the xKey/yKey correction');
+  });
+});
+
+describe('line-chart config: a renderer-shaped manifest validates', () => {
+  test('xAxis + series line-chart manifest passes the structural validator', () => {
+    const manifest = {
+      $schema: 'klebb.datafile.v1',
+      meta: {
+        id: 'bp-trend',
+        label: 'Blood Pressure Trend',
+        trends: {
+          enabled: true,
+          component: 'line-chart',
+          xAxis: 'date',
+          series: [
+            { field: 'systolic', label: 'Systolic' },
+            { field: 'diastolic', label: 'Diastolic' },
+          ],
+          yAxisLabel: 'mmHg',
+        },
+      },
+      data: [{ date: '2026-06-20', systolic: 120, diastolic: 80 }],
+    };
+    assert.doesNotThrow(() => registry.validateManifestShape(JSON.parse(JSON.stringify(manifest)), { strictId: true }));
+  });
+});


### PR DESCRIPTION
# What changed
Docs + chat prompt described line-chart config as `xKey`/`yKey`/`unit`; the renderer actually reads `xAxis`/`series`/`title`/`yAxisLabel`. Corrected in docs/CARDS.md (3 sites) and config/env.js, and added eh-line-chart.js to the chat docs catalogue.

# Why
Doc/renderer drift was steering manifest authors (and Klebbius) to write config the renderer ignores.

# How
Folded in the renderer truth (incl. that `series` is optional, auto-detecting a y-field). Registering the renderer source in the catalogue makes the code the durable contract. **Stacked on #414** (the schema artefact is the related single-source-of-truth work).

# Testing
- [x] `npm test` passes (+5). `tests/line-chart-doc-drift.test.js` guards the drift from returning and validates a renderer-shaped manifest. Doc + prompt change; test included.

Refs #441